### PR TITLE
feat(testing): add createVirtualClock() for synchronous timer tests

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -264,6 +264,7 @@
       "dependencies": {
         "@termuijs/core": "workspace:*",
         "@termuijs/jsx": "workspace:*",
+        "@termuijs/motion": "workspace:*",
         "@termuijs/widgets": "workspace:*",
       },
       "devDependencies": {
@@ -293,6 +294,7 @@
         "@termuijs/widgets": "workspace:*",
       },
       "devDependencies": {
+        "@termuijs/testing": "workspace:*",
         "tsup": "^8.0.0",
         "typescript": "^5.4.0",
       },
@@ -436,6 +438,8 @@
     "@termuijs/example-forms": ["@termuijs/example-forms@workspace:examples/forms-and-validation"],
 
     "@termuijs/example-jsx-dashboard": ["@termuijs/example-jsx-dashboard@workspace:examples/jsx-dashboard"],
+
+    "@termuijs/example-multi-screen-router": ["@termuijs/example-multi-screen-router@workspace:examples/multi-screen-router"],
 
     "@termuijs/example-showcase": ["@termuijs/example-showcase@workspace:examples/showcase"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -264,7 +264,6 @@
       "dependencies": {
         "@termuijs/core": "workspace:*",
         "@termuijs/jsx": "workspace:*",
-        "@termuijs/motion": "workspace:*",
         "@termuijs/widgets": "workspace:*",
       },
       "devDependencies": {
@@ -294,7 +293,6 @@
         "@termuijs/widgets": "workspace:*",
       },
       "devDependencies": {
-        "@termuijs/testing": "workspace:*",
         "tsup": "^8.0.0",
         "typescript": "^5.4.0",
       },
@@ -438,8 +436,6 @@
     "@termuijs/example-forms": ["@termuijs/example-forms@workspace:examples/forms-and-validation"],
 
     "@termuijs/example-jsx-dashboard": ["@termuijs/example-jsx-dashboard@workspace:examples/jsx-dashboard"],
-
-    "@termuijs/example-multi-screen-router": ["@termuijs/example-multi-screen-router@workspace:examples/multi-screen-router"],
 
     "@termuijs/example-showcase": ["@termuijs/example-showcase@workspace:examples/showcase"],
 

--- a/packages/motion/src/index.ts
+++ b/packages/motion/src/index.ts
@@ -18,5 +18,6 @@ export type { AnimationRunner } from './sequence.js';
 export { subscribe as timerPoolSubscribe, unsubscribeAll as timerPoolUnsubscribeAll } from './timer-pool.js';
 export * from './keyframes.js';
 
-
+// Virtual clock (for tests)
+export type { VirtualClock } from './virtual-clock.js';
 

--- a/packages/motion/src/timer-pool.ts
+++ b/packages/motion/src/timer-pool.ts
@@ -4,9 +4,15 @@
 // One setInterval per unique delayMs, shared across all
 // subscribers. Reduces OS timer pressure when many
 // widgets poll at the same interval.
+//
+// Tests can inject a VirtualClock to drive subscribers
+// synchronously. See `virtual-clock.ts`.
 // ─────────────────────────────────────────────────────
 
+import type { VirtualClock } from './virtual-clock.js';
+
 const pool = new Map<number, { id: ReturnType<typeof setInterval>; subs: Set<() => void> }>();
+let virtualClock: VirtualClock | null = null;
 
 /**
  * Subscribe a callback to a shared interval at `delayMs`.
@@ -14,13 +20,54 @@ const pool = new Map<number, { id: ReturnType<typeof setInterval>; subs: Set<() 
  * is created on the first subscriber and cleared automatically
  * when the last subscriber unsubscribes.
  *
+ * Pass a `VirtualClock` instead to drive subscribers from
+ * in-memory time. Existing real-time intervals are cleared
+ * when a clock is injected. The returned function detaches
+ * the clock and re-enables the real timer pool.
+ *
  * ```ts
  * const unsub = subscribe(1000, () => console.log('tick'));
  * // later:
  * unsub();
+ *
+ * // Or, in tests:
+ * const clock = createVirtualClock();
+ * const restore = subscribe(clock);
+ * clock.advance(1000); // fires every due subscriber
+ * restore();           // back to real timers
  * ```
  */
-export function subscribe(delayMs: number, cb: () => void): () => void {
+export function subscribe(clock: VirtualClock): () => void;
+export function subscribe(delayMs: number, cb: () => void): () => void;
+export function subscribe(...args: unknown[]): () => void {
+    const [first, second] = args;
+
+    // Overload 2: VirtualClock injection.
+    if (typeof first === 'object' && first !== null && 'advance' in (first as object)) {
+        const clock = first as VirtualClock;
+        // Clear any real timers; the clock takes over.
+        for (const entry of pool.values()) {
+            clearInterval(entry.id);
+        }
+        pool.clear();
+        virtualClock = clock;
+        return () => {
+            if (virtualClock === clock) {
+                virtualClock = null;
+            }
+        };
+    }
+
+    // Overload 1: periodic callback. Route to the clock if one is active.
+    if (virtualClock) {
+        const delayMs = first as number;
+        const cb = second as () => void;
+        return virtualClock._setInterval(delayMs, cb);
+    }
+
+    // Default: real setInterval.
+    const delayMs = first as number;
+    const cb = second as () => void;
     if (!pool.has(delayMs)) {
         const subs = new Set<() => void>();
         const id = setInterval(() => {
@@ -42,12 +89,14 @@ export function subscribe(delayMs: number, cb: () => void): () => void {
 }
 
 /**
- * Drain the entire pool — clears all active intervals and removes all
- * subscribers. Useful in test teardown to prevent timer leaks.
+ * Drain the entire pool — clears all active intervals, removes all
+ * subscribers, and detaches any injected virtual clock. Useful in
+ * test teardown to prevent timer leaks between cases.
  */
 export function unsubscribeAll(): void {
     for (const entry of pool.values()) {
         clearInterval(entry.id);
     }
     pool.clear();
+    virtualClock = null;
 }

--- a/packages/motion/src/virtual-clock.ts
+++ b/packages/motion/src/virtual-clock.ts
@@ -1,0 +1,57 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/motion — Virtual Clock Interface
+//
+// A clock abstraction used by tests to advance time
+// synchronously without real sleeps. Pairs with the
+// shared interval timer pool in `timer-pool.ts`.
+// ─────────────────────────────────────────────────────
+
+/**
+ * A virtual clock that tracks elapsed milliseconds in
+ * software instead of relying on `setInterval`/`setTimeout`.
+ *
+ * Tests inject an instance into the motion timer pool
+ * via `timerPoolSubscribe(clock)`. From that point on,
+ * any subscriber added through `timerPoolSubscribe(delayMs, cb)`
+ * is driven by the clock instead of real wall-clock time.
+ *
+ * ```ts
+ * import { createVirtualClock } from '@termuijs/testing';
+ * import { timerPoolSubscribe } from '@termuijs/motion';
+ *
+ * const clock = createVirtualClock();
+ * timerPoolSubscribe(clock);
+ *
+ * clock.advance(500); // fires every timer due within 500ms
+ * clock.now();        // 500
+ * ```
+ */
+export interface VirtualClock {
+    /** Current virtual time in milliseconds since the clock started. */
+    now(): number;
+
+    /**
+     * Advance virtual time by `ms` milliseconds and fire every
+     * periodic and one-shot timer whose deadline falls within the
+     * new window. Runs synchronously — no real waiting.
+     *
+     * Negative values are ignored. A value of `0` fires timers
+     * that were already due at the current time.
+     */
+    advance(ms: number): void;
+
+    /**
+     * Advance virtual time by one frame (16ms). Convenience
+     * shorthand for animation tests that step frame-by-frame.
+     */
+    tick(): void;
+
+    /**
+     * Register a periodic timer that fires every `delayMs` of
+     * virtual time. Returns an unsubscribe function. The timer
+     * pool calls this internally once a clock is injected.
+     *
+     * @internal
+     */
+    _setInterval(delayMs: number, cb: () => void): () => void;
+}

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -31,7 +31,8 @@
   "dependencies": {
     "@termuijs/core": "workspace:*",
     "@termuijs/widgets": "workspace:*",
-    "@termuijs/jsx": "workspace:*"
+    "@termuijs/jsx": "workspace:*",
+    "@termuijs/motion": "workspace:*"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -5,3 +5,7 @@
 // ── Render ──
 export { render } from './render.js';
 export type { TestInstance, TestRenderOptions } from './render.js';
+
+// ── Virtual Clock ──
+export { createVirtualClock } from './virtual-clock.js';
+export type { VirtualClock } from '@termuijs/motion';

--- a/packages/testing/src/virtual-clock.test.ts
+++ b/packages/testing/src/virtual-clock.test.ts
@@ -1,0 +1,180 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/testing — Tests for createVirtualClock()
+//
+// Covers the clock in isolation and its integration
+// with the motion timer pool.
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { createVirtualClock } from './virtual-clock.js';
+import { timerPoolSubscribe, timerPoolUnsubscribeAll } from '@termuijs/motion';
+
+afterEach(() => {
+    // Always detach the clock between tests so nothing leaks.
+    timerPoolUnsubscribeAll();
+    vi.useRealTimers();
+});
+
+describe('createVirtualClock', () => {
+    it('starts at 0', () => {
+        const clock = createVirtualClock();
+        expect(clock.now()).toBe(0);
+    });
+
+    it('advance(ms) moves now() forward by ms', () => {
+        const clock = createVirtualClock();
+        clock.advance(250);
+        expect(clock.now()).toBe(250);
+
+        clock.advance(750);
+        expect(clock.now()).toBe(1000);
+    });
+
+    it('tick() advances by one 16ms frame', () => {
+        const clock = createVirtualClock();
+        clock.tick();
+        expect(clock.now()).toBe(16);
+        clock.tick();
+        clock.tick();
+        expect(clock.now()).toBe(48);
+    });
+
+    it('negative advance is a no-op', () => {
+        const clock = createVirtualClock();
+        clock.advance(100);
+        clock.advance(-50);
+        expect(clock.now()).toBe(100);
+    });
+});
+
+describe('createVirtualClock — periodic timers', () => {
+    it('fires a registered interval once per delayMs', () => {
+        const clock = createVirtualClock();
+        const calls: number[] = [];
+        clock._setInterval(50, () => calls.push(clock.now()));
+
+        clock.advance(200);
+        expect(calls).toEqual([50, 100, 150, 200]);
+    });
+
+    it('does not fire when advance is shorter than delayMs', () => {
+        const clock = createVirtualClock();
+        const cb = vi.fn();
+        clock._setInterval(100, cb);
+
+        clock.advance(99);
+        expect(cb).not.toHaveBeenCalled();
+
+        clock.advance(1);
+        expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it('multiple intervals share the same clock', () => {
+        const clock = createVirtualClock();
+        const fast: number[] = [];
+        const slow: number[] = [];
+        clock._setInterval(25, () => fast.push(clock.now()));
+        clock._setInterval(100, () => slow.push(clock.now()));
+
+        clock.advance(200);
+
+        expect(fast).toEqual([25, 50, 75, 100, 125, 150, 175, 200]);
+        expect(slow).toEqual([100, 200]);
+    });
+
+    it('unsubscribe stops further fires', () => {
+        const clock = createVirtualClock();
+        const cb = vi.fn();
+        const unsub = clock._setInterval(50, cb);
+
+        clock.advance(100);
+        expect(cb).toHaveBeenCalledTimes(2);
+
+        unsub();
+        clock.advance(100);
+        expect(cb).toHaveBeenCalledTimes(2);
+    });
+
+    it('runs many fires in a single advance() in under 50ms wall time', () => {
+        const clock = createVirtualClock();
+        let count = 0;
+        clock._setInterval(16, () => { count++; });
+
+        const start = Date.now();
+        clock.advance(2000);
+        const elapsed = Date.now() - start;
+
+        expect(count).toBe(125); // 2000 / 16
+        expect(elapsed).toBeLessThan(50);
+    });
+});
+
+describe('createVirtualClock — integration with timer pool', () => {
+    it('a usage example: drives a timer pool subscriber synchronously', () => {
+        // This is the canonical example from the issue spec.
+        const clock = createVirtualClock();
+        timerPoolSubscribe(clock);
+
+        const seen: number[] = [];
+        timerPoolSubscribe(100, () => seen.push(clock.now()));
+
+        clock.advance(500);
+        timerPoolUnsubscribeAll();
+
+        expect(seen).toEqual([100, 200, 300, 400, 500]);
+    });
+
+    it('unsubscribeAll() detaches the clock so real timers are not used', () => {
+        const clock = createVirtualClock();
+        timerPoolSubscribe(clock);
+        timerPoolUnsubscribeAll();
+
+        // After detach, the clock should still work in isolation.
+        expect(clock.now()).toBe(0);
+        clock.advance(50);
+        expect(clock.now()).toBe(50);
+    });
+
+    it('re-injecting a new clock replaces the old one', () => {
+        const a = createVirtualClock();
+        const b = createVirtualClock();
+
+        timerPoolSubscribe(a);
+        const calls: string[] = [];
+        timerPoolSubscribe(50, () => calls.push(`a:${a.now()}`));
+
+        a.advance(100);
+        expect(calls).toEqual(['a:50', 'a:100']);
+
+        // Swap in clock b. Existing subscribers should follow the new clock.
+        timerPoolSubscribe(b);
+        timerPoolSubscribe(50, () => calls.push(`b:${b.now()}`));
+
+        b.advance(100);
+        timerPoolUnsubscribeAll();
+
+        expect(calls).toEqual([
+            'a:50', 'a:100',
+            'b:50', 'b:100',
+        ]);
+    });
+
+    it('a 2000ms animation sequence completes in under 50ms wall time', () => {
+        // Models the issue acceptance criteria: a long animation
+        // that would normally sleep finishes almost instantly.
+        const clock = createVirtualClock();
+        timerPoolSubscribe(clock);
+
+        let frames = 0;
+        timerPoolSubscribe(16, () => { frames++; });
+
+        const start = Date.now();
+        clock.advance(2000);
+        const elapsed = Date.now() - start;
+
+        timerPoolUnsubscribeAll();
+
+        expect(frames).toBe(125);
+        expect(elapsed).toBeLessThan(50);
+    });
+});

--- a/packages/testing/src/virtual-clock.ts
+++ b/packages/testing/src/virtual-clock.ts
@@ -1,0 +1,99 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/testing — Virtual Clock
+//
+// A wall-clock-free timer for tests. Tracks elapsed
+// milliseconds in software and fires subscribers on
+// demand. Pairs with `@termuijs/motion` timer pool so
+// animations and intervals can be advanced synchronously.
+// ─────────────────────────────────────────────────────
+
+import type { VirtualClock } from '@termuijs/motion';
+
+interface PeriodicTimer {
+    delayMs: number;
+    lastFiredAt: number;
+    cb: () => void;
+    cancelled: boolean;
+}
+
+/**
+ * Create a virtual clock. The returned object exposes
+ * `now()`, `advance(ms)`, and `tick()` for test code, plus
+ * an internal `_setInterval` used by the motion timer pool.
+ *
+ * Each clock instance owns its own time and its own queue
+ * of periodic timers. Two clocks do not interfere.
+ *
+ * ```ts
+ * import { createVirtualClock } from '@termuijs/testing';
+ * import { timerPoolSubscribe, timerPoolUnsubscribeAll } from '@termuijs/motion';
+ *
+ * const clock = createVirtualClock();
+ * timerPoolSubscribe(clock); // drive subscribers from the clock
+ *
+ * const ticks: number[] = [];
+ * timerPoolSubscribe(50, () => ticks.push(clock.now()));
+ *
+ * clock.advance(200); // synchronously fires the 50ms callback four times
+ *
+ * timerPoolUnsubscribeAll(); // clean up
+ * ```
+ */
+export function createVirtualClock(): VirtualClock {
+    let now = 0;
+    const periodics: PeriodicTimer[] = [];
+
+    function _setInterval(delayMs: number, cb: () => void): () => void {
+        const timer: PeriodicTimer = {
+            delayMs,
+            lastFiredAt: now,
+            cb,
+            cancelled: false,
+        };
+        periodics.push(timer);
+        return () => {
+            timer.cancelled = true;
+        };
+    }
+
+    function advance(ms: number): void {
+        if (ms < 0) return;
+        const target = now + ms;
+        drainAt(target);
+        now = target;
+    }
+
+    function drainAt(target: number): void {
+        // Snapshot existing timers. Callbacks that add new ones
+        // do not re-enter this loop in the same advance call;
+        // their timers fire on the next advance().
+        const snapshot = periodics.slice();
+
+        for (const t of snapshot) {
+            if (t.cancelled) continue;
+            while (!t.cancelled && target - t.lastFiredAt >= t.delayMs) {
+                t.lastFiredAt += t.delayMs;
+                // Make `now()` reflect the scheduled fire time so
+                // callbacks read a consistent timestamp.
+                now = t.lastFiredAt;
+                t.cb();
+            }
+        }
+
+        // Reap cancelled timers so the queue does not grow forever.
+        for (let i = periodics.length - 1; i >= 0; i--) {
+            if (periodics[i].cancelled) periodics.splice(i, 1);
+        }
+    }
+
+    function tick(): void {
+        advance(16);
+    }
+
+    return {
+        now: () => now,
+        advance,
+        tick,
+        _setInterval,
+    };
+}


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

<!-- What does this PR do? 1 to 3 sentences. -->
Adds `createVirtualClock()` to `@termuijs/testing`, plus a clock injection point on `@termuijs/motion`'s shared timer pool. Tests can drive periodic subscribers (Spinner, Skeleton, StreamingText, spring animations, etc.) with in-memory time via `clock.advance(ms)` instead of waiting on real `setInterval`.


## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #63

## Which package(s)?

<!-- Example: @termuijs/core, @termuijs/widgets, website. -->
**@termuijs/testing**

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [x] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [ x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/ffd28efb-18d5-4421-8b8e-7a4b5431fa83`

## Screenshots / Recordings (UI changes)

NA

## Notes for the Reviewer

- `VirtualClock` lives in `@termuijs/motion` (not `@termuijs/testing`) so the timer pool can use it without creating a circular import. `@termuijs/testing` re-exports the type.
- One new workspace dep: `@termuijs/motion: workspace:*` added to `@termuijs/testing`'s `dependencies`.
- No widgets, examples, or other packages were touched.
