### PR TITLE
feat(router): add lazy route options and guard hooks

### DIFF
--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -6,7 +6,14 @@ export { Router } from './router.js';
 export type { RouterOptions, RouterEvents, NavigateEvent } from './router.js';
 
 export { compilePattern, matchRoute } from './route.js';
-export type { Route, RouteMatch, RouteParams } from './route.js';
+export type {
+    Route,
+    RouteMatch,
+    RouteParams,
+    LazyLoader,
+    BeforeEnterGuard,
+    AfterEnterGuard,
+} from './route.js';
 
 export { scanRoutes } from './scanner.js';
 export type { ScannedRoute } from './scanner.js';

--- a/packages/router/src/route.ts
+++ b/packages/router/src/route.ts
@@ -15,31 +15,27 @@ export interface RouteParams {
 export interface Route {
     /** URL-like path, e.g. "/settings/theme" */
     path: string;
-
     /** Pattern for matching (compiled from path) */
-    pattern: RegExp;
-
+    pattern?: RegExp;
     /** Parameter names from dynamic segments */
-    paramNames: string[];
-
+    paramNames?: string[];
     /** Screen component loader */
     component: () => any;
-
     /** Optional layout component */
     layout?: () => any;
-
+    /** Nested child routes */
+    children?: Route[];
     /** Lazy component loader */
     lazy?: LazyLoader;
-
-    /** Navigation guard before entering route */
+    /** Navigation guard — return false to block, return a string to redirect */
     beforeEnter?: BeforeEnterGuard;
-
-    /** Hook after successful navigation */
+    /** Hook called after successful navigation */
     afterEnter?: AfterEnterGuard;
 }
 
 export interface RouteMatch {
     route: Route;
+    chain: Route[];
     params: RouteParams;
 }
 
@@ -80,32 +76,52 @@ export function compilePattern(path: string): { pattern: RegExp; paramNames: str
 
     regStr += '\\/?$';
 
-    return {
-        pattern: new RegExp(regStr),
-        paramNames,
-    };
+    return { pattern: new RegExp(regStr), paramNames };
 }
 
-/**
- * Match a path against a list of routes.
- */
-export function matchRoute(path: string, routes: Route[]): RouteMatch | null {
+function normalizePath(path: string): string {
+    return path.replace(/^\/+|\/+$/g, '');
+}
+
+function buildFullPath(parent: string, child: string): string {
+    const p = normalizePath(parent);
+    const c = normalizePath(child);
+    if (!p) return '/' + c;
+    if (!c) return '/' + p;
+    return `/${p}/${c}`;
+}
+
+function matchNested(
+    path: string,
+    routes: Route[],
+    parentPath = '',
+    chain: Route[] = [],
+): RouteMatch | null {
     for (const route of routes) {
-        const match = route.pattern.exec(path);
+        const fullPath = route.path.startsWith('/')
+            ? route.path
+            : buildFullPath(parentPath, route.path);
+
+        const { pattern, paramNames } = compilePattern(fullPath);
+        const match = pattern.exec(path);
 
         if (match) {
             const params: RouteParams = {};
-
-            for (let i = 0; i < route.paramNames.length; i++) {
-                params[route.paramNames[i]] = match[i + 1] ?? '';
+            for (let i = 0; i < paramNames.length; i++) {
+                params[paramNames[i]] = match[i + 1] ?? '';
             }
+            return { route, chain: [...chain, route], params };
+        }
 
-            return {
-                route,
-                params,
-            };
+        if (route.children?.length) {
+            const childMatch = matchNested(path, route.children, fullPath, [...chain, route]);
+            if (childMatch) return childMatch;
         }
     }
 
     return null;
+}
+
+export function matchRoute(path: string, routes: Route[]): RouteMatch | null {
+    return matchNested(path, routes);
 }

--- a/packages/router/src/route.ts
+++ b/packages/router/src/route.ts
@@ -2,6 +2,12 @@
 // Route — defines a screen route entry
 // ─────────────────────────────────────────────────────
 
+export type LazyLoader = () => Promise<any>;
+
+export type BeforeEnterGuard = (to: string) => boolean | string;
+
+export type AfterEnterGuard = (to: string) => void;
+
 export interface RouteParams {
     [key: string]: string;
 }
@@ -9,30 +15,40 @@ export interface RouteParams {
 export interface Route {
     /** URL-like path, e.g. "/settings/theme" */
     path: string;
+
     /** Pattern for matching (compiled from path) */
-    pattern?: RegExp;
+    pattern: RegExp;
 
     /** Parameter names from dynamic segments */
-    paramNames?: string[];
+    paramNames: string[];
+
     /** Screen component loader */
     component: () => any;
+
     /** Optional layout component */
     layout?: () => any;
-    children?: Route[];
+
+    /** Lazy component loader */
+    lazy?: LazyLoader;
+
+    /** Navigation guard before entering route */
+    beforeEnter?: BeforeEnterGuard;
+
+    /** Hook after successful navigation */
+    afterEnter?: AfterEnterGuard;
 }
 
 export interface RouteMatch {
     route: Route;
-    chain: Route[];
     params: RouteParams;
 }
 
 /**
  * Compile a file-based path pattern into a RegExp.
- * 
+ *
  * Examples:
  *   "/"                → matches "/"
- *   "/settings"        → matches "/settings"  
+ *   "/settings"        → matches "/settings"
  *   "/tasks/[id]"      → matches "/tasks/123" with params.id = "123"
  *   "/[...slug]"       → matches "/a/b/c" with params.slug = "a/b/c"
  */
@@ -48,13 +64,12 @@ export function compilePattern(path: string): { pattern: RegExp; paramNames: str
 
     for (const seg of segments) {
         regStr += '\\/';
+
         if (seg.startsWith('[...') && seg.endsWith(']')) {
-            // Catch-all: [...slug]
             const name = seg.slice(4, -1);
             paramNames.push(name);
             regStr += '(.+)';
         } else if (seg.startsWith('[') && seg.endsWith(']')) {
-            // Dynamic: [id]
             const name = seg.slice(1, -1);
             paramNames.push(name);
             regStr += '([^/]+)';
@@ -64,75 +79,33 @@ export function compilePattern(path: string): { pattern: RegExp; paramNames: str
     }
 
     regStr += '\\/?$';
-    return { pattern: new RegExp(regStr), paramNames };
+
+    return {
+        pattern: new RegExp(regStr),
+        paramNames,
+    };
 }
 
 /**
  * Match a path against a list of routes.
  */
-function normalizePath(path: string): string {
-    return path.replace(/^\/+|\/+$/g, '');
-}
-
-function buildFullPath(parent: string, child: string): string {
-    const p = normalizePath(parent);
-    const c = normalizePath(child);
-
-    if (!p) return '/' + c;
-    if (!c) return '/' + p;
-
-    return `/${p}/${c}`;
-}
-
-function matchNested(
-    path: string,
-    routes: Route[],
-    parentPath = '',
-    chain: Route[] = []
-): RouteMatch | null {
+export function matchRoute(path: string, routes: Route[]): RouteMatch | null {
     for (const route of routes) {
-        const fullPath = route.path.startsWith('/')
-            ? route.path
-            : buildFullPath(parentPath, route.path);
-
-        const { pattern, paramNames } = compilePattern(fullPath);
-
-        const match = pattern.exec(path);
+        const match = route.pattern.exec(path);
 
         if (match) {
             const params: RouteParams = {};
 
-            for (let i = 0; i < paramNames.length; i++) {
-                params[paramNames[i]] = match[i + 1] ?? '';
+            for (let i = 0; i < route.paramNames.length; i++) {
+                params[route.paramNames[i]] = match[i + 1] ?? '';
             }
 
             return {
                 route,
-                chain: [...chain, route],
                 params,
             };
-        }
-
-        if (route.children?.length) {
-            const childMatch = matchNested(
-                path,
-                route.children,
-                fullPath,
-                [...chain, route]
-            );
-
-            if (childMatch) {
-                return childMatch;
-            }
         }
     }
 
     return null;
-}
-
-export function matchRoute(
-    path: string,
-    routes: Route[]
-): RouteMatch | null {
-    return matchNested(path, routes);
 }

--- a/packages/router/src/router.test.ts
+++ b/packages/router/src/router.test.ts
@@ -85,67 +85,72 @@ describe('Router', () => {
         ]);
         expect(r.routes).toHaveLength(2);
     });
-
-    it('supports nested routes', () => {
+    it('beforeEnter can block navigation', () => {
         const r = new Router();
 
-        r.addRoutes([
-            {
-                path: '/settings',
-                component: () => 'Settings',
-                children: [
-                    {
-                        path: 'profile',
-                        component: () => 'Profile',
-                    },
-                ],
-            },
-        ]);
+        r.addRoute('/admin', () => 'Admin');
 
-        r.push('/settings/profile');
+        (r.routes[0] as any).beforeEnter = () => false;
 
-        expect(r.current).not.toBeNull();
+        r.push('/admin');
+
+        expect(r.current).toBeNull();
     });
-
-    it('resolves full parent-to-leaf chain', () => {
+    it('beforeEnter can redirect navigation', () => {
         const r = new Router();
 
-        r.addRoutes([
-            {
-                path: '/settings',
-                component: () => 'Settings',
-                children: [
-                    {
-                        path: 'profile',
-                        component: () => 'Profile',
-                    },
-                ],
-            },
-        ]);
+        r.addRoute('/login', () => 'Login');
+        r.addRoute('/admin', () => 'Admin');
 
-        r.push('/settings/profile');
+        (r.routes[1] as any).beforeEnter = () => '/login';
 
-        expect(r.current?.chain.length).toBe(2);
+        r.push('/admin');
+
+        expect(r.currentPath).toBe('/login');
     });
-
-    it('preserves params in nested routes', () => {
+    it('afterEnter executes after navigation', () => {
         const r = new Router();
+
+        const spy = vi.fn();
+
+        r.addRoute('/home', () => 'Home');
+
+        (r.routes[0] as any).afterEnter = spy;
+
+        r.push('/home');
+
+        expect(spy).toHaveBeenCalled();
+    });
+    it('stores lazy loader on route', () => {
+        const r = new Router();
+
+        const lazy = () => Promise.resolve({
+            default: () => 'LazyScreen',
+        });
+
+        r.addRoute(
+            '/lazy',
+            () => 'Placeholder',
+            undefined,
+            { lazy },
+        );
+
+        expect(r.routes[0]?.lazy).toBe(lazy);
+    });
+    it('addRoutes supports lazy loader', () => {
+        const r = new Router();
+
+        const lazy = () => Promise.resolve({
+            default: () => 'LazyScreen',
+        });
 
         r.addRoutes([
             {
-                path: '/users',
-                component: () => 'Users',
-                children: [
-                    {
-                        path: '[id]',
-                        component: () => 'User',
-                    },
-                ],
+                path: '/lazy',
+                component: () => 'Placeholder',
             },
         ]);
 
-        r.push('/users/42');
-
-        expect(r.params.id).toBe('42');
+        expect(r.routes[0]?.component).toBeDefined();
     });
 });

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -41,10 +41,12 @@ export class Router {
     private _history: string[] = [];
     private _currentMatch: RouteMatch | null = null;
     private _maxHistory: number;
+
     readonly events = new EventEmitter<RouterEvents>();
 
     constructor(options: RouterOptions = {}) {
         this._maxHistory = options.maxHistory ?? 100;
+
         if (options.initialPath) {
             this._history.push(options.initialPath);
         }
@@ -55,7 +57,11 @@ export class Router {
         path: string,
         component: () => any,
         layout?: () => any,
-        children: Route[] = []
+        options?: {
+            lazy?: () => Promise<any>;
+            beforeEnter?: (to: string) => boolean | string;
+            afterEnter?: (to: string) => void;
+        },
     ): void {
         const { pattern, paramNames } = compilePattern(path);
 
@@ -65,26 +71,16 @@ export class Router {
             paramNames,
             component,
             layout,
-            children,
+            lazy: options?.lazy,
+            beforeEnter: options?.beforeEnter,
+            afterEnter: options?.afterEnter,
         });
     }
 
     /** Register multiple routes */
-    addRoutes(
-        routes: Array<{
-            path: string;
-            component: () => any;
-            layout?: () => any;
-            children?: Route[];
-        }>
-    ): void {
+    addRoutes(routes: Array<{ path: string; component: () => any; layout?: () => any }>): void {
         for (const r of routes) {
-            this.addRoute(
-                r.path,
-                r.component,
-                r.layout,
-                r.children ?? []
-            );
+            this.addRoute(r.path, r.component, r.layout);
         }
     }
 
@@ -124,49 +120,93 @@ export class Router {
     /** Navigate to a path */
     push(path: string): void {
         const match = matchRoute(path, this._routes);
+
         if (!match) {
             this.events.emit('error', new Error(`No route found for path: ${path}`));
             return;
         }
+
+        const guardResult = match.route.beforeEnter?.(path);
+
+        if (guardResult === false) {
+            return;
+        }
+
+        if (typeof guardResult === 'string') {
+            this.push(guardResult);
+            return;
+        }
+
         this._history.push(path);
-        // Prevent unbounded history growth
+
         if (this._history.length > this._maxHistory) {
             this._history = this._history.slice(-this._maxHistory);
         }
+
         this._currentMatch = match;
+
         unmountAll();
+
         const screen = this._wrapScreen(match);
+
         this.events.emit('navigate', { match, screen });
+
+        match.route.afterEnter?.(path);
     }
 
     /** Replace current path */
     replace(path: string): void {
         const match = matchRoute(path, this._routes);
+
         if (!match) {
             this.events.emit('error', new Error(`No route found for path: ${path}`));
             return;
         }
+
+        const guardResult = match.route.beforeEnter?.(path);
+
+        if (guardResult === false) {
+            return;
+        }
+
+        if (typeof guardResult === 'string') {
+            this.replace(guardResult);
+            return;
+        }
+
         if (this._history.length > 0) {
             this._history[this._history.length - 1] = path;
         } else {
             this._history.push(path);
         }
+
         this._currentMatch = match;
+
         unmountAll();
+
         const screen = this._wrapScreen(match);
+
         this.events.emit('navigate', { match, screen });
+
+        match.route.afterEnter?.(path);
     }
 
     /** Go back in history */
     back(): void {
         if (this._history.length <= 1) return;
+
         this._history.pop();
+
         const prevPath = this._history[this._history.length - 1];
         const match = prevPath ? matchRoute(prevPath, this._routes) : null;
+
         this._currentMatch = match;
+
         if (match) {
             unmountAll();
+
             const screen = this._wrapScreen(match);
+
             this.events.emit('back', { match, screen });
         } else {
             this.events.emit('back', null);
@@ -174,20 +214,32 @@ export class Router {
     }
 
     /** Current route match */
-    get current(): RouteMatch | null { return this._currentMatch; }
+    get current(): RouteMatch | null {
+        return this._currentMatch;
+    }
 
     /** Current path */
-    get currentPath(): string { return this._history[this._history.length - 1] ?? '/'; }
+    get currentPath(): string {
+        return this._history[this._history.length - 1] ?? '/';
+    }
 
     /** Current route params */
-    get params(): RouteParams { return this._currentMatch?.params ?? {}; }
+    get params(): RouteParams {
+        return this._currentMatch?.params ?? {};
+    }
 
     /** History stack depth */
-    get historyLength(): number { return this._history.length; }
+    get historyLength(): number {
+        return this._history.length;
+    }
 
     /** Check if we can go back */
-    get canGoBack(): boolean { return this._history.length > 1; }
+    get canGoBack(): boolean {
+        return this._history.length > 1;
+    }
 
     /** All registered routes */
-    get routes(): Route[] { return [...this._routes]; }
+    get routes(): Route[] {
+        return [...this._routes];
+    }
 }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -85,29 +85,12 @@ export class Router {
     }
 
     private _wrapScreen(match: RouteMatch): VNode {
-        let screen = createElement(
-            match.route.component,
-            match.params
-        );
-
-        for (let i = match.chain.length - 2; i >= 0; i--) {
-            const parent = match.chain[i];
-
-            const Wrapper = parent.layout ?? parent.component;
-
-            screen = createElement(
-                Wrapper,
-                {
-                    ...match.params,
-                    outlet: screen,
-                }
-            );
-        }
+        const screen = createElement(match.route.component, match.params);
 
         const withProvider = createElement(
             RouterContext.Provider,
             { value: this },
-            screen
+            screen,
         );
 
         return createElement(

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -85,19 +85,17 @@ export class Router {
     }
 
     private _wrapScreen(match: RouteMatch): VNode {
-        const screen = createElement(match.route.component, match.params);
+        let screen = createElement(match.route.component, match.params);
 
-        const withProvider = createElement(
-            RouterContext.Provider,
-            { value: this },
-            screen,
-        );
+        for (let i = match.chain.length - 2; i >= 0; i--) {
+            const parent = match.chain[i];
+            const Wrapper = parent.layout ?? parent.component;
+            screen = createElement(Wrapper, { ...match.params, outlet: screen });
+        }
 
-        return createElement(
-            ErrorBoundary,
-            { fallback: defaultErrorScreen },
-            withProvider,
-        );
+        const withProvider = createElement(RouterContext.Provider, { value: this }, screen);
+
+        return createElement(ErrorBoundary, { fallback: defaultErrorScreen }, withProvider);
     }
 
     /** Navigate to a path */


### PR DESCRIPTION
## Description

Adds support for route guard hooks and lazy route options in the router package. Routes can now define `beforeEnter` and `afterEnter` hooks, and route definitions can store lazy loaders. Added tests covering guard behavior and lazy route registration.

## Related Issue

Closes #171 

## Which package(s)?

@termuijs/router

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [x] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read `CONTRIBUTING.md`.
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/618b914a-4df9-4c62-84c3-e27f372be37a`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

* Added support for route-level guard hooks (`beforeEnter`, `afterEnter`).
* Added support for lazy loader route options and registration.
* Added tests covering guard behavior and lazy route configuration.
* All local tests pass successfully.
