### PR TITLE
feat(adapters): add useConf adapter

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "termui",
-      "dependencies": {
-        "commander": "^15.0.0",
-      },
       "devDependencies": {
         "@types/bun": "latest",
         "@types/node": "^25.2.3",
@@ -144,14 +141,17 @@
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "conf": "^10.2.0",
         "tsup": "^8.3.0",
         "typescript": "^5.7.0",
       },
       "peerDependencies": {
         "commander": "^15.0.0",
+        "conf": "^10.2.0",
       },
       "optionalPeers": [
         "commander",
+        "conf",
       ],
     },
     "packages/core": {
@@ -277,6 +277,7 @@
       "dependencies": {
         "@termuijs/core": "workspace:*",
         "@termuijs/jsx": "workspace:*",
+        "@termuijs/motion": "workspace:*",
         "@termuijs/widgets": "workspace:*",
       },
       "devDependencies": {
@@ -515,9 +516,15 @@
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@2.1.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA=="],
+
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "atomically": ["atomically@1.7.0", "", {}, "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
@@ -533,17 +540,25 @@
 
     "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
+    "conf": ["conf@10.2.0", "", { "dependencies": { "ajv": "^8.6.3", "ajv-formats": "^2.1.1", "atomically": "^1.7.0", "debounce-fn": "^4.0.0", "dot-prop": "^6.0.1", "env-paths": "^2.2.1", "json-schema-typed": "^7.0.3", "onetime": "^5.1.2", "pkg-up": "^3.1.0", "semver": "^7.3.5" } }, "sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg=="],
+
     "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
     "create-termui-app": ["create-termui-app@workspace:packages/create-termui-app"],
 
+    "debounce-fn": ["debounce-fn@4.0.0", "", { "dependencies": { "mimic-fn": "^3.0.0" } }, "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "dot-prop": ["dot-prop@6.0.1", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA=="],
+
+    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
@@ -553,15 +568,27 @@
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "find-up": ["find-up@3.0.0", "", { "dependencies": { "locate-path": "^3.0.0" } }, "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg=="],
 
     "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "is-obj": ["is-obj@2.0.0", "", {}, "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="],
+
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@7.0.3", "", {}, "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -593,9 +620,13 @@
 
     "load-tsconfig": ["load-tsconfig@0.2.5", "", {}, "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg=="],
 
+    "locate-path": ["locate-path@3.0.0", "", { "dependencies": { "p-locate": "^3.0.0", "path-exists": "^3.0.0" } }, "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A=="],
+
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "mimic-fn": ["mimic-fn@3.1.0", "", {}, "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ=="],
 
     "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
 
@@ -606,6 +637,16 @@
     "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+
+    "p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
+    "p-locate": ["p-locate@3.0.0", "", { "dependencies": { "p-limit": "^2.0.0" } }, "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ=="],
+
+    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+
+    "path-exists": ["path-exists@3.0.0", "", {}, "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="],
 
     "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
 
@@ -619,15 +660,21 @@
 
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
+    "pkg-up": ["pkg-up@3.1.0", "", { "dependencies": { "find-up": "^3.0.0" } }, "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA=="],
+
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
     "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
     "rollup": ["rollup@4.60.4", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.4", "@rollup/rollup-android-arm64": "4.60.4", "@rollup/rollup-darwin-arm64": "4.60.4", "@rollup/rollup-darwin-x64": "4.60.4", "@rollup/rollup-freebsd-arm64": "4.60.4", "@rollup/rollup-freebsd-x64": "4.60.4", "@rollup/rollup-linux-arm-gnueabihf": "4.60.4", "@rollup/rollup-linux-arm-musleabihf": "4.60.4", "@rollup/rollup-linux-arm64-gnu": "4.60.4", "@rollup/rollup-linux-arm64-musl": "4.60.4", "@rollup/rollup-linux-loong64-gnu": "4.60.4", "@rollup/rollup-linux-loong64-musl": "4.60.4", "@rollup/rollup-linux-ppc64-gnu": "4.60.4", "@rollup/rollup-linux-ppc64-musl": "4.60.4", "@rollup/rollup-linux-riscv64-gnu": "4.60.4", "@rollup/rollup-linux-riscv64-musl": "4.60.4", "@rollup/rollup-linux-s390x-gnu": "4.60.4", "@rollup/rollup-linux-x64-gnu": "4.60.4", "@rollup/rollup-linux-x64-musl": "4.60.4", "@rollup/rollup-openbsd-x64": "4.60.4", "@rollup/rollup-openharmony-arm64": "4.60.4", "@rollup/rollup-win32-arm64-msvc": "4.60.4", "@rollup/rollup-win32-ia32-msvc": "4.60.4", "@rollup/rollup-win32-x64-gnu": "4.60.4", "@rollup/rollup-win32-x64-msvc": "4.60.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g=="],
+
+    "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
@@ -694,6 +741,8 @@
     "estree-walker/@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
     "mlly/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "onetime/mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
     "pkg-types/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -35,13 +35,18 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "conf": "^10.2.0",
     "typescript": "^5.7.0",
     "tsup": "^8.3.0"
   },
   "peerDependencies": {
+    "conf": "^10.2.0",
     "commander": "^15.0.0"
   },
   "peerDependenciesMeta": {
+    "conf": {
+      "optional": true
+    },
     "commander": {
       "optional": true
     }

--- a/packages/adapters/src/conf/index.test.ts
+++ b/packages/adapters/src/conf/index.test.ts
@@ -1,0 +1,137 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+let shouldThrowMissingConf = false
+
+function createMissingConfRequire(): NodeJS.Require {
+  // The real NodeJS.Require type has extra properties, so the test stub mirrors them.
+  const missingRequire = Object.assign(
+    (specifier: string) => {
+      const error = new Error(`Cannot find module '${specifier}'`) as NodeJS.ErrnoException
+      error.code = 'MODULE_NOT_FOUND'
+      throw error
+    },
+    {
+      resolve: (specifier: string) => specifier,
+      cache: {},
+      extensions: {},
+      main: undefined,
+    }
+  )
+
+  return missingRequire as NodeJS.Require
+}
+
+async function loadUseConf() {
+  vi.resetModules()
+  return (await import('./index.js')).useConf
+}
+
+vi.mock('node:module', async (importActual) => {
+  const actual = await importActual<typeof import('node:module')>()
+
+  return {
+    ...actual,
+    createRequire: (...args: Parameters<typeof actual.createRequire>) => {
+      return shouldThrowMissingConf ? createMissingConfRequire() : actual.createRequire(...args)
+    },
+  }
+})
+
+describe('useConf', () => {
+  let tempHomeDirectory = ''
+  const previousHome = process.env.HOME
+  const previousUserProfile = process.env.USERPROFILE
+  const previousHomeDrive = process.env.HOMEDRIVE
+  const previousHomePath = process.env.HOMEPATH
+
+  function setHomeDirectory(directory: string) {
+    process.env.HOME = directory
+    process.env.USERPROFILE = directory
+    delete process.env.HOMEDRIVE
+    delete process.env.HOMEPATH
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    shouldThrowMissingConf = false
+    process.env.HOME = previousHome
+    process.env.USERPROFILE = previousUserProfile
+
+    if (previousHomeDrive === undefined) {
+      delete process.env.HOMEDRIVE
+    } else {
+      process.env.HOMEDRIVE = previousHomeDrive
+    }
+
+    if (previousHomePath === undefined) {
+      delete process.env.HOMEPATH
+    } else {
+      process.env.HOMEPATH = previousHomePath
+    }
+
+    if (tempHomeDirectory) {
+      rmSync(tempHomeDirectory, { recursive: true, force: true })
+      tempHomeDirectory = ''
+    }
+  })
+
+  it('returns defaults when no config file exists yet', async () => {
+    tempHomeDirectory = mkdtempSync(join(tmpdir(), 'termui-conf-'))
+    setHomeDirectory(tempHomeDirectory)
+
+    const useConf = await loadUseConf()
+    const defaults = { theme: 'dark', fontSize: 14 }
+
+    const [config] = useConf('my-app', defaults)
+
+    expect(config).toEqual(defaults)
+  })
+
+  it('reads an existing config file from disk', async () => {
+    tempHomeDirectory = mkdtempSync(join(tmpdir(), 'termui-conf-'))
+    setHomeDirectory(tempHomeDirectory)
+
+    const configDirectory = join(tempHomeDirectory, '.config', 'my-app')
+    const configPath = join(configDirectory, 'config.json')
+    mkdirSync(configDirectory, { recursive: true })
+    writeFileSync(configPath, JSON.stringify({ theme: 'light', fontSize: 16 }), 'utf8')
+
+    const useConf = await loadUseConf()
+    const [config] = useConf('my-app', { theme: 'dark', fontSize: 14 })
+
+    expect(config).toEqual({ theme: 'light', fontSize: 16 })
+  })
+
+  it('updates in-memory state and writes the new config file', async () => {
+    tempHomeDirectory = mkdtempSync(join(tmpdir(), 'termui-conf-'))
+    setHomeDirectory(tempHomeDirectory)
+
+    const useConf = await loadUseConf()
+    const [config, setConfig] = useConf('my-app', { theme: 'dark', fontSize: 14 })
+
+    const updated = setConfig({ ...config, theme: 'light' })
+    const configPath = join(tempHomeDirectory, '.config', 'my-app', 'config.json')
+    const persisted = JSON.parse(readFileSync(configPath, 'utf8'))
+    const [cachedConfig] = useConf('my-app', { theme: 'dark', fontSize: 14 })
+
+    expect(updated).toEqual({ theme: 'light', fontSize: 14 })
+    expect(existsSync(configPath)).toBe(true)
+    expect(persisted).toEqual({ theme: 'light', fontSize: 14 })
+    expect(cachedConfig).toEqual({ theme: 'light', fontSize: 14 })
+  })
+
+  it('throws a helpful error when conf is not installed', async () => {
+    tempHomeDirectory = mkdtempSync(join(tmpdir(), 'termui-conf-'))
+    setHomeDirectory(tempHomeDirectory)
+    shouldThrowMissingConf = true
+
+    const useConf = await loadUseConf()
+
+    expect(() => useConf('my-app', { theme: 'dark' })).toThrow(
+      'useConf() requires the optional peer dependency `conf`.'
+    )
+  })
+})

--- a/packages/adapters/src/conf/index.ts
+++ b/packages/adapters/src/conf/index.ts
@@ -1,0 +1,96 @@
+import { mkdirSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import type { Options as ConfOptions } from 'conf'
+
+export type SetConfValue<T extends Record<string, unknown>> =
+  (value: T | ((current: T) => T)) => T
+
+export type UseConfResult<T extends Record<string, unknown>> = readonly [T, SetConfValue<T>]
+
+type ConfConstructor = new <T extends Record<string, unknown> = Record<string, unknown>>(
+  options?: Readonly<Partial<ConfOptions<T>>>
+) => { store: T }
+
+interface ConfStore<T extends Record<string, unknown>> {
+  config: { store: T }
+  value: T
+  setValue: SetConfValue<T>
+}
+
+const configStores = new Map<string, ConfStore<Record<string, unknown>>>()
+
+function isMissingConfError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error
+    && 'code' in error
+    && error.code === 'MODULE_NOT_FOUND'
+    && error.message.includes('conf')
+}
+
+function resolveConfConstructor(): ConfConstructor {
+  try {
+    const require = createRequire(import.meta.url)
+    // conf@10 ships a CommonJS default export, so the lazy loader must handle both interop shapes.
+    const loaded = require('conf') as ConfConstructor | { default: ConfConstructor }
+    return 'default' in loaded ? loaded.default : loaded
+  } catch (error) {
+    if (isMissingConfError(error)) {
+      throw new Error(
+        'useConf() requires the optional peer dependency `conf`. Install `conf@^10.2.0` in your app before calling useConf().',
+        { cause: error }
+      )
+    }
+
+    throw error
+  }
+}
+
+function resolveConfigDirectory(appName: string): string {
+  return join(homedir(), '.config', appName)
+}
+
+function resolveNextValue<T extends Record<string, unknown>>(
+  current: T,
+  value: T | ((state: T) => T)
+): T {
+  return typeof value === 'function' ? value(current) : value
+}
+
+function createStore<T extends Record<string, unknown>>(appName: string, defaults: T): ConfStore<T> {
+  const configDirectory = resolveConfigDirectory(appName)
+  mkdirSync(configDirectory, { recursive: true })
+
+  const Conf = resolveConfConstructor()
+  const config = new Conf<T>({
+    cwd: configDirectory,
+    configName: 'config',
+    defaults,
+  })
+
+  const store: ConfStore<T> = {
+    config,
+    value: config.store,
+    setValue: (value) => {
+      const nextValue = resolveNextValue(store.value, value)
+      store.value = nextValue
+      store.config.store = nextValue
+      return store.value
+    },
+  }
+
+  return store
+}
+
+export function useConf<T extends Record<string, unknown>>(appName: string, defaults: T): UseConfResult<T> {
+  // The cache is keyed by app name, so callers are responsible for reusing a consistent config shape per app.
+  const cachedStore = configStores.get(appName) as ConfStore<T> | undefined
+  const store = cachedStore ?? createStore(appName, defaults)
+
+  if (!cachedStore) {
+    // Stores are cached as a generic record because the map is shared across app names.
+    configStores.set(appName, store as ConfStore<Record<string, unknown>>)
+  }
+
+  return [store.value, store.setValue]
+}

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -1,2 +1,4 @@
 export { useCommander } from './commander/index.js' 
 export type { CommanderResult } from './commander/index.js' 
+export { useConf } from './conf/index.js'
+export type { SetConfValue, UseConfResult } from './conf/index.js'


### PR DESCRIPTION
## Summary
Adds a `useConf` adapter to `@termuijs/adapters` for persisting typed app config to `~/.config/<appName>/config.json` using the optional `conf` peer dependency.

## Changes
- added `packages/adapters/src/conf/index.ts`
- added `packages/adapters/src/conf/index.test.ts`
- exported `useConf` from `packages/adapters/src/index.ts`
- added `conf@^10.2.0` as an optional peer dependency
- added test coverage for:
  - default config read
  - existing file read
  - write/update behavior
  - missing dependency error path

## Validation
- `bun vitest run packages/adapters`
- `bun run typecheck` in `packages/adapters`
- `bun run build`
- `bun run typecheck`

## Notes
- `useConf()` throws a helpful error if `conf` is not installed
- selected `conf@^10.2.0` to stay compatible with the repo’s Node 18+ target

Closes #68 