### PR TITLE
feat: add ai-streaming example using ChatMessage, ToolCall and StreamingText

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,11 +366,14 @@ cd TermUI
 bun install
 bun run build
 
-cd examples/dashboard
+To run the AI streaming example:
+
+```bash
+cd examples/ai-streaming
 bun run dev
 ```
 
-Six examples: `cli-wrapper-live`, `dashboard`, `jsx-dashboard`, `showcase`, `system-monitor`, `todo-app`, `widget-gallery`, `forms-and-validation`.
+Examples: `ai-streaming`, `cli-wrapper-live`, `dashboard`, `jsx-dashboard`, `showcase`, `system-monitor`, `todo-app`, `widget-gallery`, `forms-and-validation`.
 
 ## Project structure
 
@@ -390,14 +393,15 @@ packages/
   quick/             Fluent builder API
   create-termui-app/ Project scaffolding CLI
 examples/
-  cli-wrapper-live/      Live subprocess log streaming
-  dashboard/             Real-time system monitor
-  forms-and-validation/  Multi-field form with validation
-  jsx-dashboard/         JSX-based dashboard
-  showcase/              Widget gallery
-  system-monitor/        Advanced monitor
-  todo-app/              Interactive todo list
-  widget-gallery/        All widgets in one place
+  ai-streaming/         Mock AI chat with StreamingText, ChatMessage, ToolCall
+  cli-wrapper-live/
+  dashboard/
+  forms-and-validation/
+  jsx-dashboard/
+  showcase/
+  system-monitor/
+  todo-app/
+  widget-gallery/
 ```
 
 ## Development

--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "termui",
-      "dependencies": {
-        "commander": "^15.0.0",
-      },
       "devDependencies": {
         "@types/bun": "latest",
         "@types/node": "^25.2.3",
@@ -16,32 +13,31 @@
         "vitest": "^2.1.0",
       },
     },
-"examples/ai-streaming": {
-  "name": "@termuijs/example-ai-streaming",
-  "version": "0.1.0",
-  "dependencies": {
-    "@termuijs/core": "workspace:*",
-    "@termuijs/dev-server": "workspace:*",
-    "@termuijs/motion": "workspace:*",
-    "@termuijs/tss": "workspace:*",
-    "@termuijs/ui": "workspace:*",
-    "@termuijs/widgets": "workspace:*"
-  }
-},
-"examples/auth-flow": {
-  "name": "@termuijs/example-auth-flow",
-  "version": "0.1.0",
-  "dependencies": {
-    "@termuijs/core": "workspace:*",
-    "@termuijs/jsx": "workspace:*",
-    "@termuijs/store": "workspace:*",
-    "@termuijs/ui": "workspace:*",
-    "@termuijs/widgets": "workspace:*"
-  },
-  "devDependencies": {
-    "typescript": "^5.9.3"
-  }
-}
+    "examples/ai-streaming": {
+      "name": "@termuijs/example-ai-streaming",
+      "version": "0.1.0",
+      "dependencies": {
+        "@termuijs/core": "workspace:*",
+        "@termuijs/dev-server": "workspace:*",
+        "@termuijs/motion": "workspace:*",
+        "@termuijs/tss": "workspace:*",
+        "@termuijs/ui": "workspace:*",
+        "@termuijs/widgets": "workspace:*",
+      },
+    },
+    "examples/auth-flow": {
+      "name": "@termuijs/example-auth-flow",
+      "version": "0.1.0",
+      "dependencies": {
+        "@termuijs/core": "workspace:*",
+        "@termuijs/jsx": "workspace:*",
+        "@termuijs/store": "workspace:*",
+        "@termuijs/ui": "workspace:*",
+        "@termuijs/widgets": "workspace:*",
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3",
+      },
     },
     "examples/cli-wrapper-live": {
       "name": "@termuijs/example-cli-wrapper-live",
@@ -290,6 +286,7 @@
       "dependencies": {
         "@termuijs/core": "workspace:*",
         "@termuijs/jsx": "workspace:*",
+        "@termuijs/motion": "workspace:*",
         "@termuijs/widgets": "workspace:*",
       },
       "devDependencies": {
@@ -457,6 +454,7 @@
     "@termuijs/dev-server": ["@termuijs/dev-server@workspace:packages/dev-server"],
 
     "@termuijs/example-ai-streaming": ["@termuijs/example-ai-streaming@workspace:examples/ai-streaming"],
+
     "@termuijs/example-auth-flow": ["@termuijs/example-auth-flow@workspace:examples/auth-flow"],
 
     "@termuijs/example-cli-wrapper-live": ["@termuijs/example-cli-wrapper-live@workspace:examples/cli-wrapper-live"],

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,18 @@
         "vitest": "^2.1.0",
       },
     },
+    "examples/ai-streaming": {
+      "name": "@termuijs/example-ai-streaming",
+      "version": "0.1.0",
+      "dependencies": {
+        "@termuijs/core": "workspace:*",
+        "@termuijs/dev-server": "workspace:*",
+        "@termuijs/motion": "workspace:*",
+        "@termuijs/tss": "workspace:*",
+        "@termuijs/ui": "workspace:*",
+        "@termuijs/widgets": "workspace:*",
+      },
+    },
     "examples/cli-wrapper-live": {
       "name": "@termuijs/example-cli-wrapper-live",
       "version": "0.1.0",
@@ -266,6 +278,7 @@
         "@termuijs/widgets": "workspace:*",
       },
       "devDependencies": {
+        "@termuijs/testing": "workspace:*",
         "tsup": "^8.0.0",
         "typescript": "^5.4.0",
       },
@@ -395,13 +408,17 @@
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw=="],
 
     "@termuijs/adapters": ["@termuijs/adapters@workspace:packages/adapters"],
+
     "@termuijs/core": ["@termuijs/core@workspace:packages/core"],
 
     "@termuijs/data": ["@termuijs/data@workspace:packages/data"],
 
     "@termuijs/dev-server": ["@termuijs/dev-server@workspace:packages/dev-server"],
 
+    "@termuijs/example-ai-streaming": ["@termuijs/example-ai-streaming@workspace:examples/ai-streaming"],
+
     "@termuijs/example-cli-wrapper-live": ["@termuijs/example-cli-wrapper-live@workspace:examples/cli-wrapper-live"],
+
     "@termuijs/example-dashboard": ["@termuijs/example-dashboard@workspace:examples/dashboard"],
 
     "@termuijs/example-forms": ["@termuijs/example-forms@workspace:examples/forms-and-validation"],

--- a/examples/ai-streaming/README.md
+++ b/examples/ai-streaming/README.md
@@ -1,0 +1,34 @@
+# AI Streaming Example
+A simple example demonstrating the AI-focused widgets available in TermUI:
+* `ChatMessage`
+* `ToolCall`
+* `StreamingText`
+
+## Features
+* Displays a user chat message using `ChatMessage`
+* Shows a tool invocation using `ToolCall`
+* Streams an AI response character-by-character using `StreamingText`
+* Uses a local mock response powered by `setInterval`
+* No API key required
+* No network requests are made
+
+## Project Structure
+```text
+ai-streaming/
+├── package.json
+├── README.md
+└── src/
+    ├── index.tsx
+    └── mockStream.ts
+```
+
+## Run
+```bash
+bun install
+bun run dev
+```
+
+## How It Works
+The example simulates an AI assistant response by gradually revealing text from a local string. A `setInterval` timer calls `StreamingText.tick()` to create a typewriter-style streaming effect.
+
+This example is intended for learning and testing the AI widgets without requiring any external APIs or services.

--- a/examples/ai-streaming/package.json
+++ b/examples/ai-streaming/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "@termuijs/example-ai-streaming",
+    "version": "0.1.0",
+    "private": true,
+    "type": "module",
+    "description": "TermUI Showcase — demonstrates all framework packages",
+    "scripts": {
+        "start": "bun src/index.tsx",
+        "dev": "bun --watch src/index.tsx",
+        "build": "echo 'no build needed'"
+    },
+    "dependencies": {
+        "@termuijs/core": "workspace:*",
+        "@termuijs/widgets": "workspace:*",
+        "@termuijs/ui": "workspace:*",
+        "@termuijs/tss": "workspace:*",
+        "@termuijs/motion": "workspace:*",
+        "@termuijs/dev-server": "workspace:*"
+    },
+    "engines": {
+        "bun": ">=1.3.0"
+    }
+}

--- a/examples/ai-streaming/src/index.tsx
+++ b/examples/ai-streaming/src/index.tsx
@@ -1,0 +1,70 @@
+import { App } from '@termuijs/core';
+import { Widget, Box, Text, ChatMessage, ToolCall, StreamingText } from '@termuijs/widgets';
+import type { Screen, KeyEvent } from '@termuijs/core';
+import { mockResponse } from './mockStream.js';
+
+class AIStreamingApp extends Widget {
+    private _streamingText: StreamingText;
+    private _toolCall: ToolCall;
+
+    constructor() {
+        super({
+            flexDirection: 'column',
+            flexGrow: 1,});
+
+        const title = new Text('🤖 AI Streaming Example', {
+            bold: true,
+            height: 1,
+        });
+
+       const userMessage = new ChatMessage({
+       role: 'user',
+       content: 'Explain what a binary tree is.',},
+       { height: 3 });
+       this._toolCall = new ToolCall({
+        name: 'search_docs',
+        args: { topic: 'binary tree' },
+        result: 'Found documentation',
+        status: 'done',
+        collapsed: false,},
+        { border: 'single', height: 6 });
+        
+        this._streamingText = new StreamingText({
+        text: mockResponse,
+        speed: 1,},
+        { border: 'single', height: 6 });
+
+        this.addChild(title);
+        this.addChild(userMessage);
+        this.addChild(this._toolCall);
+        this.addChild(this._streamingText);
+
+        setInterval(() => {
+            this._streamingText.tick();
+        }, 50);
+    }
+
+    handleKey(_event: KeyEvent): boolean {
+        return true;
+    }
+
+    protected _renderSelf(_screen: Screen): void {}
+}
+
+async function main() {
+    const root = new AIStreamingApp();
+
+    const app = new App(root, {
+        fullscreen: true,
+        title: 'AI Streaming Example',
+        fps: 30,
+    });
+
+    const exitCode = await app.mount();
+    process.exit(exitCode);
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/examples/ai-streaming/src/mockStream.ts
+++ b/examples/ai-streaming/src/mockStream.ts
@@ -1,0 +1,2 @@
+export const mockResponse =
+    "Hello! This is a mock AI response streaming token by token. No API key is required and no network requests are made.";


### PR DESCRIPTION
## Description

Adds a new `examples/ai-streaming` example application demonstrating the AI-related widgets available in TermUI.

The example includes:

* `ChatMessage`
* `ToolCall`
* `StreamingText`

A mock AI response is streamed locally using `setInterval`, requiring no API key and no network requests. Documentation has been added to the example README, and the main README has been updated to include the new example.

## Related Issue

Closes #134

## Which package(s)?

* examples/ai-streaming
* README documentation

## Type of Change

* [x] ✨ Feature (`type:feature`)
* [x] 📝 Docs (`type:docs`)

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read CONTRIBUTING.md.
- [x] Your PR title follows `type: short description`.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/040a557a-18f8-40b1-8b82-46451eaccb44`

## Screenshots / Recordings (UI changes)
Attached screenshot showing:

https://github.com/user-attachments/assets/9bf7716b-bb7a-4af0-abf2-2919979c269b

<img width="1920" height="1080" alt="Screenshot 2026-06-02 144959" src="https://github.com/user-attachments/assets/ff53a00a-2eec-4096-9a84-947f07f61848" />


* ChatMessage rendering
* ToolCall rendering
* StreamingText mock response

## Notes for the Reviewer

Implemented a standalone AI streaming example following the structure of existing examples. The response stream is simulated using `setInterval` and does not require any external APIs or API keys.
