### PR TITLE
feat: add ColorPicker widget

### DIFF
--- a/packages/ui/src/ColorPicker.test.ts
+++ b/packages/ui/src/ColorPicker.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { ColorPicker } from './ColorPicker.js';
 import { type KeyEvent, caps, Screen, parseColor } from '@termuijs/core';
 
@@ -13,6 +13,10 @@ const makeKeyEvent = (key: string): KeyEvent => ({
 });
 
 describe('ColorPicker', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
     it('initializes with the correct default value and resolves palette index', () => {
         const picker = new ColorPicker({ value: '#ff0000' }); // red hex
         expect(picker.value).toEqual(parseColor('#ff0000'));
@@ -77,23 +81,14 @@ describe('ColorPicker', () => {
         const picker = new ColorPicker({ value: 'red' });
         const screen = new Screen(40, 7);
 
-        // Render in current caps mode
         picker.mount();
         picker.updateRect({ x: 0, y: 0, width: 40, height: 7 });
+
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
         picker.render(screen);
 
-        // Toggle caps.unicode and verify no crashes
-        const origUnicode = caps.unicode;
-        
-        (caps as any).unicode = true;
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
         picker.markDirty();
         picker.render(screen);
-
-        (caps as any).unicode = false;
-        picker.markDirty();
-        picker.render(screen);
-
-        // Restore original caps mode
-        (caps as any).unicode = origUnicode;
     });
 });

--- a/packages/ui/src/ColorPicker.test.ts
+++ b/packages/ui/src/ColorPicker.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ColorPicker } from './ColorPicker.js';
+import { type KeyEvent, caps, Screen, parseColor } from '@termuijs/core';
+
+const makeKeyEvent = (key: string): KeyEvent => ({
+    key,
+    raw: Buffer.alloc(0),
+    ctrl: false,
+    alt: false,
+    shift: false,
+    stopPropagation: () => {},
+    preventDefault: () => {}
+});
+
+describe('ColorPicker', () => {
+    it('initializes with the correct default value and resolves palette index', () => {
+        const picker = new ColorPicker({ value: '#ff0000' }); // red hex
+        expect(picker.value).toEqual(parseColor('#ff0000'));
+        expect(picker.focusable).toBe(true);
+    });
+
+    it('navigates the palette grid using arrow keys and triggers onChange', () => {
+        const onChange = vi.fn();
+        const picker = new ColorPicker({ value: 'black', onChange }); // first color (index 0)
+
+        // Navigate right (index 0 -> 1, which is red)
+        picker.handleKey(makeKeyEvent('right'));
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenLastCalledWith(parseColor('red'));
+
+        // Navigate down (index 1 -> 9, which is brightRed)
+        picker.handleKey(makeKeyEvent('down'));
+        expect(onChange).toHaveBeenCalledTimes(2);
+        expect(onChange).toHaveBeenLastCalledWith(parseColor('brightRed'));
+
+        // Navigate up (index 9 -> 1, which is red)
+        picker.handleKey(makeKeyEvent('up'));
+        expect(onChange).toHaveBeenCalledTimes(3);
+        expect(onChange).toHaveBeenLastCalledWith(parseColor('red'));
+
+        // Navigate left (index 1 -> 0, which is black)
+        picker.handleKey(makeKeyEvent('left'));
+        expect(onChange).toHaveBeenCalledTimes(4);
+        expect(onChange).toHaveBeenLastCalledWith(parseColor('black'));
+    });
+
+    it('edits hex text value directly, parses it to update selection and fires onChange', () => {
+        const onChange = vi.fn();
+        const picker = new ColorPicker({ value: '#ffffff', onChange });
+
+        // Let's press backspace to remove 'f' (leaves 'fffff')
+        picker.handleKey(makeKeyEvent('backspace'));
+        // Length 5 is not a valid hex color length (3 or 6), so no onChange
+        expect(onChange).not.toHaveBeenCalled();
+
+        // Let's backspace all the way to empty
+        picker.handleKey(makeKeyEvent('backspace')); // 'ffff'
+        picker.handleKey(makeKeyEvent('backspace')); // 'fff' -> valid length 3!
+        // '#fff' parses to '#ffffff'
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenLastCalledWith(parseColor('#ffffff'));
+
+        // Clear onChange mocks
+        onChange.mockClear();
+
+        // Backspace again to 'ff' (invalid)
+        picker.handleKey(makeKeyEvent('backspace'));
+        expect(onChange).not.toHaveBeenCalled();
+
+        // Type '0' -> 'ff0' (yellow, valid!)
+        picker.handleKey(makeKeyEvent('0'));
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenLastCalledWith(parseColor('#ffff00'));
+    });
+
+    it('supports unicode and ascii fallbacks for rendering', () => {
+        const picker = new ColorPicker({ value: 'red' });
+        const screen = new Screen(40, 7);
+
+        // Render in current caps mode
+        picker.mount();
+        picker.updateRect({ x: 0, y: 0, width: 40, height: 7 });
+        picker.render(screen);
+
+        // Toggle caps.unicode and verify no crashes
+        const origUnicode = caps.unicode;
+        
+        (caps as any).unicode = true;
+        picker.markDirty();
+        picker.render(screen);
+
+        (caps as any).unicode = false;
+        picker.markDirty();
+        picker.render(screen);
+
+        // Restore original caps mode
+        (caps as any).unicode = origUnicode;
+    });
+});

--- a/packages/ui/src/ColorPicker.ts
+++ b/packages/ui/src/ColorPicker.ts
@@ -1,0 +1,250 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/ui — ColorPicker widget
+//
+// A keyboard-navigable and text-editable ColorPicker.
+// - Arrow keys (or hjkl) navigate a 16-color preset grid palette
+// - Alphanumeric entry directly edits the hex value input
+// - Shows a live swatch preview of the current color
+// - Fires onChange(color) when the selection changes
+// ─────────────────────────────────────────────────────
+
+import { Widget } from '@termuijs/widgets';
+import {
+    type Style,
+    type Screen,
+    type KeyEvent,
+    mergeStyles,
+    defaultStyle,
+    styleToCellAttrs,
+    caps,
+    parseColor,
+    colorToRgb,
+    Color,
+    NamedColor
+} from '@termuijs/core';
+
+export interface ColorPickerOptions {
+    value?: string | Color;
+    onChange?: (color: Color) => void;
+}
+
+const DEFAULT_PALETTE: NamedColor[] = [
+    'black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white',
+    'brightBlack', 'brightRed', 'brightGreen', 'brightYellow', 'brightBlue', 'brightMagenta', 'brightCyan', 'brightWhite'
+];
+
+const PALETTE_COLORS: Color[] = DEFAULT_PALETTE.map(name => parseColor(name));
+
+export class ColorPicker extends Widget {
+    private _selectedColor: Color;
+    private _hexValue = 'ffffff'; // hex digits without '#'
+    private _paletteIndex: number | null = null;
+    private _onChange?: (color: Color) => void;
+    focusable = true;
+
+    constructor(options: ColorPickerOptions = {}) {
+        super(mergeStyles(defaultStyle(), { border: 'single', height: 7 }));
+        
+        const initialValue = options.value ?? '#ffffff';
+        if (typeof initialValue === 'string') {
+            const parsed = parseColor(initialValue);
+            this._selectedColor = parsed.type !== 'none' ? parsed : parseColor('#ffffff');
+        } else {
+            this._selectedColor = initialValue.type !== 'none' ? initialValue : parseColor('#ffffff');
+        }
+
+        this._hexValue = this._colorToHexStr(this._selectedColor);
+        this._onChange = options.onChange;
+
+        // Determine if initial color is in the palette
+        const matchIdx = PALETTE_COLORS.findIndex(c => this._colorsEqual(c, this._selectedColor));
+        this._paletteIndex = matchIdx !== -1 ? matchIdx : null;
+    }
+
+    get value(): Color {
+        return this._selectedColor;
+    }
+
+    set value(val: string | Color) {
+        let newColor: Color;
+        if (typeof val === 'string') {
+            const parsed = parseColor(val);
+            newColor = parsed.type !== 'none' ? parsed : parseColor('#ffffff');
+        } else {
+            newColor = val.type !== 'none' ? val : parseColor('#ffffff');
+        }
+
+        this._selectedColor = newColor;
+        this._hexValue = this._colorToHexStr(newColor);
+
+        const matchIdx = PALETTE_COLORS.findIndex(c => this._colorsEqual(c, newColor));
+        this._paletteIndex = matchIdx !== -1 ? matchIdx : null;
+
+        this.markDirty();
+    }
+
+    private _colorToHexStr(color: Color): string {
+        const [r, g, b] = colorToRgb(color);
+        return ((r << 16) | (g << 8) | b).toString(16).padStart(6, '0');
+    }
+
+    private _colorsEqual(c1: Color, c2: Color): boolean {
+        const rgb1 = colorToRgb(c1);
+        const rgb2 = colorToRgb(c2);
+        return rgb1[0] === rgb2[0] && rgb1[1] === rgb2[1] && rgb1[2] === rgb2[2];
+    }
+
+    private _updateFromHexInput(): void {
+        const fullHex = '#' + this._hexValue;
+        const parsed = parseColor(fullHex);
+        if (parsed.type !== 'none') {
+            this._selectedColor = parsed;
+            const matchIdx = PALETTE_COLORS.findIndex(c => this._colorsEqual(c, parsed));
+            this._paletteIndex = matchIdx !== -1 ? matchIdx : null;
+            this._onChange?.(parsed);
+        }
+        this.markDirty();
+    }
+
+    handleKey(event: KeyEvent): void {
+        let index = this._paletteIndex ?? 0;
+        let paletteChanged = false;
+
+        switch (event.key) {
+            case 'left':
+            case 'h':
+                if (event.key === 'left' || (!event.ctrl && !event.alt)) {
+                    if (index > 0) {
+                        index--;
+                        paletteChanged = true;
+                    }
+                }
+                break;
+
+            case 'right':
+            case 'l':
+                if (event.key === 'right' || (!event.ctrl && !event.alt)) {
+                    if (index < 15) {
+                        index++;
+                        paletteChanged = true;
+                    }
+                }
+                break;
+
+            case 'up':
+            case 'k':
+                if (event.key === 'up' || (!event.ctrl && !event.alt)) {
+                    if (index >= 8) {
+                        index -= 8;
+                        paletteChanged = true;
+                    }
+                }
+                break;
+
+            case 'down':
+            case 'j':
+                if (event.key === 'down' || (!event.ctrl && !event.alt)) {
+                    if (index < 8) {
+                        index += 8;
+                        paletteChanged = true;
+                    }
+                }
+                break;
+
+            case 'backspace':
+                if (this._hexValue.length > 0) {
+                    this._hexValue = this._hexValue.slice(0, -1);
+                    this._updateFromHexInput();
+                }
+                break;
+
+            default:
+                if (event.key && event.key.length === 1 && !event.ctrl && !event.alt) {
+                    const char = event.key.toLowerCase();
+                    if (/^[0-9a-f]$/.test(char) && this._hexValue.length < 6) {
+                        this._hexValue += char;
+                        this._updateFromHexInput();
+                    }
+                }
+                break;
+        }
+
+        if (paletteChanged) {
+            this._paletteIndex = index;
+            const newColor = PALETTE_COLORS[index];
+            this._selectedColor = newColor;
+            this._hexValue = this._colorToHexStr(newColor);
+            this._onChange?.(newColor);
+            this.markDirty();
+        }
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const rect = this._getContentRect();
+        const { x, y, width, height } = rect;
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this._style);
+
+        // 1. Render Palette Grid (Row 0 and 1)
+        const symbol = caps.unicode ? '■' : 'o';
+
+        for (let r = 0; r < 2; r++) {
+            const rowY = y + r;
+            if (rowY >= y + height) break;
+
+            for (let c = 0; c < 8; c++) {
+                const index = r * 8 + c;
+                const cellX = x + c * 4;
+                if (cellX >= x + width) continue;
+
+                const color = PALETTE_COLORS[index];
+                const isSelected = this._paletteIndex === index;
+
+                if (isSelected) {
+                    screen.writeString(cellX, rowY, '[', attrs);
+                    screen.writeString(cellX + 1, rowY, symbol, { ...attrs, fg: color, bold: true });
+                    screen.writeString(cellX + 2, rowY, ']', attrs);
+                } else {
+                    screen.writeString(cellX + 1, rowY, symbol, { ...attrs, fg: color });
+                }
+            }
+        }
+
+        if (height < 4) return;
+
+        // 2. Render Hex Input & Live Swatch Line (Row 3)
+        const hexPrefix = 'Hex: #';
+        const hexFull = hexPrefix + this._hexValue;
+        screen.writeString(x, y + 3, hexFull, attrs);
+
+        // Render input cursor if focused
+        if (this.isFocused) {
+            const cursorX = x + hexFull.length;
+            if (cursorX < x + width) {
+                screen.setCell(cursorX, y + 3, {
+                    char: ' ',
+                    ...attrs,
+                    inverse: true
+                });
+            }
+        }
+
+        // Render Swatch next to it (starting at col 20 to give plenty of space for "Hex: #ffffff ")
+        const swatchX = x + 20;
+        if (swatchX < x + width) {
+            const swatchLabel = 'Swatch: ';
+            screen.writeString(swatchX, y + 3, swatchLabel, attrs);
+
+            const swatchTextX = swatchX + swatchLabel.length;
+            if (swatchTextX < x + width) {
+                const swatchBlocks = caps.unicode ? '████' : '####';
+                screen.writeString(swatchTextX, y + 3, swatchBlocks, {
+                    ...attrs,
+                    fg: this._selectedColor,
+                    bg: this._selectedColor
+                });
+            }
+        }
+    }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -89,6 +89,9 @@ export type { FilePickerOptions, FileEntry } from './FilePicker.js';
 export { DatePicker } from './DatePicker.js';
 export type { DatePickerOptions } from './DatePicker.js';
 
+export { ColorPicker } from './ColorPicker.js';
+export type { ColorPickerOptions } from './ColorPicker.js';
+
 export { AppShell } from './AppShell.js';
 export type { AppShellOptions } from './AppShell.js';
 export { Pagination } from './Pagination.js';


### PR DESCRIPTION
## Description

Adds a terminal-based `ColorPicker` widget to the UI library. Users can seamlessly select one of the 16 preset named ANSI colors using Arrow keys (or `hjkl`), or type a hex color code directly. A live swatch preview updates instantly, displaying the selected color in high-fidelity (Unicode blocks or ASCII characters).

## Related Issue

Closes #140

## Which package(s)?

- `@termuijs/ui`

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/666f63ca-ed6a-4d0f-8ac8-1518b06ec839`

## Notes for the Reviewer

- Extends standard `Widget` pattern with focus and keyboard controls.
- Keyboard navigation (arrows/Vim shortcuts) operates on a 2x8 grid (16 ANSI colors).
- Direct alphanumeric capture enables clean hex typing in the input field, with `backspace` support. Updates are parsed and fire `onChange` when standard lengths (3 or 6 hex digits) are entered.
- Unicode `■` grid elements and `████` live swatches degrade gracefully to `o` and `####` ASCII cells when `caps.unicode` is false.