### PR TITLE
feat: add high contrast theme

### DIFF
--- a/packages/tss/README.md
+++ b/packages/tss/README.md
@@ -12,13 +12,13 @@ Requires `@termuijs/core` and `@termuijs/widgets`.
 
 ## Built-in themes
 
-Six themes ship ready to use: Default, Cyberpunk, Nord, Dracula, Catppuccin, and Solarized.
+Seven themes ship ready to use: Default, Cyberpunk, Nord, Dracula, Catppuccin, Solarized, and High Contrast.
 
 ```typescript
 import { getBuiltinThemeNames, getBuiltinTheme, TSSEngine } from '@termuijs/tss'
 
 getBuiltinThemeNames()
-// ['default', 'cyberpunk', 'nord', 'dracula', 'catppuccin', 'solarized']
+// ['default', 'cyberpunk', 'nord', 'dracula', 'catppuccin', 'solarized', 'highContrast']
 
 const engine = new TSSEngine()
 engine.load(getBuiltinTheme('nord'))
@@ -102,7 +102,7 @@ const primaryColor = nordTheme['--primary']
 const bgColor = draculaTheme['--bg']
 ```
 
-Available token exports: `draculaTheme`, `nordTheme`, `catppuccinTheme`, `monokaiTheme`, `solarizedTheme`, `tokyoNightTheme`, `oneDarkTheme`.
+Available token exports: `draculaTheme`, `nordTheme`, `catppuccinTheme`, `monokaiTheme`, `solarizedTheme`, `tokyoNightTheme`, `oneDarkTheme`, `highContrastTheme`.
 
 ## tokensToTSS
 

--- a/packages/tss/package.json
+++ b/packages/tss/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/Karanjot786/TermUI"
   },
   "version": "0.1.5",
-  "description": "Terminal Style Sheets for TermUI: variables, selectors, and six built-in themes",
+  "description": "Terminal Style Sheets for TermUI: variables, selectors, and seven built-in themes",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/tss/src/index.ts
+++ b/packages/tss/src/index.ts
@@ -24,7 +24,7 @@ export type { ThemeTokens } from './tokens.js';
 // Named ThemeTokens
 export {
   draculaTheme, nordTheme, catppuccinTheme, monokaiTheme,
-  solarizedTheme, tokyoNightTheme, oneDarkTheme,
+  solarizedTheme, tokyoNightTheme, oneDarkTheme, highContrastTheme,
   NAMED_THEMES, getNamedTheme,
 } from './named-themes.js';
 

--- a/packages/tss/src/named-themes.test.ts
+++ b/packages/tss/src/named-themes.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { defaultDark } from './tokens.js';
+import { getNamedTheme, highContrastTheme, NAMED_THEMES } from './named-themes.js';
+
+describe('Named ThemeTokens', () => {
+  it('registers highContrast in the named theme map', () => {
+    expect(NAMED_THEMES.highContrast).toBe(highContrastTheme);
+    expect(getNamedTheme('highContrast')).toBe(highContrastTheme);
+  });
+
+  it('highContrast exposes all ThemeTokens with strong terminal contrast', () => {
+    expect(highContrastTheme).toEqual({
+      bg: '#000000',
+      fg: '#ffffff',
+      primary: '#00ffff',
+      secondary: '#ff00ff',
+      success: '#00ff00',
+      warning: '#ffff00',
+      error: '#ff5555',
+      muted: '#b3b3b3',
+      border: '#ffffff',
+      highlight: '#1a1a1a',
+    });
+  });
+
+  it('falls back to defaultDark for unknown named themes', () => {
+    expect(getNamedTheme('missing-theme')).toBe(defaultDark);
+  });
+});

--- a/packages/tss/src/named-themes.ts
+++ b/packages/tss/src/named-themes.ts
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────
-// Named ThemeTokens — 7 curated color schemes
+// Named ThemeTokens — 8 curated color schemes
 // ─────────────────────────────────────────────────────
 
 import type { ThemeTokens } from './tokens.js';
@@ -96,6 +96,19 @@ export const oneDarkTheme: ThemeTokens = {
   highlight: '#2c313a',
 };
 
+export const highContrastTheme: ThemeTokens = {
+  bg: '#000000',
+  fg: '#ffffff',
+  primary: '#00ffff',
+  secondary: '#ff00ff',
+  success: '#00ff00',
+  warning: '#ffff00',
+  error: '#ff5555',
+  muted: '#b3b3b3',
+  border: '#ffffff',
+  highlight: '#1a1a1a',
+};
+
 export const NAMED_THEMES: Record<string, ThemeTokens> = {
   dracula: draculaTheme,
   nord: nordTheme,
@@ -104,6 +117,7 @@ export const NAMED_THEMES: Record<string, ThemeTokens> = {
   solarized: solarizedTheme,
   tokyoNight: tokyoNightTheme,
   oneDark: oneDarkTheme,
+  highContrast: highContrastTheme,
 };
 
 /** Get a named theme by string key, falling back to defaultDark if not found. */

--- a/packages/tss/src/themes.test.ts
+++ b/packages/tss/src/themes.test.ts
@@ -14,7 +14,8 @@ describe('Built-in Themes', () => {
         expect(names).toContain('dracula');
         expect(names).toContain('catppuccin');
         expect(names).toContain('solarized');
-        expect(names.length).toBeGreaterThanOrEqual(6);
+        expect(names).toContain('highContrast');
+        expect(names).toHaveLength(7);
     });
 
     it('getBuiltinTheme returns source for valid name', () => {
@@ -32,5 +33,14 @@ describe('Built-in Themes', () => {
         expect(combined).toContain('@theme default');
         expect(combined).toContain('@theme nord');
         expect(combined).toContain('@theme cyberpunk');
+        expect(combined).toContain('@theme highContrast');
+    });
+
+    it('highContrast theme uses strong foreground and focus contrast tokens', () => {
+        const src = getBuiltinTheme('highContrast');
+        expect(src).toContain('--bg: #000000');
+        expect(src).toContain('--text: #ffffff');
+        expect(src).toContain('--border-color: #ffffff');
+        expect(src).toContain('--border-focus: #00ffff');
     });
 });

--- a/packages/tss/src/themes.ts
+++ b/packages/tss/src/themes.ts
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────
-// Built-in Themes — 6 curated terminal color palettes
+// Built-in Themes — 7 curated terminal color palettes
 // ─────────────────────────────────────────────────────
 
 export const BUILTIN_THEMES: Record<string, string> = {
@@ -160,6 +160,38 @@ Gauge {
 Table {
     border: var(--border);
     header-color: var(--secondary);
+}
+`,
+
+    highContrast: `
+@theme highContrast {
+    --primary: #00ffff;
+    --secondary: #ff00ff;
+    --bg: #000000;
+    --surface: #1a1a1a;
+    --text: #ffffff;
+    --text-muted: #b3b3b3;
+    --accent: #00ffff;
+    --error: #ff5555;
+    --warning: #ffff00;
+    --success: #00ff00;
+    --border: double;
+    --border-color: #ffffff;
+    --border-focus: #00ffff;
+}
+
+Gauge {
+    color: var(--primary);
+}
+
+Table {
+    border: var(--border);
+    border-color: var(--border-color);
+    header-color: var(--primary);
+}
+
+Box:focused {
+    border-color: var(--border-focus);
 }
 `,
 };


### PR DESCRIPTION
## Description

Adds a WCAG-AA-oriented high-contrast theme to `@termuijs/tss` so terminal apps can opt into stronger foreground, background, border, and focus differentiation. The theme is available from both the built-in TSS theme loader and the named ThemeTokens API.

## Related Issue

Closes #326

## Which package(s)?

@termuijs/tss

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [x] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run packages/tss`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/6a73d848-056f-4043-a79b-83dfc87113ac`

## Screenshots / Recordings (UI changes)

Not applicable; this is a package theme/token addition with automated test coverage.

## Notes for the Reviewer

Validation run locally:

- `bun run build`
- `bun vitest run packages/tss`
- `bun run typecheck`

The change is confined to `packages/tss`, leaves `bun.lock` untouched, and adds focused coverage for the built-in TSS theme registration plus the named ThemeTokens API.