### PR TITLE
feat(ui): add SnippetPrompt component

### DIFF
--- a/packages/ui/src/SnippetPrompt.test.ts
+++ b/packages/ui/src/SnippetPrompt.test.ts
@@ -1,0 +1,100 @@
+// @termuijs/ui — Tests for SnippetPrompt component
+
+import { describe, it, expect } from 'vitest';
+import { SnippetPrompt } from './SnippetPrompt.js';
+
+const TEMPLATE = '{{name}} is {{age}} years old';
+
+describe('SnippetPrompt', () => {
+    it('extracts placeholders from template', () => {
+        const prompt = new SnippetPrompt(TEMPLATE);
+
+        expect(prompt.placeholders).toEqual(['name', 'age']);
+        expect(prompt.activeField).toBe('name');
+        expect(prompt.values).toEqual({ name: '', age: '' });
+    });
+
+    it('buildResult replaces placeholders with values', () => {
+        const prompt = new SnippetPrompt(TEMPLATE);
+
+        prompt.setValue('name', 'Alice');
+        prompt.setValue('age', '30');
+
+        expect(prompt.buildResult()).toBe('Alice is 30 years old');
+    });
+
+    it('nextField advances the active field', () => {
+        const prompt = new SnippetPrompt(TEMPLATE);
+
+        prompt.nextField();
+
+        expect(prompt.activeField).toBe('age');
+    });
+
+    it('prevField moves back to the previous field', () => {
+        const prompt = new SnippetPrompt(TEMPLATE);
+
+        prompt.nextField();
+        prompt.prevField();
+
+        expect(prompt.activeField).toBe('name');
+    });
+
+    it('stores validation errors per field', () => {
+        const prompt = new SnippetPrompt(TEMPLATE, {
+            validate: {
+                age: (value) => (isNaN(Number(value)) ? 'Must be a number' : null),
+            },
+        });
+
+        prompt.setValue('name', 'Alice');
+        prompt.setValue('age', 'abc');
+
+        const isValid = prompt.validate();
+
+        expect(isValid).toBe(false);
+        expect(prompt.errors).toEqual({ age: 'Must be a number' });
+        expect(prompt.values.name).toBe('Alice');
+        expect(prompt.errors.name).toBeUndefined();
+    });
+
+    it('validates successfully when all fields pass', () => {
+        const prompt = new SnippetPrompt(TEMPLATE, {
+            validate: {
+                age: (value) => (isNaN(Number(value)) ? 'Must be a number' : null),
+            },
+        });
+
+        prompt.setValue('name', 'Alice');
+        prompt.setValue('age', '30');
+
+        const isValid = prompt.validate();
+
+        expect(isValid).toBe(true);
+        expect(prompt.errors).toEqual({});
+    });
+
+    it('setValue() stores values for known fields', () => {
+        const prompt = new SnippetPrompt(TEMPLATE);
+
+        prompt.setValue('name', 'Alice');
+        prompt.setValue('age', '30');
+
+        expect(prompt.values).toEqual({ name: 'Alice', age: '30' });
+    });
+
+    it('ignores unknown fields safely', () => {
+        const prompt = new SnippetPrompt(TEMPLATE);
+
+        prompt.setValue('unknown', 'value');
+
+        expect(prompt.values).toEqual({ name: '', age: '' });
+        expect(prompt.buildResult()).toBe(' is  years old');
+    });
+
+    it('does not duplicate placeholders when template contains repeats', () => {
+        const prompt = new SnippetPrompt('{{name}} says {{name}} is {{age}}');
+
+        expect(prompt.placeholders).toEqual(['name', 'age']);
+    });
+});

--- a/packages/ui/src/SnippetPrompt.ts
+++ b/packages/ui/src/SnippetPrompt.ts
@@ -1,0 +1,110 @@
+// SnippetPrompt — parse template placeholders and manage prompt values
+import { Widget } from '@termuijs/widgets';
+import { type Style, type Screen, mergeStyles, defaultStyle } from '@termuijs/core';
+
+export interface SnippetPromptOptions {
+    validate?: Record<string, (value: string) => string | null>;
+}
+
+export class SnippetPrompt extends Widget {
+    private _placeholders: string[];
+    private _values: Map<string, string>;
+    private _errors: Map<string, string> = new Map();
+    private _validators: Map<string, (value: string) => string | null>;
+    private _activeIndex = 0;
+
+    constructor(template: string, options: SnippetPromptOptions = {}) {
+        super(mergeStyles(defaultStyle(), { height: 1 }));
+        this._placeholders = this._parsePlaceholders(template);
+        this._values = new Map(this._placeholders.map((key) => [key, '']));
+        this._validators = new Map(Object.entries(options.validate ?? {}));
+        this.template = template;
+    }
+
+    readonly template: string;
+
+    get placeholders(): string[] {
+        return [...this._placeholders];
+    }
+
+    get activeField(): string | undefined {
+        return this._placeholders[this._activeIndex];
+    }
+
+    get values(): Record<string, string> {
+        const record: Record<string, string> = {};
+        for (const [key, value] of this._values) record[key] = value;
+        return record;
+    }
+
+    get errors(): Record<string, string> {
+        const record: Record<string, string> = {};
+        for (const [key, value] of this._errors) record[key] = value;
+        return record;
+    }
+
+    setValue(field: string, value: string): void {
+        if (!this._values.has(field)) return;
+        this._values.set(field, value);
+        this._errors.delete(field);
+        this.markDirty();
+    }
+
+    nextField(): void {
+        if (this._activeIndex < this._placeholders.length - 1) {
+            this._activeIndex++;
+            this.markDirty();
+        }
+    }
+
+    prevField(): void {
+        if (this._activeIndex > 0) {
+            this._activeIndex--;
+            this.markDirty();
+        }
+    }
+
+    validate(): boolean {
+        this._errors.clear();
+
+        for (const field of this._placeholders) {
+            const validator = this._validators.get(field);
+            if (!validator) continue;
+            const value = this._values.get(field) ?? '';
+            const error = validator(value);
+            if (error) {
+                this._errors.set(field, error);
+            }
+        }
+
+        this.markDirty();
+        return this._errors.size === 0;
+    }
+
+    buildResult(): string {
+        return this.template.replace(/{{\s*([^}]+?)\s*}}/g, (_match, name) => {
+            return this._values.get(name) ?? '';
+        });
+    }
+
+    protected _renderSelf(_screen: Screen): void {
+        // Container only
+    }
+
+    private _parsePlaceholders(template: string): string[] {
+        const placeholders: string[] = [];
+        const seen = new Set<string>();
+        const matcher = /{{\s*([^}]+?)\s*}}/g;
+        let match: RegExpExecArray | null;
+
+        while ((match = matcher.exec(template)) !== null) {
+            const key = match[1].trim();
+            if (!seen.has(key)) {
+                seen.add(key);
+                placeholders.push(key);
+            }
+        }
+
+        return placeholders;
+    }
+}

--- a/packages/ui/src/SnippetPrompt.ts
+++ b/packages/ui/src/SnippetPrompt.ts
@@ -1,6 +1,6 @@
 // SnippetPrompt — parse template placeholders and manage prompt values
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Screen, mergeStyles, defaultStyle } from '@termuijs/core';
+import { type Screen, mergeStyles, defaultStyle } from '@termuijs/core';
 
 export interface SnippetPromptOptions {
     validate?: Record<string, (value: string) => string | null>;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -41,6 +41,9 @@ export type { Page, PagesOptions } from './Pages.js';
 
 export { ContentSwitcher } from './ContentSwitcher.js';
 
+export { SnippetPrompt } from './SnippetPrompt.js';
+export type { SnippetPromptOptions } from './SnippetPrompt.js';
+
 export { MultiSelect } from './MultiSelect.js';
 export type { MultiSelectOption, MultiSelectOptions } from './MultiSelect.js';
 


### PR DESCRIPTION
## Description

This PR introduces a new `SnippetPrompt` component to `@termuijs/ui` for creating fill-in-the-blank style template prompts.

The component parses template placeholders such as `{{name}}` and `{{age}}`, provides field navigation, supports per-field validation, maintains independent validation errors, and generates the completed template string. Comprehensive test coverage has been added to ensure correct parsing, navigation, validation, and result generation behavior.

## Related Issue

Closes #89

## Which package(s)?

@termuijs/ui

## Type of Change

* [ ]  Bug fix (`type:bug`)
* [x]  Feature (`type:feature`)
* [ ]  Docs (`type:docs`)
* [x]  Tests (`type:testing`)
* [ ]  Refactor (`type:refactor`)
* [ ]  Design / UX (`type:design`)
* [ ]  Accessibility (`type:accessibility`)
* [ ]  Performance (`type:performance`)
* [ ]  DevOps / CI (`type:devops`)
* [ ]  Security (`type:security`)

## Checklist

* [x] ⭐ Starred the repository
* [x] Tests pass locally (`bun vitest run`)
* [x] Build passes successfully (`bun run build`)
* [x] Typecheck passes successfully (`bun run typecheck`)
* [x] Reviewed and followed `CONTRIBUTING.md`
* [x] PR title follows the required convention
* [x] Widget state mutators call `markDirty()` where applicable
* [x] No new `any` types introduced
* [x] No unrelated refactors included

## GSSoC 2026 Participation

* [x] I am a GSSoC 2026 contributor

GSSoC Profile:
https://gssoc.girlscript.org/profile/84adde4d-7c32-44f4-8f86-5a5f723d95cf

## Screenshots / Recordings (UI Changes)

N/A – Non-visual component

## Notes for the Reviewer

### Added Files

* `packages/ui/src/SnippetPrompt.ts`
* `packages/ui/src/SnippetPrompt.test.ts`

### Updated Files

* `packages/ui/src/index.ts`

### Implemented Features

* Parses template placeholders (`{{placeholder}}`)
* Deduplicates repeated placeholders
* Supports field navigation (`nextField()` / `prevField()`)
* Supports per-field validation
* Stores validation errors independently
* Generates completed template strings using `buildResult()`
* Safely ignores updates to unknown fields
* Calls `markDirty()` on state-changing operations

### Validation Performed

* ✅ `bun vitest run packages/ui/src/SnippetPrompt.test.ts --config vitest.config.ts`
* ✅ `bun run build`
* ✅ `bun run typecheck`
