### PR TITLE
feat(examples): add multi-screen-router example

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ cd examples/dashboard
 bun run dev
 ```
 
-Six examples: `cli-wrapper-live`, `dashboard`, `jsx-dashboard`, `showcase`, `system-monitor`, `todo-app`, `widget-gallery`, `forms-and-validation`.
+Examples: `cli-wrapper-live`, `dashboard`, `jsx-dashboard`, `showcase`, `system-monitor`, `todo-app`, `widget-gallery`, `forms-and-validation`, `multi-screen-router`.
 
 ## Project structure
 
@@ -394,6 +394,7 @@ examples/
   dashboard/             Real-time system monitor
   forms-and-validation/  Multi-field form with validation
   jsx-dashboard/         JSX-based dashboard
+    multi-screen-router/   Multi-screen router example
   showcase/              Widget gallery
   system-monitor/        Advanced monitor
   todo-app/              Interactive todo list

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,19 @@
         "@termuijs/widgets": "workspace:*",
       },
     },
+    "examples/multi-screen-router": {
+      "name": "@termuijs/example-multi-screen-router",
+      "version": "0.1.0",
+      "dependencies": {
+        "@termuijs/core": "workspace:*",
+        "@termuijs/jsx": "workspace:*",
+        "@termuijs/router": "workspace:*",
+        "@termuijs/widgets": "workspace:*",
+      },
+      "devDependencies": {
+        "typescript": "^5.4.0",
+      },
+    },
     "examples/showcase": {
       "name": "@termuijs/example-showcase",
       "version": "0.1.0",
@@ -266,6 +279,7 @@
         "@termuijs/widgets": "workspace:*",
       },
       "devDependencies": {
+        "@termuijs/testing": "workspace:*",
         "tsup": "^8.0.0",
         "typescript": "^5.4.0",
       },
@@ -395,6 +409,7 @@
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw=="],
 
     "@termuijs/adapters": ["@termuijs/adapters@workspace:packages/adapters"],
+
     "@termuijs/core": ["@termuijs/core@workspace:packages/core"],
 
     "@termuijs/data": ["@termuijs/data@workspace:packages/data"],
@@ -402,11 +417,14 @@
     "@termuijs/dev-server": ["@termuijs/dev-server@workspace:packages/dev-server"],
 
     "@termuijs/example-cli-wrapper-live": ["@termuijs/example-cli-wrapper-live@workspace:examples/cli-wrapper-live"],
+
     "@termuijs/example-dashboard": ["@termuijs/example-dashboard@workspace:examples/dashboard"],
 
     "@termuijs/example-forms": ["@termuijs/example-forms@workspace:examples/forms-and-validation"],
 
     "@termuijs/example-jsx-dashboard": ["@termuijs/example-jsx-dashboard@workspace:examples/jsx-dashboard"],
+
+    "@termuijs/example-multi-screen-router": ["@termuijs/example-multi-screen-router@workspace:examples/multi-screen-router"],
 
     "@termuijs/example-showcase": ["@termuijs/example-showcase@workspace:examples/showcase"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -279,7 +279,6 @@
         "@termuijs/widgets": "workspace:*",
       },
       "devDependencies": {
-        "@termuijs/testing": "workspace:*",
         "tsup": "^8.0.0",
         "typescript": "^5.4.0",
       },
@@ -409,7 +408,6 @@
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw=="],
 
     "@termuijs/adapters": ["@termuijs/adapters@workspace:packages/adapters"],
-
     "@termuijs/core": ["@termuijs/core@workspace:packages/core"],
 
     "@termuijs/data": ["@termuijs/data@workspace:packages/data"],
@@ -417,14 +415,12 @@
     "@termuijs/dev-server": ["@termuijs/dev-server@workspace:packages/dev-server"],
 
     "@termuijs/example-cli-wrapper-live": ["@termuijs/example-cli-wrapper-live@workspace:examples/cli-wrapper-live"],
-
     "@termuijs/example-dashboard": ["@termuijs/example-dashboard@workspace:examples/dashboard"],
+    "@termuijs/example-multi-screen-router": ["@termuijs/example-multi-screen-router@workspace:examples/multi-screen-router"],
 
     "@termuijs/example-forms": ["@termuijs/example-forms@workspace:examples/forms-and-validation"],
 
     "@termuijs/example-jsx-dashboard": ["@termuijs/example-jsx-dashboard@workspace:examples/jsx-dashboard"],
-
-    "@termuijs/example-multi-screen-router": ["@termuijs/example-multi-screen-router@workspace:examples/multi-screen-router"],
 
     "@termuijs/example-showcase": ["@termuijs/example-showcase@workspace:examples/showcase"],
 

--- a/examples/multi-screen-router/README.md
+++ b/examples/multi-screen-router/README.md
@@ -1,0 +1,28 @@
+Multi-screen Router Example
+===========================
+
+This example demonstrates using the repository-native `@termuijs/router` to build a small multi-screen terminal UI.
+
+Routes
+------
+
+- `/` — Home screen (press `i` to go to the items list)
+- `/items` — Items list (use Arrow keys to navigate, `Enter` to open an item)
+- `/items/:id` — Item details (press `b` to go back)
+
+How to run
+----------
+
+Install dependencies at the repo root, then run:
+
+```bash
+cd examples/multi-screen-router
+bun run dev
+```
+
+Navigation
+----------
+
+Flow: Home -> Items -> Item Details -> Back
+
+This example uses `router.push(path)` to navigate and `router.back()` to return.

--- a/examples/multi-screen-router/package.json
+++ b/examples/multi-screen-router/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "@termuijs/example-multi-screen-router",
+    "version": "0.1.0",
+    "private": true,
+    "type": "module",
+    "description": "Example showing multi-screen routing with @termuijs/router",
+    "scripts": {
+        "start": "bun src/index.tsx",
+        "dev": "bun --watch src/index.tsx",
+        "build": "echo 'no build needed'"
+    },
+    "dependencies": {
+        "@termuijs/core": "workspace:*",
+        "@termuijs/jsx": "workspace:*",
+        "@termuijs/widgets": "workspace:*",
+        "@termuijs/router": "workspace:*"
+    },
+    "devDependencies": {
+        "typescript": "^5.4.0"
+    },
+    "engines": {
+        "bun": ">=1.3.0"
+    }
+}

--- a/examples/multi-screen-router/src/index.tsx
+++ b/examples/multi-screen-router/src/index.tsx
@@ -1,0 +1,46 @@
+/** @jsxImportSource @termuijs/jsx */
+import { renderApp, useState, useEffect } from '@termuijs/jsx';
+import { Box, Text } from '@termuijs/widgets';
+import { Router } from '@termuijs/router';
+
+import Home from './screens/Home';
+import Items from './screens/Items';
+import ItemDetails from './screens/ItemDetails';
+
+const router = new Router();
+
+// Expose router for simple screen modules to call navigation (example pattern)
+(globalThis as any).__termui_router = router;
+
+// Register routes
+router.addRoute('/', Home);
+router.addRoute('/items', Items);
+router.addRoute('/items/[id]', ItemDetails);
+
+function App() {
+    const [screen, setScreen] = useState<any>(null);
+
+    useEffect(() => {
+        const unsubNav = router.events.on('navigate', (ev) => setScreen(ev.screen));
+        const unsubBack = router.events.on('back', (ev) => setScreen(ev ? ev.screen : null));
+
+        // Kick off at root
+        router.push('/');
+
+        return () => {
+            unsubNav();
+            unsubBack();
+        };
+    }, []);
+
+    return screen ?? (
+        <Box padding={1} border="round">
+            <Text>Loading…</Text>
+        </Box>
+    );
+}
+
+renderApp(App, { title: 'Multi-screen Router' }).catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/examples/multi-screen-router/src/screens/Home.tsx
+++ b/examples/multi-screen-router/src/screens/Home.tsx
@@ -1,0 +1,40 @@
+/** @jsxImportSource @termuijs/jsx */
+import { Box, Text } from '@termuijs/widgets';
+import { useKeymap } from '@termuijs/jsx';
+import { Router } from '@termuijs/router';
+
+// Use the same router instance from the entry module via import from index.
+// To avoid circular imports, create a small singleton import path —
+// the example keeps a module-local router in index and captures it by reference.
+// Here we import the Router type and access the global router via require cache.
+
+declare const router: Router;
+
+export default function Home() {
+    // Navigate to items list with `i` or Enter
+    useKeymap([
+        {
+            key: 'i',
+            action: () => (globalThis as any).__termui_router.push('/items'),
+            description: 'Open items',
+        },
+        {
+            key: 'enter',
+            action: () => (globalThis as any).__termui_router.push('/items'),
+            description: 'Open items',
+        },
+        {
+            key: 'q',
+            action: () => process.exit(0),
+            description: 'Quit',
+        },
+    ]);
+
+    return (
+        <Box flexDirection="column" padding={1} gap={1}>
+            <Text bold>Multi-screen Router</Text>
+            <Text dim>Press <Text bold>i</Text> to open the items list.</Text>
+            <Text dim>Press <Text bold>q</Text> to quit.</Text>
+        </Box>
+    );
+}

--- a/examples/multi-screen-router/src/screens/ItemDetails.tsx
+++ b/examples/multi-screen-router/src/screens/ItemDetails.tsx
@@ -1,0 +1,23 @@
+/** @jsxImportSource @termuijs/jsx */
+import { Box, Text } from '@termuijs/widgets';
+import { useKeymap } from '@termuijs/jsx';
+
+export default function ItemDetails(props: { id?: string }) {
+    const id = props?.id ?? 'unknown';
+
+    useKeymap([
+        { key: 'b', action: () => (globalThis as any).__termui_router.back(), description: 'Back' },
+        { key: 'q', action: () => process.exit(0), description: 'Quit' },
+    ]);
+
+    // Render content based on id
+    const content = `Details for item #${id}`;
+
+    return (
+        <Box flexDirection="column" padding={1} gap={1}>
+            <Text bold>Item Details</Text>
+            <Text>{content}</Text>
+            <Text dim>Press <Text bold>b</Text> to go back.</Text>
+        </Box>
+    );
+}

--- a/examples/multi-screen-router/src/screens/Items.tsx
+++ b/examples/multi-screen-router/src/screens/Items.tsx
@@ -1,0 +1,27 @@
+/** @jsxImportSource @termuijs/jsx */
+import { Box, Text } from '@termuijs/widgets';
+import { useKeymap, useState } from '@termuijs/jsx';
+
+const ITEMS = Array.from({ length: 8 }, (_, i) => ({ id: String(i + 1), name: `Item ${i + 1}` }));
+
+export default function Items() {
+    const [selected, setSelected] = useState(0);
+
+    useKeymap([
+        { key: 'arrowup', action: () => setSelected((s) => Math.max(0, s - 1)), description: 'Up' },
+        { key: 'arrowdown', action: () => setSelected((s) => Math.min(ITEMS.length - 1, s + 1)), description: 'Down' },
+        { key: 'enter', action: () => (globalThis as any).__termui_router.push(`/items/${ITEMS[selected].id}`), description: 'Open' },
+        { key: 'b', action: () => (globalThis as any).__termui_router.back(), description: 'Back' },
+        { key: 'q', action: () => process.exit(0), description: 'Quit' },
+    ]);
+
+    return (
+        <Box flexDirection="column" padding={1} gap={1}>
+            <Text bold>Items</Text>
+            {ITEMS.map((it, idx) => (
+                <Text key={it.id} dim={idx !== selected}>{idx === selected ? '▸ ' : '  '}{it.name}</Text>
+            ))}
+            <Text dim>Use Arrow keys to move, Enter to open, b to go back.</Text>
+        </Box>
+    );
+}


### PR DESCRIPTION
## Summary

Adds a new `multi-screen-router` example application demonstrating navigation with `@termuijs/router`.

The example includes:

* multiple screens
* dynamic route params
* back navigation
* screen-to-screen routing patterns

## Changes Made

* Added `examples/multi-screen-router`
* Added:

  * `package.json`
  * `README.md`
  * `src/index.tsx`
  * screen components
* Updated root `README.md` examples table

## Features

* Three-screen navigation flow
* Dynamic `[id]` route example
* Back navigation support
* Router-based screen transitions
* Interactive keyboard navigation

## Routes

* `/`
* `/items`
* `/items/[id]`

## Validation

Manually verified with:

```bash id="g2x9rm"
cd examples/multi-screen-router
bun run dev
```

Successfully tested:

* screen navigation
* dynamic route params
* back navigation
* item detail rendering

Closes #132
