### PR TITLE
feat: add useReducer hook

### DIFF
--- a/packages/jsx/src/hooks.ts
+++ b/packages/jsx/src/hooks.ts
@@ -434,6 +434,43 @@ export function useCallback<T extends (...args: any[]) => any>(callback: T, deps
     return useMemo(() => callback, deps);
 }
 
+/**
+ * useReducer — manage state with a reducer function.
+ *
+ * ```tsx
+ * const [state, dispatch] = useReducer((state, action) => {
+ *     if (action === 'inc') return state + 1;
+ *     if (action === 'dec') return state - 1;
+ *     return state;
+ * }, 0);
+ * dispatch('inc');
+ * ```
+ */
+export function useReducer<S, A>(
+    reducer: (state: S, action: A) => S,
+    initialState: S,
+): [S, (action: A) => void] {
+    const fiber = currentFiber();
+    const idx = fiber.hookIndex++;
+
+    if (idx >= fiber.hooks.length) {
+        fiber.hooks.push({ value: initialState });
+    }
+
+    const hookState = fiber.hooks[idx];
+
+    const dispatch = (action: A): void => {
+        const next = reducer(hookState.value, action);
+        if (!Object.is(hookState.value, next)) {
+            hookState.value = next;
+            fiber.isDirty = true;
+            scheduleRender(fiber);
+        }
+    };
+
+    return [hookState.value, dispatch];
+}
+
 /** Run all pending effects for a fiber */
 export function runEffects(fiber: Fiber): void {
     for (const record of fiber.effects) {

--- a/packages/jsx/src/hooks/useReducer.test.ts
+++ b/packages/jsx/src/hooks/useReducer.test.ts
@@ -1,0 +1,132 @@
+// ─────────────────────────────────────────────────────
+// Tests — useReducer hook
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+    createFiber, setCurrentFiber, clearCurrentFiber,
+    setRequestRender, useReducer,
+    type Fiber,
+} from '../hooks.js';
+
+type CountAction = 'inc' | 'dec' | 'reset';
+
+function countReducer(state: number, action: CountAction): number {
+    if (action === 'inc') return state + 1;
+    if (action === 'dec') return state - 1;
+    if (action === 'reset') return 0;
+    return state;
+}
+
+describe('useReducer', () => {
+    let fiber: Fiber;
+
+    beforeEach(() => {
+        fiber = createFiber();
+        setRequestRender(() => { });
+        setCurrentFiber(fiber);
+    });
+
+    afterEach(() => {
+        clearCurrentFiber();
+    });
+
+    it('returns the initial state on first render', () => {
+        const [state] = useReducer(countReducer, 10);
+        expect(state).toBe(10);
+    });
+
+    it('dispatch runs the reducer and updates state', () => {
+        const [, dispatch] = useReducer(countReducer, 0);
+        dispatch('inc');
+
+        fiber.hookIndex = 0;
+        const [state] = useReducer(countReducer, 0);
+        expect(state).toBe(1);
+    });
+
+    it('multiple dispatches accumulate correctly', () => {
+        const [, dispatch] = useReducer(countReducer, 0);
+        dispatch('inc');
+        dispatch('inc');
+        dispatch('inc');
+
+        fiber.hookIndex = 0;
+        const [state] = useReducer(countReducer, 0);
+        expect(state).toBe(3);
+    });
+
+    it('dec action reduces state', () => {
+        const [, dispatch] = useReducer(countReducer, 5);
+        dispatch('dec');
+
+        fiber.hookIndex = 0;
+        const [state] = useReducer(countReducer, 5);
+        expect(state).toBe(4);
+    });
+
+    it('reset action returns state to 0', () => {
+        const [, dispatch] = useReducer(countReducer, 42);
+        dispatch('reset');
+
+        fiber.hookIndex = 0;
+        const [state] = useReducer(countReducer, 42);
+        expect(state).toBe(0);
+    });
+
+    it('does not schedule a re-render when dispatch produces the same value', () => {
+        const renders: number[] = [];
+        setRequestRender(() => renders.push(1));
+
+        // reducer that always returns the same state
+        const [, dispatch] = useReducer((s: number, _a: null) => s, 5);
+        dispatch(null);
+
+        expect(renders.length).toBe(0);
+    });
+
+    it('works with object state', () => {
+        type State = { name: string; age: number };
+        type Action = { type: 'setName'; name: string } | { type: 'birthday' };
+
+        function personReducer(state: State, action: Action): State {
+            if (action.type === 'setName') return { ...state, name: action.name };
+            if (action.type === 'birthday') return { ...state, age: state.age + 1 };
+            return state;
+        }
+
+        const [, dispatch] = useReducer(personReducer, { name: 'Alice', age: 30 });
+        dispatch({ type: 'birthday' });
+
+        fiber.hookIndex = 0;
+        const [state] = useReducer(personReducer, { name: 'Alice', age: 30 });
+        expect(state.age).toBe(31);
+        expect(state.name).toBe('Alice');
+    });
+
+    it('two independent fibers maintain separate state', () => {
+        const [, dispatch1] = useReducer(countReducer, 0);
+        clearCurrentFiber();
+
+        const fiber2 = createFiber();
+        setCurrentFiber(fiber2);
+        const [, dispatch2] = useReducer(countReducer, 100);
+        clearCurrentFiber();
+
+        dispatch1('inc');
+        dispatch2('dec');
+
+        setCurrentFiber(fiber);
+        fiber.hookIndex = 0;
+        const [state1] = useReducer(countReducer, 0);
+        clearCurrentFiber();
+
+        setCurrentFiber(fiber2);
+        fiber2.hookIndex = 0;
+        const [state2] = useReducer(countReducer, 100);
+        clearCurrentFiber();
+
+        expect(state1).toBe(1);
+        expect(state2).toBe(99);
+    });
+});

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -23,6 +23,7 @@ export {
     useKeymap,
     useMotion,
     useInsertBefore,
+    useReducer,
 } from './hooks.js';
 export type { AsyncState, KeyBinding, MotionPreferences } from './hooks.js';
 


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

Adds a `useReducer(reducer, initialState)` hook to `@termuijs/jsx`. It follows the same fiber hook slot pattern as `useState` — state is stored in `fiber.hooks[idx].value`, and `dispatch(action)` runs the reducer, updates the slot, marks the fiber dirty, and schedules a re-render. Dispatch is a no-op when the reducer returns the same value (`Object.is` bail-out).

## Related Issue

closes issue #137 

## Which package(s)?

 @termuijs/jsx

## Type of Change

- [x] ✨ Feature (`type:feature`)
- [ ] 🐛 Bug fix (`type:bug`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build` — pre-existing failure in `render.ts:64` unrelated to this PR (see Notes)
- [ ] Typecheck passes: `bun run typecheck` — same pre-existing failure
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- GSSoC profile: [https://gssoc.girlscript.org/profile/____`](https://gssoc.girlscript.org/profile/a8dd8aa7-2131-48b1-b6c3-4383bd6313da)

## Screenshots / Recordings (UI changes)
N/A — hook only, no visual output.


## Notes for the Reviewer

Implementation mirrors `useState` exactly — same `currentFiber()` + `hookIndex` slot pattern, same `scheduleRender(fiber)` call, same `Object.is` bail-out to skip no-op dispatches.
- 8 tests covering: initial state, dispatch updating state, multiple dispatches accumulating, dec/reset actions, no-op dispatch skipping re-render, object state, and two independent fibers maintaining separate state.
- The pre-existing TypeScript error in `render.ts` (`Property 'insertBefore' does not exist on type 'App'`) is unrelated to this PR — it exists on `main` before this branch.
