### PR TITLE
fix: validate threshold input in compare-bench script

### DIFF
--- a/scripts/compare-bench.mjs
+++ b/scripts/compare-bench.mjs
@@ -19,6 +19,11 @@ const [headPath, mainPath] = args;
 const thresholdIdx = args.indexOf('--threshold');
 const threshold = thresholdIdx >= 0 ? parseFloat(args[thresholdIdx + 1]) : 0.20;
 
+if (Number.isNaN(threshold) || !Number.isFinite(threshold) || threshold < 0) {
+    console.error('Threshold must be a non-negative number');
+    process.exit(2);
+}
+
 const head = JSON.parse(readFileSync(headPath, 'utf8'));
 const main = JSON.parse(readFileSync(mainPath, 'utf8'));
 


### PR DESCRIPTION
Description

This PR adds validation for the "--threshold" argument in the benchmark comparison script.

Previously, invalid values such as non-numeric input, "NaN", infinite values, or negative numbers could be accepted and lead to unexpected comparison behavior. The script now validates the threshold and exits with a clear error message when an invalid value is provided.

Related Issue

Closes #228 

Which package(s)?

scripts

Type of Change

-  🐛 Bug fix ("type:bug")

Checklist

-  ⭐ You starred the repo. The "needs-star" check blocks your merge otherwise.
-  Tests pass locally: "bun vitest run"
-  Build passes: "bun run build"
-  You read "CONTRIBUTING.md".
-  Your PR title follows "type: short description".
-  Widget state mutators call "markDirty()" (if your change affects rendering).
-  No new "any" types without an inline comment explaining why.
- No unrelated refactors bundled into this PR.

GSSoC 2026 Participation

-  a GSSoC 2026 contributor.
-GSSoC profile: https://gssoc.girlscript.org/profile/25fbcf55-c2fa-4ec9-b7c1-b6635cccd345

Screenshots / Recordings (UI changes)

N/A

Notes for the Reviewer

Added validation for the "--threshold" argument to ensure only valid non-negative numeric values are accepted. Invalid inputs now produce a clear error message and terminate execution before benchmark comparison begins.