### PR TITLE
docs(vscode): add TermUI code snippets

### DIFF
--- a/.vscode/termui.code-snippets
+++ b/.vscode/termui.code-snippets
@@ -1,0 +1,92 @@
+{
+    "termui-widget": {
+        "prefix": "termui-widget",
+        "body": [
+            "export class ${1:MyWidget} extends Widget {",
+            "    constructor() {",
+            "        super({});",
+            "        $0",
+            "    }",
+            "}"
+        ],
+        "description": "Scaffold a new Widget class extending Widget"
+    },
+    "termui-test": {
+        "prefix": "termui-test",
+        "body": [
+            "it('${1:renders correctly}', () => {",
+            "    const widget = new ${2:Widget}();",
+            "    const screen = new Screen(20, 3);",
+            "",
+            "    widget.updateRect({ x: 0, y: 0, width: 20, height: 3 });",
+            "    widget.render(screen);",
+            "",
+            "    const row0 = screen.back[0].map(c => c.char).join('');",
+            "    ${3}",
+            "});"
+        ],
+        "description": "Scaffold a widget test using the real Screen"
+    },
+    "termui-hook": {
+        "prefix": "termui-hook",
+        "body": [
+            "const [${1:value}, set${2:Value}] = useState(${3:0});",
+            "",
+            "useEffect(() => {",
+            "    ${4}",
+            "}, []);"
+        ],
+        "description": "Scaffold a JSX hook using useState/useEffect"
+    },
+    "termui-gauge": {
+        "prefix": "termui-gauge",
+        "body": [
+            "gauge('${1:CPU}', () => {",
+            "    ${2:return value / 100;}",
+            "})"
+        ],
+        "description": "Gauge data binding snippet"
+    },
+    "termui-screen": {
+        "prefix": "termui-screen",
+        "body": [
+            "const screen = new Screen(40, 10);"
+        ],
+        "description": "Screen instantiation for tests"
+    },
+    "termui-spyon": {
+        "prefix": "termui-spyon",
+        "body": [
+            "const spy = vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);",
+            "",
+            "try {",
+            "    $0",
+            "} finally {",
+            "    spy.mockRestore();",
+            "}"
+        ],
+        "description": "vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false) + restore"
+    },
+    "termui-export": {
+        "prefix": "termui-export",
+        "body": [
+            "export { ${1:name} } from './${2:file}.js';"
+        ],
+        "description": "Named export from index.ts"
+    },
+    "termui-handlekey": {
+        "prefix": "termui-handlekey",
+        "body": [
+            "handleKey(event: KeyEvent): boolean {",
+            "    switch (event.key) {",
+            "        case 'left':",
+            "        case 'right':",
+            "            return true;",
+            "        default:",
+            "            return false;",
+            "    }",
+            "}"
+        ],
+        "description": "handleKey method stub with lowercase key names"
+    }
+}


### PR DESCRIPTION
## Description

Adds a VS Code snippets file for common TermUI development patterns.

The snippets cover frequently used repository patterns including widget scaffolding, widget tests, JSX hooks, gauge bindings, screen creation, `vi.spyOn` helpers, export statements, and `handleKey` method stubs.

## Related Issue

Closes #332 

## Which package(s)?

* Developer tooling / VS Code snippets

## Type of Change

* [x] 📝 Docs (`type:docs`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [ ] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md](https://chatgpt.com/c/CONTRIBUTING.md)`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/18507c29-4949-45a4-8946-f46458f84e31`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

The snippets were derived from existing patterns already used throughout the repository examples, tests, widgets, and package exports. No runtime code was modified.