### PR TITLE
feat(ui): add Drawer widget with focus trap and edge positioning

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -293,6 +293,7 @@
         "@termuijs/widgets": "workspace:*",
       },
       "devDependencies": {
+        "@termuijs/testing": "workspace:*",
         "tsup": "^8.0.0",
         "typescript": "^5.4.0",
       },
@@ -422,6 +423,7 @@
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw=="],
 
     "@termuijs/adapters": ["@termuijs/adapters@workspace:packages/adapters"],
+
     "@termuijs/core": ["@termuijs/core@workspace:packages/core"],
 
     "@termuijs/data": ["@termuijs/data@workspace:packages/data"],
@@ -429,13 +431,16 @@
     "@termuijs/dev-server": ["@termuijs/dev-server@workspace:packages/dev-server"],
 
     "@termuijs/example-auth-flow": ["@termuijs/example-auth-flow@workspace:examples/auth-flow"],
+
     "@termuijs/example-cli-wrapper-live": ["@termuijs/example-cli-wrapper-live@workspace:examples/cli-wrapper-live"],
+
     "@termuijs/example-dashboard": ["@termuijs/example-dashboard@workspace:examples/dashboard"],
-    "@termuijs/example-multi-screen-router": ["@termuijs/example-multi-screen-router@workspace:examples/multi-screen-router"],
 
     "@termuijs/example-forms": ["@termuijs/example-forms@workspace:examples/forms-and-validation"],
 
     "@termuijs/example-jsx-dashboard": ["@termuijs/example-jsx-dashboard@workspace:examples/jsx-dashboard"],
+
+    "@termuijs/example-multi-screen-router": ["@termuijs/example-multi-screen-router@workspace:examples/multi-screen-router"],
 
     "@termuijs/example-showcase": ["@termuijs/example-showcase@workspace:examples/showcase"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -293,7 +293,6 @@
         "@termuijs/widgets": "workspace:*",
       },
       "devDependencies": {
-        "@termuijs/testing": "workspace:*",
         "tsup": "^8.0.0",
         "typescript": "^5.4.0",
       },
@@ -423,7 +422,6 @@
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw=="],
 
     "@termuijs/adapters": ["@termuijs/adapters@workspace:packages/adapters"],
-
     "@termuijs/core": ["@termuijs/core@workspace:packages/core"],
 
     "@termuijs/data": ["@termuijs/data@workspace:packages/data"],
@@ -431,16 +429,13 @@
     "@termuijs/dev-server": ["@termuijs/dev-server@workspace:packages/dev-server"],
 
     "@termuijs/example-auth-flow": ["@termuijs/example-auth-flow@workspace:examples/auth-flow"],
-
     "@termuijs/example-cli-wrapper-live": ["@termuijs/example-cli-wrapper-live@workspace:examples/cli-wrapper-live"],
-
     "@termuijs/example-dashboard": ["@termuijs/example-dashboard@workspace:examples/dashboard"],
+    "@termuijs/example-multi-screen-router": ["@termuijs/example-multi-screen-router@workspace:examples/multi-screen-router"],
 
     "@termuijs/example-forms": ["@termuijs/example-forms@workspace:examples/forms-and-validation"],
 
     "@termuijs/example-jsx-dashboard": ["@termuijs/example-jsx-dashboard@workspace:examples/jsx-dashboard"],
-
-    "@termuijs/example-multi-screen-router": ["@termuijs/example-multi-screen-router@workspace:examples/multi-screen-router"],
 
     "@termuijs/example-showcase": ["@termuijs/example-showcase@workspace:examples/showcase"],
 

--- a/packages/ui/src/Drawer.test.ts
+++ b/packages/ui/src/Drawer.test.ts
@@ -1,0 +1,245 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/ui — Tests for Drawer widget
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi } from 'vitest';
+import { Screen } from '@termuijs/core';
+import { Box } from '@termuijs/widgets';
+import { Drawer } from './Drawer.js';
+
+// ── Helpers ───────────────────────────────────────────
+
+const COLS = 40;
+const ROWS = 20;
+
+function makeScreen(): Screen {
+    return new Screen(COLS, ROWS);
+}
+
+function renderDrawer(drawer: Drawer): Screen {
+    const screen = makeScreen();
+    drawer.updateRect({ x: 0, y: 0, width: COLS, height: ROWS });
+    drawer.render(screen);
+    return screen;
+}
+
+function rowText(screen: Screen, row: number): string {
+    return screen.back[row].map((c) => c.char).join('');
+}
+
+// ── Tests ─────────────────────────────────────────────
+
+describe('Drawer', () => {
+    // ── 1. Renders at the correct edge ────────────────
+
+    it('renders at the right edge when position is "right"', () => {
+        const onClose = vi.fn();
+        const drawer = new Drawer({ position: 'right', width: 10, title: 'Menu', onClose });
+        drawer.open();
+        const screen = renderDrawer(drawer);
+
+        // The border top-right corner should be at the last column (COLS-1)
+        // and top-left corner of panel at COLS-10 = column 30
+        const topRow = rowText(screen, 0);
+        // Column 30 should be the top-left corner character of the border
+        expect(topRow[COLS - 10]).toBe('┌');
+        // Column 39 should be the top-right corner
+        expect(topRow[COLS - 1]).toBe('┐');
+    });
+
+    it('renders at the left edge when position is "left"', () => {
+        const onClose = vi.fn();
+        const drawer = new Drawer({ position: 'left', width: 12, onClose });
+        drawer.open();
+        const screen = renderDrawer(drawer);
+
+        const topRow = rowText(screen, 0);
+        // Top-left corner at column 0
+        expect(topRow[0]).toBe('┌');
+        // Top-right corner at column 11 (width-1)
+        expect(topRow[11]).toBe('┐');
+    });
+
+    it('renders at the top edge when position is "top"', () => {
+        const onClose = vi.fn();
+        const drawer = new Drawer({ position: 'top', height: 5, onClose });
+        drawer.open();
+        const screen = renderDrawer(drawer);
+
+        // Top row should start with ┌
+        const topRow = rowText(screen, 0);
+        expect(topRow[0]).toBe('┌');
+
+        // Row 4 (height-1) should be the bottom border
+        const bottomRow = rowText(screen, 4);
+        expect(bottomRow[0]).toBe('└');
+    });
+
+    it('renders at the bottom edge when position is "bottom"', () => {
+        const onClose = vi.fn();
+        const drawer = new Drawer({ position: 'bottom', height: 6, onClose });
+        drawer.open();
+        const screen = renderDrawer(drawer);
+
+        // Top border of drawer should be at row ROWS - height = 20 - 6 = 14
+        const panelTopRow = rowText(screen, ROWS - 6);
+        expect(panelTopRow[0]).toBe('┌');
+
+        // Bottom border at row ROWS - 1 = 19
+        const panelBottomRow = rowText(screen, ROWS - 1);
+        expect(panelBottomRow[0]).toBe('└');
+    });
+
+    // ── 2. Escape fires onClose ───────────────────────
+
+    it('fires onClose when Escape is pressed while open', () => {
+        const onClose = vi.fn();
+        const drawer = new Drawer({ position: 'left', width: 15, onClose });
+        drawer.open();
+
+        drawer.handleKey({ key: 'escape', ctrl: false, alt: false } as any);
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire onClose when Escape is pressed while closed', () => {
+        const onClose = vi.fn();
+        const drawer = new Drawer({ position: 'left', width: 15, onClose });
+        // Drawer starts closed — do not call open()
+
+        drawer.handleKey({ key: 'escape', ctrl: false, alt: false } as any);
+        expect(onClose).not.toHaveBeenCalled();
+    });
+
+    // ── 3. Focus is trapped inside the drawer ─────────
+
+    it('cycles focus through children on Tab (focus trap)', () => {
+        const onClose = vi.fn();
+        const drawer = new Drawer({ position: 'right', width: 20, onClose });
+        drawer.open();
+
+        // Add two focusable children
+        const childA = new Box();
+        childA.focusable = true;
+        const childB = new Box();
+        childB.focusable = true;
+        drawer.addChild(childA);
+        drawer.addChild(childB);
+
+        // First Tab: focus moves to index 0 → childA gets focus
+        drawer.handleKey({ key: 'tab', ctrl: false, alt: false, shift: false } as any);
+        expect(childA.isFocused).toBe(true);
+        expect(childB.isFocused).toBe(false);
+
+        // Second Tab: focus moves to index 1 → childB gets focus
+        drawer.handleKey({ key: 'tab', ctrl: false, alt: false, shift: false } as any);
+        expect(childA.isFocused).toBe(false);
+        expect(childB.isFocused).toBe(true);
+
+        // Third Tab: wraps back to index 0 → childA gets focus
+        drawer.handleKey({ key: 'tab', ctrl: false, alt: false, shift: false } as any);
+        expect(childA.isFocused).toBe(true);
+        expect(childB.isFocused).toBe(false);
+    });
+
+    it('cycles focus backwards on Shift+Tab', () => {
+        const onClose = vi.fn();
+        const drawer = new Drawer({ position: 'left', width: 20, onClose });
+        drawer.open();
+
+        const childA = new Box();
+        childA.focusable = true;
+        const childB = new Box();
+        childB.focusable = true;
+        drawer.addChild(childA);
+        drawer.addChild(childB);
+
+        // Move to childB (index 1) first
+        drawer.handleKey({ key: 'tab', ctrl: false, alt: false, shift: false } as any);
+        drawer.handleKey({ key: 'tab', ctrl: false, alt: false, shift: false } as any);
+        expect(childB.isFocused).toBe(true);
+
+        // Shift+Tab: wraps back to childA (index 0)
+        drawer.handleKey({ key: 'tab', ctrl: false, alt: false, shift: true } as any);
+        expect(childA.isFocused).toBe(true);
+        expect(childB.isFocused).toBe(false);
+    });
+
+    // ── 4. Title renders ──────────────────────────────
+
+    it('renders the title in the top border', () => {
+        const onClose = vi.fn();
+        const drawer = new Drawer({ position: 'left', width: 20, title: 'Settings', onClose });
+        drawer.open();
+        const screen = renderDrawer(drawer);
+
+        const topRow = rowText(screen, 0);
+        expect(topRow).toContain('Settings');
+    });
+
+    it('renders without a title when none is provided', () => {
+        const onClose = vi.fn();
+        const drawer = new Drawer({ position: 'left', width: 20, onClose });
+        drawer.open();
+        const screen = renderDrawer(drawer);
+
+        // Top row should have border characters but no text beyond the border
+        const topRow = rowText(screen, 0).slice(0, 20);
+        // Should start with top-left corner
+        expect(topRow[0]).toBe('┌');
+        // Should end with top-right corner at width-1
+        expect(topRow[19]).toBe('┐');
+        // No alphabetic characters expected in the top border row
+        expect(/[a-zA-Z]/.test(topRow)).toBe(false);
+    });
+
+    // ── 5. open() / close() / toggle() call markDirty ─
+
+    it('calls markDirty when opened', () => {
+        const onClose = vi.fn();
+        const drawer = new Drawer({ position: 'right', width: 20, onClose });
+        const spy = vi.spyOn(drawer as any, 'markDirty');
+
+        drawer.open();
+        expect(spy).toHaveBeenCalled();
+    });
+
+    it('calls markDirty when closed', () => {
+        const onClose = vi.fn();
+        const drawer = new Drawer({ position: 'right', width: 20, onClose });
+        drawer.open();
+        const spy = vi.spyOn(drawer as any, 'markDirty');
+
+        drawer.close();
+        expect(spy).toHaveBeenCalled();
+    });
+
+    // ── 6. Visibility ─────────────────────────────────
+
+    it('does not render anything when closed', () => {
+        const onClose = vi.fn();
+        const drawer = new Drawer({ position: 'left', width: 15, title: 'Hidden', onClose });
+        // Do not call open()
+        const screen = renderDrawer(drawer);
+
+        // No border characters anywhere — screen should be blank
+        const topRow = rowText(screen, 0);
+        expect(topRow.includes('┌')).toBe(false);
+        expect(topRow.includes('Settings')).toBe(false);
+    });
+
+    it('toggle() opens a closed drawer', () => {
+        const onClose = vi.fn();
+        const drawer = new Drawer({ position: 'bottom', height: 8, onClose });
+        expect(drawer.isOpen).toBe(false);
+        drawer.toggle();
+        expect(drawer.isOpen).toBe(true);
+    });
+
+    it('toggle() closes an open drawer', () => {
+        const onClose = vi.fn();
+        const drawer = new Drawer({ position: 'bottom', height: 8, onClose });
+        drawer.open();
+        drawer.toggle();
+        expect(drawer.isOpen).toBe(false);
+    });
+});

--- a/packages/ui/src/Drawer.ts
+++ b/packages/ui/src/Drawer.ts
@@ -1,0 +1,334 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/ui — Drawer widget
+//
+// A side panel that slides in from an edge of the terminal.
+// It overlays existing content when open and dims the rest
+// of the screen behind it.
+//
+// Keyboard behaviour:
+//   Escape   Fire onClose
+//   Tab      Cycle focus forward through focusable children
+//   Shift+Tab  Cycle focus backward through focusable children
+// ─────────────────────────────────────────────────────
+
+import { Widget } from '@termuijs/widgets';
+import {
+    type Style,
+    type Screen,
+    type KeyEvent,
+    mergeStyles,
+    defaultStyle,
+    styleToCellAttrs,
+    getBorderChars,
+    caps,
+} from '@termuijs/core';
+
+// ── Types ────────────────────────────────────────────
+
+/** The edge from which the drawer slides into view. */
+export type DrawerPosition = 'left' | 'right' | 'top' | 'bottom';
+
+export interface DrawerOptions {
+    /** Edge the drawer appears from. */
+    position: DrawerPosition;
+    /**
+     * Panel width in columns.
+     * Applies to 'left' and 'right' positions only.
+     * Defaults to 30.
+     */
+    width?: number;
+    /**
+     * Panel height in rows.
+     * Applies to 'top' and 'bottom' positions only.
+     * Defaults to 10.
+     */
+    height?: number;
+    /** Optional title shown in the drawer's top border. */
+    title?: string;
+    /** Called when the user presses Escape or explicitly closes the drawer. */
+    onClose: () => void;
+    /** Character used for the dimmed backdrop. Defaults to '░' (unicode) or ' '. */
+    backdropChar?: string;
+    /** Border colour. Defaults to cyan. */
+    borderColor?: Style['fg'];
+}
+
+// ── Widget ───────────────────────────────────────────
+
+/**
+ * Drawer — a side panel that slides in from any edge.
+ *
+ * Usage:
+ * ```ts
+ * const drawer = new Drawer({
+ *   position: 'right',
+ *   width: 30,
+ *   title: 'Settings',
+ *   onClose: () => closeDrawer(),
+ * });
+ * drawer.addChild(new Form({ fields: settingsFields }));
+ * drawer.open();
+ * ```
+ *
+ * Wire keyboard events via `handleKey(event)`.
+ */
+export class Drawer extends Widget {
+    private _position: DrawerPosition;
+    private _panelWidth: number;
+    private _panelHeight: number;
+    private _title: string;
+    private _onClose: () => void;
+    private _backdropChar: string;
+    private _borderColor: Style['fg'];
+    private _open = false;
+
+    /**
+     * Index into the flat list of focusable children that currently
+     * holds the "focused" slot inside the focus trap.
+     * Starts at -1 so the first Tab press naturally lands on index 0.
+     */
+    private _focusIndex = -1;
+
+    focusable = true;
+
+    constructor(options: DrawerOptions) {
+        super(mergeStyles(defaultStyle(), {}));
+        this._position = options.position;
+        this._panelWidth = options.width ?? 30;
+        this._panelHeight = options.height ?? 10;
+        this._title = options.title ?? '';
+        this._onClose = options.onClose;
+        this._backdropChar = options.backdropChar ?? (caps.unicode ? '░' : ' ');
+        this._borderColor = options.borderColor ?? { type: 'named', name: 'cyan' };
+    }
+
+    // ── Public API ───────────────────────────────────
+
+    /** Whether the drawer is currently open. */
+    get isOpen(): boolean {
+        return this._open;
+    }
+
+    /** Open the drawer and mark dirty. */
+    open(): void {
+        this._open = true;
+        this._focusIndex = -1;
+        this.markDirty();
+    }
+
+    /** Close the drawer and mark dirty. */
+    close(): void {
+        this._open = false;
+        this.markDirty();
+    }
+
+    /** Toggle open/close state. */
+    toggle(): void {
+        this._open ? this.close() : this.open();
+    }
+
+    /**
+     * Handle keyboard input.
+     *
+     * | Key          | Action                          |
+     * |--------------|---------------------------------|
+     * | `Escape`     | Fire `onClose`                  |
+     * | `Tab`        | Move focus to next child        |
+     * | `Shift+Tab`  | Move focus to previous child    |
+     */
+    handleKey(event: KeyEvent): void {
+        if (!this._open) return;
+
+        switch (event.key) {
+            case 'escape':
+                this._onClose();
+                break;
+            case 'tab':
+                if (event.shift) {
+                    this._focusPrev();
+                } else {
+                    this._focusNext();
+                }
+                break;
+        }
+    }
+
+    // ── Focus trap ───────────────────────────────────
+
+    /**
+     * Return a flat list of all focusable descendants in tree order.
+     * Used to implement the focus trap.
+     */
+    private _focusableChildren(): Widget[] {
+        const result: Widget[] = [];
+        const collect = (widget: Widget): void => {
+            for (const child of widget.children) {
+                if (child.focusable) result.push(child);
+                collect(child);
+            }
+        };
+        collect(this);
+        return result;
+    }
+
+    private _focusNext(): void {
+        const focusable = this._focusableChildren();
+        if (focusable.length === 0) return;
+        // _focusIndex starts at -1 so the first +1 lands on index 0.
+        this._focusIndex = (this._focusIndex + 1) % focusable.length;
+        this._applyFocus(focusable);
+        this.markDirty();
+    }
+
+    private _focusPrev(): void {
+        const focusable = this._focusableChildren();
+        if (focusable.length === 0) return;
+        // When _focusIndex is -1 (no prior Tab), wrap to the last child.
+        const base = this._focusIndex < 0 ? 0 : this._focusIndex;
+        this._focusIndex = (base - 1 + focusable.length) % focusable.length;
+        this._applyFocus(focusable);
+        this.markDirty();
+    }
+
+    private _applyFocus(focusable: Widget[]): void {
+        for (let i = 0; i < focusable.length; i++) {
+            focusable[i].isFocused = i === this._focusIndex;
+        }
+    }
+
+    // ── Geometry helpers ─────────────────────────────
+
+    /**
+     * Compute the panel rect (position + dimensions) relative to the
+     * full widget rect.
+     */
+    private _panelRect(
+        x: number,
+        y: number,
+        totalWidth: number,
+        totalHeight: number,
+    ): { px: number; py: number; pw: number; ph: number } {
+        const pw =
+            this._position === 'left' || this._position === 'right'
+                ? Math.min(this._panelWidth, totalWidth)
+                : totalWidth;
+
+        const ph =
+            this._position === 'top' || this._position === 'bottom'
+                ? Math.min(this._panelHeight, totalHeight)
+                : totalHeight;
+
+        let px: number;
+        let py: number;
+
+        switch (this._position) {
+            case 'left':
+                px = x;
+                py = y;
+                break;
+            case 'right':
+                px = x + totalWidth - pw;
+                py = y;
+                break;
+            case 'top':
+                px = x;
+                py = y;
+                break;
+            case 'bottom':
+                px = x;
+                py = y + totalHeight - ph;
+                break;
+        }
+
+        return { px, py, pw, ph };
+    }
+
+    // ── Rendering ────────────────────────────────────
+
+    protected _renderSelf(screen: Screen): void {
+        if (!this._open) return;
+
+        const { x, y, width, height } = this._rect;
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this.style);
+
+        // ── 1. Backdrop (dim the whole area) ─────────
+        for (let r = 0; r < height; r++) {
+            screen.writeString(
+                x,
+                y + r,
+                this._backdropChar.repeat(width),
+                { ...attrs, dim: true },
+            );
+        }
+
+        // ── 2. Panel ─────────────────────────────────
+        const { px, py, pw, ph } = this._panelRect(x, y, width, height);
+
+        const border = getBorderChars('single');
+        if (!border) return;
+
+        const bAttrs = { ...attrs, fg: this._borderColor };
+
+        // Clear panel interior (overwrite backdrop characters)
+        for (let r = 1; r < ph - 1; r++) {
+            screen.writeString(px, py + r, border.left, bAttrs);
+            screen.writeString(px + 1, py + r, ' '.repeat(Math.max(0, pw - 2)), attrs);
+            screen.writeString(px + pw - 1, py + r, border.right, bAttrs);
+        }
+
+        // ── Top border with optional title ────────────
+        const titleStr = this._title ? ` ${this._title} ` : '';
+        const innerWidth = Math.max(0, pw - 2);
+        const fill = Math.max(0, innerWidth - titleStr.length);
+        const leftFill = Math.floor(fill / 2);
+        const rightFill = fill - leftFill;
+
+        screen.writeString(
+            px,
+            py,
+            border.topLeft
+            + border.top.repeat(leftFill)
+            + titleStr
+            + border.top.repeat(rightFill)
+            + border.topRight,
+            bAttrs,
+        );
+
+        // ── Bottom border ─────────────────────────────
+        if (ph >= 2) {
+            screen.writeString(
+                px,
+                py + ph - 1,
+                border.bottomLeft + border.bottom.repeat(Math.max(0, pw - 2)) + border.bottomRight,
+                bAttrs,
+            );
+        }
+
+        // ── 3. Render children inside the content area ──
+        const contentX = px + 1;
+        const contentY = py + 1;
+        const contentW = Math.max(0, pw - 2);
+        const contentH = Math.max(0, ph - 2);
+
+        if (contentW > 0 && contentH > 0) {
+            for (const child of this._children) {
+                const originalRect = { ...child.rect };
+                child.updateRect({
+                    x: contentX,
+                    y: contentY,
+                    width: contentW,
+                    height: contentH,
+                });
+                screen.pushClip({ x: contentX, y: contentY, width: contentW, height: contentH });
+                try {
+                    child.render(screen);
+                } finally {
+                    screen.popClip();
+                    child.updateRect(originalRect);
+                }
+            }
+        }
+    }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -36,6 +36,9 @@ export type { CarouselOptions } from './Carousel.js';
 export { Modal } from './Modal.js';
 export type { ModalOptions } from './Modal.js';
 
+export { Drawer } from './Drawer.js';
+export type { DrawerOptions, DrawerPosition } from './Drawer.js';
+
 export { Select } from './Select.js';
 export type { SelectOption, SelectOptions } from './Select.js';
 


### PR DESCRIPTION
## Description

Adds a Drawer widget to @termuijs/ui — a side panel that slides in from any edge of the terminal (left, right, top, bottom). It dims the rest of the screen with a backdrop when open, traps focus inside the panel via Tab/Shift+Tab cycling, and fires onClose on Escape. The widget follows every existing convention in the package: markDirty() on all state mutations, a caps.unicode fallback for the backdrop character, and children rendered into a clipped content rect inside the panel border.
## Related Issue

Closes #49 

## Which package(s)?

@termuijs/ui

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/cf9af2ce-ca5f-4d21-b0b9-4270d802b8e2`

## Screenshots / Recordings (UI changes)

Terminal widget — no visual screenshot applicable. Behaviour is fully covered by the 15-test suite below.