### PR TITLE
feat(ui): add Wizard widget

### DIFF
--- a/packages/ui/src/Wizard.test.ts
+++ b/packages/ui/src/Wizard.test.ts
@@ -1,0 +1,147 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/ui — Tests for Wizard component
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi } from 'vitest';
+import { Screen } from '@termuijs/core';
+import { Box, TextInput } from '@termuijs/widgets';
+import { Wizard } from './Wizard.js';
+
+const makeSteps = () => [
+    { title: 'Configure Account', render: () => new Box() },
+    { title: 'Configure Database', render: () => new TextInput() },
+    { title: 'Confirmation', render: () => new Box() },
+];
+
+describe('Wizard', () => {
+    it('renders step indicator correctly', () => {
+        const wizard = new Wizard(makeSteps());
+        wizard.updateRect({ x: 0, y: 0, width: 40, height: 10 });
+        const screen = new Screen(40, 10);
+        wizard.render(screen);
+
+        const renderedText = screen.back[0].map((c) => c.char).join('');
+        expect(renderedText).toContain('Step 1 of 3: Configure Account');
+    });
+
+    it('advances to next step on handleKey right/n', () => {
+        const wizard = new Wizard(makeSteps());
+        wizard.updateRect({ x: 0, y: 0, width: 40, height: 10 });
+        const screen = new Screen(40, 10);
+
+        // Right Arrow key triggers navigation
+        wizard.handleKey({ key: 'right', ctrl: false, alt: false } as any);
+        screen.clear();
+        wizard.render(screen);
+        let renderedText = screen.back[0].map((c) => c.char).join('');
+        expect(wizard.currentStepIndex).toBe(1);
+        expect(renderedText).toContain('Step 2 of 3: Configure Database');
+
+        // 'n' key triggers navigation
+        wizard.handleKey({ key: 'n', ctrl: false, alt: false } as any);
+        screen.clear();
+        wizard.render(screen);
+        renderedText = screen.back[0].map((c) => c.char).join('');
+        expect(wizard.currentStepIndex).toBe(2);
+        expect(renderedText).toContain('Step 3 of 3: Confirmation');
+    });
+
+    it('validation string blocks advancement and stores/renders error', () => {
+        const validateMock = vi.fn().mockReturnValue('Username must not be empty');
+        const customSteps = [
+            { title: 'Configure Account', render: () => new Box(), validate: validateMock },
+            { title: 'Configure Database', render: () => new Box() },
+        ];
+        const wizard = new Wizard(customSteps);
+        wizard.updateRect({ x: 0, y: 0, width: 40, height: 10 });
+        const screen = new Screen(40, 10);
+
+        wizard.handleKey({ key: 'right', ctrl: false, alt: false } as any);
+        expect(validateMock).toHaveBeenCalled();
+        expect(wizard.currentStepIndex).toBe(0);
+        expect(wizard.error).toBe('Username must not be empty');
+
+        wizard.render(screen);
+        const renderedIndicator = screen.back[0].map((c) => c.char).join('');
+        const renderedError = screen.back[1].map((c) => c.char).join('');
+
+        expect(renderedIndicator).toContain('Step 1 of 2: Configure Account');
+        expect(renderedError).toContain('Username must not be empty');
+    });
+
+    it('validation false blocks advancement silently', () => {
+        const validateMock = vi.fn().mockReturnValue(false);
+        const customSteps = [
+            { title: 'Configure Account', render: () => new Box(), validate: validateMock },
+            { title: 'Configure Database', render: () => new Box() },
+        ];
+        const wizard = new Wizard(customSteps);
+        wizard.updateRect({ x: 0, y: 0, width: 40, height: 10 });
+        const screen = new Screen(40, 10);
+
+        wizard.handleKey({ key: 'right', ctrl: false, alt: false } as any);
+        expect(validateMock).toHaveBeenCalled();
+        expect(wizard.currentStepIndex).toBe(0);
+        expect(wizard.error).toBe('');
+
+        wizard.render(screen);
+        const renderedError = screen.back[1].map((c) => c.char).join('').trim();
+        expect(renderedError).toBe('');
+    });
+
+    it('goes back to previous step on handleKey left/b', () => {
+        const wizard = new Wizard(makeSteps());
+        wizard.updateRect({ x: 0, y: 0, width: 40, height: 10 });
+        const screen = new Screen(40, 10);
+
+        // Move to step 2
+        wizard.handleKey({ key: 'right', ctrl: false, alt: false } as any);
+        expect(wizard.currentStepIndex).toBe(1);
+
+        // Left Arrow key triggers back navigation
+        wizard.handleKey({ key: 'left', ctrl: false, alt: false } as any);
+        screen.clear();
+        wizard.render(screen);
+        let renderedText = screen.back[0].map((c) => c.char).join('');
+        expect(wizard.currentStepIndex).toBe(0);
+        expect(renderedText).toContain('Step 1 of 3: Configure Account');
+
+        // Move to step 2 again
+        wizard.handleKey({ key: 'right', ctrl: false, alt: false } as any);
+        expect(wizard.currentStepIndex).toBe(1);
+
+        // 'b' key triggers back navigation
+        wizard.handleKey({ key: 'b', ctrl: false, alt: false } as any);
+        screen.clear();
+        wizard.render(screen);
+        renderedText = screen.back[0].map((c) => c.char).join('');
+        expect(wizard.currentStepIndex).toBe(0);
+        expect(renderedText).toContain('Step 1 of 3: Configure Account');
+    });
+
+    it('fires onComplete on enter/return on the final step and collects step data', () => {
+        const onCompleteMock = vi.fn();
+        
+        const firstInput = new TextInput();
+        firstInput.value = 'john_doe';
+
+        const secondInput = new TextInput();
+        secondInput.value = 'postgres://db';
+
+        const customSteps = [
+            { title: 'Step One', render: () => firstInput },
+            { title: 'Step Two', render: () => secondInput },
+        ];
+
+        const wizard = new Wizard(customSteps, { onComplete: onCompleteMock });
+        wizard.updateRect({ x: 0, y: 0, width: 40, height: 10 });
+
+        // Advance to step 2 (final step)
+        wizard.handleKey({ key: 'right', ctrl: false, alt: false } as any);
+        expect(wizard.currentStepIndex).toBe(1);
+
+        // Enter triggers completion
+        wizard.handleKey({ key: 'enter', ctrl: false, alt: false } as any);
+        expect(onCompleteMock).toHaveBeenCalledWith(['john_doe', 'postgres://db']);
+    });
+});

--- a/packages/ui/src/Wizard.ts
+++ b/packages/ui/src/Wizard.ts
@@ -1,0 +1,238 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/ui — Wizard widget
+//
+// A multi-step form flow wizard.
+// ─────────────────────────────────────────────────────
+
+import { Widget } from '@termuijs/widgets';
+import {
+    type Style,
+    type Screen,
+    type KeyEvent,
+    mergeStyles,
+    defaultStyle,
+    styleToCellAttrs,
+    truncate,
+} from '@termuijs/core';
+
+export interface WizardStep {
+    title: string;
+    render: () => Widget;
+    validate?: () => boolean | string;
+}
+
+export interface WizardOptions {
+    style?: Partial<Style>;
+    onComplete?: (stepData: unknown[]) => void;
+}
+
+export class Wizard extends Widget {
+    private _steps: WizardStep[];
+    private _stepWidgets: Widget[];
+    private _currentStepIndex = 0;
+    private _error = '';
+    private _onComplete?: (stepData: unknown[]) => void;
+    focusable = true;
+
+    constructor(steps: WizardStep[], options: WizardOptions = {}) {
+        const topPadding = 2;
+        const style = mergeStyles(defaultStyle(), {
+            flexDirection: 'column',
+            flexGrow: 1,
+            ...options.style,
+            padding: {
+                top: topPadding,
+                right: (options.style?.padding as any)?.right ?? 0,
+                bottom: (options.style?.padding as any)?.bottom ?? 0,
+                left: (options.style?.padding as any)?.left ?? 0,
+            },
+        });
+        super(style);
+        this._steps = steps;
+        this._onComplete = options.onComplete;
+
+        // Instantiate all step widgets so widget state persists while navigating
+        this._stepWidgets = steps.map((s) => s.render());
+
+        // Keep only the active widget attached as a child
+        if (this._stepWidgets[0]) {
+            this.addChild(this._stepWidgets[0]);
+        }
+
+        // Register default key listener
+        this.events.on('key', (event) => this.handleKey(event));
+    }
+
+    get currentStepIndex(): number {
+        return this._currentStepIndex;
+    }
+
+    get error(): string {
+        return this._error;
+    }
+
+    get stepWidgets(): ReadonlyArray<Widget> {
+        return this._stepWidgets;
+    }
+
+    nextStep(): void {
+        const step = this._steps[this._currentStepIndex];
+        if (step && step.validate) {
+            const validationResult = step.validate();
+            if (typeof validationResult === 'string') {
+                this._error = validationResult;
+                this.markDirty();
+                return;
+            } else if (validationResult === false) {
+                // block silently
+                this.markDirty();
+                return;
+            }
+        }
+
+        // Validation passed
+        this._error = '';
+        if (this._currentStepIndex < this._steps.length - 1) {
+            this._showStep(this._currentStepIndex + 1);
+        }
+    }
+
+    prevStep(): void {
+        this._error = '';
+        if (this._currentStepIndex > 0) {
+            this._showStep(this._currentStepIndex - 1);
+        }
+    }
+
+    complete(): void {
+        this._onComplete?.(this._getStepData());
+    }
+
+    private _showStep(index: number): void {
+        const currentWidget = this._stepWidgets[this._currentStepIndex];
+        if (currentWidget) {
+            this.removeChild(currentWidget);
+        }
+        this._currentStepIndex = index;
+        const nextWidget = this._stepWidgets[index];
+        if (nextWidget) {
+            this.addChild(nextWidget);
+        }
+        this.markDirty();
+    }
+
+    private _getStepData(): unknown[] {
+        return this._stepWidgets.map((widget) => {
+            if ('value' in widget) {
+                return (widget as any).value;
+            }
+            if ('values' in widget) {
+                return (widget as any).values;
+            }
+            if ('numericValue' in widget) {
+                return (widget as any).numericValue;
+            }
+            if ('selectedOption' in widget) {
+                return (widget as any).selectedOption;
+            }
+            if ('selectedOptions' in widget) {
+                return (widget as any).selectedOptions;
+            }
+            return undefined;
+        });
+    }
+
+    handleKey(event: KeyEvent): void {
+        if (event._propagationStopped || event._defaultPrevented) return;
+
+        // Bypassing letters if an input widget is focused within the active step
+        const isFocusInInput = (widget: Widget): boolean => {
+            if (widget.isFocused && ('insertChar' in widget || 'value' in widget)) {
+                return true;
+            }
+            for (const child of widget.children) {
+                if (isFocusInInput(child)) return true;
+            }
+            return false;
+        };
+
+        const activeWidget = this._stepWidgets[this._currentStepIndex];
+        const inputFocused = activeWidget ? isFocusInInput(activeWidget) : false;
+
+        switch (event.key) {
+            case 'right':
+                if (!inputFocused) {
+                    this.nextStep();
+                    event.stopPropagation?.();
+                }
+                break;
+            case 'n':
+                if (!event.ctrl && !event.alt && !inputFocused) {
+                    this.nextStep();
+                    event.stopPropagation?.();
+                }
+                break;
+            case 'left':
+                if (!inputFocused) {
+                    this.prevStep();
+                    event.stopPropagation?.();
+                }
+                break;
+            case 'b':
+                if (!event.ctrl && !event.alt && !inputFocused) {
+                    this.prevStep();
+                    event.stopPropagation?.();
+                }
+                break;
+            case 'enter':
+            case 'return':
+                if (this._currentStepIndex === this._steps.length - 1) {
+                    this.complete();
+                    event.stopPropagation?.();
+                }
+                break;
+        }
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width, height } = this._rect;
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this.style);
+        const border = this._style.border && this._style.border !== 'none' ? 1 : 0;
+
+        const step = this._steps[this._currentStepIndex];
+        if (!step) return;
+
+        const stepNum = this._currentStepIndex + 1;
+        const total = this._steps.length;
+        const indicatorText = `Step ${stepNum} of ${total}: ${step.title}`;
+        const contentWidth = Math.max(0, width - border * 2);
+
+        // Write the step indicator on row 0 of the content area
+        screen.writeString(
+            x + border,
+            y + border,
+            truncate(indicatorText, contentWidth),
+            { ...attrs, bold: true }
+        );
+
+        // Write validation error if present on row 1 of the content area
+        if (this._error) {
+            screen.writeString(
+                x + border,
+                y + border + 1,
+                truncate(this._error, contentWidth),
+                { ...attrs, fg: { type: 'named', name: 'red' } }
+            );
+        } else {
+            // Write blank line to clear any old error
+            screen.writeString(
+                x + border,
+                y + border + 1,
+                ' '.repeat(contentWidth),
+                attrs
+            );
+        }
+    }
+}

--- a/packages/ui/src/Wizard.ts
+++ b/packages/ui/src/Wizard.ts
@@ -11,6 +11,7 @@ import {
     type KeyEvent,
     mergeStyles,
     defaultStyle,
+    normalizeEdges,
     styleToCellAttrs,
     truncate,
 } from '@termuijs/core';
@@ -36,15 +37,16 @@ export class Wizard extends Widget {
 
     constructor(steps: WizardStep[], options: WizardOptions = {}) {
         const topPadding = 2;
+        const userPadding = normalizeEdges(options.style?.padding);
         const style = mergeStyles(defaultStyle(), {
             flexDirection: 'column',
             flexGrow: 1,
             ...options.style,
             padding: {
                 top: topPadding,
-                right: (options.style?.padding as any)?.right ?? 0,
-                bottom: (options.style?.padding as any)?.bottom ?? 0,
-                left: (options.style?.padding as any)?.left ?? 0,
+                right: userPadding.right,
+                bottom: userPadding.bottom,
+                left: userPadding.left,
             },
         });
         super(style);
@@ -124,19 +126,19 @@ export class Wizard extends Widget {
     private _getStepData(): unknown[] {
         return this._stepWidgets.map((widget) => {
             if ('value' in widget) {
-                return (widget as any).value;
+                return (widget as { value: unknown }).value;
             }
             if ('values' in widget) {
-                return (widget as any).values;
+                return (widget as { values: unknown }).values;
             }
             if ('numericValue' in widget) {
-                return (widget as any).numericValue;
+                return (widget as { numericValue: unknown }).numericValue;
             }
             if ('selectedOption' in widget) {
-                return (widget as any).selectedOption;
+                return (widget as { selectedOption: unknown }).selectedOption;
             }
             if ('selectedOptions' in widget) {
-                return (widget as any).selectedOptions;
+                return (widget as { selectedOptions: unknown }).selectedOptions;
             }
             return undefined;
         });

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -98,3 +98,5 @@ export { Pagination } from './Pagination.js';
 export type { PaginationOptions } from './Pagination.js';
 export { Toggle } from './Toggle.js';
 export type { ToggleOptions } from './Toggle.js';
+export { Wizard } from './Wizard.js';
+export type { WizardStep, WizardOptions } from './Wizard.js';


### PR DESCRIPTION
## Description

Adds a new `Wizard` widget to `@termuijs/ui` for building multi-step form flows in terminal applications.

The widget supports step navigation, validation, error display, completion callbacks, and step data collection. Comprehensive tests have been added to verify navigation, validation, and completion behavior.

## Related Issue

Closes #46

## Which package(s)?

@termuijs/ui

## Type of Change

* [x] ✨ Feature (`type:feature`)
* [x] 🧪 Tests (`type:testing`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read `CONTRIBUTING.md`.
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: https://gssoc.girlscript.org/profile/42e0e4bf-0550-4021-a19c-29f6f92ca35d
## Screenshots / Recordings (UI changes)

N/A (terminal UI widget library change)

## Notes for the Reviewer


### Added
Added Wizard widget to @termuijs/ui
Added test coverage for navigation, validation, and completion flows
Exported Wizard from packages/ui/src/index.ts
* `packages/ui/src/Wizard.ts`
* `packages/ui/src/Wizard.test.ts`

### Updated

* `packages/ui/src/index.ts`

### Features

* Step indicator rendering
* Previous/next navigation
* Validation support
* Error rendering
* Completion callback support
* Step data collection on completion

### Verification

* `bun run build` ✅
* `bun run typecheck` ✅
* `Wizard.test.ts` passes ✅
