### PR TITLE
feat(widgets): add Badge and Tag widgets

### DIFF
--- a/packages/widgets/src/display/Badge.test.ts
+++ b/packages/widgets/src/display/Badge.test.ts
@@ -1,0 +1,121 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for Badge widget
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import { Badge } from './Badge.js';
+import { Screen, caps } from '@termuijs/core';
+
+/** Helper: create widget, set rect, render to a screen, return both. */
+function renderBadge(
+    text: string,
+    opts: ConstructorParameters<typeof Badge>[1] = {},
+    style: ConstructorParameters<typeof Badge>[2] = {},
+    width = 20,
+    height = 3,
+) {
+    const badge = new Badge(text, opts, style);
+    const screen = new Screen(width, height);
+    badge.updateRect({ x: 0, y: 0, width, height });
+    badge.render(screen);
+    return { badge, screen };
+}
+
+/** Read a single row from the back buffer as a plain string. */
+function rowText(screen: Screen, row: number): string {
+    return screen.back[row].map(c => c.char).join('').trimEnd();
+}
+
+describe('Badge', () => {
+    // ── 1. Default render ────────────────────────────────────────────────
+    it('renders text inside a bordered box with default neutral variant', () => {
+        const { screen } = renderBadge('ok');
+        // Row 1 is the content row; text should appear space-padded: " ok "
+        const contentRow = rowText(screen, 1);
+        expect(contentRow).toContain('ok');
+    });
+
+    it('renders top border with Unicode box-drawing corners', () => {
+        const { screen } = renderBadge('hi');
+        // Top-left corner should be ┌ in unicode mode
+        expect(screen.back[0][0].char).toBe('┌');
+    });
+
+    it('renders bottom border with Unicode box-drawing corners', () => {
+        const { screen } = renderBadge('hi');
+        // Bottom-left corner should be └
+        expect(screen.back[2][0].char).toBe('└');
+    });
+
+    // ── 2. Variant colors ────────────────────────────────────────────────
+    it('applies cyan background for info variant', () => {
+        const { screen } = renderBadge('info', { variant: 'info' });
+        // Content cell (row 1, col 1 = first char of padded text " info ")
+        // The space char at col 1 should have the cyan background
+        expect(screen.back[1][1].bg).toEqual({ type: 'named', name: 'cyan' });
+    });
+
+    it('applies green background for success variant', () => {
+        const { screen } = renderBadge('ok', { variant: 'success' });
+        expect(screen.back[1][1].bg).toEqual({ type: 'named', name: 'green' });
+    });
+
+    it('applies yellow background for warning variant', () => {
+        const { screen } = renderBadge('warn', { variant: 'warning' });
+        expect(screen.back[1][1].bg).toEqual({ type: 'named', name: 'yellow' });
+    });
+
+    it('applies red background for error variant', () => {
+        const { screen } = renderBadge('err', { variant: 'error' });
+        expect(screen.back[1][1].bg).toEqual({ type: 'named', name: 'red' });
+    });
+
+    it('applies white background for neutral variant', () => {
+        const { screen } = renderBadge('ok', { variant: 'neutral' });
+        expect(screen.back[1][1].bg).toEqual({ type: 'named', name: 'white' });
+    });
+
+    // ── 3. ASCII fallback ────────────────────────────────────────────────
+    it('uses ASCII border chars when caps.unicode is false', () => {
+        const orig = caps.unicode;
+        (caps as any).unicode = false;
+        try {
+            const { screen } = renderBadge('test');
+            // ASCII corners should be +
+            expect(screen.back[0][0].char).toBe('+');
+            expect(screen.back[2][0].char).toBe('+');
+            // Horizontal border should be -
+            expect(screen.back[0][1].char).toBe('-');
+            // Vertical border should be |
+            expect(screen.back[1][0].char).toBe('|');
+        } finally {
+            (caps as any).unicode = orig;
+        }
+    });
+
+    // ── 4. Setters call markDirty ────────────────────────────────────────
+    it('setText marks widget dirty', () => {
+        const badge = new Badge('old');
+        badge.clearDirty();
+        badge.setText('new');
+        expect(badge.isDirty).toBe(true);
+        expect(badge.getText()).toBe('new');
+    });
+
+    it('setVariant marks widget dirty', () => {
+        const badge = new Badge('ok');
+        badge.clearDirty();
+        badge.setVariant('error');
+        expect(badge.isDirty).toBe(true);
+        expect(badge.getVariant()).toBe('error');
+    });
+
+    // ── 5. Edge cases ────────────────────────────────────────────────────
+    it('handles empty text without error', () => {
+        expect(() => renderBadge('')).not.toThrow();
+    });
+
+    it('handles zero-size rect without error', () => {
+        expect(() => renderBadge('test', {}, {}, 0, 0)).not.toThrow();
+    });
+});

--- a/packages/widgets/src/display/Badge.ts
+++ b/packages/widgets/src/display/Badge.ts
@@ -1,0 +1,132 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Badge widget
+// ─────────────────────────────────────────────────────
+
+import { type Screen, type Style, type Color, styleToCellAttrs, stringWidth, caps } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export type BadgeVariant = 'info' | 'success' | 'warning' | 'error' | 'neutral';
+
+export interface BadgeOptions {
+    /** Variant determines background color. Default: 'neutral'. */
+    variant?: BadgeVariant;
+}
+
+/** Background colors for each variant. */
+const BG_COLORS: Record<BadgeVariant, Color> = {
+    info:    { type: 'named', name: 'cyan' },
+    success: { type: 'named', name: 'green' },
+    warning: { type: 'named', name: 'yellow' },
+    error:   { type: 'named', name: 'red' },
+    neutral: { type: 'named', name: 'white' },
+};
+
+/** Foreground color — black for readability on colored backgrounds. */
+const FG_COLOR: Color = { type: 'named', name: 'black' };
+
+/**
+ * Badge — a short inline label with a colored background.
+ *
+ * Used for status indicators such as "online", "error", "beta".
+ * Renders a bordered box with the text on a colored background.
+ * Uses `caps.unicode` to choose between Unicode box-drawing and ASCII fallback.
+ */
+export class Badge extends Widget {
+    private _text: string;
+    private _variant: BadgeVariant;
+
+    constructor(text: string, opts: BadgeOptions = {}, style: Partial<Style> = {}) {
+        super(style);
+        this._text = text;
+        this._variant = opts.variant ?? 'neutral';
+    }
+
+    /** Update the badge text. */
+    setText(text: string): void {
+        this._text = text;
+        this.markDirty();
+    }
+
+    /** Get the current badge text. */
+    getText(): string {
+        return this._text;
+    }
+
+    /** Update the badge variant. */
+    setVariant(variant: BadgeVariant): void {
+        this._variant = variant;
+        this.markDirty();
+    }
+
+    /** Get the current badge variant. */
+    getVariant(): BadgeVariant {
+        return this._variant;
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width, height } = this._rect;
+        if (width <= 0 || height <= 0) return;
+
+        const bg = BG_COLORS[this._variant];
+        const fg = FG_COLOR;
+
+        // Choose border characters based on unicode support
+        const tl = caps.unicode ? '┌' : '+';
+        const tr = caps.unicode ? '┐' : '+';
+        const bl = caps.unicode ? '└' : '+';
+        const br = caps.unicode ? '┘' : '+';
+        const hz = caps.unicode ? '─' : '-';
+        const vt = caps.unicode ? '│' : '|';
+
+        const borderAttrs = { fg: bg };
+        const contentAttrs = { fg, bg, bold: true };
+
+        // Padded text: " text "
+        const padded = ` ${this._text} `;
+        const textWidth = stringWidth(padded);
+
+        // Inner width is the area between left and right border
+        const innerWidth = Math.min(textWidth, Math.max(0, width - 2));
+
+        // ── Row 0: top border ──
+        if (height >= 1) {
+            screen.setCell(x, y, { char: tl, ...borderAttrs });
+            for (let c = 1; c <= innerWidth; c++) {
+                screen.setCell(x + c, y, { char: hz, ...borderAttrs });
+            }
+            if (innerWidth + 1 < width) {
+                screen.setCell(x + innerWidth + 1, y, { char: tr, ...borderAttrs });
+            }
+        }
+
+        // ── Row 1: content row ──
+        if (height >= 2) {
+            screen.setCell(x, y + 1, { char: vt, ...borderAttrs });
+
+            // Write padded text with colored background
+            const visibleText = padded.slice(0, innerWidth);
+            screen.writeString(x + 1, y + 1, visibleText, contentAttrs);
+
+            // Fill remaining inner space with background
+            const written = stringWidth(visibleText);
+            for (let c = written; c < innerWidth; c++) {
+                screen.setCell(x + 1 + c, y + 1, { char: ' ', ...contentAttrs });
+            }
+
+            if (innerWidth + 1 < width) {
+                screen.setCell(x + innerWidth + 1, y + 1, { char: vt, ...borderAttrs });
+            }
+        }
+
+        // ── Row 2: bottom border ──
+        if (height >= 3) {
+            screen.setCell(x, y + 2, { char: bl, ...borderAttrs });
+            for (let c = 1; c <= innerWidth; c++) {
+                screen.setCell(x + c, y + 2, { char: hz, ...borderAttrs });
+            }
+            if (innerWidth + 1 < width) {
+                screen.setCell(x + innerWidth + 1, y + 2, { char: br, ...borderAttrs });
+            }
+        }
+    }
+}

--- a/packages/widgets/src/display/Badge.ts
+++ b/packages/widgets/src/display/Badge.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets — Badge widget
 // ─────────────────────────────────────────────────────
 
-import { type Screen, type Style, type Color, styleToCellAttrs, stringWidth, caps } from '@termuijs/core';
+import { type Screen, type Style, type Color, stringWidth, caps } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
 export type BadgeVariant = 'info' | 'success' | 'warning' | 'error' | 'neutral';

--- a/packages/widgets/src/display/Tag.test.ts
+++ b/packages/widgets/src/display/Tag.test.ts
@@ -1,0 +1,127 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for Tag widget
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import { Tag } from './Tag.js';
+import { Screen, caps } from '@termuijs/core';
+
+/** Helper: create widget, set rect, render to a screen, return both. */
+function renderTag(
+    text: string,
+    opts: ConstructorParameters<typeof Tag>[1] = {},
+    style: ConstructorParameters<typeof Tag>[2] = {},
+    width = 20,
+    height = 3,
+) {
+    const tag = new Tag(text, opts, style);
+    const screen = new Screen(width, height);
+    tag.updateRect({ x: 0, y: 0, width, height });
+    tag.render(screen);
+    return { tag, screen };
+}
+
+/** Read a single row from the back buffer as a plain string. */
+function rowText(screen: Screen, row: number): string {
+    return screen.back[row].map(c => c.char).join('').trimEnd();
+}
+
+describe('Tag', () => {
+    // ── 1. Default render ────────────────────────────────────────────────
+    it('renders text inside a bordered box with default neutral variant', () => {
+        const { screen } = renderTag('ts');
+        // Row 1 is the content row; text should appear space-padded: " ts "
+        const contentRow = rowText(screen, 1);
+        expect(contentRow).toContain('ts');
+    });
+
+    it('renders top border with Unicode box-drawing corners', () => {
+        const { screen } = renderTag('hi');
+        expect(screen.back[0][0].char).toBe('┌');
+    });
+
+    it('renders bottom border with Unicode box-drawing corners', () => {
+        const { screen } = renderTag('hi');
+        expect(screen.back[2][0].char).toBe('└');
+    });
+
+    it('does not apply a background fill to content cells', () => {
+        const { screen } = renderTag('ts', { variant: 'info' });
+        // Tag should NOT set a bg color on content cells (unlike Badge)
+        // The bg should remain the default (type: 'none')
+        expect(screen.back[1][2].bg).toEqual({ type: 'none' });
+    });
+
+    // ── 2. Variant colors (foreground) ───────────────────────────────────
+    it('applies cyan foreground for info variant', () => {
+        const { screen } = renderTag('info', { variant: 'info' });
+        // Border corner should have cyan foreground
+        expect(screen.back[0][0].fg).toEqual({ type: 'named', name: 'cyan' });
+        // Text cell should also have cyan foreground
+        expect(screen.back[1][2].fg).toEqual({ type: 'named', name: 'cyan' });
+    });
+
+    it('applies green foreground for success variant', () => {
+        const { screen } = renderTag('ok', { variant: 'success' });
+        expect(screen.back[0][0].fg).toEqual({ type: 'named', name: 'green' });
+    });
+
+    it('applies yellow foreground for warning variant', () => {
+        const { screen } = renderTag('warn', { variant: 'warning' });
+        expect(screen.back[0][0].fg).toEqual({ type: 'named', name: 'yellow' });
+    });
+
+    it('applies red foreground for error variant', () => {
+        const { screen } = renderTag('err', { variant: 'error' });
+        expect(screen.back[0][0].fg).toEqual({ type: 'named', name: 'red' });
+    });
+
+    it('applies white foreground for neutral variant', () => {
+        const { screen } = renderTag('ok', { variant: 'neutral' });
+        expect(screen.back[0][0].fg).toEqual({ type: 'named', name: 'white' });
+    });
+
+    // ── 3. ASCII fallback ────────────────────────────────────────────────
+    it('uses ASCII border chars when caps.unicode is false', () => {
+        const orig = caps.unicode;
+        (caps as any).unicode = false;
+        try {
+            const { screen } = renderTag('test');
+            // ASCII corners should be +
+            expect(screen.back[0][0].char).toBe('+');
+            expect(screen.back[2][0].char).toBe('+');
+            // Horizontal border should be -
+            expect(screen.back[0][1].char).toBe('-');
+            // Vertical border should be |
+            expect(screen.back[1][0].char).toBe('|');
+        } finally {
+            (caps as any).unicode = orig;
+        }
+    });
+
+    // ── 4. Setters call markDirty ────────────────────────────────────────
+    it('setText marks widget dirty', () => {
+        const tag = new Tag('old');
+        tag.clearDirty();
+        tag.setText('new');
+        expect(tag.isDirty).toBe(true);
+        expect(tag.getText()).toBe('new');
+    });
+
+    it('setVariant marks widget dirty', () => {
+        const tag = new Tag('ok');
+        tag.clearDirty();
+        tag.setVariant('error');
+        expect(tag.isDirty).toBe(true);
+        expect(tag.getVariant()).toBe('error');
+    });
+
+    // ── 5. Edge cases ────────────────────────────────────────────────────
+    it('handles empty text without error', () => {
+        expect(() => renderTag('')).not.toThrow();
+    });
+
+    it('handles zero-size rect without error', () => {
+        expect(() => renderTag('test', {}, {}, 0, 0)).not.toThrow();
+    });
+});

--- a/packages/widgets/src/display/Tag.ts
+++ b/packages/widgets/src/display/Tag.ts
@@ -1,0 +1,122 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tag widget
+// ─────────────────────────────────────────────────────
+
+import { type Screen, type Style, type Color, styleToCellAttrs, stringWidth, caps } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export type TagVariant = 'info' | 'success' | 'warning' | 'error' | 'neutral';
+
+export interface TagOptions {
+    /** Variant determines border and text color. Default: 'neutral'. */
+    variant?: TagVariant;
+}
+
+/** Foreground colors for each variant (used for border + text). */
+const FG_COLORS: Record<TagVariant, Color> = {
+    info:    { type: 'named', name: 'cyan' },
+    success: { type: 'named', name: 'green' },
+    warning: { type: 'named', name: 'yellow' },
+    error:   { type: 'named', name: 'red' },
+    neutral: { type: 'named', name: 'white' },
+};
+
+/**
+ * Tag — a short inline label with a colored border and no background fill.
+ *
+ * Used for categorical labels such as "typescript", "react", "v2.0".
+ * Renders a bordered box with the text colored by variant but no background.
+ * Uses `caps.unicode` to choose between Unicode box-drawing and ASCII fallback.
+ */
+export class Tag extends Widget {
+    private _text: string;
+    private _variant: TagVariant;
+
+    constructor(text: string, opts: TagOptions = {}, style: Partial<Style> = {}) {
+        super(style);
+        this._text = text;
+        this._variant = opts.variant ?? 'neutral';
+    }
+
+    /** Update the tag text. */
+    setText(text: string): void {
+        this._text = text;
+        this.markDirty();
+    }
+
+    /** Get the current tag text. */
+    getText(): string {
+        return this._text;
+    }
+
+    /** Update the tag variant. */
+    setVariant(variant: TagVariant): void {
+        this._variant = variant;
+        this.markDirty();
+    }
+
+    /** Get the current tag variant. */
+    getVariant(): TagVariant {
+        return this._variant;
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width, height } = this._rect;
+        if (width <= 0 || height <= 0) return;
+
+        const fg = FG_COLORS[this._variant];
+
+        // Choose border characters based on unicode support
+        const tl = caps.unicode ? '┌' : '+';
+        const tr = caps.unicode ? '┐' : '+';
+        const bl = caps.unicode ? '└' : '+';
+        const br = caps.unicode ? '┘' : '+';
+        const hz = caps.unicode ? '─' : '-';
+        const vt = caps.unicode ? '│' : '|';
+
+        const borderAttrs = { fg };
+        const textAttrs = { fg };
+
+        // Padded text: " text "
+        const padded = ` ${this._text} `;
+        const textWidth = stringWidth(padded);
+
+        // Inner width is the area between left and right border
+        const innerWidth = Math.min(textWidth, Math.max(0, width - 2));
+
+        // ── Row 0: top border ──
+        if (height >= 1) {
+            screen.setCell(x, y, { char: tl, ...borderAttrs });
+            for (let c = 1; c <= innerWidth; c++) {
+                screen.setCell(x + c, y, { char: hz, ...borderAttrs });
+            }
+            if (innerWidth + 1 < width) {
+                screen.setCell(x + innerWidth + 1, y, { char: tr, ...borderAttrs });
+            }
+        }
+
+        // ── Row 1: content row (no background fill) ──
+        if (height >= 2) {
+            screen.setCell(x, y + 1, { char: vt, ...borderAttrs });
+
+            // Write padded text with variant foreground, no background
+            const visibleText = padded.slice(0, innerWidth);
+            screen.writeString(x + 1, y + 1, visibleText, textAttrs);
+
+            if (innerWidth + 1 < width) {
+                screen.setCell(x + innerWidth + 1, y + 1, { char: vt, ...borderAttrs });
+            }
+        }
+
+        // ── Row 2: bottom border ──
+        if (height >= 3) {
+            screen.setCell(x, y + 2, { char: bl, ...borderAttrs });
+            for (let c = 1; c <= innerWidth; c++) {
+                screen.setCell(x + c, y + 2, { char: hz, ...borderAttrs });
+            }
+            if (innerWidth + 1 < width) {
+                screen.setCell(x + innerWidth + 1, y + 2, { char: br, ...borderAttrs });
+            }
+        }
+    }
+}

--- a/packages/widgets/src/display/Tag.ts
+++ b/packages/widgets/src/display/Tag.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets — Tag widget
 // ─────────────────────────────────────────────────────
 
-import { type Screen, type Style, type Color, styleToCellAttrs, stringWidth, caps } from '@termuijs/core';
+import { type Screen, type Style, type Color, stringWidth, caps } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
 export type TagVariant = 'info' | 'success' | 'warning' | 'error' | 'neutral';

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -98,3 +98,7 @@ export type { GradientOptions } from './display/Gradient.js';
 
 export { Markdown } from './display/Markdown.js';
 export type { MarkdownOptions } from './display/Markdown.js';
+export { Badge } from './display/Badge.js';
+export type { BadgeOptions, BadgeVariant } from './display/Badge.js';
+export { Tag } from './display/Tag.js';
+export type { TagOptions, TagVariant } from './display/Tag.js';


### PR DESCRIPTION
## Description

Adds the `Badge` and `Tag` widgets to `@termuijs/widgets` for inline labels. `Badge` renders text with a colored background (used for status indicators), and `Tag` renders text with a colored border and no background fill (used for categorical labels). Both share the same 5 variants (`info`, `success`, `warning`, `error`, `neutral`) and support Unicode/ASCII box-drawing fallbacks.

## Related Issue

Closes #23

## Which package(s)?

@termuijs/widgets

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/557492d3-891a-40c7-b174-9d0feaecf81b` 

## Screenshots / Recordings (UI changes)

 ✓ packages/widgets/src/display/Badge.test.ts (13)
 ✓ packages/widgets/src/display/Tag.test.ts (14)

 Test Files  2 passed (2)
      Tests  27 passed (27)
   Start at  10:32:02
   Duration  866ms (transform 253ms, setup 0ms, collect 375ms, tests 18ms, environment 0ms, prepare 350ms)

## Notes for the Reviewer

Both widgets follow the base `Widget` design pattern seen in `StatusMessage` and `Text`. `caps.unicode` controls the border rendering. Extensive tests (27 new test cases) were added to ensure default rendering, correct variants, `markDirty()` triggers, and ASCII fallback work as expected.