### PR TITLE
feat(store): add slices helper for composing store from named slice definitions

### DIFF
--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -16,3 +16,6 @@ export type {
     StoreOptions,
     PersistOptions,
 } from './store.js';
+
+export { slices } from './slices.js';
+export type { SliceDef } from './slices.js';

--- a/packages/store/src/slices.test.ts
+++ b/packages/store/src/slices.test.ts
@@ -1,0 +1,205 @@
+// ─────────────────────────────────────────────────────
+// Tests — slices helper
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi } from 'vitest';
+import { createStore } from './store.js';
+import { slices } from './slices.js';
+
+// ── Slice type helpers ────────────────────────────────
+
+type CounterSlice = {
+    count: number;
+    inc: () => void;
+    dec: () => void;
+    reset: () => void;
+};
+
+type LabelSlice = {
+    label: string;
+    setLabel: (t: string) => void;
+};
+
+type StoreState = CounterSlice & LabelSlice;
+
+// ── Tests ─────────────────────────────────────────────
+
+describe('slices', () => {
+    it('composes two slices into a single store', () => {
+        const useStore = createStore(
+            slices<StoreState>({
+                counter: (set) => ({
+                    count: 0,
+                    inc:   () => set((s) => ({ count: s.count + 1 })),
+                    dec:   () => set((s) => ({ count: s.count - 1 })),
+                    reset: () => set({ count: 0 }),
+                }),
+                label: (set) => ({
+                    label:    'hello',
+                    setLabel: (t: string) => set({ label: t }),
+                }),
+            }),
+        );
+
+        expect(useStore.getState().count).toBe(0);
+        expect(useStore.getState().label).toBe('hello');
+    });
+
+    it('actions from each slice update state correctly', () => {
+        const useStore = createStore(
+            slices<StoreState>({
+                counter: (set) => ({
+                    count: 0,
+                    inc:   () => set((s) => ({ count: s.count + 1 })),
+                    dec:   () => set((s) => ({ count: s.count - 1 })),
+                    reset: () => set({ count: 0 }),
+                }),
+                label: (set) => ({
+                    label:    'hello',
+                    setLabel: (t: string) => set({ label: t }),
+                }),
+            }),
+        );
+
+        useStore.getState().inc();
+        useStore.getState().inc();
+        expect(useStore.getState().count).toBe(2);
+
+        useStore.getState().setLabel('world');
+        expect(useStore.getState().label).toBe('world');
+    });
+
+    it('slices do not interfere with each other on update', () => {
+        const useStore = createStore(
+            slices<StoreState>({
+                counter: (set) => ({
+                    count: 10,
+                    inc:   () => set((s) => ({ count: s.count + 1 })),
+                    dec:   () => set((s) => ({ count: s.count - 1 })),
+                    reset: () => set({ count: 0 }),
+                }),
+                label: (set) => ({
+                    label:    'foo',
+                    setLabel: (t: string) => set({ label: t }),
+                }),
+            }),
+        );
+
+        useStore.getState().inc();
+        // label should remain unchanged
+        expect(useStore.getState().label).toBe('foo');
+
+        useStore.getState().setLabel('bar');
+        // count should remain unchanged
+        expect(useStore.getState().count).toBe(11);
+    });
+
+    it('a slice can read another slice state via get()', () => {
+        type CrossSliceState = {
+            count: number;
+            inc: () => void;
+            doubled: () => number;
+        };
+
+        const useStore = createStore(
+            slices<CrossSliceState>({
+                counter: (set) => ({
+                    count: 5,
+                    inc:   () => set((s) => ({ count: s.count + 1 })),
+                }),
+                derived: (_set, get) => ({
+                    // reads counter slice state via get()
+                    doubled: () => get().count * 2,
+                }),
+            }),
+        );
+
+        expect(useStore.getState().doubled()).toBe(10);
+        useStore.getState().inc();
+        expect(useStore.getState().doubled()).toBe(12);
+    });
+
+    it('reset action restores initial value', () => {
+        const useStore = createStore(
+            slices<StoreState>({
+                counter: (set) => ({
+                    count: 0,
+                    inc:   () => set((s) => ({ count: s.count + 1 })),
+                    dec:   () => set((s) => ({ count: s.count - 1 })),
+                    reset: () => set({ count: 0 }),
+                }),
+                label: (set) => ({
+                    label:    'hello',
+                    setLabel: (t: string) => set({ label: t }),
+                }),
+            }),
+        );
+
+        useStore.getState().inc();
+        useStore.getState().inc();
+        useStore.getState().reset();
+        expect(useStore.getState().count).toBe(0);
+    });
+
+    it('subscribe fires when a slice updates', () => {
+        const useStore = createStore(
+            slices<StoreState>({
+                counter: (set) => ({
+                    count: 0,
+                    inc:   () => set((s) => ({ count: s.count + 1 })),
+                    dec:   () => set((s) => ({ count: s.count - 1 })),
+                    reset: () => set({ count: 0 }),
+                }),
+                label: (set) => ({
+                    label:    'hello',
+                    setLabel: (t: string) => set({ label: t }),
+                }),
+            }),
+        );
+
+        const spy = vi.fn();
+        useStore.subscribe(spy);
+
+        useStore.getState().inc();
+        expect(spy).toHaveBeenCalledOnce();
+        expect(spy.mock.calls[0][0].count).toBe(1);
+    });
+
+    it('empty slices object does not throw and returns an empty store', () => {
+        expect(() => {
+            const useStore = createStore(slices<object>({}));
+            useStore.getState();
+        }).not.toThrow();
+    });
+
+    it('three slices all merge correctly', () => {
+        type ThreeSliceState = {
+            a: number;
+            b: string;
+            c: boolean;
+            setA: (v: number) => void;
+            setB: (v: string) => void;
+            setC: (v: boolean) => void;
+        };
+
+        const useStore = createStore(
+            slices<ThreeSliceState>({
+                sliceA: (set) => ({ a: 1,     setA: (v) => set({ a: v }) }),
+                sliceB: (set) => ({ b: 'hi',  setB: (v) => set({ b: v }) }),
+                sliceC: (set) => ({ c: false, setC: (v) => set({ c: v }) }),
+            }),
+        );
+
+        expect(useStore.getState().a).toBe(1);
+        expect(useStore.getState().b).toBe('hi');
+        expect(useStore.getState().c).toBe(false);
+
+        useStore.getState().setA(99);
+        useStore.getState().setB('world');
+        useStore.getState().setC(true);
+
+        expect(useStore.getState().a).toBe(99);
+        expect(useStore.getState().b).toBe('world');
+        expect(useStore.getState().c).toBe(true);
+    });
+});

--- a/packages/store/src/slices.ts
+++ b/packages/store/src/slices.ts
@@ -1,0 +1,61 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/store — Slices helper
+//
+// Composes a single store state from multiple independent
+// named slice definitions. Each slice receives the full
+// store's set/get, allowing cross-slice reads and actions.
+// ─────────────────────────────────────────────────────
+
+import type { SetState, GetState, StateCreator } from './store.js';
+
+/**
+ * A slice definition — a function that receives the full store's
+ * set/get and returns the state contributed by this slice.
+ *
+ * `TStore` defaults to `object` so callers can omit it when composing
+ * via `slices<CombinedType>()`, which infers the full store type.
+ * The `any` default is intentional: at the point of individual slice
+ * definition the combined store type is not yet known.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type SliceDef<TSlice, TStore extends object = any> = (
+    set: SetState<TStore>,
+    get: GetState<TStore>,
+) => TSlice;
+
+/**
+ * slices — compose a single store state from multiple named slice definitions.
+ *
+ * Returns a `StateCreator` that can be passed directly to `createStore`.
+ * Each slice is merged left-to-right into the combined state object.
+ * Slices can read each other's state and call each other's actions via `get()`.
+ *
+ * ```typescript
+ * type StoreState = CounterSlice & LabelSlice;
+ *
+ * const useStore = createStore(
+ *     slices<StoreState>({
+ *         counter: (set) => ({
+ *             count: 0,
+ *             inc: () => set((s) => ({ count: s.count + 1 })),
+ *             reset: () => set({ count: 0 }),
+ *         }),
+ *         label: (set) => ({
+ *             text: 'hello',
+ *             setLabel: (t: string) => set({ text: t }),
+ *         }),
+ *     })
+ * );
+ * ```
+ */
+export function slices<T extends object>(
+    defs: Record<string, SliceDef<Partial<T>, T>>,
+): StateCreator<T> {
+    return (set, get) => {
+        let combined = {} as T;
+        for (const creator of Object.values(defs)) {
+            combined = { ...combined, ...creator(set, get) };
+        }
+        return combined;
+    };
+}


### PR DESCRIPTION
## Description

Adds a `slices()` helper to `@termuijs/store` that composes a single store from multiple independent named slice definitions. Each slice is a function that receives the full store's `set`/`get` and returns its own piece of state. The helper merges all slices left-to-right and returns a `StateCreator<T>` that can be passed directly to `createStore` — no new abstractions, no changes to existing APIs.

## Related Issue

Closes #304

## Which package(s)?

`@termuijs/store`

## Type of Change

- [x] ✨ Feature (`type:feature`)

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build` — pre-existing DTS failure unrelated to this PR (exists on `main` before this branch)
- [ ] Typecheck passes: `bun run typecheck` — same pre-existing failure
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (not applicable — store feature only).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/a8dd8aa7-2131-48b1-b6c3-4383bd6313da`

## Screenshots / Recordings (UI changes)

N/A — store helper only, no visual output.

## Notes for the Reviewer

- `slices()` returns a `StateCreator<T>` — it plugs directly into the existing `createStore` signature with zero changes to `store.ts` or any other existing file.
- The `any` default on `SliceDef<TSlice, TStore extends object = any>` is intentional and documented inline — at the point of defining an individual slice, the combined store type is not yet known. The caller constrains it via `slices<CombinedType>()`.
- Slices receive the full store's `set`/`get`, meaning they can read each other's state and call each other's actions — this is tested explicitly in "a slice can read another slice state via get()".
- Merge order is left-to-right over `Object.values(defs)`. If two slices define the same key, the later one wins — consistent with `{ ...a, ...b }` spread semantics.
- 8 tests covering: two-slice composition, actions from each slice, slices not interfering with each other, cross-slice reads via `get()`, reset action, subscribe integration, empty slices edge case, and three-slice merge.
- The pre-existing DTS build error (`cannot find module '@termuijs/jsx'`) exists on `main` before this branch and is unrelated to this PR.