### PR TITLE
test(widgets): add ASCII fallback tests for Gauge widget

### DIFF
--- a/packages/widgets/src/data/Gauge.test.ts
+++ b/packages/widgets/src/data/Gauge.test.ts
@@ -2,8 +2,9 @@
 // @termuijs/widgets — Tests for Gauge widget
 // ─────────────────────────────────────────────────────
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { Gauge } from './Gauge.js';
+import { caps } from '@termuijs/core';
 
 describe('Gauge', () => {
     it('initializes with 0 value', () => {
@@ -25,5 +26,19 @@ describe('Gauge', () => {
         const g = new Gauge('CPU');
         g.setLabel('Memory');
         expect(g).toBeDefined();
+    });
+
+    it('caps.unicode is false when NO_UNICODE=1', () => {
+        process.env.NO_UNICODE = '1';
+        expect(process.env.NO_UNICODE).toBe('1');
+        delete process.env.NO_UNICODE;
+    });
+
+    it('getValue returns 0.5 after setValue(0.5) in ASCII mode', () => {
+        process.env.NO_UNICODE = '1';
+        const g = new Gauge('CPU');
+        g.setValue(0.5);
+        expect(g.getValue()).toBe(0.5);
+        delete process.env.NO_UNICODE;
     });
 });

--- a/packages/widgets/src/data/Gauge.test.ts
+++ b/packages/widgets/src/data/Gauge.test.ts
@@ -2,17 +2,21 @@
 // @termuijs/widgets — Tests for Gauge widget
 // ─────────────────────────────────────────────────────
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { Gauge } from './Gauge.js';
-import { caps } from '@termuijs/core';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+afterEach(() => {
+    vi.unstubAllEnvs();
+});
 
 describe('Gauge', () => {
-    it('initializes with 0 value', () => {
+    it('initializes with 0 value', async () => {
+        const { Gauge } = await import('./Gauge.js');
         const g = new Gauge('CPU');
         expect(g.getValue()).toBe(0);
     });
 
-    it('setValue sets and clamps the value', () => {
+    it('setValue sets and clamps the value', async () => {
+        const { Gauge } = await import('./Gauge.js');
         const g = new Gauge('CPU');
         g.setValue(0.75);
         expect(g.getValue()).toBe(0.75);
@@ -22,23 +26,47 @@ describe('Gauge', () => {
         expect(g.getValue()).toBe(0);
     });
 
-    it('setLabel updates the label', () => {
+    it('setLabel updates the label', async () => {
+        const { Gauge } = await import('./Gauge.js');
         const g = new Gauge('CPU');
         g.setLabel('Memory');
         expect(g).toBeDefined();
     });
 
-    it('caps.unicode is false when NO_UNICODE=1', () => {
-        process.env.NO_UNICODE = '1';
-        expect(process.env.NO_UNICODE).toBe('1');
-        delete process.env.NO_UNICODE;
+    it('uses ASCII chars when NO_UNICODE=1', async () => {
+        vi.stubEnv('NO_UNICODE', '1');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { Gauge } = await import('./Gauge.js');
+
+        const gauge = new Gauge('CPU');
+        gauge.setValue(0.5);
+        gauge.updateRect({ x: 0, y: 0, width: 20, height: 1 });
+        const screen = new Screen(20, 1);
+        gauge.render(screen);
+
+        const rendered = screen.back[0].map((cell: { char: string }) => cell.char).join('');
+        expect(rendered).toContain('#');
+        expect(rendered).toContain('-');
+        expect(rendered).not.toMatch(/[█░]/);
     });
 
-    it('getValue returns 0.5 after setValue(0.5) in ASCII mode', () => {
-        process.env.NO_UNICODE = '1';
-        const g = new Gauge('CPU');
-        g.setValue(0.5);
-        expect(g.getValue()).toBe(0.5);
-        delete process.env.NO_UNICODE;
+    it('uses unicode chars when unicode is available', async () => {
+        vi.stubEnv('NO_UNICODE', '');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { Gauge } = await import('./Gauge.js');
+
+        const gauge = new Gauge('CPU');
+        gauge.setValue(0.5);
+        gauge.updateRect({ x: 0, y: 0, width: 20, height: 1 });
+        const screen = new Screen(20, 1);
+        gauge.render(screen);
+
+        const rendered = screen.back[0].map((cell: { char: string }) => cell.char).join('');
+        expect(rendered).toMatch(/[█░]/);
+        expect(rendered).not.toContain('#');
     });
 });

--- a/packages/widgets/src/data/Gauge.test.ts
+++ b/packages/widgets/src/data/Gauge.test.ts
@@ -70,3 +70,4 @@ describe('Gauge', () => {
         expect(rendered).not.toContain('#');
     });
 });
+


### PR DESCRIPTION

## Description

Added missing unit tests for the ASCII fallback behavior in the Gauge widget. Tests verify that the widget works correctly when `NO_UNICODE=1` is set.

## Related Issue

Closes #4

## Which package(s)?

@termuijs/widgets

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/9d129ba7-b2c3-46e7-aa8a-9557f15eef5f`


## Notes for the Reviewer

The Gauge widget already had the ASCII fallback implemented using `caps.unicode` checks, but no tests existed to verify this behavior. This PR adds tests for the `NO_UNICODE=1` case.
