### PR TITLE
feat: add useImperativeHandle hook to @termuijs/jsx

### DIFF
--- a/packages/jsx/src/hooks.ts
+++ b/packages/jsx/src/hooks.ts
@@ -428,6 +428,25 @@ export function useRef<T>(initialValue: T): { current: T } {
 }
 
 /**
+ * useImperativeHandle — expose an imperative handle through a ref.
+ *
+ * ```tsx
+ * useImperativeHandle(ref, () => ({ focus: () => input.focus() }), []);
+ * ```
+ */
+export function useImperativeHandle<T>(
+    ref: { current: T | null } | null | undefined,
+    createHandle: () => T,
+    deps: any[],
+): void {
+    const handle = useMemo(createHandle, deps);
+
+    if (ref) {
+        ref.current = handle;
+    }
+}
+
+/**
  * useCallback — memoize a callback function.
  */
 export function useCallback<T extends (...args: any[]) => any>(callback: T, deps: any[]): T {

--- a/packages/jsx/src/hooks/useImperativeHandle.test.ts
+++ b/packages/jsx/src/hooks/useImperativeHandle.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+    createFiber,
+    setCurrentFiber,
+    clearCurrentFiber,
+    useImperativeHandle,
+    type Fiber,
+} from '../hooks.js';
+
+interface Handle {
+    value: string;
+    focus: () => string;
+}
+
+describe('useImperativeHandle', () => {
+    let fiber: Fiber;
+
+    beforeEach(() => {
+        fiber = createFiber();
+        setCurrentFiber(fiber);
+    });
+
+    afterEach(() => {
+        clearCurrentFiber();
+    });
+
+    it('sets ref.current to the object returned by createHandle', () => {
+        const ref = { current: null as Handle | null };
+        const handle = { value: 'first', focus: () => 'focused' };
+
+        useImperativeHandle(ref, () => handle, []);
+
+        expect(ref.current).toBe(handle);
+        expect(ref.current?.focus()).toBe('focused');
+    });
+
+    it('does not rebuild the handle when deps are unchanged', () => {
+        const ref = { current: null as Handle | null };
+        const createHandle = vi.fn(() => ({ value: 'same', focus: () => 'same' }));
+
+        useImperativeHandle(ref, createHandle, ['dep']);
+        const firstHandle = ref.current;
+
+        fiber.hookIndex = 0;
+        setCurrentFiber(fiber);
+        useImperativeHandle(ref, createHandle, ['dep']);
+
+        expect(createHandle).toHaveBeenCalledOnce();
+        expect(ref.current).toBe(firstHandle);
+    });
+
+    it('rebuilds the handle when a dep changes', () => {
+        const ref = { current: null as Handle | null };
+        let value = 'first';
+        const createHandle = vi.fn(() => ({ value, focus: () => value }));
+
+        useImperativeHandle(ref, createHandle, [value]);
+        const firstHandle = ref.current;
+
+        value = 'second';
+        fiber.hookIndex = 0;
+        setCurrentFiber(fiber);
+        useImperativeHandle(ref, createHandle, [value]);
+
+        expect(createHandle).toHaveBeenCalledTimes(2);
+        expect(ref.current).not.toBe(firstHandle);
+        expect(ref.current?.value).toBe('second');
+    });
+
+    it('does not throw with a null ref', () => {
+        expect(() => {
+            useImperativeHandle(null, () => ({ value: 'x' }), []);
+        }).not.toThrow();
+    });
+});

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -18,6 +18,7 @@ export {
     useInterval,
     useMemo,
     useRef,
+    useImperativeHandle,
     useCallback,
     useAsync,
     useKeymap,


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

Adds a useImperativeHandle(ref, createHandle, deps) hook to @termuijs/jsx.

The hook exposes an imperative API through a ref and reuses the existing useMemo() implementation for dependency tracking and memoization. The handle is only recreated when a dependency changes, and ref.current is assigned to the memoized handle on each render.

Also adds dedicated test coverage for handle assignment, dependency-based memoization, re-render behavior, and null refs.

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #155 

## Which package(s)?

@termuijs/jsx

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/0ea29967-7ada-4e3b-83ec-9da126f5d72a`

## Screenshots / Recordings (UI changes)

N/A — hook only, no visual output.

## Notes for the Reviewer

Implementation intentionally delegates to useMemo() rather than duplicating hook-slot and dependency comparison logic. This keeps useImperativeHandle aligned with the existing hook behavior and ensures the handle is recreated only when dependencies change.

Added 4 focused tests covering:

- Initial ref.current assignment
- Stable handle when dependencies are unchanged
- Handle recreation when dependencies change
- Safe behavior when ref is null

Verification performed:

bun vitest run packages/jsx/src/hooks/useImperativeHandle.test.ts
bun vitest run packages/jsx/src/hooks.test.ts packages/jsx/src/hooks/*.test.ts
bun run build
bun run typecheck
