### PR TITLE
test(tss): Verify Nord palette hex values in built-in theme

### DIFF
--- a/packages/tss/src/themes.test.ts
+++ b/packages/tss/src/themes.test.ts
@@ -42,5 +42,13 @@ describe('Built-in Themes', () => {
         expect(src).toContain('--text: #ffffff');
         expect(src).toContain('--border-color: #ffffff');
         expect(src).toContain('--border-focus: #00ffff');
+
+         });
+
+    it('nord theme uses official Nord palette hex values', () => {
+        const src = getBuiltinTheme('nord');
+        expect(src).toContain('--bg: #2e3440');
+        expect(src).toContain('--primary: #88c0d0');
+        expect(src).toContain('--error: #bf616a');
     });
 });


### PR DESCRIPTION
## Description

Adds Nord theme validation coverage for built-in themes in @termuijs/tss.

This PR adds tests verifying the Nord theme can be loaded by key and that official Nord palette values are present.

## Related Issue

Closes #ISSUE_NUMBER -  #316

## Which package(s)?

@termuijs/tss

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read `CONTRIBUTING.md`.
* [x] Your PR title follows `type: short description`.
* [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

* Added Nord theme verification tests in packages/tss/src/themes.test.ts
* Verified official palette values through built-in theme loading
* Changes confined to packages/tss
