### PR TITLE
feat(core): add RenderHook to buffer stdout during active UI rendering

### DIFF
--- a/packages/core/src/app/App.ts
+++ b/packages/core/src/app/App.ts
@@ -108,6 +108,9 @@ export class App {
 
         this._mounted = true;
 
+        // Start the stdout interceptor right before UI rendering begins
+        this.renderer.hook.start();
+
         // Set up terminal
         this.terminal.enterRawMode();
         if (this._options.fullscreen) {
@@ -207,6 +210,9 @@ export class App {
         this._unsubKey = null;
         this._unsubMouse?.();
         this._unsubMouse = null;
+
+        // Stop the stdout interceptor to restore native console.log behavior
+        this.renderer.hook.stop();
 
         this.renderer.stop();
         this.input.stop();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,9 @@ export type { Layer } from './terminal/LayerManager.js';
 export { caps } from './terminal/env-caps.js';
 export { BOX, BRAILLE_SPIN, BLOCK } from './terminal/ascii-map.js';
 
+// ── Renderer ──────────────────────────────────────────
+export { RenderHook } from './renderer/render-hook.js';
+
 // ── Input ─────────────────────────────────────────────
 export { InputParser } from './input/InputParser.js';
 export { ESCAPE_SEQUENCES, CTRL_KEYS, SPECIAL_KEYS } from './input/KeyMap.js';

--- a/packages/core/src/renderer/render-hook.test.ts
+++ b/packages/core/src/renderer/render-hook.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { RenderHook } from './render-hook.js';
+
+describe('RenderHook', () => {
+    let hook: RenderHook;
+
+    beforeEach(() => {
+        hook = new RenderHook();
+    });
+
+    afterEach(() => {
+        // Guarantee restoration even if a test fails
+        hook.stop(); 
+    });
+
+    it('intercepts stdout when active', () => {
+        hook.start();
+        process.stdout.write('test log 1\n');
+        process.stdout.write('test log 2\n');
+        
+        expect(hook.flush()).toBe('test log 1\ntest log 2\n');
+        expect(hook.flush()).toBe(''); // Buffer should be empty after flush
+    });
+
+    it('restores original stdout on stop', () => {
+        const originalWrite = process.stdout.write;
+        hook.start();
+        expect(process.stdout.write).not.toBe(originalWrite);
+        
+        hook.stop();
+        expect(process.stdout.write).toBe(originalWrite);
+    });
+
+    it('writeRaw bypasses the buffer', () => {
+        hook.start();
+        hook.writeRaw('direct write bypass');
+        
+        // The buffer shouldn't capture writeRaw output
+        expect(hook.flush()).toBe(''); 
+    });
+});

--- a/packages/core/src/renderer/render-hook.ts
+++ b/packages/core/src/renderer/render-hook.ts
@@ -1,0 +1,58 @@
+export class RenderHook {
+    private _originalWrite: typeof process.stdout.write | null = null;
+    private _buffer: string[] = [];
+    private _isActive = false;
+
+    /** Check if the hook is currently intercepting stdout */
+    get isActive(): boolean {
+        return this._isActive;
+    }
+
+    /** Hijack stdout to buffer external logs */
+    start(): void {
+        if (this._isActive) return;
+        this._isActive = true;
+        this._originalWrite = process.stdout.write;
+
+        process.stdout.write = (
+            chunk: any,
+            encodingOrCb?: any,
+            cb?: any
+        ): boolean => {
+            const text = Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk);
+            this._buffer.push(text);
+
+            // Handle Node stream callback variations
+            const callback = typeof encodingOrCb === 'function' ? encodingOrCb : cb;
+            if (typeof callback === 'function') {
+                callback();
+            }
+            return true; 
+        };
+    }
+
+    /** Restore original stdout behavior */
+    stop(): void {
+        if (!this._isActive || !this._originalWrite) return;
+        process.stdout.write = this._originalWrite;
+        this._originalWrite = null;
+        this._isActive = false;
+    }
+
+    /** Retrieve and clear the buffered logs */
+    flush(): string {
+        if (this._buffer.length === 0) return '';
+        const out = this._buffer.join('');
+        this._buffer = [];
+        return out;
+    }
+
+    /** Write directly to the terminal, bypassing the buffer */
+    writeRaw(text: string): void {
+        if (this._originalWrite) {
+            this._originalWrite.call(process.stdout, text);
+        } else {
+            process.stdout.write(text);
+        }
+    }
+}

--- a/packages/core/src/terminal/Renderer.ts
+++ b/packages/core/src/terminal/Renderer.ts
@@ -6,6 +6,7 @@ import type { Terminal } from './Terminal.js';
 import { type Cell, cellsEqual, type Screen } from './Screen.js';
 import { type ColorDepth, colorToAnsiFg, colorToAnsiBg } from '../style/Color.js';
 import { moveTo, beginSyncUpdate, endSyncUpdate, reset as ansiReset } from '../utils/ansi.js';
+import { RenderHook } from '../renderer/render-hook.js';
 
 /**
  * Differential renderer — compares front/back screen buffers and
@@ -20,12 +21,16 @@ export class Renderer {
     private _renderRequested = false;
     private _colorDepth: ColorDepth;
     private _onTick: (() => void) | null = null;
+    
+    /** The stdout interceptor hook for buffering external logs */
+    public readonly hook: RenderHook;
 
     constructor(terminal: Terminal, screen: Screen, fps = 30) {
         this._terminal = terminal;
         this._screen = screen;
         this._fps = fps;
         this._colorDepth = terminal.colorDepth;
+        this.hook = new RenderHook();
     }
 
     /** Change the rendering frame rate cap */
@@ -82,6 +87,14 @@ export class Renderer {
      * emit only changed cells.
      */
     private _flush(): void {
+        // 1. Grab any logs that console.log() caught while we were rendering
+        const bufferedLogs = this.hook.flush();
+        
+        if (bufferedLogs) {
+            // Force a full redraw of the UI underneath the new logs so it doesn't get corrupted
+            this._screen.invalidate();
+        }
+
         const { front, back, cols, rows } = this._screen;
         let output = beginSyncUpdate;
         let lastRow = -1;
@@ -111,7 +124,25 @@ export class Renderer {
         output += ansiReset;
         output += endSyncUpdate;
 
+        // 2. Pause the hook temporarily so our own UI rendering doesn't get buffered
+        const isHookActive = this.hook.isActive;
+        if (isHookActive) {
+            this.hook.stop();
+        }
+
+        // 3. Print the captured logs FIRST (above the UI)
+        if (bufferedLogs) {
+            this._terminal.write(bufferedLogs);
+        }
+
+        // 4. Print the actual UI diff natively
         this._terminal.write(output);
+
+        // 5. Resume catching external logs
+        if (isHookActive) {
+            this.hook.start();
+        }
+
         this._screen.swap();
     }
 


### PR DESCRIPTION
Closes #99 

### What to build
This PR introduces a `RenderHook` to intercept and buffer `process.stdout.write()` calls originating from non-TermUI code (like standard `console.log`) while the UI is actively rendering.

### Implementation Details
* Created `RenderHook` in `packages/core/src/renderer/render-hook.ts` to hijack and buffer standard output.
* Integrated the hook into `Renderer.ts`, automatically flushing buffered logs *above* the UI right before the diff engine draws the next frame.
* Wired `hook.start()` and `hook.stop()` to the `App.ts` mount and unmount lifecycles to ensure original stdout behavior is gracefully restored on exit.
* Added comprehensive unit tests in `render-hook.test.ts` mocking `process.stdout.write`.

### Acceptance Criteria Met
- [x] `console.log()` during active renders above the bar, not through it
- [x] Multiple buffered lines accumulate correctly
- [x] Tests mock `process.stdout.write`
- [x] Original `stdout.write` is restored on unmount