### PR TITLE
feat(quick): re-export batch() from @termuijs/store

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -161,6 +161,7 @@
         "@termuijs/core": "workspace:*",
         "@termuijs/data": "workspace:*",
         "@termuijs/jsx": "workspace:*",
+        "@termuijs/store": "workspace:*",
         "@termuijs/tss": "workspace:*",
         "@termuijs/ui": "workspace:*",
         "@termuijs/widgets": "workspace:*",

--- a/packages/quick/package.json
+++ b/packages/quick/package.json
@@ -34,6 +34,7 @@
     "@termuijs/widgets": "workspace:*",
     "@termuijs/jsx": "workspace:*",
     "@termuijs/tss": "workspace:*",
+    "@termuijs/store": "workspace:*",
     "@termuijs/data": "workspace:*",
     "@termuijs/ui": "workspace:*"
   },

--- a/packages/quick/src/index.test.ts
+++ b/packages/quick/src/index.test.ts
@@ -17,3 +17,10 @@ describe('quick – index exports grid (not gridWidget)', () => {
         expect(typeof (mod as any).grid).toBe('function');
     });
 });
+
+describe('quick – index exports batch from @termuijs/store', () => {
+    it('re-exports batch from @termuijs/store', async () => {
+        const mod = await import('./index.js');
+        expect(typeof (mod as any).batch).toBe('function');
+    });
+});

--- a/packages/quick/src/index.ts
+++ b/packages/quick/src/index.ts
@@ -64,6 +64,9 @@ export type {
     ToolCallStatus,
 } from './widgets.js';
 
+// ── Store (re-exported for convenience) ───────────────
+export { batch } from '@termuijs/store';
+
 // ── Reactive ──────────────────────────────────────────
 export { resolve, isReactive } from './reactive.js';
 export type { Reactive } from './reactive.js';


### PR DESCRIPTION
## Description

Re-exports `batch()` from `@termuijs/store` so developers using the quick API can write:

```ts
import { app, batch } from '@termuijs/quick'

batch(() => {
  todos.push(newItem)
  todos.splice(0, 1)
})
```

Without this change, quick-API users had to install `@termuijs/store` separately to access `batch()`.

## Changes

- `packages/quick/package.json` — Added `@termuijs/store` as workspace dependency
- `packages/quick/src/index.ts` — Added re-export: `export { batch } from '@termuijs/store'`
- `packages/quick/src/index.test.ts` — Added test verifying `batch` is re-exported as a function

## Verification

- `bun run build` — ✅ 19/19 tasks successful
- `bun run typecheck` — ✅ 14/14 tasks successful
- `bun run test` — ✅ 600 tests passed across 58 files

Closes #11

---

<p align="center">
  <strong>GirlScript Summer of Code 2026</strong>
</p>

<p align="center">
  <img src="https://img.shields.io/badge/GSSoC-2026-purple?style=for-the-badge" alt="GSSoC 2026"/>
  <img src="https://img.shields.io/badge/level-beginner-brightgreen?style=for-the-badge" alt="Level: Beginner"/>
</p>

<p align="center">
  <sub>Contributed as part of <a href="https://gssoc.girlscript.tech/">GirlScript Summer of Code 2026</a> — Issue <a href="https://github.com/Karanjot786/TermUI/issues/11">#11</a></sub>
</p>