### PR TITLE
feat(jsx): add useId hook

### DIFF
--- a/packages/jsx/src/hooks.test.ts
+++ b/packages/jsx/src/hooks.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { timerPoolUnsubscribeAll } from '@termuijs/motion';
 import {
     createFiber, setCurrentFiber, clearCurrentFiber,
-    useState, useEffect, useRef, useCallback,
+    useState, useEffect, useRef, useId, useCallback,
     useAsync, useInterval, useInsertBefore, setRequestRender, setInsertBefore, runEffects, destroyFiber,
     type Fiber, type AsyncState,
 } from './hooks.js';
@@ -255,5 +255,45 @@ describe('useInsertBefore', () => {
 
         expect(insertBefore).toHaveBeenCalledOnce();
         expect(insertBefore).toHaveBeenCalledWith('HEADER LINE');
+    });
+});
+describe('useId', () => {
+    it('returns a string id', () => {
+        const fiber = createFiber();
+
+        setCurrentFiber(fiber);
+        const id = useId();
+        clearCurrentFiber();
+
+        expect(typeof id).toBe('string');
+    });
+
+    it('returns the same id across re-renders', () => {
+        const fiber = createFiber();
+
+        setCurrentFiber(fiber);
+        const id1 = useId();
+        clearCurrentFiber();
+
+        setCurrentFiber(fiber);
+        const id2 = useId();
+        clearCurrentFiber();
+
+        expect(id1).toBe(id2);
+    });
+
+    it('returns different ids for different fibers', () => {
+        const fiberA = createFiber();
+        const fiberB = createFiber();
+
+        setCurrentFiber(fiberA);
+        const idA = useId();
+        clearCurrentFiber();
+
+        setCurrentFiber(fiberB);
+        const idB = useId();
+        clearCurrentFiber();
+
+        expect(idA).not.toBe(idB);
     });
 });

--- a/packages/jsx/src/hooks.ts
+++ b/packages/jsx/src/hooks.ts
@@ -63,6 +63,19 @@ let _currentFiber: Fiber | null = null;
 let _requestRender: (() => void) | null = null;
 let _insertBefore: ((line: string) => (() => void) | void) | null = null;
 let _nextFiberId = 0;
+let _nextHookId = 0;
+export function useId(): string {
+    const fiber = currentFiber();
+    const idx = fiber.hookIndex++;
+
+    if (idx >= fiber.hooks.length) {
+        fiber.hooks.push({
+            value: `id-${++_nextHookId}`,
+        });
+    }
+
+    return fiber.hooks[idx].value;
+}
 
 /** Get or throw the current fiber (hooks must be called inside a component) */
 export function currentFiber(): Fiber {

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -13,6 +13,7 @@ export { isVElement, isVFragment, flattenChildren } from './vnode.js';
 // ── Hooks ──
 export {
     useState,
+    useId,
     useEffect,
     useInput,
     useInterval,


### PR DESCRIPTION
## Description

This PR introduces a new `useId()` hook in `@termuijs/jsx` for generating stable, unique IDs within components. The generated ID remains consistent across re-renders of the same component instance while ensuring uniqueness across different component instances. Tests have been added to verify ID stability and uniqueness.

## Related Issue

Closes #150 

## Package :
@termuijs/jsx

## Type of Change
- [x] ✨ Feature (`type:feature`)
- [x] 🧪 Tests (`type:testing`)


## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
-  [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: https://gssoc.girlscript.org/profile/afb86927-2458-4696-b143-6a623d25ceee

## Screenshots / Recordings (UI changes)

N/A — this PR does not introduce any UI changes.
