### PR TITLE
feat(motion): add stagger helper

### DIFF
--- a/packages/motion/src/index.ts
+++ b/packages/motion/src/index.ts
@@ -9,7 +9,13 @@ export { transition, fadeIn, fadeOut, slideIn, typewriter, pulse, easings } from
 export type { TransitionOptions, EasingFn } from './transitions.js';
 // Sequencing
 export { sequence, parallel } from './sequence.js';
+<<<<<<< HEAD
 export type { AnimationRunner, SequenceStep, AnimatableValue } from './sequence.js';
+=======
+export type { AnimationRunner } from './sequence.js';
+export { stagger } from './stagger.js';
+
+>>>>>>> a7cc189 (feat(motion): add stagger helper)
 // Shared interval timer pool
 export { subscribe as timerPoolSubscribe, unsubscribeAll as timerPoolUnsubscribeAll } from './timer-pool.js';
 // Path animation

--- a/packages/motion/src/index.ts
+++ b/packages/motion/src/index.ts
@@ -9,13 +9,8 @@ export { transition, fadeIn, fadeOut, slideIn, typewriter, pulse, easings } from
 export type { TransitionOptions, EasingFn } from './transitions.js';
 // Sequencing
 export { sequence, parallel } from './sequence.js';
-<<<<<<< HEAD
 export type { AnimationRunner, SequenceStep, AnimatableValue } from './sequence.js';
-=======
-export type { AnimationRunner } from './sequence.js';
 export { stagger } from './stagger.js';
-
->>>>>>> a7cc189 (feat(motion): add stagger helper)
 // Shared interval timer pool
 export { subscribe as timerPoolSubscribe, unsubscribeAll as timerPoolUnsubscribeAll } from './timer-pool.js';
 // Path animation

--- a/packages/motion/src/stagger.test.ts
+++ b/packages/motion/src/stagger.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { stagger } from './stagger.js';
+import { sequence, type AnimationRunner } from './sequence.js';
+import * as sequencing from './sequence.js';
+import { timerPoolUnsubscribeAll } from './index.js';
+
+describe('stagger()', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+        timerPoolUnsubscribeAll();
+    });
+
+    it('stagger starts animations with per-item delay offsets', () => {
+        vi.useFakeTimers();
+
+        const starts: number[] = [];
+        const onComplete = vi.fn();
+        const animations: AnimationRunner[] = [
+            done => { starts.push(1); done(); return () => {}; },
+            done => { starts.push(2); done(); return () => {}; },
+            done => { starts.push(3); done(); return () => {}; },
+        ];
+
+        stagger(animations, 100, onComplete);
+
+        expect(starts).toEqual([1]);
+        expect(onComplete).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(99);
+        expect(starts).toEqual([1]);
+
+        vi.advanceTimersByTime(1);
+        expect(starts).toEqual([1, 2]);
+
+        vi.advanceTimersByTime(100);
+        expect(starts).toEqual([1, 2, 3]);
+        expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles empty input without throwing', () => {
+        const onComplete = vi.fn();
+        expect(() => stagger([], 100, onComplete)).not.toThrow();
+        expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('starts all animations immediately for zero delay', () => {
+        const starts: number[] = [];
+        const onComplete = vi.fn();
+        const animations: AnimationRunner[] = [
+            done => { starts.push(1); done(); return () => {}; },
+            done => { starts.push(2); done(); return () => {}; },
+            done => { starts.push(3); done(); return () => {}; },
+        ];
+
+        stagger(animations, 0, onComplete);
+
+        expect(starts).toEqual([1, 2, 3]);
+        expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('single animation starts immediately even with delay', () => {
+        vi.useFakeTimers();
+
+        const starts: number[] = [];
+        const onComplete = vi.fn();
+        const animation: AnimationRunner = done => {
+            starts.push(1);
+            done();
+            return () => {};
+        };
+
+        stagger([animation], 250, onComplete);
+
+        expect(starts).toEqual([1]);
+        expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles empty array as a boundary value', () => {
+        const onComplete = vi.fn();
+        const cancel = stagger([], 0, onComplete);
+
+        expect(typeof cancel).toBe('function');
+        expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('is compatible with existing sequence API', () => {
+        vi.useFakeTimers();
+
+        const order: string[] = [];
+        const onComplete = vi.fn();
+
+        const a1: AnimationRunner = done => { order.push('a1'); done(); return () => {}; };
+        const a2: AnimationRunner = done => { order.push('a2'); done(); return () => {}; };
+        const b1: AnimationRunner = done => { order.push('b1'); done(); return () => {}; };
+
+        const staggerGroup: AnimationRunner = done => stagger([a1, a2], 100, done);
+        sequence([staggerGroup, b1], onComplete);
+
+        expect(order).toEqual(['a1']);
+        vi.advanceTimersByTime(100);
+        expect(order).toEqual(['a1', 'a2', 'b1']);
+        expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('reuses parallel primitive internally', () => {
+        const parallelSpy = vi.spyOn(sequencing, 'parallel');
+        const animation: AnimationRunner = done => { done(); return () => {}; };
+
+        stagger([animation], 50);
+
+        expect(parallelSpy).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/motion/src/stagger.ts
+++ b/packages/motion/src/stagger.ts
@@ -2,7 +2,6 @@
 // Animation Staggering — delayed parallel starts
 // ─────────────────────────────────────────────────────
 
-import { subscribe } from './timer-pool.js';
 import type { AnimationRunner } from './sequence.js';
 import * as sequencing from './sequence.js';
 
@@ -23,21 +22,16 @@ function withDelay(runner: AnimationRunner, delayMs: number): AnimationRunner {
             return runner(done);
         }
 
-        const startTime = Date.now();
         let cancelStarted: (() => void) | null = null;
         let isStarted = false;
 
-        const unsubDelay = subscribe(16, () => {
-            const elapsed = Date.now() - startTime;
-            if (elapsed < delayMs) return;
-
-            unsubDelay();
+        const timeoutId = setTimeout(() => {
             isStarted = true;
             cancelStarted = runner(done);
-        });
+        }, delayMs);
 
         return () => {
-            unsubDelay();
+            clearTimeout(timeoutId);
             if (isStarted) {
                 cancelStarted?.();
             }

--- a/packages/motion/src/stagger.ts
+++ b/packages/motion/src/stagger.ts
@@ -23,13 +23,13 @@ function withDelay(runner: AnimationRunner, delayMs: number): AnimationRunner {
             return runner(done);
         }
 
-        let elapsedMs = 0;
+        const startTime = Date.now();
         let cancelStarted: (() => void) | null = null;
         let isStarted = false;
 
         const unsubDelay = subscribe(16, () => {
-            elapsedMs += 16;
-            if (elapsedMs < delayMs) return;
+            const elapsed = Date.now() - startTime;
+            if (elapsed < delayMs) return;
 
             unsubDelay();
             isStarted = true;

--- a/packages/motion/src/stagger.ts
+++ b/packages/motion/src/stagger.ts
@@ -1,0 +1,47 @@
+// ─────────────────────────────────────────────────────
+// Animation Staggering — delayed parallel starts
+// ─────────────────────────────────────────────────────
+
+import { subscribe } from './timer-pool.js';
+import type { AnimationRunner } from './sequence.js';
+import * as sequencing from './sequence.js';
+
+/**
+ * Run a list of animations in parallel with a fixed start offset per item.
+ * item 0 starts immediately, item 1 after delayMs, item 2 after 2*delayMs, etc.
+ * Returns a master cancel function to stop pending and active animations.
+ */
+export function stagger(animations: AnimationRunner[], delayMs: number, onComplete?: () => void): () => void {
+    const normalizedDelayMs = Math.max(0, delayMs);
+    const delayedAnimations = animations.map((runner, index) => withDelay(runner, index * normalizedDelayMs));
+    return sequencing.parallel(delayedAnimations, onComplete);
+}
+
+function withDelay(runner: AnimationRunner, delayMs: number): AnimationRunner {
+    return (done) => {
+        if (delayMs <= 0) {
+            return runner(done);
+        }
+
+        let elapsedMs = 0;
+        let cancelStarted: (() => void) | null = null;
+        let isStarted = false;
+
+        const unsubDelay = subscribe(16, () => {
+            elapsedMs += 16;
+            if (elapsedMs < delayMs) return;
+
+            unsubDelay();
+            isStarted = true;
+            cancelStarted = runner(done);
+        });
+
+        return () => {
+            unsubDelay();
+            if (isStarted) {
+                cancelStarted?.();
+            }
+            cancelStarted = null;
+        };
+    };
+}


### PR DESCRIPTION
## Description

This PR introduces a new `stagger` helper to `@termuijs/motion`, allowing animations to start with configurable per-item delay offsets. The implementation follows the existing motion sequencing patterns and reuses existing motion primitives to maintain consistency within the package.

## Related Issue

Closes #307

## Which package(s)?

@termuijs/motion

## Type of Change

- [x] ✨ Feature (`type:feature`)

## Checklist

- [x] ⭐ You starred the repository.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [x] You read `CONTRIBUTING.md`.
- [x] Your PR title follows `type: short description`.
- [x] No new `any` types without justification.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/YOUR_PROFILE_ID`

## Notes for the Reviewer

### Changes Made

- Added `packages/motion/src/stagger.ts`
- Added `packages/motion/src/stagger.test.ts`
- Exported the helper from `packages/motion/src/index.ts`

### Implementation Details

- Added a new `stagger` helper that starts animations with a configurable delay offset per item.
- Reused existing motion sequencing primitives to keep the implementation aligned with the current architecture.
- Included test coverage for:
  - Core stagger behavior
  - Empty input handling
  - Boundary values such as zero delay and single animation
  - Compatibility with existing sequencing APIs

### Scope

All changes are confined to `packages/motion` as required by the issue specification.