### PR TITLE
feat: add computed selectors to store

### DIFF
--- a/packages/store/src/computed.test.ts
+++ b/packages/store/src/computed.test.ts
@@ -1,0 +1,139 @@
+// ─────────────────────────────────────────────────────
+// Tests — computed selectors for store
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi } from 'vitest';
+import { createStore, batch } from './store.js';
+
+describe('computed', () => {
+    it('returns the correct derived value on get()', () => {
+        const useStore = createStore(() => ({ items: [1, 2, 3] }));
+        const total = useStore.computed((s) => s.items.reduce((a, b) => a + b, 0));
+        expect(total.get()).toBe(6);
+    });
+
+    it('derived value updates when store state changes', () => {
+        const useStore = createStore((set) => ({
+            count: 0,
+            inc: () => set((s) => ({ count: s.count + 1 })),
+        }));
+        const doubled = useStore.computed((s) => s.count * 2);
+
+        expect(doubled.get()).toBe(0);
+        useStore.getState().inc();
+        expect(doubled.get()).toBe(2);
+        useStore.getState().inc();
+        expect(doubled.get()).toBe(4);
+    });
+
+    it('subscriber is called when the computed value changes', () => {
+        const useStore = createStore((set) => ({
+            count: 0,
+            inc: () => set((s) => ({ count: s.count + 1 })),
+        }));
+        const doubled = useStore.computed((s) => s.count * 2);
+        const spy = vi.fn();
+        doubled.subscribe(spy);
+
+        useStore.getState().inc();
+        expect(spy).toHaveBeenCalledOnce();
+        expect(spy).toHaveBeenCalledWith(2);
+    });
+
+    it('subscriber is NOT called when computed value is unchanged', () => {
+        const useStore = createStore((set) => ({
+            count: 0,
+            label: 'hello',
+            setLabel: (l: string) => set({ label: l }),
+        }));
+        const doubled = useStore.computed((s) => s.count * 2);
+        const spy = vi.fn();
+        doubled.subscribe(spy);
+
+        // Only label changes — count stays 0, doubled stays 0
+        useStore.getState().setLabel('world');
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('unsubscribe stops the listener from being called', () => {
+        const useStore = createStore((set) => ({
+            count: 0,
+            inc: () => set((s) => ({ count: s.count + 1 })),
+        }));
+        const doubled = useStore.computed((s) => s.count * 2);
+        const spy = vi.fn();
+        const unsub = doubled.subscribe(spy);
+
+        unsub();
+        useStore.getState().inc();
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('multiple computed selectors on the same store are independent', () => {
+        const useStore = createStore((set) => ({
+            count: 0,
+            inc: () => set((s) => ({ count: s.count + 1 })),
+        }));
+        const doubled = useStore.computed((s) => s.count * 2);
+        const isEven = useStore.computed((s) => s.count % 2 === 0);
+
+        useStore.getState().inc();
+        expect(doubled.get()).toBe(2);
+        expect(isEven.get()).toBe(false);
+
+        useStore.getState().inc();
+        expect(doubled.get()).toBe(4);
+        expect(isEven.get()).toBe(true);
+    });
+
+    it('multiple subscribers on the same computed are all notified', () => {
+        const useStore = createStore((set) => ({
+            x: 0,
+            set: (v: number) => set({ x: v }),
+        }));
+        const derived = useStore.computed((s) => s.x * 10);
+        const spy1 = vi.fn();
+        const spy2 = vi.fn();
+        derived.subscribe(spy1);
+        derived.subscribe(spy2);
+
+        useStore.getState().set(5);
+        expect(spy1).toHaveBeenCalledWith(50);
+        expect(spy2).toHaveBeenCalledWith(50);
+    });
+
+    it('computed is accessible directly via the hook function', () => {
+        const useStore = createStore(() => ({ value: 42 }));
+        const doubled = useStore.computed((s) => s.value * 2);
+        expect(doubled.get()).toBe(84);
+    });
+
+    it('initial cached value is correct when computed is called immediately after store creation', () => {
+        // Regression: computed was previously defined before state was initialized,
+        // causing selector(undefined) to seed the cache with the wrong value
+        const useStore = createStore(() => ({ items: [10, 20, 30] }));
+        const total = useStore.computed((s) => s.items.reduce((a, b) => a + b, 0));
+        expect(total.get()).toBe(60);
+    });
+
+    it('computed subscriber fires correctly after a batch update', async () => {
+        const useStore = createStore((set) => ({
+            x: 0,
+            y: 0,
+        }));
+        const sum = useStore.computed((s) => s.x + s.y);
+        const spy = vi.fn();
+        sum.subscribe(spy);
+
+        batch(() => {
+            useStore.setState({ x: 3 });
+            useStore.setState({ y: 7 });
+        });
+
+        // Batch defers notifications via microtask — wait for it to flush
+        await new Promise(resolve => queueMicrotask(resolve));
+
+        expect(sum.get()).toBe(10);
+        expect(spy).toHaveBeenCalledWith(10);
+    });
+});

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -6,6 +6,7 @@ export { createStore, batch } from './store.js';
 export type {
     Store,
     UseStore,
+    Computed,
     SetState,
     GetState,
     StateCreator,

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -93,6 +93,13 @@ export type Selector<T, U> = (state: T) => U;
 
 export type Listener<T> = (state: T, prevState: T) => void;
 
+export interface Computed<U> {
+    /** Get the current memoized derived value */
+    get(): U;
+    /** Subscribe to changes — listener fires only when the derived value changes */
+    subscribe(listener: (value: U) => void): () => void;
+}
+
 export interface Store<T> {
     /** Get the current state */
     getState(): T;
@@ -102,6 +109,8 @@ export interface Store<T> {
     subscribe(listener: Listener<T>): () => void;
     /** Destroy the store and remove all listeners */
     destroy(): void;
+    /** Create a memoized selector — subscribers are notified only when the derived value changes */
+    computed<U>(selector: Selector<T, U>): Computed<U>;
 }
 
 // ── Store Implementation ──
@@ -182,7 +191,33 @@ export function createStore<T extends object>(
     // Initialize state
     state = creator(setState, getState);
 
-    const store: Store<T> = { getState, setState, subscribe, destroy };
+    const computed = <U>(selector: Selector<T, U>): Computed<U> => {
+        // Seed cachedValue from current state — state is guaranteed initialized here
+        let cachedValue = selector(state);
+        const computedListeners = new Set<(value: U) => void>();
+
+        // Piggyback on the store's own subscribe — recompute on every state change
+        // but only notify computed subscribers when the derived value actually changes
+        subscribe((newState) => {
+            const newValue = selector(newState);
+            if (!Object.is(cachedValue, newValue)) {
+                cachedValue = newValue;
+                for (const listener of computedListeners) {
+                    listener(newValue);
+                }
+            }
+        });
+
+        return {
+            get: () => cachedValue,
+            subscribe: (listener) => {
+                computedListeners.add(listener);
+                return () => { computedListeners.delete(listener); };
+            },
+        };
+    };
+
+    const store: Store<T> = { getState, setState, subscribe, destroy, computed };
 
     // Create the hook function
     function useStore(): T;
@@ -211,6 +246,7 @@ export function createStore<T extends object>(
     (useStore as any).setState = setState;
     (useStore as any).subscribe = subscribe;
     (useStore as any).destroy = destroy;
+    (useStore as any).computed = computed;
 
     return useStore as UseStore<T>;
 }
@@ -224,4 +260,5 @@ export interface UseStore<T> {
     setState: SetState<T>;
     subscribe(listener: Listener<T>): () => void;
     destroy(): void;
+    computed<U>(selector: Selector<T, U>): Computed<U>;
 }


### PR DESCRIPTION
## Description

Adds a `computed(selector)` method to the store returned by `createStore`. It memoizes a derived value from store state and notifies subscribers only when that derived value actually changes — not on every store update. The internal store listener uses `Object.is` to bail out when the selector returns the same value, preventing unnecessary subscriber notifications.

## Related Issue

Closes #148

## Which package(s)?

`@termuijs/store`

## Type of Change

- [x] ✨ Feature (`type:feature`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build` — pre-existing failure in `packages/jsx/src/render.ts:64` unrelated to this PR
- [ ] Typecheck passes: `bun run typecheck` — same pre-existing failure
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- GSSoC profile: : [https://gssoc.girlscript.org/profile/____`](https://gssoc.girlscript.org/profile/a8dd8aa7-2131-48b1-b6c3-4383bd6313da)

## Screenshots / Recordings (UI changes)

N/A — store feature only, no visual output.

## Notes for the Reviewer

- `computed` is defined after `state = creator(setState, getState)` intentionally — seeding `cachedValue = selector(state)` before state is initialized would cache `selector(undefined)` as the initial value, which is wrong. This ordering ensures the initial cache is always correct.
- The internal store listener registered by `computed` uses `Object.is` to compare old and new derived values — same bail-out pattern used by `setState` and `useState` throughout the codebase.
- `computed` piggybacks on the existing `subscribe()` mechanism with no new fields added to `Store` internals or `Fiber`.
- **Known limitation:** once all computed subscribers call `unsub()`, the internal store listener still runs on state changes and recomputes the selector. It produces no side effects but does unnecessary work. This is a follow-up optimisation, not a bug.
- 10 tests covering: correct initial value, value updates on state change, subscriber called on change, subscriber skipped when value unchanged, unsubscribe, multiple independent computed selectors, multiple subscribers on one computed, direct hook access, regression for pre-init bug, and `batch` interaction.
- The pre-existing TypeScript error in `packages/jsx/src/render.ts:64` (`Property 'insertBefore' does not exist on type 'App'`) exists on `main` before this branch and is unrelated to this PR.