### PR TITLE
test(widgets): cover sparkline ASCII fallback

### DIFF
--- a/packages/widgets/src/data/Sparkline.test.ts
+++ b/packages/widgets/src/data/Sparkline.test.ts
@@ -1,0 +1,30 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for Sparkline widget
+// ─────────────────────────────────────────────────────
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+afterEach(() => {
+    vi.unstubAllEnvs();
+});
+
+describe('Sparkline', () => {
+    it('uses ASCII spark characters when unicode is disabled', async () => {
+        vi.stubEnv('NO_UNICODE', '1');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { Sparkline } = await import('./Sparkline.js');
+
+        const sparkline = new Sparkline('Load');
+        sparkline.setData([0, 1, 2, 3, 4, 5, 6, 7]);
+        sparkline.updateRect({ x: 0, y: 0, width: 20, height: 1 });
+        const screen = new Screen(20, 1);
+
+        sparkline.render(screen);
+
+        const rendered = screen.back[0].map(cell => cell.char).join('');
+        expect(rendered).toContain('Load 12345678');
+        expect(rendered).not.toMatch(/[▁▂▃▄▅▆▇█]/);
+    });
+});


### PR DESCRIPTION
## Summary
- Add a regression test for Sparkline when unicode output is disabled via `NO_UNICODE=1` / `caps.unicode=false`.
- Verify Sparkline renders ASCII proportional fallback characters (`12345678`) instead of unicode block characters.

## Notes
- The current `main` implementation already selects `SPARK_CHARS_ASCII` when `caps.unicode` is false, so this PR adds coverage to lock the behavior and prevent regressions.

## Test Plan
- `corepack pnpm vitest run packages/widgets/src/data/Sparkline.test.ts`
- `corepack pnpm --filter @termuijs/widgets typecheck`
- `corepack pnpm --filter @termuijs/widgets build`
- `git diff --check`

Fixes #5