### PR TITLE
Feat/add use previous hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
   <p align="center">Build terminal applications in TypeScript.</p>
 </p>
 
+
 <p align="center">
   <a href="https://www.termui.io/docs/getting-started/installation"><img src="https://img.shields.io/badge/docs-termui.io-00ff88?style=flat" alt="Documentation"></a>
   <a href="https://www.npmjs.com/package/@termuijs/core"><img src="https://img.shields.io/npm/v/@termuijs/core.svg" alt="npm version"></a>

--- a/packages/jsx/src/hooks/usePrevious.test.ts
+++ b/packages/jsx/src/hooks/usePrevious.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  createFiber,
+  setCurrentFiber,
+  clearCurrentFiber,
+  runEffects,
+} from '../hooks.js';
+import { usePrevious } from './usePrevious';
+
+describe('usePrevious', () => {
+  let fiber = createFiber();
+
+  beforeEach(() => {
+    fiber = createFiber();
+    setCurrentFiber(fiber);
+  });
+
+  afterEach(() => {
+    clearCurrentFiber();
+  });
+
+  it('returns undefined on the first render', () => {
+    const result = usePrevious('initial');
+    expect(result).toBeUndefined();
+    runEffects(fiber);
+  });
+
+  it('returns the previous value on subsequent renders', () => {
+    usePrevious('initial');
+    runEffects(fiber);
+
+    fiber.hookIndex = 0;
+    const result = usePrevious('updated');
+    expect(result).toBe('initial');
+    runEffects(fiber);
+  });
+});

--- a/packages/jsx/src/hooks/usePrevious.ts
+++ b/packages/jsx/src/hooks/usePrevious.ts
@@ -1,0 +1,11 @@
+import { useEffect, useRef } from '../hooks';
+
+export function usePrevious<T>(value: T): T | undefined {
+  const ref = useRef<T | undefined>(undefined);
+
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -65,3 +65,4 @@ export { setRequestRender, getRequestRender, setInsertBefore, collectInputHandle
 // ── Convenience alias ──
 /** h() — shorthand for createElement */
 export { createElement as h } from './createElement.js';
+export { usePrevious } from './hooks/usePrevious';

--- a/packages/testing/src/render.ts
+++ b/packages/testing/src/render.ts
@@ -121,9 +121,10 @@ function renderToScreen(container: Box, screen: Screen): void {
     // Simple vertical stacking layout for testing
     assignRects(container, 0, 0, screen.cols, screen.rows);
 
-    // Clear and render using the widget tree's own render path
+    // Clear and render
     screen.clear();
-    container.render(screen);
+    (container as any)._renderSelf?.(screen);
+    renderChildren(container, screen);
 }
 
 /** Simple recursive layout: stack children vertically */

--- a/packages/testing/src/render.ts
+++ b/packages/testing/src/render.ts
@@ -121,10 +121,9 @@ function renderToScreen(container: Box, screen: Screen): void {
     // Simple vertical stacking layout for testing
     assignRects(container, 0, 0, screen.cols, screen.rows);
 
-    // Clear and render
+    // Clear and render using the widget tree's own render path
     screen.clear();
-    (container as any)._renderSelf?.(screen);
-    renderChildren(container, screen);
+    container.render(screen);
 }
 
 /** Simple recursive layout: stack children vertically */


### PR DESCRIPTION
## Description
This pull request implements the `usePrevious` hook for the `@termuijs/jsx` package. The hook allows components to track the value of a prop or state from the previous render cycle, providing access to the "old" value in the current render. This implementation follows the requested API contract and uses `useRef` to store the value and `useEffect` to trigger the update after the render cycle.

## Related Issue
Closes #285

## Which package(s)?
@termuijs/jsx

## Type of Change
- [x] Feature (type:feature)

## Testing Performed
- Created `packages/jsx/src/hooks/usePrevious.test.ts` to verify the hook's behavior.
- Confirmed that the hook returns `undefined` on the first render.
- Confirmed that the hook returns the previous value on subsequent renders.
- Ran `bun vitest run packages/jsx` and confirmed all tests passed.
- Performed `bun run typecheck` and `bun run build` to ensure no regressions.