### PR TITLE
test(widgets): add ScrollView unit tests

### DIFF
--- a/packages/widgets/src/layout/ScrollView.test.ts
+++ b/packages/widgets/src/layout/ScrollView.test.ts
@@ -4,7 +4,13 @@
 
 import { describe, it, expect } from 'vitest';
 import { ScrollView } from './ScrollView.js';
-import { Screen } from '@termuijs/core';
+import { Screen, type KeyEvent } from '@termuijs/core';
+
+const key = (k: string): KeyEvent => ({
+    key: k,
+    stopPropagation: () => {},
+    preventDefault: () => {},
+});
 
 describe('ScrollView', () => {
     it('renders without error when content is taller than viewport', () => {
@@ -100,7 +106,8 @@ describe('ScrollView', () => {
         const sv = new ScrollView({ width: 10, height: 5 }, { contentHeight: 20, showScrollbar: false });
         const screen = new Screen(10, 5);
         sv.updateRect({ x: 0, y: 0, width: 10, height: 5 });
-        expect(() => sv.render(screen)).not.toThrow();
+        sv.render(screen);
+        expect(screen.back[0][9].char).toBe(' ');
     });
 
     it('does not render scrollbar when content fits viewport', () => {
@@ -109,5 +116,35 @@ describe('ScrollView', () => {
         sv.updateRect({ x: 0, y: 0, width: 10, height: 5 });
         sv.render(screen);
         expect(screen.back[0][9].char).toBe(' ');
+    });
+
+    it('ArrowDown scrolls down by 1', () => {
+        const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
+        sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
+        sv.onKey(key('ArrowDown'));
+        expect(sv.scrollOffset).toBe(1);
+    });
+
+    it('ArrowUp scrolls up by 1', () => {
+        const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
+        sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
+        sv.scrollBy(5);
+        sv.onKey(key('ArrowUp'));
+        expect(sv.scrollOffset).toBe(4);
+    });
+
+    it('PageDown scrolls down by viewport height - 1', () => {
+        const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
+        sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
+        sv.onKey(key('PageDown'));
+        expect(sv.scrollOffset).toBe(4);
+    });
+
+    it('PageUp scrolls up by viewport height - 1', () => {
+        const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
+        sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
+        sv.scrollBy(10);
+        sv.onKey(key('PageUp'));
+        expect(sv.scrollOffset).toBe(6);
     });
 });

--- a/packages/widgets/src/layout/ScrollView.test.ts
+++ b/packages/widgets/src/layout/ScrollView.test.ts
@@ -1,0 +1,113 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for ScrollView widget
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import { ScrollView } from './ScrollView.js';
+import { Screen } from '@termuijs/core';
+
+describe('ScrollView', () => {
+    it('renders without error when content is taller than viewport', () => {
+        const sv = new ScrollView({ width: 10, height: 5 }, { contentHeight: 20 });
+        const screen = new Screen(10, 5);
+        sv.updateRect({ x: 0, y: 0, width: 10, height: 5 });
+        expect(() => sv.render(screen)).not.toThrow();
+    });
+
+    it('scrollBy with positive delta increments scrollOffset', () => {
+        const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
+        sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
+        sv.scrollBy(1);
+        expect(sv.scrollOffset).toBe(1);
+    });
+
+    it('scrollBy with negative delta decrements scrollOffset', () => {
+        const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
+        sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
+        sv.scrollBy(5);
+        sv.scrollBy(-1);
+        expect(sv.scrollOffset).toBe(4);
+    });
+
+    it('scrollBy floors offset at 0', () => {
+        const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
+        sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
+        sv.scrollBy(-5);
+        expect(sv.scrollOffset).toBe(0);
+    });
+
+    it('scrollBy pages down by viewport height', () => {
+        const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
+        sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
+        sv.scrollBy(4);
+        expect(sv.scrollOffset).toBe(4);
+    });
+
+    it('scrollBy pages up decrements offset and floors at 0', () => {
+        const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
+        sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
+        sv.scrollBy(10);
+        expect(sv.scrollOffset).toBe(10);
+        sv.scrollBy(-4);
+        expect(sv.scrollOffset).toBe(6);
+        sv.scrollBy(-20);
+        expect(sv.scrollOffset).toBe(0);
+    });
+
+    it('clamps offset so it does not exceed contentHeight - viewHeight', () => {
+        const sv = new ScrollView({ height: 5 }, { contentHeight: 10 });
+        sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
+        sv.scrollBy(20);
+        expect(sv.scrollOffset).toBe(5);
+    });
+
+    it('scrollTo sets exact offset clamped to valid range', () => {
+        const sv = new ScrollView({ height: 5 }, { contentHeight: 10 });
+        sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
+        sv.scrollTo(3);
+        expect(sv.scrollOffset).toBe(3);
+        sv.scrollTo(-5);
+        expect(sv.scrollOffset).toBe(0);
+        sv.scrollTo(100);
+        expect(sv.scrollOffset).toBe(5);
+    });
+
+    it('setContentHeight clamps offset when content shrinks', () => {
+        const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
+        sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
+        sv.scrollBy(15);
+        expect(sv.scrollOffset).toBe(15);
+        sv.setContentHeight(10);
+        expect(sv.scrollOffset).toBe(5);
+    });
+
+    it('initial scrollOffset is 0', () => {
+        const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
+        expect(sv.scrollOffset).toBe(0);
+    });
+
+    it('renders scrollbar when content exceeds viewport', () => {
+        const sv = new ScrollView({ width: 12, height: 5, border: true }, { contentHeight: 20 });
+        const screen = new Screen(12, 5);
+        sv.updateRect({ x: 0, y: 0, width: 12, height: 5 });
+        sv.render(screen);
+        // Scrollbar track is drawn at the right edge of the content rect
+        // Row 3 (y=1 + i=2) is track (not thumb) when scrollOffset=0
+        expect(screen.back[3][11].char).toBe('\u2591');
+    });
+
+    it('renders without scrollbar when showScrollbar is false', () => {
+        const sv = new ScrollView({ width: 10, height: 5 }, { contentHeight: 20, showScrollbar: false });
+        const screen = new Screen(10, 5);
+        sv.updateRect({ x: 0, y: 0, width: 10, height: 5 });
+        expect(() => sv.render(screen)).not.toThrow();
+    });
+
+    it('does not render scrollbar when content fits viewport', () => {
+        const sv = new ScrollView({ width: 10, height: 5 }, { contentHeight: 3 });
+        const screen = new Screen(10, 5);
+        sv.updateRect({ x: 0, y: 0, width: 10, height: 5 });
+        sv.render(screen);
+        expect(screen.back[0][9].char).toBe(' ');
+    });
+});


### PR DESCRIPTION
## Description

Adds 13 unit tests for the ScrollView widget covering scroll offset clamping, scrollBy/scrollTo operations, setContentHeight updates, scrollbar rendering, and keyboard event handling (ArrowUp, ArrowDown, PageUp, PageDown).

## Related Issue

Closes #8

## Which package(s)?

@termuijs/widgets

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Docs
- [x] 🧪 Tests
- [ ] ♻️ Refactor
- [ ] 🎨 Design / UX
- [ ] ♿ Accessibility
- [ ] ⚡ Performance
- [ ] 🔧 DevOps / CI
- [ ] 🔒 Security

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (N/A — tests only, no widget changes).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Notes for the Reviewer

All 13 tests pass. The test file follows the existing patterns in `packages/widgets/src/data/Gauge.test.ts`. Tests use the in-memory Screen buffer from `@termuijs/core` and verify scroll behavior, clamping, rendering, and keyboard input.