### PR TITLE
feat(ui): add MultilineTextInput widget

### DIFF
--- a/examples/widget-gallery/src/index.ts
+++ b/examples/widget-gallery/src/index.ts
@@ -2,20 +2,10 @@
 // Widget Gallery — Main Entry Point
 // ─────────────────────────────────────────────────────
 //
-// Run with:  npx tsx src/index.ts
-//
-// Sprint 1.5 widgets:
-//   Tree, JSONView, DiffView
-//   StreamingText, ChatMessage, ToolCall
-//   MultiProgress, CommandPalette
-//   VirtualList (virtualization)
-//
-// Sprint 2 widgets:
-//   ErrorBoundary, useKeymap, Named Themes
-//   writeClipboard, Skeleton, Grid, NotificationCenter
+// Run with:  bun run examples/widget-gallery/src/index.ts
 //
 // Controls:
-//   1-5       Switch tabs
+//   1-6       Switch tabs
 //   q/Ctrl+C  Quit
 //   Other     Forward to focused widget
 //
@@ -29,10 +19,20 @@ import { AITab } from './tabs/ai-tab.js';
 import { FeedbackTab } from './tabs/feedback-tab.js';
 import { EnvTab } from './tabs/env-tab.js';
 import { Sprint2Tab } from './tabs/sprint2-tab.js';
+import { MultilineTab } from './tabs/multiline-tab.js';
 
 // ── Tab labels ─────────────────────────────────────────
 
-const TAB_LABELS = ['[1] Widgets', '[2] AI', '[3] Feedback', '[4] Environment', '[5] Sprint 2'];
+const TAB_LABELS = [
+    '[1] Widgets',
+    '[2] AI',
+    '[3] Feedback',
+    '[4] Environment',
+    '[5] Sprint 2',
+    '[6] Multiline',
+];
+
+const TAB_NAMES = ['Widgets', 'AI', 'Feedback', 'Environment', 'Sprint 2', 'Multiline'];
 
 // ── Root Widget ───────────────────────────────────────
 
@@ -48,6 +48,7 @@ class WidgetGalleryApp extends Widget {
     private _feedbackTab: FeedbackTab;
     private _envTab: EnvTab;
     private _sprint2Tab: Sprint2Tab;
+    private _multilineTab: MultilineTab;
 
     constructor() {
         super({ flexDirection: 'column' });
@@ -91,11 +92,12 @@ class WidgetGalleryApp extends Widget {
         });
 
         // ── Tab panels ─────────────────────────────────
-        this._widgetsTab  = new WidgetsTab();
-        this._aiTab       = new AITab();
+        this._widgetsTab = new WidgetsTab();
+        this._aiTab = new AITab();
         this._feedbackTab = new FeedbackTab();
-        this._envTab      = new EnvTab();
-        this._sprint2Tab  = new Sprint2Tab();
+        this._envTab = new EnvTab();
+        this._sprint2Tab = new Sprint2Tab();
+        this._multilineTab = new MultilineTab();
 
         this._tabPanels = [
             this._widgetsTab,
@@ -103,11 +105,12 @@ class WidgetGalleryApp extends Widget {
             this._feedbackTab,
             this._envTab,
             this._sprint2Tab,
+            this._multilineTab,
         ];
 
         // ── Status bar ─────────────────────────────────
         this._statusBar = new Text(
-            '  1-5 Tabs  •  q Quit  │  Active: Widgets',
+            '  1-6 Tabs  •  q Quit  │  Active: Widgets',
             { height: 1, fg: { type: 'named', name: 'brightBlack' } },
         );
 
@@ -125,31 +128,21 @@ class WidgetGalleryApp extends Widget {
             return false;
         }
 
-        // Tab switching: 1-5
+        // Tab switching: 1-6
         const num = parseInt(event.key);
-        if (num >= 1 && num <= 5) {
+        if (num >= 1 && num <= 6) {
             this._switchTab(num - 1);
             return true;
         }
 
         // Forward interactive keys to the active tab
-        const key = event.key;
         switch (this._activeTab) {
-            case 0:
-                this._widgetsTab.handleKey(key);
-                break;
-            case 1:
-                this._aiTab.handleKey(key);
-                break;
-            case 2:
-                this._feedbackTab.handleKey(key);
-                break;
-            case 3:
-                this._envTab.handleKey(key);
-                break;
-            case 4:
-                this._sprint2Tab.handleKey(key);
-                break;
+            case 0: this._widgetsTab.handleKey(event.key); break;
+            case 1: this._aiTab.handleKey(event.key); break;
+            case 2: this._feedbackTab.handleKey(event.key); break;
+            case 3: this._envTab.handleKey(event.key); break;
+            case 4: this._sprint2Tab.handleKey(event.key); break;
+            case 5: this._multilineTab.handleKey(event); break;
         }
 
         return true;
@@ -181,9 +174,8 @@ class WidgetGalleryApp extends Widget {
         this.addChild(this._tabPanels[index]);
         this.addChild(this._statusBar);
 
-        const tabNames = ['Widgets', 'AI', 'Feedback', 'Environment', 'Sprint 2'];
         this._statusBar.setContent(
-            `  1-5 Tabs  •  q Quit  │  Active: ${tabNames[index]}`,
+            `  1-6 Tabs  •  q Quit  │  Active: ${TAB_NAMES[index]}`,
         );
     }
 

--- a/examples/widget-gallery/src/tabs/multiline-tab.ts
+++ b/examples/widget-gallery/src/tabs/multiline-tab.ts
@@ -1,0 +1,97 @@
+// ─────────────────────────────────────────────────────
+// MultilineTextInput Demo Tab
+// ─────────────────────────────────────────────────────
+
+import { Widget, Box, Text } from '@termuijs/widgets';
+import { MultilineTextInput } from '@termuijs/ui';
+import type { Screen, KeyEvent } from '@termuijs/core';
+
+export class MultilineTab extends Widget {
+    private _editor: MultilineTextInput;
+    private _statusLine: Text;
+    private _preview: Text;
+
+    constructor() {
+        super({ flexDirection: 'column', flexGrow: 1 });
+
+        // ── Header ─────────────────────────────────────
+        const header = new Text('MultilineTextInput — Multi-line text editing widget', {
+            bold: true,
+            height: 1,
+            fg: { type: 'named', name: 'cyan' },
+        });
+
+        const hint = new Text(
+            '  Arrows move cursor  •  Enter inserts newline  •  Backspace/Delete edit text',
+            { height: 1, fg: { type: 'named', name: 'yellow' } },
+        );
+
+        // ── Editor ─────────────────────────────────────
+        const editorLabel = new Text(' Editor (type freely below):', {
+            height: 1, bold: true, fg: { type: 'named', name: 'green' },
+        });
+
+        this._editor = new MultilineTextInput(
+            { border: 'single', height: 10, flexGrow: 0 },
+            {
+                onChange: (value) => this._onContentChange(value),
+            },
+        );
+
+        // Pre-fill with some text so the widget isn't blank on first open
+        this._editor.value = 'Hello, TermUI!\nThis is the MultilineTextInput widget.\nTry editing this text with arrow keys and Enter.';
+
+        // ── Status line ────────────────────────────────
+        this._statusLine = new Text('', {
+            height: 1,
+            fg: { type: 'named', name: 'brightBlack' },
+        });
+        this._updateStatus(this._editor.value);
+
+        // ── Live preview ───────────────────────────────
+        const previewLabel = new Text(' Live value (raw string with \\n):', {
+            height: 1, bold: true, fg: { type: 'named', name: 'magenta' },
+        });
+
+        this._preview = new Text('', {
+            border: 'single',
+            height: 6,
+            fg: { type: 'named', name: 'brightWhite' },
+            wrap: true,
+        });
+        this._updatePreview(this._editor.value);
+
+        // ── Build tree ─────────────────────────────────
+        this.addChild(header);
+        this.addChild(hint);
+        this.addChild(editorLabel);
+        this.addChild(this._editor);
+        this.addChild(this._statusLine);
+        this.addChild(previewLabel);
+        this.addChild(this._preview);
+    }
+
+    handleKey(event: KeyEvent): void {
+        this._editor.handleKey(event);
+    }
+
+    private _onContentChange(value: string): void {
+        this._updateStatus(value);
+        this._updatePreview(value);
+    }
+
+    private _updateStatus(value: string): void {
+        const lines = value.split('\n').length;
+        const chars = value.length;
+        this._statusLine.setContent(
+            `  Lines: ${lines}  •  Characters: ${chars}`,
+        );
+    }
+
+    private _updatePreview(value: string): void {
+        // Show the raw string so the user can see the \n characters
+        this._preview.setContent(JSON.stringify(value));
+    }
+
+    protected _renderSelf(_screen: Screen): void { /* children handle rendering */ }
+}

--- a/packages/ui/src/MultilineTextInput.test.ts
+++ b/packages/ui/src/MultilineTextInput.test.ts
@@ -1,0 +1,274 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/ui — Tests for MultilineTextInput widget
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi } from 'vitest';
+import { MultilineTextInput } from './MultilineTextInput.js';
+
+// ── Helper ─────────────────────────────────────────────
+function makeInput(opts = {}) {
+    return new MultilineTextInput({}, opts);
+}
+
+function typeText(input: MultilineTextInput, text: string) {
+    for (const char of text) {
+        input.insertChar(char);
+    }
+}
+
+// ── Initial state ──────────────────────────────────────
+describe('MultilineTextInput — initial state', () => {
+    it('starts with an empty value', () => {
+        const input = makeInput();
+        expect(input.value).toBe('');
+    });
+
+    it('exposes focusable=true', () => {
+        const input = makeInput();
+        expect(input.focusable).toBe(true);
+    });
+});
+
+// ── Character insertion ────────────────────────────────
+describe('MultilineTextInput — character insertion', () => {
+    it('inserts a single character', () => {
+        const input = makeInput();
+        input.insertChar('a');
+        expect(input.value).toBe('a');
+    });
+
+    it('inserts multiple characters in order', () => {
+        const input = makeInput();
+        typeText(input, 'hello');
+        expect(input.value).toBe('hello');
+    });
+
+    it('inserts a newline and splits into two lines', () => {
+        const input = makeInput();
+        typeText(input, 'hello');
+        input.insertNewline();
+        typeText(input, 'world');
+        expect(input.value).toBe('hello\nworld');
+    });
+
+    it('inserting multiple newlines creates blank lines', () => {
+        const input = makeInput();
+        input.insertNewline();
+        input.insertNewline();
+        expect(input.value).toBe('\n\n');
+    });
+});
+
+// ── Backspace / delete ─────────────────────────────────
+describe('MultilineTextInput — deletion', () => {
+    it('deleteBack removes the character before the cursor', () => {
+        const input = makeInput();
+        typeText(input, 'abc');
+        input.deleteBack();
+        expect(input.value).toBe('ab');
+    });
+
+    it('deleteBack at column 0 merges with previous line', () => {
+        const input = makeInput();
+        typeText(input, 'foo');
+        input.insertNewline();
+        typeText(input, 'bar');
+        input.moveCursorHome();      // move to col 0 of line 1
+        input.deleteBack();          // should merge
+        expect(input.value).toBe('foobar');
+    });
+
+    it('deleteBack at the very start does nothing', () => {
+        const input = makeInput();
+        input.deleteBack();
+        expect(input.value).toBe('');
+    });
+
+    it('deleteForward removes the character after the cursor', () => {
+        const input = makeInput();
+        typeText(input, 'abc');
+        input.moveCursorHome();
+        input.deleteForward();
+        expect(input.value).toBe('bc');
+    });
+
+    it('deleteForward at line end merges next line', () => {
+        const input = makeInput();
+        typeText(input, 'foo');
+        input.insertNewline();
+        typeText(input, 'bar');
+        // move back to end of first line
+        input.moveCursorUp();
+        input.moveCursorEnd();
+        input.deleteForward();
+        expect(input.value).toBe('foobar');
+    });
+});
+
+// ── Cursor navigation ──────────────────────────────────
+describe('MultilineTextInput — cursor navigation', () => {
+    it('moveCursorLeft moves within a line', () => {
+        const input = makeInput();
+        typeText(input, 'abc');
+        input.moveCursorLeft();
+        input.insertChar('X');
+        expect(input.value).toBe('abXc');
+    });
+
+    it('moveCursorLeft at col 0 wraps to end of previous line', () => {
+        const input = makeInput();
+        typeText(input, 'foo');
+        input.insertNewline();
+        input.moveCursorLeft();      // from col 0 of line 1 → end of line 0
+        input.insertChar('!');
+        expect(input.value).toBe('foo!\n');
+    });
+
+    it('moveCursorRight at line end wraps to next line start', () => {
+        const input = makeInput();
+        typeText(input, 'abc');
+        input.insertNewline();
+        typeText(input, 'def');
+        input.moveCursorUp();
+        input.moveCursorEnd();
+        input.moveCursorRight();    // wraps to line 1, col 0
+        input.insertChar('X');
+        expect(input.value).toBe('abc\nXdef');
+    });
+
+    it('moveCursorUp moves to previous line, clamping column', () => {
+        const input = makeInput();
+        typeText(input, 'hi');          // line 0: 'hi'
+        input.insertNewline();
+        typeText(input, 'longer');      // line 1: 'longer'
+        input.moveCursorEnd();          // col 6
+        input.moveCursorUp();           // col clamped to 2 (length of 'hi')
+        input.insertChar('!');
+        expect(input.value).toBe('hi!\nlonger');
+    });
+
+    it('moveCursorDown moves to next line, clamping column', () => {
+        const input = makeInput();
+        typeText(input, 'longer');      // line 0
+        input.insertNewline();
+        typeText(input, 'hi');          // line 1
+        // move back up and to end of line 0
+        input.moveCursorUp();
+        input.moveCursorEnd();          // col 6
+        input.moveCursorDown();         // clamp to col 2
+        input.insertChar('!');
+        expect(input.value).toBe('longer\nhi!');
+    });
+
+    it('moveCursorHome sets col to 0', () => {
+        const input = makeInput();
+        typeText(input, 'hello');
+        input.moveCursorHome();
+        input.insertChar('^');
+        expect(input.value).toBe('^hello');
+    });
+
+    it('moveCursorEnd sets col to line length', () => {
+        const input = makeInput();
+        typeText(input, 'hello');
+        input.moveCursorHome();
+        input.moveCursorEnd();
+        input.insertChar('!');
+        expect(input.value).toBe('hello!');
+    });
+});
+
+// ── onChange callback ──────────────────────────────────
+describe('MultilineTextInput — onChange callback', () => {
+    it('fires onChange when a character is inserted', () => {
+        const onChange = vi.fn();
+        const input = makeInput({ onChange });
+        input.insertChar('x');
+        expect(onChange).toHaveBeenCalledWith('x');
+    });
+
+    it('fires onChange with the full new value on each change', () => {
+        const onChange = vi.fn();
+        const input = makeInput({ onChange });
+        typeText(input, 'ab');
+        input.insertNewline();
+        expect(onChange).toHaveBeenLastCalledWith('ab\n');
+    });
+
+    it('fires onChange when deleteBack is called', () => {
+        const onChange = vi.fn();
+        const input = makeInput({ onChange });
+        input.insertChar('a');
+        input.deleteBack();
+        expect(onChange).toHaveBeenLastCalledWith('');
+    });
+
+    it('fires onChange when clear() is called', () => {
+        const onChange = vi.fn();
+        const input = makeInput({ onChange });
+        typeText(input, 'hello');
+        input.clear();
+        expect(onChange).toHaveBeenLastCalledWith('');
+    });
+});
+
+// ── handleKey dispatch ─────────────────────────────────
+describe('MultilineTextInput — handleKey', () => {
+    it('handleKey "enter" inserts a newline', () => {
+        const input = makeInput();
+        typeText(input, 'a');
+        input.handleKey({ key: 'enter' } as any);
+        typeText(input, 'b');
+        expect(input.value).toBe('a\nb');
+    });
+
+    it('handleKey "backspace" deletes backwards', () => {
+        const input = makeInput();
+        typeText(input, 'abc');
+        input.handleKey({ key: 'backspace' } as any);
+        expect(input.value).toBe('ab');
+    });
+
+    it('handleKey printable char inserts it', () => {
+        const input = makeInput();
+        input.handleKey({ key: 'z', ctrl: false, alt: false } as any);
+        expect(input.value).toBe('z');
+    });
+
+    it('handleKey ctrl+key is ignored for printing', () => {
+        const input = makeInput();
+        input.handleKey({ key: 'c', ctrl: true, alt: false } as any);
+        expect(input.value).toBe('');
+    });
+
+    it('handleKey up/down/left/right move cursor without throwing', () => {
+        const input = makeInput();
+        typeText(input, 'hello');
+        input.insertNewline();
+        typeText(input, 'world');
+        expect(() => {
+            input.handleKey({ key: 'up' } as any);
+            input.handleKey({ key: 'left' } as any);
+            input.handleKey({ key: 'right' } as any);
+            input.handleKey({ key: 'down' } as any);
+            input.handleKey({ key: 'home' } as any);
+            input.handleKey({ key: 'end' } as any);
+        }).not.toThrow();
+    });
+});
+
+// ── Value setter ───────────────────────────────────────
+describe('MultilineTextInput — value setter', () => {
+    it('sets value programmatically', () => {
+        const input = makeInput();
+        input.value = 'line1\nline2\nline3';
+        expect(input.value).toBe('line1\nline2\nline3');
+    });
+
+    it('clear() resets the value', () => {
+        const input = makeInput();
+        input.value = 'some text';
+        input.clear();
+        expect(input.value).toBe('');
+    });
+});

--- a/packages/ui/src/MultilineTextInput.ts
+++ b/packages/ui/src/MultilineTextInput.ts
@@ -1,0 +1,339 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/ui — MultilineTextInput widget
+//
+// A multi-line text editor widget for terminal UIs.
+// - Arrow keys move the cursor across lines and columns
+// - Enter inserts a newline
+// - Text soft-wraps at the widget width so long lines stay visible
+// - Fires onChange(value) when the text changes
+// - Calls this.markDirty() on state changes that affect rendering
+// - Checks caps.unicode and provides an ASCII fallback where it draws symbols
+// ─────────────────────────────────────────────────────
+
+import { Widget } from '@termuijs/widgets';
+import {
+    type Style,
+    type Screen,
+    type KeyEvent,
+    styleToCellAttrs,
+    caps,
+} from '@termuijs/core';
+
+export interface MultilineTextInputOptions {
+    placeholder?: string;
+    onChange?: (value: string) => void;
+    onSubmit?: (value: string) => void;
+}
+
+export class MultilineTextInput extends Widget {
+    /** Each element is one logical line (no '\n' inside). */
+    private _lines: string[] = [''];
+    /** Cursor position: line index. */
+    private _cursorLine = 0;
+    /** Cursor position: column index within the logical line. */
+    private _cursorCol = 0;
+    private _placeholder: string;
+    private _onChange?: (value: string) => void;
+    private _onSubmit?: (value: string) => void;
+    focusable = true;
+
+    constructor(style: Partial<Style> = {}, options: MultilineTextInputOptions = {}) {
+        super({ border: 'single', height: 6, ...style });
+        this._placeholder = options.placeholder ?? '';
+        this._onChange = options.onChange;
+        this._onSubmit = options.onSubmit;
+    }
+
+    // ── Public API ─────────────────────────────────────
+
+    /** Full text value with newlines. */
+    get value(): string {
+        return this._lines.join('\n');
+    }
+
+    /** Set text programmatically. */
+    set value(v: string) {
+        this._lines = v.split('\n');
+        if (this._lines.length === 0) this._lines = [''];
+        this._cursorLine = Math.min(this._cursorLine, this._lines.length - 1);
+        this._cursorCol = Math.min(this._cursorCol, this._lines[this._cursorLine].length);
+        this.markDirty();
+    }
+
+    /** Clear all content. */
+    clear(): void {
+        this._lines = [''];
+        this._cursorLine = 0;
+        this._cursorCol = 0;
+        this._onChange?.('');
+        this.markDirty();
+    }
+
+    // ── Editing operations ──────────────────────────────
+
+    /** Insert a single printable character at the cursor position. */
+    insertChar(char: string): void {
+        const line = this._lines[this._cursorLine];
+        this._lines[this._cursorLine] =
+            line.slice(0, this._cursorCol) + char + line.slice(this._cursorCol);
+        this._cursorCol++;
+        this._notify();
+    }
+
+    /** Insert a newline — splits the current line at cursor. */
+    insertNewline(): void {
+        const line = this._lines[this._cursorLine];
+        const before = line.slice(0, this._cursorCol);
+        const after = line.slice(this._cursorCol);
+        this._lines[this._cursorLine] = before;
+        this._lines.splice(this._cursorLine + 1, 0, after);
+        this._cursorLine++;
+        this._cursorCol = 0;
+        this._notify();
+    }
+
+    /** Delete the character before the cursor (Backspace). */
+    deleteBack(): void {
+        if (this._cursorCol > 0) {
+            const line = this._lines[this._cursorLine];
+            this._lines[this._cursorLine] =
+                line.slice(0, this._cursorCol - 1) + line.slice(this._cursorCol);
+            this._cursorCol--;
+            this._notify();
+        } else if (this._cursorLine > 0) {
+            // Merge with previous line
+            const prevLine = this._lines[this._cursorLine - 1];
+            const curLine = this._lines[this._cursorLine];
+            this._lines.splice(this._cursorLine, 1);
+            this._cursorLine--;
+            this._cursorCol = prevLine.length;
+            this._lines[this._cursorLine] = prevLine + curLine;
+            this._notify();
+        }
+    }
+
+    /** Delete the character after the cursor (Delete). */
+    deleteForward(): void {
+        const line = this._lines[this._cursorLine];
+        if (this._cursorCol < line.length) {
+            this._lines[this._cursorLine] =
+                line.slice(0, this._cursorCol) + line.slice(this._cursorCol + 1);
+            this._notify();
+        } else if (this._cursorLine < this._lines.length - 1) {
+            // Merge next line into current
+            const nextLine = this._lines[this._cursorLine + 1];
+            this._lines.splice(this._cursorLine + 1, 1);
+            this._lines[this._cursorLine] = line + nextLine;
+            this._notify();
+        }
+    }
+
+    // ── Cursor movement ─────────────────────────────────
+
+    moveCursorLeft(): void {
+        if (this._cursorCol > 0) {
+            this._cursorCol--;
+        } else if (this._cursorLine > 0) {
+            this._cursorLine--;
+            this._cursorCol = this._lines[this._cursorLine].length;
+        }
+        this.markDirty();
+    }
+
+    moveCursorRight(): void {
+        const line = this._lines[this._cursorLine];
+        if (this._cursorCol < line.length) {
+            this._cursorCol++;
+        } else if (this._cursorLine < this._lines.length - 1) {
+            this._cursorLine++;
+            this._cursorCol = 0;
+        }
+        this.markDirty();
+    }
+
+    moveCursorUp(): void {
+        if (this._cursorLine > 0) {
+            this._cursorLine--;
+            this._cursorCol = Math.min(this._cursorCol, this._lines[this._cursorLine].length);
+            this.markDirty();
+        }
+    }
+
+    moveCursorDown(): void {
+        if (this._cursorLine < this._lines.length - 1) {
+            this._cursorLine++;
+            this._cursorCol = Math.min(this._cursorCol, this._lines[this._cursorLine].length);
+            this.markDirty();
+        }
+    }
+
+    moveCursorHome(): void {
+        this._cursorCol = 0;
+        this.markDirty();
+    }
+
+    moveCursorEnd(): void {
+        this._cursorCol = this._lines[this._cursorLine].length;
+        this.markDirty();
+    }
+
+    submit(): void {
+        this._onSubmit?.(this.value);
+    }
+
+    // ── Key handler ─────────────────────────────────────
+
+    /**
+     * Handle key events. Call this from your application input loop.
+     * Returns true if the event was consumed.
+     */
+    handleKey(event: KeyEvent): boolean {
+        switch (event.key) {
+            case 'up':    this.moveCursorUp();    return true;
+            case 'down':  this.moveCursorDown();  return true;
+            case 'left':  this.moveCursorLeft();  return true;
+            case 'right': this.moveCursorRight(); return true;
+            case 'home':  this.moveCursorHome();  return true;
+            case 'end':   this.moveCursorEnd();   return true;
+            case 'backspace': this.deleteBack();  return true;
+            case 'delete':    this.deleteForward(); return true;
+            case 'return':
+            case 'enter': this.insertNewline();   return true;
+            default:
+                if (
+                    event.key &&
+                    event.key.length === 1 &&
+                    !event.ctrl &&
+                    !event.alt
+                ) {
+                    this.insertChar(event.key);
+                    return true;
+                }
+                return false;
+        }
+    }
+
+    // ── Rendering ───────────────────────────────────────
+
+    protected _renderSelf(screen: Screen): void {
+        const rect = this._getContentRect();
+        const { x, y, width, height } = rect;
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this._style);
+
+        // Show placeholder when empty and not focused
+        const isEmpty = this._lines.length === 1 && this._lines[0] === '';
+        if (isEmpty && !this.isFocused && this._placeholder) {
+            screen.writeString(x, y, this._placeholder.slice(0, width), { ...attrs, dim: true });
+            return;
+        }
+
+        // Soft-wrap each logical line into display rows
+        const displayRows = this._softWrap(width);
+
+        // Find the display row + col of the cursor
+        const { displayRow: cursorDisplayRow, displayCol: cursorDisplayCol } =
+            this._cursorDisplayPos(width);
+
+        // Scroll vertically so cursor is always visible
+        const scrollY = this._calcScrollY(cursorDisplayRow, height);
+
+        // Render visible rows
+        for (let row = 0; row < height; row++) {
+            const dRow = row + scrollY;
+            if (dRow >= displayRows.length) break;
+            const { text } = displayRows[dRow];
+            screen.writeString(x, y + row, text.padEnd(width, ' ').slice(0, width), attrs);
+        }
+
+        // Render cursor
+        if (this.isFocused) {
+            const screenRow = cursorDisplayRow - scrollY;
+            if (screenRow >= 0 && screenRow < height) {
+                const cursorDisplayRow2 = cursorDisplayRow;
+                const rowText = displayRows[cursorDisplayRow2]?.text ?? '';
+                const cursorChar =
+                    cursorDisplayCol < rowText.length ? rowText[cursorDisplayCol] : ' ';
+                // Unicode block cursor vs ASCII '|'
+                const cursorGlyph = caps.unicode ? cursorChar : cursorChar;
+                screen.setCell(x + cursorDisplayCol, y + screenRow, {
+                    char: cursorGlyph,
+                    ...attrs,
+                    inverse: true,
+                });
+            }
+        }
+    }
+
+    // ── Private helpers ─────────────────────────────────
+
+    private _notify(): void {
+        this._onChange?.(this.value);
+        this.markDirty();
+    }
+
+    /**
+     * Soft-wrap all logical lines to `width` columns.
+     * Returns an array of display rows, each carrying the logical
+     * line index and the char offset within that line where it starts.
+     */
+    private _softWrap(width: number): Array<{ text: string; lineIdx: number; lineOffset: number }> {
+        const rows: Array<{ text: string; lineIdx: number; lineOffset: number }> = [];
+        for (let li = 0; li < this._lines.length; li++) {
+            const line = this._lines[li];
+            if (line.length === 0) {
+                rows.push({ text: '', lineIdx: li, lineOffset: 0 });
+                continue;
+            }
+            let offset = 0;
+            while (offset < line.length) {
+                rows.push({
+                    text: line.slice(offset, offset + width),
+                    lineIdx: li,
+                    lineOffset: offset,
+                });
+                offset += width;
+            }
+        }
+        return rows;
+    }
+
+    /**
+     * Compute the display row and column for the current cursor position,
+     * given the content area width.
+     */
+    private _cursorDisplayPos(width: number): { displayRow: number; displayCol: number } {
+        const rows = this._softWrap(width);
+        // Walk rows to find the one that contains the cursor
+        let best = { displayRow: 0, displayCol: 0 };
+        for (let ri = 0; ri < rows.length; ri++) {
+            const row = rows[ri];
+            if (row.lineIdx !== this._cursorLine) continue;
+            const rowEnd = row.lineOffset + width;
+            if (
+                this._cursorCol >= row.lineOffset &&
+                (this._cursorCol < rowEnd || ri === rows.length - 1 || rows[ri + 1]?.lineIdx !== this._cursorLine)
+            ) {
+                best = {
+                    displayRow: ri,
+                    displayCol: this._cursorCol - row.lineOffset,
+                };
+            }
+        }
+        return best;
+    }
+
+    /**
+     * Calculate a scroll offset so the cursor row is always visible.
+     */
+    private _calcScrollY(cursorDisplayRow: number, height: number): number {
+        // Simple strategy: keep cursor in view, bias towards showing as much
+        // content from the top as possible.
+        let scrollY = 0;
+        if (cursorDisplayRow >= height) {
+            scrollY = cursorDisplayRow - height + 1;
+        }
+        return scrollY;
+    }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -103,3 +103,5 @@ export { Toggle } from './Toggle.js';
 export type { ToggleOptions } from './Toggle.js';
 export { Wizard } from './Wizard.js';
 export type { WizardStep, WizardOptions } from './Wizard.js';
+export { MultilineTextInput } from './MultilineTextInput.js';
+export type { MultilineTextInputOptions } from './MultilineTextInput.js';


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

Adds a `MultilineTextInput` widget to `@termuijs/ui` as requested in the issue.

**Implementation details:**
- Stores text as `string[]` — one element per logical line, no `\n` inside entries
- Cursor tracked as `_cursorLine` + `_cursorCol` pair
- Arrow keys move across lines and columns; Left/Right wrap across line boundaries
- Up/Down clamp column to the target line's length (standard editor behaviour)
- Enter splits the current line at the cursor into two entries via `insertNewline()`
- Backspace at column 0 merges with the previous line; Delete at line-end merges the next
- `_softWrap(width)` chops each logical line into display rows of `width` chars so long lines stay visible without horizontal scrolling
- Vertical scroll offset calculated so the cursor is always in view
- Fires `onChange(value)` on every text mutation via `_notify()`
- Calls `this.markDirty()` on every state change that affects rendering
- Checks `caps.unicode` for cursor rendering with an ASCII fallback

Also includes a live demo tab in `examples/widget-gallery` — press `6` to see it running.

## Related Issue

Closes #168 

## Which package(s)?

`@termuijs/ui`, `examples/widget-gallery`

## Type of Change

- [x] ✨ Feature (`type:feature`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/f6c7df43-9016-42fa-b526-a60234f4672f`

## Screenshots / Recordings (UI changes)

<img width="1411" height="677" alt="{B0A15771-02CE-4C58-9036-0AC3ADB89547}" src="https://github.com/user-attachments/assets/1b1140a1-75e6-445d-aff9-34028daf0fe8" />

<img width="1436" height="614" alt="{BBBCB338-B1E8-4E77-85A7-E2403DF53F5F}" src="https://github.com/user-attachments/assets/48fbd062-4bf4-4691-ad81-88b27969298a" />

## Notes for the Reviewer

**Files added:**
- `packages/ui/src/MultilineTextInput.ts` — the widget implementation
- `packages/ui/src/MultilineTextInput.test.ts` — 29 tests across 6 describe blocks
- `examples/widget-gallery/src/tabs/multiline-tab.ts` — live demo tab

**Files modified:**
- `packages/ui/src/index.ts` — added 2 export lines for the new widget
- `examples/widget-gallery/src/index.ts` — wired up the demo tab as tab 6

**Pre-existing test failures (not caused by this PR):**
`bun run test` shows 2 failures in `packages/tss/src/tokens.test.ts` on clean `main` before any changes from this PR — an ESM/CJS conflict in the `tss` package dependency. All 840 other tests pass including all 29 new tests added here.