### PR TITLE
feat: add useCounter hook

### DIFF
--- a/packages/jsx/src/hooks/useCounter.test.ts
+++ b/packages/jsx/src/hooks/useCounter.test.ts
@@ -1,0 +1,85 @@
+﻿import { describe, it, expect, afterEach } from 'vitest';
+import { clearCurrentFiber, createFiber, setCurrentFiber } from '../hooks.js';
+import { useCounter } from './useCounter.js';
+
+function renderCounter(
+    fiber = createFiber(),
+    initialValue?: number,
+    opts?: { min?: number; max?: number; step?: number },
+) {
+    fiber.hookIndex = 0;
+    setCurrentFiber(fiber);
+    const result = useCounter(initialValue, opts);
+    clearCurrentFiber();
+
+    return { fiber, result };
+}
+
+describe('useCounter', () => {
+    afterEach(() => {
+        clearCurrentFiber();
+    });
+
+    it('increment() increases the counter by step defaulting to 1', () => {
+        const { fiber, result } = renderCounter(undefined, 0);
+        const [, actions] = result;
+
+        actions.increment();
+
+        const [, nextResult] = renderCounter(fiber, 0).result;
+        expect(nextResult.increment).toBeTypeOf('function');
+        expect(renderCounter(fiber, 0).result[0]).toBe(1);
+    });
+
+    it('increment() increases the counter by the configured step', () => {
+        const { fiber, result } = renderCounter(undefined, 2, { step: 3 });
+        const [, actions] = result;
+
+        actions.increment();
+
+        expect(renderCounter(fiber, 2, { step: 3 }).result[0]).toBe(5);
+    });
+
+    it('decrement() decreases the counter by step', () => {
+        const { fiber, result } = renderCounter(undefined, 10, { step: 4 });
+        const [, actions] = result;
+
+        actions.decrement();
+
+        expect(renderCounter(fiber, 10, { step: 4 }).result[0]).toBe(6);
+    });
+
+    it('counter does not exceed max or go below min when set', () => {
+        const { fiber, result } = renderCounter(undefined, 5, { min: 0, max: 10 });
+        const [, actions] = result;
+
+        actions.set(25);
+        expect(renderCounter(fiber, 5, { min: 0, max: 10 }).result[0]).toBe(10);
+
+        renderCounter(fiber, 5, { min: 0, max: 10 }).result[1].set(-5);
+        expect(renderCounter(fiber, 5, { min: 0, max: 10 }).result[0]).toBe(0);
+    });
+
+    it('increment() and decrement() respect min and max bounds', () => {
+        const { fiber, result } = renderCounter(undefined, 9, { min: 0, max: 10, step: 3 });
+        const [, actions] = result;
+
+        actions.increment();
+        expect(renderCounter(fiber, 9, { min: 0, max: 10, step: 3 }).result[0]).toBe(10);
+
+        renderCounter(fiber, 9, { min: 0, max: 10, step: 3 }).result[1].set(1);
+        renderCounter(fiber, 9, { min: 0, max: 10, step: 3 }).result[1].decrement();
+        expect(renderCounter(fiber, 9, { min: 0, max: 10, step: 3 }).result[0]).toBe(0);
+    });
+
+    it('reset() restores the initial value', () => {
+        const { fiber, result } = renderCounter(undefined, 7, { step: 2 });
+        const [, actions] = result;
+
+        actions.increment();
+        expect(renderCounter(fiber, 7, { step: 2 }).result[0]).toBe(9);
+
+        renderCounter(fiber, 7, { step: 2 }).result[1].reset();
+        expect(renderCounter(fiber, 7, { step: 2 }).result[0]).toBe(7);
+    });
+});

--- a/packages/jsx/src/hooks/useCounter.ts
+++ b/packages/jsx/src/hooks/useCounter.ts
@@ -1,0 +1,47 @@
+﻿import { useRef, useState } from '../hooks.js';
+
+export interface UseCounterOptions {
+    min?: number;
+    max?: number;
+    step?: number;
+}
+
+export interface UseCounterActions {
+    increment: () => void;
+    decrement: () => void;
+    reset: () => void;
+    set: (v: number) => void;
+}
+
+function clamp(value: number, min?: number, max?: number): number {
+    if (typeof min === 'number' && value < min) return min;
+    if (typeof max === 'number' && value > max) return max;
+    return value;
+}
+
+export function useCounter(
+    initialValue = 0,
+    opts: UseCounterOptions = {},
+): [number, UseCounterActions] {
+    const initialRef = useRef(clamp(initialValue, opts.min, opts.max));
+    const [count, setCount] = useState(initialRef.current);
+    const step = opts.step ?? 1;
+
+    const set = (value: number): void => {
+        setCount(clamp(value, opts.min, opts.max));
+    };
+
+    const increment = (): void => {
+        setCount((current) => clamp(current + step, opts.min, opts.max));
+    };
+
+    const decrement = (): void => {
+        setCount((current) => clamp(current - step, opts.min, opts.max));
+    };
+
+    const reset = (): void => {
+        setCount(initialRef.current);
+    };
+
+    return [count, { increment, decrement, reset, set }];
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -1,4 +1,4 @@
-// ─────────────────────────────────────────────────────
+﻿// ─────────────────────────────────────────────────────
 // @termuijs/jsx — Public API
 // ─────────────────────────────────────────────────────
 
@@ -28,6 +28,8 @@ export {
     useReducer,
 } from './hooks.js';
 export type { AsyncState, KeyBinding, MotionPreferences } from './hooks.js';
+export { useCounter } from './hooks/useCounter.js';
+export type { UseCounterActions, UseCounterOptions } from './hooks/useCounter.js';
 
 // ── Error Boundary ──
 export { ErrorBoundary } from './error-boundary.js';


### PR DESCRIPTION
## Description

Adds a `useCounter` hook to `@termuijs/jsx` for managing numeric counter state with `increment`, `decrement`, `reset`, and `set` actions. The hook supports optional `min`, `max`, and `step` options and includes tests for the required behavior.

## Related Issue

Closes #287

## Which package(s)?

@termuijs/jsx

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: https://gssoc.girlscript.org/profile/e8572518-cd18-4f66-a3c6-26e5c9794861

## Screenshots / Recordings (UI changes)

N/A - this is a hook/API change and does not include UI changes.

## Notes for the Reviewer

The change is confined to `packages/jsx` and does not modify `bun.lock` or add dependencies.

Ran package tests: `bun vitest run packages/jsx`
Ran typecheck: `bun run typecheck`