### PR TITLE
feat(widgets): add UnorderedList widget

### DIFF
--- a/packages/widgets/src/display/UnorderedList.test.ts
+++ b/packages/widgets/src/display/UnorderedList.test.ts
@@ -1,0 +1,111 @@
+// -----------------------------------------------------------------------------
+// @termuijs/widgets - Tests for UnorderedList widget
+// -----------------------------------------------------------------------------
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { caps, Screen } from '@termuijs/core';
+import { UnorderedList, type ListItem } from './UnorderedList.js';
+
+function renderList(
+    items: ListItem[],
+    opts = {},
+    width = 40,
+    height = 10,
+): { list: UnorderedList; screen: Screen } {
+    const list = new UnorderedList(items, {}, opts);
+    const screen = new Screen(width, height);
+
+    list.updateRect({ x: 0, y: 0, width, height });
+    list.render(screen);
+
+    return { list, screen };
+}
+
+function rowText(screen: Screen, row: number): string {
+    let line = '';
+    for (let col = 0; col < screen.cols; col++) {
+        line += screen.back[row]?.[col]?.char ?? ' ';
+    }
+    return line.trimEnd();
+}
+
+describe('UnorderedList', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('renders a two-item list with bullet prefixes', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+
+        const { screen } = renderList([
+            { text: 'Install dependencies' },
+            { text: 'Run tests' },
+        ]);
+
+        expect(rowText(screen, 0)).toBe('\u2022 Install dependencies');
+        expect(rowText(screen, 1)).toBe('\u2022 Run tests');
+    });
+
+    it('renders nested items with indentation and level-specific markers', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+
+        const { screen } = renderList([
+            {
+                text: 'Parent',
+                children: [{ text: 'Child' }],
+            },
+        ]);
+
+        expect(rowText(screen, 0)).toBe('\u2022 Parent');
+        expect(rowText(screen, 1)).toBe('  \u25E6 Child');
+    });
+
+    it('uses ASCII fallback markers when unicode is unavailable', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+
+        const { screen } = renderList([
+            {
+                text: 'Parent',
+                children: [{ text: 'Child' }],
+            },
+        ]);
+
+        expect(rowText(screen, 0)).toBe('* Parent');
+        expect(rowText(screen, 1)).toBe('  - Child');
+    });
+
+    it('uses custom markers for each nesting level', () => {
+        const { screen } = renderList(
+            [
+                {
+                    text: 'Root',
+                    children: [
+                        {
+                            text: 'Branch',
+                            children: [{ text: 'Leaf' }],
+                        },
+                    ],
+                },
+            ],
+            { markers: ['>', '~'], indent: 3 },
+        );
+
+        expect(rowText(screen, 0)).toBe('> Root');
+        expect(rowText(screen, 1)).toBe('   ~ Branch');
+        expect(rowText(screen, 2)).toBe('      ~ Leaf');
+    });
+
+    it('setItems updates the list and marks the widget dirty', () => {
+        const { list, screen } = renderList([{ text: 'Old item' }]);
+        expect(rowText(screen, 0)).toContain('Old item');
+
+        list.clearDirty();
+        list.setItems([{ text: 'New item' }]);
+
+        const nextScreen = new Screen(40, 10);
+        list.render(nextScreen);
+
+        expect(list.isDirty).toBe(true);
+        expect(rowText(nextScreen, 0)).toContain('New item');
+    });
+});

--- a/packages/widgets/src/display/UnorderedList.ts
+++ b/packages/widgets/src/display/UnorderedList.ts
@@ -1,0 +1,95 @@
+// -----------------------------------------------------------------------------
+// @termuijs/widgets - UnorderedList widget
+// -----------------------------------------------------------------------------
+
+import {
+    type Screen,
+    type Style,
+    caps,
+    styleToCellAttrs,
+    truncate,
+} from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export interface ListItem {
+    text: string;
+    children?: ListItem[];
+}
+
+export interface UnorderedListOptions {
+    /** Bullet characters per nesting level. Default uses Unicode with ASCII fallback. */
+    markers?: string[];
+    /** Indent width per level. Default: 2 */
+    indent?: number;
+}
+
+interface VisibleItem {
+    item: ListItem;
+    depth: number;
+}
+
+/**
+ * UnorderedList - renders a bulleted list with optional nested children.
+ */
+export class UnorderedList extends Widget {
+    private _items: ListItem[];
+    private _markers?: string[];
+    private _indent: number;
+
+    constructor(
+        items: ListItem[],
+        style: Partial<Style> = {},
+        opts: UnorderedListOptions = {},
+    ) {
+        super(style);
+        this._items = items;
+        this._markers = opts.markers;
+        this._indent = opts.indent ?? 2;
+    }
+
+    setItems(items: ListItem[]): void {
+        this._items = items;
+        this.markDirty();
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width, height } = this._getContentRect();
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this._style);
+        const rows = _flattenItems(this._items);
+
+        for (let i = 0; i < Math.min(rows.length, height); i++) {
+            const row = rows[i];
+            const marker = this._markerForDepth(row.depth);
+            const indent = ' '.repeat(row.depth * this._indent);
+            const line = truncate(`${indent}${marker} ${row.item.text}`, width);
+
+            screen.writeString(x, y + i, line, attrs);
+        }
+    }
+
+    private _markerForDepth(depth: number): string {
+        const markers = this._markers ?? _defaultMarkers();
+        if (markers.length === 0) return caps.unicode ? '\u2022' : '*';
+
+        return markers[Math.min(depth, markers.length - 1)];
+    }
+}
+
+function _defaultMarkers(): string[] {
+    return caps.unicode
+        ? ['\u2022', '\u25E6', '\u25AA']
+        : ['*', '-', '+'];
+}
+
+function _flattenItems(items: ListItem[], depth = 0, out: VisibleItem[] = []): VisibleItem[] {
+    for (const item of items) {
+        out.push({ item, depth });
+        if (item.children && item.children.length > 0) {
+            _flattenItems(item.children, depth + 1, out);
+        }
+    }
+
+    return out;
+}

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -14,6 +14,8 @@ export { LogView } from './display/LogView.js';
 export type { LogViewOptions } from './display/LogView.js';
 export { Tree } from './display/Tree.js';
 export type { TreeNode, TreeOptions } from './display/Tree.js';
+export { UnorderedList } from './display/UnorderedList.js';
+export type { UnorderedListOptions } from './display/UnorderedList.js';
 export { JSONView, jsonToTree } from './display/JSONView.js';
 export type { JSONViewOptions, JSONNodeData, JSONNodeType } from './display/JSONView.js';
 export { DiffView } from './display/DiffView.js';


### PR DESCRIPTION
## Summary
- add `UnorderedList` display widget for nested bulleted lists
- support custom markers, configurable indentation, and Unicode/ASCII default markers via `caps.unicode`
- add tests for rendering, nesting, ASCII fallback, custom markers, and `setItems()` dirty state

Closes #270

## Validation
- `bun run build`
- `bun vitest run packages/widgets`
- `bun vitest run`
- `bun run typecheck`