### PR TITLE
feat(data): add useGpu hook

### DIFF
--- a/packages/data/src/hooks/useGpu.test.ts
+++ b/packages/data/src/hooks/useGpu.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as os from 'node:os';
+import * as cp from 'node:child_process';
+
+let stateValues: unknown[] = [];
+let stateSetters: Array<ReturnType<typeof vi.fn>> = [];
+let effectCb: (() => (() => void) | void) | null = null;
+let stateCallCount = 0;
+
+vi.mock('@termuijs/jsx', () => ({
+    useState: (initial: unknown) => {
+        const id = stateCallCount++;
+        if (stateValues[id] === undefined) {
+            stateValues[id] = typeof initial === 'function' ? (initial as () => unknown)() : initial;
+        }
+        if (!stateSetters[id]) {
+            stateSetters[id] = vi.fn((newVal: unknown) => {
+                stateValues[id] = typeof newVal === 'function'
+                    ? (newVal as (prev: unknown) => unknown)(stateValues[id])
+                    : newVal;
+            });
+        }
+        return [stateValues[id], stateSetters[id]];
+    },
+    useEffect: (cb: () => (() => void) | void) => {
+        effectCb = cb;
+    },
+    useInterval: vi.fn(),
+}));
+
+const flushPromises = () => new Promise<void>(resolve => process.nextTick(resolve));
+
+vi.mock('node:os', () => ({
+    platform: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+    exec: vi.fn(),
+}));
+
+const { useGpu } = await import('./useGpu.js');
+
+describe('useGpu', () => {
+    beforeEach(() => {
+        stateValues = [];
+        stateSetters = [];
+        stateCallCount = 0;
+        effectCb = null;
+
+        vi.useFakeTimers();
+        vi.spyOn(os, 'platform').mockReturnValue('linux');
+
+        (cp.exec as ReturnType<typeof vi.fn>).mockImplementation((cmd: string, opts: unknown, cb: unknown) => {
+            const callback = typeof opts === 'function' ? opts : cb;
+            if (typeof callback !== 'function') return;
+
+            if (cmd.includes('nvidia-smi')) {
+                callback(null, '72, 4096, 8192\n', '');
+                return;
+            }
+            callback(new Error('Command failed'), '', '');
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    it('initial state is loading', () => {
+        const { data, error, loading } = useGpu(1000);
+
+        expect(loading).toBe(true);
+        expect(data).toBeNull();
+        expect(error).toBeNull();
+    });
+
+    it('fetches data and updates state after async resolution', async () => {
+        useGpu(1000);
+
+        if (effectCb) {
+            effectCb();
+        }
+
+        await flushPromises();
+
+        expect(stateValues[0]).toEqual({
+            utilizationPercent: 72,
+            vramUsedMb: 4096,
+            vramTotalMb: 8192,
+        });
+        expect(stateValues[1]).toBeNull();
+        expect(stateValues[2]).toBe(false);
+    });
+
+    it('cleans up interval on unmount', () => {
+        useGpu(1000);
+
+        const cleanup = effectCb ? effectCb() : undefined;
+
+        expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+        if (typeof cleanup === 'function') {
+            cleanup();
+        }
+
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('sets error when GPU metrics cannot be read', async () => {
+        vi.spyOn(os, 'platform').mockReturnValue('darwin');
+        (cp.exec as ReturnType<typeof vi.fn>).mockImplementation((cmd: string, opts: unknown, cb: unknown) => {
+            const callback = typeof opts === 'function' ? opts : cb;
+            if (typeof callback === 'function') {
+                callback(new Error('nvidia-smi not found'), '', '');
+            }
+        });
+
+        useGpu(1000);
+
+        if (effectCb) {
+            effectCb();
+        }
+
+        await flushPromises();
+
+        expect(stateValues[1]).toBeInstanceOf(Error);
+        expect((stateValues[1] as Error).message).toContain('GPU metrics not available');
+        expect(stateValues[2]).toBe(false);
+    });
+});

--- a/packages/data/src/hooks/useGpu.ts
+++ b/packages/data/src/hooks/useGpu.ts
@@ -1,0 +1,131 @@
+import { useState, useEffect } from '@termuijs/jsx';
+import { exec, type ExecOptions } from 'node:child_process';
+import * as os from 'node:os';
+
+const execAsync = (cmd: string, opts?: ExecOptions): Promise<{ stdout: string; stderr: string }> => {
+    return new Promise((resolve, reject) => {
+        exec(cmd, opts, (err, stdout, stderr) => {
+            if (err) reject(err);
+            else resolve({ stdout: String(stdout), stderr: String(stderr) });
+        });
+    });
+};
+
+export interface GpuData {
+    utilizationPercent: number;
+    vramUsedMb: number | null;
+    vramTotalMb: number | null;
+}
+
+export interface UseGpuResult {
+    data: GpuData | null;
+    error: Error | null;
+    loading: boolean;
+}
+
+async function fetchNvidiaGpu(): Promise<GpuData> {
+    const { stdout } = await execAsync(
+        'nvidia-smi --query-gpu=utilization.gpu,memory.used,memory.total --format=csv,noheader,nounits',
+        { timeout: 5000 },
+    );
+    const line = stdout.trim().split('\n')[0];
+    if (!line) {
+        throw new Error('No GPU data from nvidia-smi');
+    }
+    const parts = line.split(',').map(part => part.trim());
+    const utilizationPercent = parseInt(parts[0] ?? '', 10);
+    if (Number.isNaN(utilizationPercent)) {
+        throw new Error('Could not parse GPU utilization');
+    }
+    const vramUsedMb = parseOptionalInt(parts[1]);
+    const vramTotalMb = parseOptionalInt(parts[2]);
+    return { utilizationPercent, vramUsedMb, vramTotalMb };
+}
+
+function parseOptionalInt(value: string | undefined): number | null {
+    if (value === undefined || value === '') return null;
+    const parsed = parseInt(value, 10);
+    return Number.isNaN(parsed) ? null : parsed;
+}
+
+async function fetchLinuxAmdGpu(): Promise<GpuData> {
+    const { stdout: busy } = await execAsync('cat /sys/class/drm/card0/device/gpu_busy_percent', { timeout: 2000 });
+    const utilizationPercent = parseInt(busy.trim(), 10);
+    if (Number.isNaN(utilizationPercent)) {
+        throw new Error('Could not parse GPU utilization');
+    }
+
+    let vramUsedMb: number | null = null;
+    let vramTotalMb: number | null = null;
+    try {
+        const { stdout: used } = await execAsync('cat /sys/class/drm/card0/device/mem_info_vram_used', { timeout: 2000 });
+        const { stdout: total } = await execAsync('cat /sys/class/drm/card0/device/mem_info_vram_total', { timeout: 2000 });
+        vramUsedMb = Math.round(parseInt(used.trim(), 10) / (1024 * 1024));
+        vramTotalMb = Math.round(parseInt(total.trim(), 10) / (1024 * 1024));
+        if (Number.isNaN(vramUsedMb)) vramUsedMb = null;
+        if (Number.isNaN(vramTotalMb)) vramTotalMb = null;
+    } catch {
+        // VRAM sysfs nodes are optional on some drivers
+    }
+
+    return { utilizationPercent, vramUsedMb, vramTotalMb };
+}
+
+async function fetchGpuMetrics(): Promise<GpuData> {
+    try {
+        return await fetchNvidiaGpu();
+    } catch {
+        // nvidia-smi unavailable — try platform fallbacks
+    }
+
+    if (os.platform() === 'linux') {
+        return fetchLinuxAmdGpu();
+    }
+
+    throw new Error(`GPU metrics not available on platform: ${os.platform()}`);
+}
+
+/**
+ * useGpu — reactive GPU utilization and VRAM metrics, updated every `intervalMs` milliseconds.
+ *
+ * Uses `nvidia-smi` when available; on Linux falls back to AMDGPU sysfs when present.
+ * VRAM fields are `null` when the platform does not expose memory usage.
+ */
+export function useGpu(intervalMs = 5000): UseGpuResult {
+    const [data, setData] = useState<GpuData | null>(null);
+    const [error, setError] = useState<Error | null>(null);
+    const [loading, setLoading] = useState<boolean>(true);
+
+    useEffect(() => {
+        let isMounted = true;
+        let timer: ReturnType<typeof setInterval> | null = null;
+
+        const update = async () => {
+            try {
+                const metrics = await fetchGpuMetrics();
+                if (isMounted) {
+                    setData(metrics);
+                    setError(null);
+                    setLoading(false);
+                }
+            } catch (err) {
+                if (isMounted) {
+                    setError(err instanceof Error ? err : new Error(String(err)));
+                    setLoading(false);
+                }
+            }
+        };
+
+        update();
+        timer = setInterval(update, intervalMs);
+
+        return () => {
+            isMounted = false;
+            if (timer !== null) {
+                clearInterval(timer);
+            }
+        };
+    }, [intervalMs]);
+
+    return { data, error, loading };
+}

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -46,3 +46,5 @@ export type { BatteryData, UseBatteryResult } from './hooks/useBattery.js';
 
 export { usePolling } from './hooks/usePolling.js';
 export type { UsePollingResult } from './hooks/usePolling.js';
+export { useGpu } from './hooks/useGpu.js';
+export type { GpuData, UseGpuResult } from './hooks/useGpu.js';


### PR DESCRIPTION
## Description

This PR adds a new `useGpu` hook to `@termuijs/data` that reports GPU utilization and VRAM usage where available. The hook exposes a typed result object containing `data`, `error`, and `loading` state, supports polling on mount, and performs proper cleanup on unmount.

## Related Issue

Closes #299

## Which package(s)?

@termuijs/data

## Type of Change

- [x] ✨ Feature (`type:feature`)

## Checklist

- [x] ⭐ You starred the repository.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [x] You read `CONTRIBUTING.md`.
- [x] Your PR title follows `type: short description`.
- [x] No new `any` types without justification.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.


## Notes for the Reviewer

### Changes Made

- Added `packages/data/src/hooks/useGpu.ts`
- Added `packages/data/src/hooks/useGpu.test.ts`
- Exported `useGpu` from `packages/data/src/index.ts`

### Implementation Details

- Added a new `useGpu` hook that provides GPU utilization and VRAM metrics where available.
- Returns a typed result object with `data`, `error`, and `loading` fields.
- Starts polling on mount and performs cleanup on unmount.
- Re-triggers when the polling interval dependency changes.
- Includes test coverage for:
  - Initial loading state
  - Successful async data updates
  - Cleanup on unmount
  - Error handling when GPU metrics are unavailable

### Scope

All changes are confined to `packages/data` as required by the issue specification.