### PR TITLE
feat(widgets): add Markdown widget

### DIFF
--- a/packages/widgets/src/display/Markdown.test.ts
+++ b/packages/widgets/src/display/Markdown.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Screen, caps } from '@termuijs/core';
 import { Markdown } from './Markdown.js';
 
@@ -135,7 +135,8 @@ describe('Markdown', () => {
 
         expect(screen.back[0][0].char).toBe('i');
         expect(screen.back[0][0].italic).toBe(true);
-    }); it('renders inline code', () => {
+    });
+    it('renders inline code', () => {
         const md = new Markdown({ content: '`code`' });
 
         const screen = new Screen(20, 5);
@@ -170,5 +171,26 @@ describe('Markdown', () => {
     expect(rendered).toContain('└');
     expect(rendered).toContain('│');
     expect(rendered).not.toContain('```');
-});
+    });
+
+    it('renders code block with ASCII chars when NO_UNICODE=1', async () => {
+        vi.stubEnv('NO_UNICODE', '1');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { Markdown } = await import('./Markdown.js');
+
+        const md = new Markdown({ content: '```ts\nconst x = 1\n```' });
+        const screen = new Screen(40, 10);
+        md.updateRect({ x: 0, y: 0, width: 40, height: 10 });
+        md.render(screen);
+
+        const rendered = screen.back.map(row => row.map(c => c.char).join('')).join('\n');
+        expect(rendered).toContain('const x = 1');
+        expect(rendered).toContain('+');
+        expect(rendered).toContain('|');
+        expect(rendered).not.toContain('┌');
+
+        vi.unstubAllEnvs();
+    });
 });

--- a/packages/widgets/src/display/Markdown.test.ts
+++ b/packages/widgets/src/display/Markdown.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import { Screen, caps } from '@termuijs/core';
+import { Markdown } from './Markdown.js';
+
+describe('Markdown', () => {
+    it('renders heading text with bold and underline', () => {
+        const md = new Markdown({
+            content: '# Hello'
+        });
+
+        const screen = new Screen(20, 5);
+
+        md.updateRect({
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 5
+        });
+
+        md.render(screen);
+
+        expect(screen.back[0][0].char).toBe('H');
+        expect(screen.back[0][0].bold).toBe(true);
+        expect(screen.back[0][0].underline).toBe(true);
+    });
+    it('setContent updates content', () => {
+        const md = new Markdown({
+            content: 'old'
+        });
+
+        md.setContent('new');
+
+        expect(md.getContent()).toBe('new');
+    });
+    it('setContent marks widget dirty', () => {
+        const md = new Markdown({
+            content: 'old'
+        });
+
+        md.clearDirty();
+
+        expect(md.isDirty).toBe(false);
+
+        md.setContent('new');
+
+        expect(md.isDirty).toBe(true);
+    });
+    it('renders list items', () => {
+        const md = new Markdown({
+            content: '- Item'
+        });
+
+        const screen = new Screen(20, 5);
+
+        md.updateRect({
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 5
+        });
+
+        md.render(screen);
+
+        const expected = caps.unicode ? '•' : '*';
+
+        expect(screen.back[0][0].char).toBe(expected);
+    });
+    it('renders numbered list items', () => {
+        const md = new Markdown({
+            content: '1. First item'
+        });
+
+        const screen = new Screen(20, 5);
+
+        md.updateRect({
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 5
+        });
+
+        md.render(screen);
+
+        expect(screen.back[0][0].char).toBe('1');
+        expect(screen.back[0][1].char).toBe('.');
+    });
+    it('wraps long paragraphs', () => {
+        const md = new Markdown({
+            content: 'This is a very long paragraph that should wrap'
+        });
+
+        const screen = new Screen(10, 5);
+
+        md.updateRect({
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 5
+        });
+
+        md.render(screen);
+
+        const firstRow = screen.back[0].map(c => c.char).join('');
+        const secondRow = screen.back[1].map(c => c.char).join('');
+
+        expect(firstRow.trim().length).toBeGreaterThan(0);
+        expect(secondRow.trim().length).toBeGreaterThan(0);
+    });
+    it('renders bold text', () => {
+        const md = new Markdown({
+            content: '**bold**'
+        });
+
+        const screen = new Screen(20, 5);
+
+        md.updateRect({
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 5
+        });
+
+        md.render(screen);
+
+        expect(screen.back[0][0].char).toBe('b');
+        expect(screen.back[0][0].bold).toBe(true);
+    });
+    it('renders italic text', () => {
+        const md = new Markdown({ content: '_italic_' });
+
+        const screen = new Screen(20, 5);
+
+        md.updateRect({ x: 0, y: 0, width: 20, height: 5 });
+        md.render(screen);
+
+        expect(screen.back[0][0].char).toBe('i');
+        expect(screen.back[0][0].italic).toBe(true);
+    }); it('renders inline code', () => {
+        const md = new Markdown({ content: '`code`' });
+
+        const screen = new Screen(20, 5);
+
+        md.updateRect({ x: 0, y: 0, width: 20, height: 5 });
+        md.render(screen);
+
+        expect(screen.back[0][0].char).toBe('c');
+    });
+   it('renders code block as a boxed block', () => {
+    const md = new Markdown({
+        content: '```ts\nconst x = 1\n```'
+    });
+
+    const screen = new Screen(40, 10);
+
+    md.updateRect({
+        x: 0,
+        y: 0,
+        width: 40,
+        height: 10
+    });
+
+    md.render(screen);
+
+    const rendered = screen.back
+        .map(row => row.map(cell => cell.char).join(''))
+        .join('\n');
+
+    expect(rendered).toContain('const x = 1');
+    expect(rendered).toContain('┌');
+    expect(rendered).toContain('└');
+    expect(rendered).toContain('│');
+    expect(rendered).not.toContain('```');
+});
+});

--- a/packages/widgets/src/display/Markdown.ts
+++ b/packages/widgets/src/display/Markdown.ts
@@ -1,0 +1,217 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — ChatMessage widget
+// ─────────────────────────────────────────────────────
+
+import { Screen, Style, caps, wordWrap } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export interface MarkdownOptions {
+    content: string;
+}
+
+// ── Markdown widget ──────────────────────────────────
+
+/**
+ * Markdown — renders a subset of Markdown syntax in the terminal.
+ *
+ * Supported:
+ * - Headings (#)
+ * - Bold (**text**)
+ * - Italic (_text_)
+ * - Inline code (`code`)
+ * - Unordered lists (- item)
+ * - Ordered lists (1. item)
+ * - Code fences (```lang)
+ */
+
+export class Markdown extends Widget {
+    private _content: string;
+
+    private writeText(
+        screen: Screen,
+        x: number,
+        y: number,
+        text: string,
+        attrs: Record<string, unknown> = {}
+    ): void {
+        for (let i = 0; i < text.length && x + i < this._getContentRect().x + this._getContentRect().width; i++) {
+            screen.setCell(x + i, y, {
+                char: text[i],
+                ...attrs
+            });
+        }
+    }
+
+    private renderInline(screen: Screen, x: number, y: number, text: string): void {
+    let bold = false;
+    let italic = false;
+    let code = false;
+    let col = x;
+    let segment = '';
+
+    const flush = () => {
+        if (segment.length === 0) return;
+        screen.writeString(col - segment.length, y, segment, {
+            bold,
+            italic,
+            inverse: code
+        });
+        segment = '';
+    };
+
+    for (let i = 0; i < text.length; i++) {
+        if (text.slice(i, i + 2) === '**') {
+            flush();
+            bold = !bold;
+            i++;
+            continue;
+        }
+        if (text[i] === '_') {
+            flush();
+            italic = !italic;
+            continue;
+        }
+        if (text[i] === '`') {
+            flush();
+            code = !code;
+            continue;
+        }
+        segment += text[i];
+        col++;
+    }
+    flush();
+}
+    private renderCodeBlock(
+        screen: Screen,
+        x: number,
+        y: number,
+        width: number,
+        language: string,
+        lines: string[]
+    ): number {
+        const top = `┌─ ${language} ${'─'.repeat(Math.max(0, width - language.length - 5))}┐`;
+
+        this.writeText(screen, x, y, top);
+
+        for (let i = 0; i < lines.length; i++) {
+            this.writeText(
+                screen,
+                x,
+                y + i + 1,
+                `│ ${lines[i]}`
+            );
+        }
+
+        const bottom = `└${'─'.repeat(Math.max(0, width - 2))}┘`;
+
+        this.writeText(
+            screen,
+            x,
+            y + lines.length + 1,
+            bottom
+        );
+
+        return lines.length + 2;
+    }
+
+    constructor(options: MarkdownOptions, style: Partial<Style> = {}) {
+        super(style);
+        this._content = options.content;
+    }
+
+    /** Update markdown content and mark dirty. */
+
+    setContent(content: string): void {
+        this._content = content;
+        this.markDirty();
+    }
+
+    getContent(): string {
+        return this._content;
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const rect = this._getContentRect();
+
+        const lines = this._content.split('\n');
+
+        let screenRow = 0;
+
+        for (let row = 0; row < lines.length && row < rect.height; row++) {
+            const line = lines[row];
+
+            if (line.startsWith('```')) {
+                const language = line.slice(3).trim();
+
+                const codeLines: string[] = [];
+
+                row++;
+                screenRow++;
+
+                while (
+                    row < lines.length &&
+                    !lines[row].startsWith('```')
+                ) {
+                    codeLines.push(lines[row]);
+                    row++;
+                }
+
+                screenRow += this.renderCodeBlock(
+                    screen,
+                    rect.x,
+                    rect.y + screenRow,
+                    rect.width,
+                    language,
+                    codeLines
+                );
+
+                continue;
+            }
+
+            if (line.startsWith('# ')) {
+                screen.writeString(rect.x, rect.y + screenRow, line.slice(2), {
+                    bold: true,
+                    underline: true
+                });
+                screenRow++;
+            }
+            else if (line.startsWith('- ')) {
+                const bullet = caps.unicode ? '•' : '*';
+
+                this.renderInline(
+                    screen,
+                    rect.x,
+                    rect.y + screenRow,
+                    `${bullet} ${line.slice(2)}`
+                );
+                screenRow++;
+            }
+            else if (/^\d+\.\s/.test(line)) {
+                this.renderInline(
+                    screen,
+                    rect.x,
+                    rect.y + screenRow,
+                    line
+                );
+                screenRow++;
+            }
+            else {
+                const wrapped = wordWrap(line, rect.width);
+
+                const wrappedLines = wrapped.split('\n');
+
+                for (let i = 0; i < wrappedLines.length; i++) {
+                    if (row + i >= rect.height) break;
+
+                    this.renderInline(
+                        screen,
+                        rect.x,
+                        rect.y + screenRow + i,
+                        wrappedLines[i]
+                    );
+                }
+                screenRow += wrappedLines.length;
+            }
+        }
+    }
+}

--- a/packages/widgets/src/display/Markdown.ts
+++ b/packages/widgets/src/display/Markdown.ts
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────
-// @termuijs/widgets — ChatMessage widget
+// @termuijs/widgets — Markdown widget
 // ─────────────────────────────────────────────────────
 
 import { Screen, Style, caps, wordWrap } from '@termuijs/core';
@@ -89,7 +89,13 @@ export class Markdown extends Widget {
         language: string,
         lines: string[]
     ): number {
-        const top = `┌─ ${language} ${'─'.repeat(Math.max(0, width - language.length - 5))}┐`;
+        const tl = caps.unicode ? '┌' : '+';
+        const tr = caps.unicode ? '┐' : '+';
+        const hl = caps.unicode ? '─' : '-';
+        const vl = caps.unicode ? '│' : '|';
+        const bl = caps.unicode ? '└' : '+';
+        const br = caps.unicode ? '┘' : '+';
+        const top = `${tl}${hl} ${language} ${hl.repeat(Math.max(0, width - language.length - 5))}${tr}`;
 
         this.writeText(screen, x, y, top);
 
@@ -98,11 +104,11 @@ export class Markdown extends Widget {
                 screen,
                 x,
                 y + i + 1,
-                `│ ${lines[i]}`
+                `${vl} ${lines[i]}`
             );
         }
 
-        const bottom = `└${'─'.repeat(Math.max(0, width - 2))}┘`;
+        const bottom = `${bl}${hl.repeat(Math.max(0, width - 2))}${br}`;
 
         this.writeText(
             screen,

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -95,3 +95,6 @@ export { BigText } from './display/BigText.js';
 export type { BigTextOptions } from './display/BigText.js';
 export { Gradient } from './display/Gradient.js';
 export type { GradientOptions } from './display/Gradient.js';
+
+export { Markdown } from './display/Markdown.js';
+export type { MarkdownOptions } from './display/Markdown.js';


### PR DESCRIPTION
## Description

Adds a new Markdown widget to `@termuijs/widgets` that renders a subset of Markdown syntax in the terminal. The widget supports headings, bold text, italic text, inline code, lists, code fences, and wrapped paragraphs.

## Related Issue

Closes #41

## Which package(s)?

@termuijs/widgets

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [x] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read `CONTRIBUTING.md`.
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [ ] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/YOUR_USERNAME`

## Screenshots / Recordings (UI changes)

<img width="1842" height="577" alt="file" src="https://github.com/user-attachments/assets/14ee9745-07cf-4c59-807c-36ebb156983c" />


## Notes for the Reviewer

* Added `Markdown.ts` and corresponding tests.
* Exported the widget from `packages/widgets/src/index.ts`.
* Uses `caps.unicode` for unordered list bullets.
* Calls `markDirty()` when content changes.
* Includes tests for heading style, bold text, inline code, list items, and code blocks.
