### PR TITLE
feat: add Pagination widget

### DIFF
--- a/packages/ui/src/Pagination.test.ts
+++ b/packages/ui/src/Pagination.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Pagination } from './Pagination.js';
+
+describe('Pagination', () => {
+    it('renders page/total text', async () => {
+        const p = new Pagination(3, 10);
+        p.updateRect({ x: 0, y: 0, width: 20, height: 1 });
+        const { Screen } = await import('@termuijs/core');
+        const screen = new Screen(20, 1);
+        p.render(screen);
+        const rendered = screen.back[0].map((c: { char: string }) => c.char).join('');
+        expect(rendered).toContain('<');
+        expect(rendered).toContain('>');
+        expect(rendered).toContain('3 / 10');
+    });
+
+    it('left navigation decrements page and calls onChange', () => {
+        const onChange = vi.fn();
+        const p = new Pagination(3, 5, { onChange });
+        const spy = vi.spyOn(p as any, 'markDirty');
+        p.handleKey({ key: 'left', ctrl: false, alt: false } as any);
+        expect(p.page).toBe(2);
+        expect(onChange).toHaveBeenCalledWith(2);
+        expect(spy).toHaveBeenCalled();
+    });
+
+    it('right navigation increments page and calls onChange', () => {
+        const onChange = vi.fn();
+        const p = new Pagination(2, 5, { onChange });
+        const spy = vi.spyOn(p as any, 'markDirty');
+        p.handleKey({ key: 'l', ctrl: false, alt: false } as any);
+        expect(p.page).toBe(3);
+        expect(onChange).toHaveBeenCalledWith(3);
+        expect(spy).toHaveBeenCalled();
+    });
+
+    it('clamps at boundaries and does not call onChange when unchanged', () => {
+        const onChange = vi.fn();
+        const p1 = new Pagination(1, 5, { onChange });
+        p1.handleKey({ key: 'h', ctrl: false, alt: false } as any);
+        expect(p1.page).toBe(1);
+        expect(onChange).not.toHaveBeenCalled();
+
+        const p2 = new Pagination(5, 5, { onChange });
+        p2.handleKey({ key: 'right', ctrl: false, alt: false } as any);
+        expect(p2.page).toBe(5);
+        expect(onChange).not.toHaveBeenCalled();
+    });
+});

--- a/packages/ui/src/Pagination.test.ts
+++ b/packages/ui/src/Pagination.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
+import { Screen } from '@termuijs/core';
 import { Pagination } from './Pagination.js';
 
 describe('Pagination', () => {
-    it('renders page/total text', async () => {
+    it('renders page/total text', () => {
         const p = new Pagination(3, 10);
         p.updateRect({ x: 0, y: 0, width: 20, height: 1 });
-        const { Screen } = await import('@termuijs/core');
         const screen = new Screen(20, 1);
         p.render(screen);
         const rendered = screen.back[0].map((c: { char: string }) => c.char).join('');

--- a/packages/ui/src/Pagination.ts
+++ b/packages/ui/src/Pagination.ts
@@ -60,5 +60,3 @@ export class Pagination extends Widget {
         screen.writeString(x, y, text.slice(0, width), attrs);
     }
 }
-
-export default Pagination;

--- a/packages/ui/src/Pagination.ts
+++ b/packages/ui/src/Pagination.ts
@@ -1,0 +1,64 @@
+// Pagination — simple page navigator
+import { Widget } from '@termuijs/widgets';
+import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs } from '@termuijs/core';
+
+export interface PaginationOptions {
+    onChange?: (page: number) => void;
+}
+
+export class Pagination extends Widget {
+    private _page: number;
+    private _totalPages: number;
+    private _onChange?: (page: number) => void;
+    focusable = true;
+
+    constructor(page: number, totalPages: number, options: PaginationOptions = {}) {
+        super(mergeStyles(defaultStyle(), { height: 1 }));
+        this._totalPages = Math.max(1, Math.floor(totalPages));
+        this._page = this._clamp(Math.floor(page));
+        this._onChange = options.onChange;
+    }
+
+    get page(): number { return this._page; }
+    get totalPages(): number { return this._totalPages; }
+
+    private _clamp(n: number): number {
+        if (isNaN(n) || !isFinite(n)) return 1;
+        return Math.min(this._totalPages, Math.max(1, n));
+    }
+
+    setPage(n: number): void {
+        const next = this._clamp(Math.floor(n));
+        if (next === this._page) return;
+        this._page = next;
+        this._onChange?.(this._page);
+        this.markDirty();
+    }
+
+    next(): void {
+        this.setPage(this._page + 1);
+    }
+
+    prev(): void {
+        this.setPage(this._page - 1);
+    }
+
+    handleKey(event: KeyEvent): void {
+        switch (event.key) {
+            case 'left': this.prev(); break;
+            case 'h': if (!event.ctrl && !event.alt) this.prev(); break;
+            case 'right': this.next(); break;
+            case 'l': if (!event.ctrl && !event.alt) this.next(); break;
+        }
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width } = this._rect;
+        if (width <= 0) return;
+        const attrs = styleToCellAttrs(this.style);
+        const text = `< ${this._page} / ${this._totalPages} >`;
+        screen.writeString(x, y, text.slice(0, width), attrs);
+    }
+}
+
+export default Pagination;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -74,3 +74,6 @@ export type { ShortcutBinding, KeyboardShortcutsOptions } from './KeyboardShortc
 
 export { FilePicker } from './FilePicker.js';
 export type { FilePickerOptions, FileEntry } from './FilePicker.js';
+
+export { Pagination } from './Pagination.js';
+export type { PaginationOptions } from './Pagination.js';


### PR DESCRIPTION
## Summary

Adds a new `Pagination` widget to `packages/ui`.

This widget displays the current page, total pages, and supports keyboard-based navigation.

## Changes Made

* Added `Pagination.ts`
* Added `Pagination.test.ts`
* Exported `Pagination` from `packages/ui/src/index.ts`

## Features

* Displays pagination in the format:

  ```txt
  < 3 / 10 >
  ```

* Supports keyboard navigation:

  * Left Arrow / `h` → previous page
  * Right Arrow / `l` → next page

* Prevents navigation:

  * below page `1`
  * above `totalPages`

* Fires `onChange(page)` callback on page updates

* Calls `this.markDirty()` on every page change

## Tests

Added tests covering:

* render output
* left navigation
* right navigation
* boundary clamping

## Validation

Successfully ran:

```bash
bun run build
bun run test
bun run typecheck
```

Closes #29 

