### PR TITLE
feat(create-termui-app): add minimal cli-tool template

### DIFF
--- a/packages/create-termui-app/src/index.ts
+++ b/packages/create-termui-app/src/index.ts
@@ -8,8 +8,8 @@ import { getBuiltinThemeNames } from '@termuijs/tss';
 import { textPrompt, selectPrompt, multiSelectPrompt } from './prompts.js';
 import { generateProject, type ProjectConfig } from './templates.js';
 
-const TEMPLATES = ['Empty (start from scratch)', 'Dashboard (real-time data)', 'Interactive Tool (forms, prompts)', 'CLI Wrapper (wrap existing CLI)'];
-const TEMPLATE_KEYS = ['empty', 'dashboard', 'interactive-tool', 'cli-wrapper'] as const;
+const TEMPLATES = ['Empty (start from scratch)', 'Dashboard (real-time data)', 'Interactive Tool (forms, prompts)', 'CLI Wrapper (wrap existing CLI)', 'CLI Tool (minimal: box + text + useKeymap)'];
+const TEMPLATE_KEYS = ['empty', 'dashboard', 'interactive-tool', 'cli-wrapper', 'cli-tool'] as const;
 const FEATURES = ['Screen Router', 'Data Providers', 'Hot Reload'];
 
 async function main() {

--- a/packages/create-termui-app/src/templates.test.ts
+++ b/packages/create-termui-app/src/templates.test.ts
@@ -68,6 +68,22 @@ describe('generateProject', () => {
         expect(files.length).toBeGreaterThan(0)
     })
 
+    it('cli-tool template generates a minimal entry under 15 source lines', () => {
+        const files = generateProject({
+            ...baseConfig,
+            template: 'cli-tool',
+        })
+        const entry = files.find((f) => f.path === 'src/index.tsx')!
+        expect(entry).toBeDefined()
+        expect(entry.content).toContain("from '@termuijs/jsx'")
+        expect(entry.content).toContain('useKeymap')
+        expect(entry.content).toContain("key: 'q'")
+        const sourceLines = entry.content
+            .split('\n')
+            .filter((l) => l.trim() && !l.trim().startsWith('//') && !l.trim().startsWith('/**'))
+        expect(sourceLines.length).toBeLessThanOrEqual(15)
+    })
+
     it('each generated file has non-empty content', () => {
         const files = generateProject(baseConfig)
         for (const file of files) {

--- a/packages/create-termui-app/src/templates.ts
+++ b/packages/create-termui-app/src/templates.ts
@@ -6,7 +6,7 @@ import { getBuiltinTheme } from '@termuijs/tss';
 
 export interface ProjectConfig {
     name: string;
-    template: 'empty' | 'dashboard' | 'interactive-tool' | 'cli-wrapper';
+    template: 'empty' | 'dashboard' | 'interactive-tool' | 'cli-wrapper' | 'cli-tool';
     theme: string;
     features: {
         router: boolean;
@@ -106,6 +106,9 @@ export default defineConfig({
             break;
         case 'cli-wrapper':
             files.push(...generateCliWrapperTemplate(config));
+            break;
+        case 'cli-tool':
+            files.push(...generateCliToolTemplate(config));
             break;
         default:
             files.push(...generateEmptyTemplate(config));
@@ -349,6 +352,26 @@ render(<App />, { title: '${config.name}' });
 `,
     }];
 }
+
+function generateCliToolTemplate(config: ProjectConfig): GeneratedFile[] {
+    return [{
+        path: 'src/index.tsx',
+        content: `/** @jsxImportSource @termuijs/jsx */
+import { render, useKeymap } from '@termuijs/jsx';
+function App() {
+    useKeymap([{ key: 'q', action: () => process.exit(0), description: 'Quit' }]);
+    return (
+        <box flexDirection="column">
+            <text bold>${config.name}</text>
+            <text dim>Press q to quit</text>
+        </box>
+    );
+}
+render(<App />, { title: '${config.name}' });
+`,
+    }];
+}
+
 
 function generateCliWrapperTemplate(config: ProjectConfig): GeneratedFile[] {
     return [{


### PR DESCRIPTION
## Description

Adds a fifth scaffolding option to `create-termui-app` that generates a sub-15-line `src/index.tsx` using only `box`, `text`, and `useKeymap`, suitable for simple interactive CLI tools that don't need a full layout shell. The new `cli-tool` key is wired into the picker alongside the existing `empty`, `dashboard`, `interactive-tool`, and `cli-wrapper` options.

## Related Issue

Closes #98

## Which package(s)?

`create-termui-app`

## Type of Change

- [x] Feature (`type:feature`)

## Checklist

- [x] Repo starred.
- [x] Tests pass locally: `bun vitest run` (728 passing across 68 files).
- [x] Build passes: `bun run build`.
- [x] Typecheck passes: `bun run typecheck`.
- [x] Read `CONTRIBUTING.md`.
- [x] PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` — not applicable; no widget rendering changes.
- [x] No new `any` types.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] GSSoC 2026 contributor.

## Notes for the Reviewer

Two implementation choices worth flagging:

1. **Inline-string generator vs. physical template directory.** The issue body suggests placing files at `packages/create-termui-app/templates/cli-tool/`, but every existing template (`empty`, `dashboard`, `interactive-tool`, `cli-wrapper`) is implemented as an inline-string generator function in `src/templates.ts`. I followed that pattern to stay consistent. If a directory-based template registry is actually the intended direction, that is a larger restructure across all five templates and would be better tracked as a separate issue.
2. **Imports from `@termuijs/jsx` rather than `@termuijs/core`.** The issue's example imports `Box`, `Text`, and `useKeymap` from `@termuijs/core`, but the other templates all use `@termuijs/jsx` with lowercase `<box>` and `<text>` JSX. I matched that convention so the generated project is consistent with what `create-termui-app` already produces.

The generated `src/index.tsx` is 13 source lines (whitespace and the JSX pragma comment excluded). The new vitest assertion enforces a 15-line budget so the template cannot drift past the spec.