### PR TITLE
feat(jsx): add useToggle hook with tests and docs

### DIFF
--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -54,6 +54,7 @@ render(<App />)
 | Hook | What it does |
 |------|-------------|
 | `useState` | Component state. Triggers a re-render when the value changes |
+| `useToggle` | Boolean state with `toggle`, `on`, and `off` helpers |
 | `useEffect` | Side effects with cleanup. Runs after render, re-runs when deps change |
 | `useRef` | Mutable ref that persists across renders without causing re-renders |
 | `useInput` | Register a keyboard handler for this component |
@@ -106,6 +107,28 @@ function AnimatedWidget() {
     }, [prefersReducedMotion])
 
     return <Box>...</Box>
+}
+```
+
+## useToggle
+
+Manage a simple boolean state with helpers to flip, enable, or disable it.
+
+```tsx
+import { useToggle } from '@termuijs/jsx'
+import { Box, Text, Button } from '@termuijs/widgets'
+
+function ToggleExample() {
+    const [isOpen, controls] = useToggle()
+
+    return (
+        <Box>
+            <Text>{isOpen ? 'Open' : 'Closed'}</Text>
+            <Button onPress={controls.toggle}>Toggle</Button>
+            <Button onPress={controls.on}>Open</Button>
+            <Button onPress={controls.off}>Close</Button>
+        </Box>
+    )
 }
 ```
 

--- a/packages/jsx/src/hooks/useToggle.test.ts
+++ b/packages/jsx/src/hooks/useToggle.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createFiber, setCurrentFiber, clearCurrentFiber, setRequestRender } from '../hooks.js';
+import { useToggle } from './useToggle';
+
+describe('useToggle', () => {
+  let fiber = createFiber();
+
+  beforeEach(() => {
+    fiber = createFiber();
+    setRequestRender(() => { });
+    setCurrentFiber(fiber);
+  });
+
+  afterEach(() => {
+    clearCurrentFiber();
+  });
+
+  it('defaults initial value to false', () => {
+    const [value] = useToggle();
+    expect(value).toBe(false);
+  });
+
+  it('toggle() flips the value', () => {
+    const [initial, controls] = useToggle(false);
+    expect(initial).toBe(false);
+
+    controls.toggle();
+
+    fiber.hookIndex = 0;
+    const [nextValue] = useToggle(false);
+    expect(nextValue).toBe(true);
+  });
+
+  it('on() sets the value to true', () => {
+    const [, controls] = useToggle(false);
+    controls.on();
+
+    fiber.hookIndex = 0;
+    const [nextValue] = useToggle(false);
+    expect(nextValue).toBe(true);
+  });
+
+  it('off() sets the value to false', () => {
+    const [, controls] = useToggle(true);
+    controls.off();
+
+    fiber.hookIndex = 0;
+    const [nextValue] = useToggle(true);
+    expect(nextValue).toBe(false);
+  });
+});

--- a/packages/jsx/src/hooks/useToggle.ts
+++ b/packages/jsx/src/hooks/useToggle.ts
@@ -1,0 +1,17 @@
+import { useState } from '../hooks.js';
+
+export interface UseToggleResult {
+  toggle: () => void;
+  on: () => void;
+  off: () => void;
+}
+
+export function useToggle(initialValue = false): [boolean, UseToggleResult] {
+  const [value, setValue] = useState(initialValue);
+
+  return [value, {
+    toggle: () => setValue((prev) => !prev),
+    on: () => setValue(true),
+    off: () => setValue(false),
+  }];
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -27,6 +27,7 @@ export {
     useInsertBefore,
     useReducer,
 } from './hooks.js';
+export { useToggle } from './hooks/useToggle.js';
 export type { AsyncState, KeyBinding, MotionPreferences } from './hooks.js';
 
 // ── Error Boundary ──


### PR DESCRIPTION
## Description

Adds a new `useToggle` hook to `@termuijs/jsx` for boolean state management with helper actions: `toggle()`, `on()`, and `off()`. The hook defaults to `false`, is exported from the JSX public API, and is documented in `packages/jsx/README.md`.

## Related Issue

Closes #286

## Which package(s)?

- @termuijs/jsx

## Type of Change

- [x] ✨ Feature (`type:feature`)
- [x] 🧪 Tests (`type:testing`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run packages/jsx`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
-  GSSoC profile: `https://gssoc.girlscript.org/profile/8272bdf2-0dcb-495a-986d-5b830169eb1e`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

- Implemented `packages/jsx/src/hooks/useToggle.ts`
- Added tests in `packages/jsx/src/hooks/useToggle.test.ts`
- Exported `useToggle` from `packages/jsx/src/index.ts`
- Updated `packages/jsx/README.md` with usage docs
- Verified `bun vitest run packages/jsx` and `bun run typecheck`