### PR TITLE
feat(widgets): add Clock widget

### DIFF
--- a/packages/widgets/src/display/Clock.test.ts
+++ b/packages/widgets/src/display/Clock.test.ts
@@ -1,0 +1,118 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for Clock widget
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi } from 'vitest';
+import { Screen } from '@termuijs/core';
+import { Clock } from './Clock.js';
+
+describe('Clock', () => {
+    it('setTime(new Date("2026-06-02T14:30:45")) renders 14:30:45 in 24h mode', () => {
+        const clock = new Clock({ width: 50, height: 3 }, { use24Hour: true, showSeconds: true });
+        clock.setTime(new Date('2026-06-02T14:30:45'));
+
+        clock.updateRect({ x: 0, y: 0, width: 50, height: 3 });
+        const screen = new Screen(50, 3);
+        clock.render(screen);
+
+        const rows = screen.back.map(row => row.map(cell => cell.char).join(''));
+
+        // Assert that the screen does not contain 'PM' or 'AM' since it's 24h mode
+        expect(rows.some(row => row.includes('PM') || row.includes('AM'))).toBe(false);
+
+        // 14:30:45 has length 8. At 5 columns per digit, it should render up to column 39.
+        // Verify that there are non-empty characters inside columns 25-39.
+        const midRowSnippet = rows[1].slice(25, 40);
+        expect(midRowSnippet.trim().length).toBeGreaterThan(0);
+    });
+
+    it('showSeconds:false renders 14:30 and omits seconds', () => {
+        const clock = new Clock({ width: 50, height: 3 }, { use24Hour: true, showSeconds: false });
+        clock.setTime(new Date('2026-06-02T14:30:45'));
+
+        clock.updateRect({ x: 0, y: 0, width: 50, height: 3 });
+        const screen = new Screen(50, 3);
+        clock.render(screen);
+
+        const rows = screen.back.map(row => row.map(cell => cell.char).join(''));
+
+        // 14:30 has length 5. At 5 columns per digit, it should only render up to column 24.
+        // Columns 25 onwards should be completely empty/spaces.
+        for (const row of rows) {
+            const rightSnippet = row.slice(25);
+            expect(rightSnippet.trim()).toBe('');
+        }
+
+        // Verify there is visible content before column 24
+        expect(rows[1].slice(0, 24).trim().length).toBeGreaterThan(0);
+    });
+
+    it('use24Hour:false converts 14:30:45 to 2:30:45 PM', () => {
+        const clock = new Clock({ width: 50, height: 3 }, { use24Hour: false, showSeconds: true });
+        clock.setTime(new Date('2026-06-02T14:30:45'));
+
+        clock.updateRect({ x: 0, y: 0, width: 50, height: 3 });
+        const screen = new Screen(50, 3);
+        clock.render(screen);
+
+        const rows = screen.back.map(row => row.map(cell => cell.char).join(''));
+
+        // Assert that the 'PM' label is rendered on the screen (row 2)
+        expect(rows[2]).toContain('PM');
+
+        // 2:30:45 has length 7. PM should start exactly at index 35.
+        expect(rows[2].slice(35, 37)).toBe('PM');
+    });
+
+    it('use24Hour:false converts 09:15:30 to 9:15:30 AM', () => {
+        const clock = new Clock({ width: 50, height: 3 }, { use24Hour: false, showSeconds: true });
+        clock.setTime(new Date('2026-06-02T09:15:30'));
+
+        clock.updateRect({ x: 0, y: 0, width: 50, height: 3 });
+        const screen = new Screen(50, 3);
+        clock.render(screen);
+
+        const rows = screen.back.map(row => row.map(cell => cell.char).join(''));
+
+        // Assert that the 'AM' label is rendered on the screen (row 2)
+        expect(rows[2]).toContain('AM');
+
+        // 9:15:30 has length 7. AM should start exactly at index 35.
+        expect(rows[2].slice(35, 37)).toBe('AM');
+    });
+
+    it('use24Hour:false converts 00:05:10 to 12:05:10 AM', () => {
+        const clock = new Clock({ width: 50, height: 3 }, { use24Hour: false, showSeconds: true });
+        clock.setTime(new Date('2026-06-02T00:05:10'));
+
+        clock.updateRect({ x: 0, y: 0, width: 50, height: 3 });
+        const screen = new Screen(50, 3);
+        clock.render(screen);
+
+        const rows = screen.back.map(row => row.map(cell => cell.char).join(''));
+        expect(rows[2]).toContain('AM');
+        // 12:05:10 has length 8. AM should start exactly at index 40.
+        expect(rows[2].slice(40, 42)).toBe('AM');
+    });
+
+    it('use24Hour:false converts 12:05:10 to 12:05:10 PM', () => {
+        const clock = new Clock({ width: 50, height: 3 }, { use24Hour: false, showSeconds: true });
+        clock.setTime(new Date('2026-06-02T12:05:10'));
+
+        clock.updateRect({ x: 0, y: 0, width: 50, height: 3 });
+        const screen = new Screen(50, 3);
+        clock.render(screen);
+
+        const rows = screen.back.map(row => row.map(cell => cell.char).join(''));
+        expect(rows[2]).toContain('PM');
+        // 12:05:10 has length 8. PM should start exactly at index 40.
+        expect(rows[2].slice(40, 42)).toBe('PM');
+    });
+
+    it('setTime triggers markDirty()', () => {
+        const clock = new Clock({ width: 50, height: 3 });
+        const spy = vi.spyOn(clock, 'markDirty');
+        clock.setTime(new Date());
+        expect(spy).toHaveBeenCalled();
+    });
+});

--- a/packages/widgets/src/display/Clock.ts
+++ b/packages/widgets/src/display/Clock.ts
@@ -1,0 +1,87 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Clock widget
+// ─────────────────────────────────────────────────────
+
+import { type Screen, type Style, type Color, styleToCellAttrs } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+import { Digits } from './Digits.js';
+
+export interface ClockOptions {
+    showSeconds?: boolean;
+    use24Hour?: boolean;
+    digitColor?: Color;
+}
+
+export class Clock extends Widget {
+    private _showSeconds: boolean;
+    private _use24Hour: boolean;
+    private _digits: Digits;
+    private _digitColor: Color;
+    private _ampm: string = '';
+    private _digitPartLength: number = 0;
+
+    constructor(style: Partial<Style> = {}, opts: ClockOptions = {}) {
+        super(style);
+        this._showSeconds = opts.showSeconds ?? true;
+        this._use24Hour = opts.use24Hour ?? true;
+        this._digitColor = opts.digitColor ?? { type: 'named', name: 'white' };
+
+        // Strip layout and border styles from style passed to Digits
+        const { border, padding, margin, width, height, ...digitsStyle } = style;
+        this._digits = new Digits(digitsStyle, { color: this._digitColor });
+
+        // Initialize with current time
+        this.setTime(new Date());
+    }
+
+    setTime(time: Date): void {
+        const hours = time.getHours();
+        const minutes = time.getMinutes();
+        const seconds = time.getSeconds();
+
+        const minStr = String(minutes).padStart(2, '0');
+        const secStr = String(seconds).padStart(2, '0');
+
+        let digitPart: string;
+        let ampmPart: string = '';
+
+        if (this._use24Hour) {
+            const hourStr = String(hours).padStart(2, '0');
+            digitPart = this._showSeconds 
+                ? `${hourStr}:${minStr}:${secStr}` 
+                : `${hourStr}:${minStr}`;
+        } else {
+            ampmPart = hours >= 12 ? 'PM' : 'AM';
+            const displayHour = hours % 12 === 0 ? 12 : hours % 12;
+            const hourStr = String(displayHour);
+            digitPart = this._showSeconds 
+                ? `${hourStr}:${minStr}:${secStr}` 
+                : `${hourStr}:${minStr}`;
+        }
+
+        this._digits.setValue(digitPart);
+        this._ampm = ampmPart;
+        this._digitPartLength = digitPart.length;
+        this.markDirty();
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const rect = this._getContentRect();
+        const { x, y, width, height } = rect;
+        if (width <= 0 || height <= 0) return;
+
+        // Position and render the internal digits widget
+        this._digits.updateRect(rect);
+        this._digits.render(screen);
+
+        // If in 12h mode, render AM/PM text separately
+        if (this._ampm) {
+            const digitsWidth = this._digitPartLength * 5; // each digit consumes 5 columns
+
+            if (digitsWidth + this._ampm.length <= width && height >= 3) {
+                const attrs = styleToCellAttrs(this._style);
+                screen.writeString(x + digitsWidth, y + 2, this._ampm, { ...attrs, fg: this._digitColor });
+            }
+        }
+    }
+}

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -121,3 +121,5 @@ export { DirectoryTree } from './display/DirectoryTree.js';
 export type { DirectoryTreeOptions } from './display/DirectoryTree.js';
 export { Tooltip } from './display/Tooltip.js';
 export type { TooltipOptions } from './display/Tooltip.js';
+export { Clock } from './display/Clock.js';
+export type { ClockOptions } from './display/Clock.js';


### PR DESCRIPTION
## Description

Adds a new `Clock` widget to `@termuijs/widgets` using the existing `Digits` renderer.

The widget supports:

* 24-hour and 12-hour formats
* Optional seconds display
* Configurable digit color

Unit tests were added to verify formatting behavior and `markDirty()` calls.

## Related Issue

Closes #253 

## Which package(s)?

* @termuijs/widgets

## Type of Change

* [x] ✨ Feature (`type:feature`)
* [x] 🧪 Tests (`type:testing`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read `CONTRIBUTING.md`.
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: https://gssoc.girlscript.org/profile/YOUR_PROFILE_ID`](https://gssoc.girlscript.org/profile/42e0e4bf-0550-4021-a19c-29f6f92ca35d

## Screenshots / Recordings (UI changes)

Added a Clock widget rendered using the existing Digits renderer.
<img width="1013" height="291" alt="image" src="https://github.com/user-attachments/assets/4be561ed-225e-40eb-ba16-fcd58d530004" />


## Notes for the Reviewer

* Uses the existing `Digits` widget for rendering; no digit rendering logic was duplicated.
* Supports both 24-hour (`HH:MM:SS`) and 12-hour (`H:MM:SS AM/PM`) formats.
* `setTime()` updates the displayed value and calls `markDirty()`.
* Changes are confined to:

  * `packages/widgets/src/display/Clock.ts`
  * `packages/widgets/src/display/Clock.test.ts`
  * `packages/widgets/src/index.ts`
