### PR TITLE
feat(tss): add gruvbox built-in theme

### DIFF
--- a/packages/tss/README.md
+++ b/packages/tss/README.md
@@ -12,13 +12,13 @@ Requires `@termuijs/core` and `@termuijs/widgets`.
 
 ## Built-in themes
 
-Seven themes ship ready to use: Default, Cyberpunk, Nord, Dracula, Catppuccin, Solarized, and High Contrast.
+Eight themes ship ready to use: Default, Cyberpunk, Nord, Dracula, Gruvbox, Catppuccin, Solarized, and High Contrast.
 
 ```typescript
 import { getBuiltinThemeNames, getBuiltinTheme, TSSEngine } from '@termuijs/tss'
 
 getBuiltinThemeNames()
-// ['default', 'cyberpunk', 'nord', 'dracula', 'catppuccin', 'solarized', 'highContrast']
+// ['default', 'cyberpunk', 'nord', 'dracula', 'gruvbox', 'catppuccin', 'solarized', 'highContrast']
 
 const engine = new TSSEngine()
 engine.load(getBuiltinTheme('nord'))
@@ -102,7 +102,7 @@ const primaryColor = nordTheme['--primary']
 const bgColor = draculaTheme['--bg']
 ```
 
-Available token exports: `draculaTheme`, `nordTheme`, `catppuccinTheme`, `monokaiTheme`, `solarizedTheme`, `tokyoNightTheme`, `oneDarkTheme`, `highContrastTheme`.
+Available token exports: `draculaTheme`, `nordTheme`, `catppuccinTheme`, `monokaiTheme`, `solarizedTheme`, `tokyoNightTheme`, `oneDarkTheme`, `gruvboxTheme`, `highContrastTheme`.
 
 ## tokensToTSS
 

--- a/packages/tss/package.json
+++ b/packages/tss/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/Karanjot786/TermUI"
   },
   "version": "0.1.5",
-  "description": "Terminal Style Sheets for TermUI: variables, selectors, and seven built-in themes",
+  "description": "Terminal Style Sheets for TermUI: variables, selectors, and eight built-in themes",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/tss/src/named-themes.ts
+++ b/packages/tss/src/named-themes.ts
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────
-// Named ThemeTokens — 8 curated color schemes
+// Named ThemeTokens — 9 curated color schemes
 // ─────────────────────────────────────────────────────
 
 import type { ThemeTokens } from './tokens.js';
@@ -96,6 +96,19 @@ export const oneDarkTheme: ThemeTokens = {
   highlight: '#2c313a',
 };
 
+export const gruvboxTheme: ThemeTokens = {
+  bg: '#282828',
+  fg: '#ebdbb2',
+  primary: '#458588',
+  secondary: '#b16286',
+  success: '#98971a',
+  warning: '#d79921',
+  error: '#cc241d',
+  muted: '#928374',
+  border: '#504945',
+  highlight: '#3c3836',
+};
+
 export const highContrastTheme: ThemeTokens = {
   bg: '#000000',
   fg: '#ffffff',
@@ -117,6 +130,7 @@ export const NAMED_THEMES: Record<string, ThemeTokens> = {
   solarized: solarizedTheme,
   tokyoNight: tokyoNightTheme,
   oneDark: oneDarkTheme,
+  gruvbox: gruvboxTheme,
   highContrast: highContrastTheme,
 };
 

--- a/packages/tss/src/themes.test.ts
+++ b/packages/tss/src/themes.test.ts
@@ -15,7 +15,8 @@ describe('Built-in Themes', () => {
         expect(names).toContain('catppuccin');
         expect(names).toContain('solarized');
         expect(names).toContain('highContrast');
-        expect(names).toHaveLength(7);
+        expect(names).toContain('gruvbox');
+        expect(names).toHaveLength(8);
     });
 
     it('getBuiltinTheme returns source for valid name', () => {
@@ -42,5 +43,16 @@ describe('Built-in Themes', () => {
         expect(src).toContain('--text: #ffffff');
         expect(src).toContain('--border-color: #ffffff');
         expect(src).toContain('--border-focus: #00ffff');
+    });
+
+    it('loads the gruvbox theme with correct palette values', () => {
+        const src = getBuiltinTheme('gruvbox');
+
+        expect(src).toBeDefined();
+
+        expect(src).toContain('@theme gruvbox');
+        expect(src).toContain('--bg: #282828');
+        expect(src).toContain('--text: #ebdbb2');
+        expect(src).toContain('--primary: #458588');
     });
 });

--- a/packages/tss/src/themes.ts
+++ b/packages/tss/src/themes.ts
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────
-// Built-in Themes — 7 curated terminal color palettes
+// Built-in Themes — 8 curated terminal color palettes
 // ─────────────────────────────────────────────────────
 
 export const BUILTIN_THEMES: Record<string, string> = {
@@ -106,6 +106,33 @@ Gauge {
 Text:focused {
     color: var(--secondary);
     bold: true;
+}
+`,
+
+    gruvbox: `
+@theme gruvbox {
+    --primary: #458588;
+    --secondary: #b16286;
+    --bg: #282828;
+    --surface: #3c3836;
+    --text: #ebdbb2;
+    --text-muted: #928374;
+    --accent: #98971a;
+    --error: #cc241d;
+    --warning: #d79921;
+    --success: #98971a;
+    --border: round;
+    --border-color: #504945;
+    --border-focus: #458588;
+}
+
+Gauge {
+    color: var(--primary);
+}
+
+Table {
+    border: var(--border);
+    header-color: var(--secondary);
 }
 `,
 


### PR DESCRIPTION
## Description

Adds the Gruvbox color palette as a built-in theme for `@termuijs/tss`.

This PR adds Gruvbox theme tokens, registers Gruvbox in `BUILTIN_THEMES`, updates documentation and package metadata, and adds tests to verify theme registration and palette values.

## Related Issue

Closes #317

## Which package(s)?

* `@termuijs/tss`

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [x] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [ ] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md](https://chatgpt.com/c/CONTRIBUTING.md)`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/18507c29-4949-45a4-8946-f46458f84e31`

## Screenshots / Recordings (UI changes)

N/A (theme registration, tests, and documentation changes only).

## Notes for the Reviewer

* Added `gruvboxTheme` to named theme tokens.
* Added Gruvbox to `BUILTIN_THEMES`.
* Updated built-in theme count in documentation and package metadata.
* Added tests to verify Gruvbox theme loading and key palette values.