### PR TITLE
feat: add useModal hook for typed modal dialogs

### DIFF
--- a/packages/jsx/src/hooks/useModal.test.ts
+++ b/packages/jsx/src/hooks/useModal.test.ts
@@ -77,4 +77,15 @@ describe('useModal', () => {
         expect(finalRender.visible).toBe(false);
         expect(finalRender.props).toBeUndefined();
     });
+
+    it('supports the default useModal() call pattern with props', async () => {
+        setCurrentFiber(fiber);
+        const modal = useModal();
+        clearCurrentFiber();
+
+        const promise = modal.show({ message: 'Delete this file?' });
+        modal.dismiss(true);
+
+        await expect(promise).resolves.toBe(true);
+    });
 });

--- a/packages/jsx/src/hooks/useModal.test.ts
+++ b/packages/jsx/src/hooks/useModal.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createFiber, setCurrentFiber, clearCurrentFiber } from '../hooks.js';
+import { useModal } from './useModal.js';
+
+describe('useModal', () => {
+    let fiber: ReturnType<typeof createFiber>;
+
+    function renderModal() {
+        setCurrentFiber(fiber);
+        const modal = useModal<{ message: string }, boolean>();
+        clearCurrentFiber();
+        return modal;
+    }
+
+    beforeEach(() => {
+        fiber = createFiber();
+    });
+
+    afterEach(() => {
+        clearCurrentFiber();
+    });
+
+    it('returns a Promise from show()', () => {
+        const modal = renderModal();
+        const result = modal.show({ message: 'Delete?' });
+
+        expect(result).toBeInstanceOf(Promise);
+    });
+
+    it('dismiss(value) resolves the promise with the provided value', async () => {
+        const modal = renderModal();
+        const promise = modal.show({ message: 'Delete?' });
+
+        modal.dismiss(true);
+
+        await expect(promise).resolves.toBe(true);
+
+        const updated = renderModal();
+        expect(updated.visible).toBe(false);
+        expect(updated.props).toBeUndefined();
+    });
+
+    it('hide() resolves undefined', async () => {
+        const modal = renderModal();
+        const promise = modal.show({ message: 'Cancel?' });
+
+        modal.hide();
+
+        await expect(promise).resolves.toBeUndefined();
+
+        const updated = renderModal();
+        expect(updated.visible).toBe(false);
+        expect(updated.props).toBeUndefined();
+    });
+
+    it('queues multiple modals and processes them in FIFO order', async () => {
+        const modal = renderModal();
+
+        const first = modal.show({ message: 'First?' });
+        const second = modal.show({ message: 'Second?' });
+
+        const firstRender = renderModal();
+        expect(firstRender.visible).toBe(true);
+        expect(firstRender.props).toEqual({ message: 'First?' });
+
+        modal.dismiss(false);
+        await expect(first).resolves.toBe(false);
+
+        const secondRender = renderModal();
+        expect(secondRender.visible).toBe(true);
+        expect(secondRender.props).toEqual({ message: 'Second?' });
+
+        modal.hide();
+        await expect(second).resolves.toBeUndefined();
+
+        const finalRender = renderModal();
+        expect(finalRender.visible).toBe(false);
+        expect(finalRender.props).toBeUndefined();
+    });
+});

--- a/packages/jsx/src/hooks/useModal.ts
+++ b/packages/jsx/src/hooks/useModal.ts
@@ -4,6 +4,10 @@
 // Lightweight typed modal dialog controller with FIFO queueing.
 // Each modal is shown in order, and show() resolves when the
 // active modal is dismissed or hidden.
+//
+// Usage:
+//   const confirm = useModal<{ message: string }, boolean>();
+//   const ok = await confirm.show({ message: 'Delete this file?' });
 // ─────────────────────────────────────────────────────
 
 import { useState, useEffect, useRef, useCallback } from '../hooks.js';
@@ -17,7 +21,7 @@ type ModalShow<Props, Result> = [Props] extends [undefined]
     ? () => Promise<Result | undefined>
     : (props: Props) => Promise<Result | undefined>;
 
-export interface UseModalResult<Props = undefined, Result = undefined> {
+export interface UseModalResult<Props = unknown, Result = unknown> {
     /** True when a modal is currently active */
     visible: boolean;
     /** Props passed to the active modal, or undefined when no modal is active */
@@ -33,16 +37,22 @@ export interface UseModalResult<Props = undefined, Result = undefined> {
 /**
  * useModal — typed modal manager with queueing and cleanup.
  *
+ * Manages a queue of modals and shows them one at a time. Each modal
+ * can be dismissed with a typed result value or hidden (resolving undefined).
+ * Modals are processed in FIFO order.
+ *
  * ```tsx
  * const confirm = useModal<{ message: string }, boolean>();
- * const result = await confirm.show({ message: 'Delete?' });
+ * const ok = await confirm.show({ message: 'Delete this file?' });
+ * if (ok === true) deleteFile();
  * ```
  */
-export function useModal<Props = undefined, Result = undefined>(): UseModalResult<Props, Result> {
+export function useModal<Props = unknown, Result = unknown>(): UseModalResult<Props, Result> {
     const [visible, setVisible] = useState(false);
     const [props, setProps] = useState<Props | undefined>(undefined);
     const queueRef = useRef<ModalEntry<Props, Result>[]>([]);
 
+    // Cleanup on unmount: resolve all pending modals with undefined
     useEffect(() => {
         return () => {
             const queue = queueRef.current.splice(0);

--- a/packages/jsx/src/hooks/useModal.ts
+++ b/packages/jsx/src/hooks/useModal.ts
@@ -1,0 +1,105 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/jsx — useModal
+//
+// Lightweight typed modal dialog controller with FIFO queueing.
+// Each modal is shown in order, and show() resolves when the
+// active modal is dismissed or hidden.
+// ─────────────────────────────────────────────────────
+
+import { useState, useEffect, useRef, useCallback } from '../hooks.js';
+
+interface ModalEntry<Props, Result> {
+    props: Props | undefined;
+    resolve: (value: Result | undefined) => void;
+}
+
+type ModalShow<Props, Result> = [Props] extends [undefined]
+    ? () => Promise<Result | undefined>
+    : (props: Props) => Promise<Result | undefined>;
+
+export interface UseModalResult<Props = undefined, Result = undefined> {
+    /** True when a modal is currently active */
+    visible: boolean;
+    /** Props passed to the active modal, or undefined when no modal is active */
+    props?: Props;
+    /** Show a modal and await its resolution */
+    show: ModalShow<Props, Result>;
+    /** Hide the active modal and resolve it with undefined */
+    hide: () => void;
+    /** Dismiss the active modal and resolve it with the provided value */
+    dismiss: (value: Result) => void;
+}
+
+/**
+ * useModal — typed modal manager with queueing and cleanup.
+ *
+ * ```tsx
+ * const confirm = useModal<{ message: string }, boolean>();
+ * const result = await confirm.show({ message: 'Delete?' });
+ * ```
+ */
+export function useModal<Props = undefined, Result = undefined>(): UseModalResult<Props, Result> {
+    const [visible, setVisible] = useState(false);
+    const [props, setProps] = useState<Props | undefined>(undefined);
+    const queueRef = useRef<ModalEntry<Props, Result>[]>([]);
+
+    useEffect(() => {
+        return () => {
+            const queue = queueRef.current.splice(0);
+            for (const entry of queue) {
+                entry.resolve(undefined);
+            }
+        };
+    }, []);
+
+    const advanceQueue = useCallback(() => {
+        const queue = queueRef.current;
+
+        queue.shift();
+
+        if (queue.length > 0) {
+            setProps(queue[0]!.props);
+            setVisible(true);
+            return;
+        }
+
+        setProps(undefined);
+        setVisible(false);
+    }, []);
+
+    const show = useCallback(((nextProps?: Props) => {
+        return new Promise<Result | undefined>((resolve) => {
+            const queue = queueRef.current;
+            queue.push({ props: nextProps as Props | undefined, resolve });
+
+            if (queue.length === 1) {
+                setProps(nextProps as Props | undefined);
+                setVisible(true);
+            }
+        });
+    }) as ModalShow<Props, Result>, []);
+
+    const hide = useCallback(() => {
+        const queue = queueRef.current;
+        if (queue.length === 0) return;
+
+        queue[0]!.resolve(undefined);
+        advanceQueue();
+    }, [advanceQueue]);
+
+    const dismiss = useCallback((value: Result) => {
+        const queue = queueRef.current;
+        if (queue.length === 0) return;
+
+        queue[0]!.resolve(value);
+        advanceQueue();
+    }, [advanceQueue]);
+
+    return {
+        visible,
+        props,
+        show,
+        hide,
+        dismiss,
+    };
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -48,6 +48,8 @@ export type { UseFocusOptions, UseFocusResult } from './hooks/useFocus.js';
 export { useFocusTrap } from './hooks/useFocusTrap.js';
 export { useKeyboardNavigation } from './hooks/useKeyboardNavigation.js';
 export type { KeyboardNavigationOptions, KeyboardNavigationResult } from './hooks/useKeyboardNavigation.js';
+export { useModal } from './hooks/useModal.js';
+export type { UseModalResult } from './hooks/useModal.js';
 
 // ── Subprocess ──
 export { useSubprocess } from './hooks/useSubprocess.js';


### PR DESCRIPTION
## Description

Adds a new `useModal` hook to `@termuijs/jsx` for managing typed modal dialogs with a Promise-based API.

### Features
- Promise-based modal resolution
- Typed props and result values
- FIFO queue support for multiple modal requests
- Automatic cleanup of pending promises on unmount
- Public API export via `index.ts`

### Tests Added
- `show()` returns a Promise
- `dismiss(value)` resolves with the provided value
- `hide()` resolves as `undefined`
- FIFO queue behavior
- Default `useModal()` usage pattern

## Related Issue

Closes #85

## Which package(s)?

@termuijs/jsx

## Type of Change

- [ ]  Bug fix (`type:bug`)
- [x]  Feature (`type:feature`)
- [ ]  Docs (`type:docs`)
- [x]  Tests (`type:testing`)
- [ ]  Refactor (`type:refactor`)
- [ ]  Design / UX (`type:design`)
- [ ]  Accessibility (`type:accessibility`)
- [ ]  Performance (`type:performance`)
- [ ]  DevOps / CI (`type:devops`)
- [ ]  Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] I read `CONTRIBUTING.md`
- [x] PR title follows `type: short description`
- [ ] Widget state mutators call `markDirty()` (Not Applicable)
- [x] No new `any` types without justification
- [x] No unrelated refactors bundled into this PR

## GSSoC 2026 Participation

- [x] I am a GSSoC 2026 contributor

GSSoC Profile:

https://gssoc.girlscript.org/profile/84adde4d-7c32-44f4-8f86-5a5f723d95cf

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

Implemented `useModal` using the existing hook patterns in `@termuijs/jsx`.

The hook provides:
- Promise-based modal control
- Typed props and result values
- FIFO queue handling for concurrent modal requests
- Cleanup of pending promises on unmount

Validation:
- ✅ Vitest passing
- ✅ Build passing
- ✅ Typecheck passing