### PR TITLE
Bug: detect benchmark sizes removed from PR results

### DIFF
--- a/scripts/compare-bench.mjs
+++ b/scripts/compare-bench.mjs
@@ -24,6 +24,7 @@ const main = JSON.parse(readFileSync(mainPath, 'utf8'));
 
 const byKey = (r) => `${r.cols}x${r.rows}`;
 const mainBySize = new Map(main.results.map((r) => [byKey(r), r]));
+const headSizes = new Set(head.results.map(byKey));
 
 let regressed = false;
 const rows = [];
@@ -43,7 +44,17 @@ for (const r of head.results) {
     if (delta <= -threshold) regressed = true;
     rows.push(`| ${k} | ${(m.cellsPerSec / 1e6).toFixed(2)}M | ${(r.cellsPerSec / 1e6).toFixed(2)}M | ${deltaStr}${flag} |`);
 }
+for (const r of main.results) {
+    const k = byKey(r);
 
+    if (!headSizes.has(k)) {
+        rows.push(
+            `| ${k} | ${(r.cellsPerSec / 1e6).toFixed(2)}M | _missing_ | ❌ Removed |`
+        );
+
+        regressed = true;
+    }
+}
 const markdown = [
     '<!-- termui-bench-comment -->',
     '## Render-loop benchmark',


### PR DESCRIPTION
Description

This PR improves the benchmark comparison script by detecting benchmark sizes that exist in "main.json" but are missing from "head.json".

Previously, removed benchmark entries were silently ignored. The script now reports missing benchmark sizes in the generated markdown output and marks the comparison as regressed.

Related Issue

Closes #223 

Which package(s)?

scripts

Type of Change

-  🐛 Bug fix ("type:bug")

Checklist

- ⭐ Istarred the repo. The "needs-star" check blocks your merge otherwise.
- I   read "CONTRIBUTING.md".
- PR title follows "type: short description".
-  Widget state mutators call "markDirty()" (if your change affects rendering).
-  No new "any" types without an inline comment explaining why.
- No unrelated refactors bundled into this PR.

GSSoC 2026 Participation

-  a GSSoC 2026 contributor.
- GSSoC profile: https://gssoc.girlscript.org/profile/25fbcf55-c2fa-4ec9-b7c1-b6635cccd345

Screenshots / Recordings (UI changes)

N/A

Notes for the Reviewer

Added detection for benchmark sizes present in "main.json" but missing from "head.json". Missing entries are now included in the markdown report and flagged as removed.