### PR TITLE
feat(widgets): add Fill widget

### DIFF
--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -69,6 +69,8 @@ export { ScrollView } from './layout/ScrollView.js';
 export type { ScrollViewOptions } from './layout/ScrollView.js';
 export { Center } from './layout/Center.js';
 export type { CenterOptions } from './layout/Center.js';
+export { Fill } from './layout/Fill.js';
+export type { FillOptions } from './layout/Fill.js';
 export { Card } from './layout/Card.js';
 export type { CardOptions } from './layout/Card.js';
 export { Columns } from './layout/Columns.js';

--- a/packages/widgets/src/layout/Fill.test.ts
+++ b/packages/widgets/src/layout/Fill.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Screen } from '@termuijs/core';
+import { Fill } from './Fill.js';
+
+describe('Fill widget', () => {
+    it('all cells in a 10x5 widget contain the fill character', () => {
+        const fill = new Fill({}, { char: '#' });
+
+        fill.updateRect({ x: 0, y: 0, width: 10, height: 5 });
+
+        const screen = new Screen(10, 5);
+        fill.render(screen);
+
+        for (let y = 0; y < 5; y++) {
+            for (let x = 0; x < 10; x++) {
+                expect(screen.back[y][x].char).toBe('#');
+            }
+        }
+    });
+
+    it('setChar updates the fill character', () => {
+        const fill = new Fill({}, { char: '#' });
+
+        fill.setChar('*');
+
+        fill.updateRect({ x: 0, y: 0, width: 10, height: 5 });
+
+        const screen = new Screen(10, 5);
+        fill.render(screen);
+
+        expect(screen.back[0][0].char).toBe('*');
+    });
+
+    it('setChar triggers markDirty', () => {
+        const fill = new Fill();
+
+        const spy = vi.spyOn(fill, 'markDirty');
+
+        fill.setChar('*');
+
+        expect(spy).toHaveBeenCalled();
+    });
+});

--- a/packages/widgets/src/layout/Fill.ts
+++ b/packages/widgets/src/layout/Fill.ts
@@ -1,0 +1,38 @@
+import { type Screen, type Style, type Color } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export interface FillOptions {
+    char?: string;
+    color?: Color;
+}
+
+export class Fill extends Widget {
+    private _char: string;
+    private _color?: Color;
+
+    constructor(style: Partial<Style> = {}, opts: FillOptions = {}) {
+        super(style);
+        this._char = opts.char ?? ' ';
+        this._color = opts.color;
+    }
+
+    setChar(char: string): void {
+        this._char = char;
+        this.markDirty();
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width, height } = this._getContentRect();
+
+        if (width <= 0 || height <= 0) return;
+
+        for (let row = y; row < y + height; row++) {
+            for (let col = x; col < x + width; col++) {
+                screen.setCell(col, row, {
+                    char: this._char,
+                    fg: this._color,
+                });
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Added a new Fill widget that fills the allocated widget area with a specified character. Added tests to verify rendering behavior and exported the widget through the public API of the widgets package.

## Related Issue

Closes #280

## Which package(s)?

@termuijs/widgets

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [x] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md](https://chatgpt.com/c/CONTRIBUTING.md)`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

       You are a GSSoC 2026 contributor.

* Your GSSoC profile: `https://gssoc.girlscript.org/profile/e28902d6-ac09-4030-a305-38827f21efb0`

## Screenshots / Recordings (UI changes)

N/A (No visual UI changes)

## Notes for the Reviewer

* Added Fill widget implementation.
* Added unit tests for Fill widget behavior.
* Exported Fill and FillOptions from the public API.
* Build and tests pass successfully.