### PR TITLE
feat(ui): add Pages and ContentSwitcher widgets

### DIFF
--- a/packages/ui/src/ContentSwitcher.test.ts
+++ b/packages/ui/src/ContentSwitcher.test.ts
@@ -1,6 +1,4 @@
-// ─────────────────────────────────────────────────────
-// @termuijs/ui — Tests for ContentSwitcher component
-// ─────────────────────────────────────────────────────
+// @termuijs/ui - Tests for ContentSwitcher component
 
 import { describe, it, expect } from 'vitest';
 import { ContentSwitcher } from './ContentSwitcher.js';

--- a/packages/ui/src/ContentSwitcher.test.ts
+++ b/packages/ui/src/ContentSwitcher.test.ts
@@ -1,0 +1,66 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/ui — Tests for ContentSwitcher component
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import { ContentSwitcher } from './ContentSwitcher.js';
+import { Box } from '@termuijs/widgets';
+
+describe('ContentSwitcher', () => {
+    it('initial active child is the first added child', () => {
+        const switcher = new ContentSwitcher();
+        const first = new Box();
+        const second = new Box();
+
+        switcher.addChild(first);
+        switcher.addChild(second);
+
+        expect(switcher.activeId).toBe(first.id);
+        expect(first.style.visible).toBe(true);
+        expect(second.style.visible).toBe(false);
+    });
+
+    it('setActive(id) changes the active child by id', () => {
+        const switcher = new ContentSwitcher();
+        const first = new Box();
+        const second = new Box();
+
+        switcher.addChild(first);
+        switcher.addChild(second);
+        switcher.setActive(second.id);
+
+        expect(switcher.activeId).toBe(second.id);
+        expect(first.style.visible).toBe(false);
+        expect(second.style.visible).toBe(true);
+    });
+
+    it('invalid ids are ignored', () => {
+        const switcher = new ContentSwitcher();
+        const first = new Box();
+
+        switcher.addChild(first);
+        const originalId = switcher.activeId;
+
+        switcher.setActive('invalid-id');
+
+        expect(switcher.activeId).toBe(originalId);
+        expect(first.style.visible).toBe(true);
+    });
+
+    it('only the active child is visible', () => {
+        const switcher = new ContentSwitcher();
+        const first = new Box();
+        const second = new Box();
+        const third = new Box();
+
+        switcher.addChild(first);
+        switcher.addChild(second);
+        switcher.addChild(third);
+
+        switcher.setActive(third.id);
+
+        expect(first.style.visible).toBe(false);
+        expect(second.style.visible).toBe(false);
+        expect(third.style.visible).toBe(true);
+    });
+});

--- a/packages/ui/src/ContentSwitcher.ts
+++ b/packages/ui/src/ContentSwitcher.ts
@@ -1,0 +1,42 @@
+// ContentSwitcher — show a single active child widget
+import { Widget } from '@termuijs/widgets';
+import { type Style, type Screen, mergeStyles, defaultStyle } from '@termuijs/core';
+
+export class ContentSwitcher extends Widget {
+    private _activeId?: string;
+
+    constructor(style: Partial<Style> = {}) {
+        super(mergeStyles(defaultStyle(), style));
+    }
+
+    get activeId(): string | undefined {
+        return this._activeId;
+    }
+
+    override addChild(child: Widget): void {
+        super.addChild(child);
+        if (this._activeId === undefined) {
+            this._activeId = child.id;
+        }
+        this._updateChildVisibility();
+    }
+
+    setActive(id: string): void {
+        if (id === this._activeId) return;
+        const child = this._children.find((c) => c.id === id);
+        if (!child) return;
+        this._activeId = id;
+        this._updateChildVisibility();
+        this.markDirty();
+    }
+
+    protected _renderSelf(_screen: Screen): void {
+        // Container only
+    }
+
+    private _updateChildVisibility(): void {
+        for (const child of this._children) {
+            child.setStyle({ visible: child.id === this._activeId });
+        }
+    }
+}

--- a/packages/ui/src/Pages.test.ts
+++ b/packages/ui/src/Pages.test.ts
@@ -1,6 +1,4 @@
-// ─────────────────────────────────────────────────────
-// @termuijs/ui — Tests for Pages component
-// ─────────────────────────────────────────────────────
+// @termuijs/ui - Tests for Pages component
 
 import { describe, it, expect } from 'vitest';
 import { Pages } from './Pages.js';

--- a/packages/ui/src/Pages.test.ts
+++ b/packages/ui/src/Pages.test.ts
@@ -1,0 +1,61 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/ui — Tests for Pages component
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import { Pages } from './Pages.js';
+import { Box } from '@termuijs/widgets';
+
+describe('Pages', () => {
+    it('renders initial page correctly', () => {
+        const home = new Box();
+        const settings = new Box();
+        const pages = new Pages([
+            { name: 'home', content: home },
+            { name: 'settings', content: settings },
+        ]);
+
+        expect(pages.activePage).toBe('home');
+        expect(home.style.visible).toBe(true);
+        expect(settings.style.visible).toBe(false);
+    });
+
+    it('switchTo(name) changes the active page', () => {
+        const home = new Box();
+        const settings = new Box();
+        const pages = new Pages([
+            { name: 'home', content: home },
+            { name: 'settings', content: settings },
+        ]);
+
+        pages.switchTo('settings');
+
+        expect(pages.activePage).toBe('settings');
+        expect(home.style.visible).toBe(false);
+        expect(settings.style.visible).toBe(true);
+    });
+
+    it('invalid page names do not crash', () => {
+        const home = new Box();
+        const pages = new Pages([{ name: 'home', content: home }]);
+
+        expect(() => pages.switchTo('missing')).not.toThrow();
+        expect(pages.activePage).toBe('home');
+        expect(home.style.visible).toBe(true);
+    });
+
+    it('tracks active page and overlay visibility', () => {
+        const base = new Box();
+        const overlay = new Box();
+        const pages = new Pages([
+            { name: 'base', content: base },
+            { name: 'modal', content: overlay, overlay: true },
+        ]);
+
+        pages.switchTo('modal');
+
+        expect(pages.activePage).toBe('modal');
+        expect(base.style.visible).toBe(true);
+        expect(overlay.style.visible).toBe(true);
+    });
+});

--- a/packages/ui/src/Pages.ts
+++ b/packages/ui/src/Pages.ts
@@ -1,0 +1,54 @@
+// Pages — named page container with optional overlay behavior
+import { Widget } from '@termuijs/widgets';
+import { type Style, type Screen, mergeStyles, defaultStyle } from '@termuijs/core';
+
+export interface Page {
+    name: string;
+    content: Widget;
+    overlay?: boolean;
+}
+
+export interface PagesOptions {
+    style?: Partial<Style>;
+}
+
+export class Pages extends Widget {
+    private _pages: Page[];
+    private _activePageName?: string;
+
+    constructor(pages: Page[], options: PagesOptions = {}) {
+        super(mergeStyles(defaultStyle(), options.style ?? { flexGrow: 1 }));
+        this._pages = pages;
+        for (const page of pages) {
+            this.addChild(page.content);
+        }
+        this._activePageName = pages[0]?.name;
+        this._updatePageVisibility();
+    }
+
+    get activePage(): string | undefined {
+        return this._activePageName;
+    }
+
+    switchTo(name: string): void {
+        const page = this._pages.find((item) => item.name === name);
+        if (!page || page.name === this._activePageName) return;
+        this._activePageName = page.name;
+        this._updatePageVisibility();
+        this.markDirty();
+    }
+
+    protected _renderSelf(_screen: Screen): void {
+        // Container only
+    }
+
+    private _updatePageVisibility(): void {
+        const active = this._pages.find((item) => item.name === this._activePageName) ?? this._pages[0];
+        const base = this._pages[0];
+
+        for (const page of this._pages) {
+            const shouldShow = page === active || (active?.overlay === true && page === base && page !== active);
+            page.content.setStyle({ visible: shouldShow });
+        }
+    }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -36,6 +36,11 @@ export type { ModalOptions } from './Modal.js';
 export { Select } from './Select.js';
 export type { SelectOption, SelectOptions } from './Select.js';
 
+export { Pages } from './Pages.js';
+export type { Page, PagesOptions } from './Pages.js';
+
+export { ContentSwitcher } from './ContentSwitcher.js';
+
 export { MultiSelect } from './MultiSelect.js';
 export type { MultiSelectOption, MultiSelectOptions } from './MultiSelect.js';
 


### PR DESCRIPTION
## Description

This PR adds two new UI components to `@termuijs/ui`:

* `Pages` for managing named pages and page visibility.
* `ContentSwitcher` for displaying a single active child widget and switching content by widget id.

The implementation includes test coverage and exports both components through the package entry point.

## Related Issue

Closes #83

## Which package(s)?

* @termuijs/ui

## Type of Change

* [x]  Feature (`type:feature`)
* [x]  Tests (`type:testing`)

## Checklist

* [x] You starred the repo.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read `CONTRIBUTING.md`.
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (where applicable).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] GSSoC 2026 Contributor

**Contributor Profile:**

https://gssoc.girlscript.org/profile/84adde4d-7c32-44f4-8f86-5a5f723d95cf

## Screenshots / Recordings (UI changes)

Not applicable. This PR adds reusable UI library components and test coverage without introducing a standalone visual interface.

## Notes for the Reviewer

### Pages

* Added support for named page navigation using `switchTo(name)`.
* Manages page visibility automatically.
* Supports overlay pages while keeping the base page visible.
* Invalid page names are ignored safely without throwing errors.

### ContentSwitcher

* Supports switching the active child by widget id.
* Ensures only the active child remains visible.
* Automatically tracks the first added child as active.
* Invalid ids are ignored safely without throwing errors.

## Validation

```bash
bun vitest run packages/ui/src/Pages.test.ts packages/ui/src/ContentSwitcher.test.ts --config vitest.config.ts
bun run build
bun run typecheck
```

Results:

* ✅ 2 test files passed
* ✅ 8 tests passed
* ✅ Build passed
* ✅ Typecheck passed
