### PR TITLE
fix(widgets): respect reduced motion in spinner tick

### DIFF
--- a/packages/widgets/src/feedback/Spinner.test.ts
+++ b/packages/widgets/src/feedback/Spinner.test.ts
@@ -2,10 +2,27 @@
 // @termuijs/widgets — Tests for Spinner widget
 // ─────────────────────────────────────────────────────
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { caps } from '@termuijs/core';
 import { Spinner, SPINNER_FRAMES } from './Spinner.js';
 
 describe('Spinner', () => {
+    const originalMotion = caps.motion;
+
+    afterEach(() => {
+        (caps as unknown as { motion: boolean }).motion = originalMotion;
+    });
+
+    it('does not advance frames on manual tick when motion is disabled', () => {
+        (caps as unknown as { motion: boolean }).motion = false;
+        const spinner = new Spinner({}, { spinner: 'line' });
+
+        spinner.tick(130);
+
+        const frameIndex = (spinner as unknown as { _frameIndex: number })._frameIndex;
+        expect(frameIndex).toBe(0);
+    });
+
     it('starts at first frame', () => {
         // Default spinner is 'dots' with frames ['⠋', '⠙', ...]
         const spinner = new Spinner();

--- a/packages/widgets/src/feedback/Spinner.ts
+++ b/packages/widgets/src/feedback/Spinner.ts
@@ -100,6 +100,8 @@ export class Spinner extends Widget {
      * Call this with a delta (ms) from the render loop.
      */
     tick(deltaMs: number): void {
+        if (!caps.motion) return;
+
         this._elapsed += deltaMs;
         if (this._elapsed >= this._interval) {
             this._frameIndex = (this._frameIndex + 1) % this._frames.length;


### PR DESCRIPTION
## Summary
- Make `Spinner.tick()` a no-op when `caps.motion` is disabled.
- Add a regression test that keeps the spinner frame index static under reduced-motion settings.

## Test Plan
- `corepack pnpm vitest run packages/widgets/src/feedback/Spinner.test.ts -t "does not advance frames on manual tick when motion is disabled"`
- `corepack pnpm vitest run packages/widgets/src/feedback/Spinner.test.ts`
- `corepack pnpm --filter @termuijs/widgets typecheck`
- `corepack pnpm --filter @termuijs/widgets build`

Fixes #6