### PR TITLE
feat(tss): add nested rule support to parser and compiler

### DIFF
--- a/packages/tss/src/compile.test.ts
+++ b/packages/tss/src/compile.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { compile } from './engine.js';
+
+describe('TSS compiler (nested rules)', () => {
+    it('flattens nested rules into standalone rules joining selectors', () => {
+        const css = `
+          .card {
+            color: red;
+            .title { color: blue; }
+          }
+        `;
+        const result = compile(css);
+        
+        expect(result).toContain('.card { color: red; }');
+        expect(result).toContain('.card .title { color: blue; }');
+    });
+
+    it('works with multiple levels of nesting', () => {
+        const css = `
+          Box.panel {
+            bg: #111;
+            .header {
+              fg: #fff;
+              :hover {
+                fg: red;
+              }
+            }
+          }
+        `;
+        const result = compile(css);
+        
+        expect(result).toContain('Box.panel { bg: #111; }');
+        expect(result).toContain('Box.panel .header { fg: #fff; }');
+        expect(result).toContain('Box.panel .header :hover { fg: red; }');
+    });
+});

--- a/packages/tss/src/engine.ts
+++ b/packages/tss/src/engine.ts
@@ -134,34 +134,15 @@ export class ThemeEngine {
             const active = this._stylesheet.themes.find(t => t.name === this._activeTheme);
             if (active) Object.assign(this._variables, active.variables);
         }
-        // Resolve rules and flatten any nested rules
-        this._resolvedRules = [];
-
-        const processAstRule = (rule: TSSRule, parentSel: TSSSelector | null) => {
-            let combinedSel = rule.selector;
-            // TermUI's matching engine doesn't technically support descendant matching
-            // natively but we store the flattened selector for completeness.
-            // If we needed descendant matching, we would track parents in _matchesSelector,
-            // but for now, we just flatten the properties into the child selector directly
-            // or build a combined string representation if supported.
-            // Since TSSSelector is flat, we'll just use the child selector for matching,
-            // but in reality we should probably implement descendant logic.
-            // For now, following the exact engine pattern:
-            this._resolvedRules.push({
-                selector: rule.selector, // Ideally this would be a descendant selector
-                properties: this._resolveProperties(rule),
-            });
-
-            if (rule.nested) {
-                for (const child of rule.nested) {
-                    processAstRule(child, rule.selector);
-                }
-            }
-        };
-
-        for (const rule of this._stylesheet.rules) {
-            processAstRule(rule, null);
-        }
+        // Resolve top-level rules only.
+        // Nested rules (rule.nested) are supported by the parser and compile()
+        // but ThemeEngine's selector matching is flat and does not support
+        // descendant combinators. Nested rules are intentionally skipped here
+        // to avoid silently applying child selectors at the wrong scope.
+        this._resolvedRules = this._stylesheet.rules.map(rule => ({
+            selector: rule.selector,
+            properties: this._resolveProperties(rule),
+        }));
 
         // Notify listeners
         for (const fn of this._listeners) fn();

--- a/packages/tss/src/engine.ts
+++ b/packages/tss/src/engine.ts
@@ -6,6 +6,48 @@ import { tokenize } from './tokenizer.js';
 import { parse, type TSSStylesheet, type TSSRule, type TSSSelector, type TSSValue } from './parser.js';
 import { type Style, type Color, type BorderStyle, parseColor } from '@termuijs/core';
 
+export function compile(source: string): string {
+    const tokens = tokenize(source);
+    const ast = parse(tokens);
+    let output: string[] = [];
+
+    function serializeSelector(sel: TSSSelector): string {
+        let s = sel.widget === '*' ? '' : sel.widget;
+        if (sel.className) s += '.' + sel.className;
+        if (sel.pseudo) s += ':' + sel.pseudo;
+        return s || '*';
+    }
+
+    function processRule(rule: TSSRule, parentSelStr: string) {
+        const selStr = serializeSelector(rule.selector);
+        const fullSelStr = parentSelStr ? `${parentSelStr} ${selStr}` : selStr;
+        
+        if (rule.properties.length > 0) {
+            let block = `${fullSelStr} {`;
+            for (const prop of rule.properties) {
+                let valStr = '';
+                if (prop.value.kind === 'var') valStr = `var(${prop.value.name})`;
+                else valStr = String(prop.value.value);
+                block += ` ${prop.name}: ${valStr};`;
+            }
+            block += ` }`;
+            output.push(block);
+        }
+
+        if (rule.nested) {
+            for (const child of rule.nested) {
+                processRule(child, fullSelStr);
+            }
+        }
+    }
+
+    for (const rule of ast.rules) {
+        processRule(rule, '');
+    }
+
+    return output.join('\n');
+}
+
 export interface ThemeVariables {
     [key: string]: string;
 }
@@ -92,11 +134,35 @@ export class ThemeEngine {
             const active = this._stylesheet.themes.find(t => t.name === this._activeTheme);
             if (active) Object.assign(this._variables, active.variables);
         }
-        // Resolve rules
-        this._resolvedRules = this._stylesheet.rules.map(rule => ({
-            selector: rule.selector,
-            properties: this._resolveProperties(rule),
-        }));
+        // Resolve rules and flatten any nested rules
+        this._resolvedRules = [];
+
+        const processAstRule = (rule: TSSRule, parentSel: TSSSelector | null) => {
+            let combinedSel = rule.selector;
+            // TermUI's matching engine doesn't technically support descendant matching
+            // natively but we store the flattened selector for completeness.
+            // If we needed descendant matching, we would track parents in _matchesSelector,
+            // but for now, we just flatten the properties into the child selector directly
+            // or build a combined string representation if supported.
+            // Since TSSSelector is flat, we'll just use the child selector for matching,
+            // but in reality we should probably implement descendant logic.
+            // For now, following the exact engine pattern:
+            this._resolvedRules.push({
+                selector: rule.selector, // Ideally this would be a descendant selector
+                properties: this._resolveProperties(rule),
+            });
+
+            if (rule.nested) {
+                for (const child of rule.nested) {
+                    processAstRule(child, rule.selector);
+                }
+            }
+        };
+
+        for (const rule of this._stylesheet.rules) {
+            processAstRule(rule, null);
+        }
+
         // Notify listeners
         for (const fn of this._listeners) fn();
     }

--- a/packages/tss/src/index.ts
+++ b/packages/tss/src/index.ts
@@ -11,7 +11,7 @@ export { parse } from './parser.js';
 export type { TSSStylesheet, TSSTheme, TSSSelector, TSSProperty, TSSValue, TSSRule } from './parser.js';
 
 // Theme Engine
-export { ThemeEngine } from './engine.js';
+export { ThemeEngine, compile } from './engine.js';
 export type { ThemeVariables, ResolvedRule } from './engine.js';
 
 // Built-in Themes

--- a/packages/tss/src/parser.ts
+++ b/packages/tss/src/parser.ts
@@ -36,6 +36,7 @@ export type TSSValue =
 export interface TSSRule {
     selector: TSSSelector;
     properties: TSSProperty[];
+    nested?: TSSRule[];
 }
 
 // ── Parser ──
@@ -55,7 +56,7 @@ export function parse(tokens: Token[]): TSSStylesheet {
     while (peek().type !== TokenType.EOF) {
         if (peek().type === TokenType.AtTheme) {
             stylesheet.themes.push(parseTheme());
-        } else if (peek().type === TokenType.Ident) {
+        } else if (peek().type === TokenType.Ident || peek().type === TokenType.Dot || peek().type === TokenType.PseudoClass) {
             stylesheet.rules.push(parseRule());
         } else {
             advance(); // skip unknown
@@ -88,25 +89,33 @@ export function parse(tokens: Token[]): TSSStylesheet {
         const selector = parseSelector();
         expect(TokenType.LBrace);
         const properties: TSSProperty[] = [];
+        const nested: TSSRule[] = [];
         while (peek().type !== TokenType.RBrace && peek().type !== TokenType.EOF) {
-            if (peek().type === TokenType.Ident) {
+            if (peek().type === TokenType.Ident && tokens[pos + 1]?.type === TokenType.Colon) {
                 const propName = advance().value;
-                expect(TokenType.Colon);
+                advance(); // skip Colon
                 const value = parseValue();
                 properties.push({ name: propName, value });
                 if (peek().type === TokenType.Semicolon) advance();
+            } else if (peek().type === TokenType.Ident || peek().type === TokenType.Dot || peek().type === TokenType.PseudoClass) {
+                nested.push(parseRule());
             } else {
-                advance();
+                advance(); // skip unknown
             }
         }
         expect(TokenType.RBrace);
-        return { selector, properties };
+        return { selector, properties, nested: nested.length > 0 ? nested : undefined };
     }
 
     function parseSelector(): TSSSelector {
-        const widget = expect(TokenType.Ident).value;
+        let widget = '*';
         let className: string | undefined;
         let pseudo: string | undefined;
+
+        if (peek().type === TokenType.Ident) {
+            widget = advance().value;
+        }
+
         if (peek().type === TokenType.Dot) {
             advance();
             className = expect(TokenType.Ident).value;


### PR DESCRIPTION
## Description

Adds support for SCSS-like nested rules to the TSS parser. This extends the AST to support nested blocks, modifies the parser to correctly build out the tree when a nested selector is detected, and introduces a new `compile()` function in `engine.ts` to flatten those nested rules into standalone selectors.

## Related Issue

Closes #146 

## Which package(s)?

`@termuijs/tss`

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/00bcdf9e-cd87-4516-8572-5dfd618ac784`

## Screenshots / Recordings (UI changes)

*(Not applicable - CLI/compiler behavior only)*

## Notes for the Reviewer

The `TSSRule` AST node has been updated to include a `nested?: TSSRule[]` property. The parser uses a simple look-ahead on the `Ident` token inside a rule block to distinguish between standard property assignments (which always expect a `:`) and nested rule declarations. The compilation flattening joins the parent and child selectors together recursively.