### PR TITLE
feat(tss): add size media queries

### DIFF
--- a/packages/tss/src/index.ts
+++ b/packages/tss/src/index.ts
@@ -14,6 +14,10 @@ export type { TSSStylesheet, TSSTheme, TSSSelector, TSSProperty, TSSValue, TSSRu
 export { ThemeEngine, compile } from './engine.js';
 export type { ThemeVariables, ResolvedRule } from './engine.js';
 
+// Size Media Queries
+export { loadMediaStyles, mediaConditionMatches, parseMediaCondition, resolveMediaSource } from './media.js';
+export type { MediaCondition, MediaFeature, MediaStyleEngine, TerminalDimensions } from './media.js';
+
 // Built-in Themes
 export { BUILTIN_THEMES, getBuiltinThemeNames, getBuiltinTheme, getAllBuiltinThemes } from './themes.js';
 

--- a/packages/tss/src/media.test.ts
+++ b/packages/tss/src/media.test.ts
@@ -1,0 +1,84 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/tss — Tests for size media queries
+// ─────────────────────────────────────────────────────
+
+import { describe, expect, it } from 'vitest';
+import { ThemeEngine } from './engine.js';
+import { loadMediaStyles, resolveMediaSource } from './media.js';
+
+const TSS_SOURCE = `
+Box {
+    color: red;
+}
+
+@media min-width 80 {
+    Box {
+        color: green;
+    }
+}
+
+@media max-height 12 {
+    Gauge {
+        color: cyan;
+    }
+}
+`;
+
+describe('size media queries', () => {
+    it('applies min-width rules when the terminal is wide enough', () => {
+        const engine = new ThemeEngine();
+        loadMediaStyles(engine, TSS_SOURCE, { width: 100, height: 20 });
+
+        expect(engine.resolveStyle('Box').fg).toEqual({ type: 'named', name: 'green' });
+    });
+
+    it('skips min-width rules when the terminal is too narrow', () => {
+        const engine = new ThemeEngine();
+        loadMediaStyles(engine, TSS_SOURCE, { width: 60, height: 20 });
+
+        expect(engine.resolveStyle('Box').fg).toEqual({ type: 'named', name: 'red' });
+    });
+
+    it('applies max-height rules when the terminal is short enough', () => {
+        const engine = new ThemeEngine();
+        loadMediaStyles(engine, TSS_SOURCE, { width: 60, height: 10 });
+
+        expect(engine.resolveStyle('Gauge').fg).toEqual({ type: 'named', name: 'cyan' });
+    });
+
+    it('skips max-height rules when the terminal is too tall', () => {
+        const engine = new ThemeEngine();
+        loadMediaStyles(engine, TSS_SOURCE, { width: 60, height: 20 });
+
+        expect(engine.resolveStyle('Gauge').fg).toBeUndefined();
+    });
+
+    it('ignores malformed media blocks without throwing', () => {
+        const engine = new ThemeEngine();
+
+        expect(() => loadMediaStyles(engine, `
+@media min-width {
+    Box {
+        color: green;
+    }
+}
+
+Gauge {
+    bold: true;
+}
+`, { width: 100, height: 20 })).not.toThrow();
+
+        expect(engine.resolveStyle('Gauge').bold).toBe(true);
+        expect(engine.resolveStyle('Box').fg).toBeUndefined();
+    });
+
+    it('keeps non-media stylesheets unchanged', () => {
+        const source = `
+Box {
+    border: single;
+}
+`;
+
+        expect(resolveMediaSource(source, { width: 80, height: 24 })).toBe(source);
+    });
+});

--- a/packages/tss/src/media.ts
+++ b/packages/tss/src/media.ts
@@ -1,0 +1,189 @@
+// ─────────────────────────────────────────────────────
+// Size media queries — filters @media blocks by terminal dimensions
+// ─────────────────────────────────────────────────────
+
+import { type ThemeEngine } from './engine.js';
+
+const MEDIA_AT_RULE = '@media';
+
+export interface TerminalDimensions {
+    width: number;
+    height: number;
+}
+
+export type MediaFeature = 'min-width' | 'max-height';
+
+export interface MediaCondition {
+    feature: MediaFeature;
+    value: number;
+}
+
+export type MediaStyleEngine = Pick<ThemeEngine, 'load'>;
+
+interface MediaBlock {
+    condition: MediaCondition | undefined;
+    body: string;
+    endIndex: number;
+}
+
+/** Load a TSS source into a ThemeEngine after applying size media queries. */
+export function loadMediaStyles(engine: MediaStyleEngine, source: string, dimensions: TerminalDimensions): void {
+    engine.load(resolveMediaSource(source, dimensions));
+}
+
+/** Return TSS with matching @media blocks expanded and non-matching blocks removed. */
+export function resolveMediaSource(source: string, dimensions: TerminalDimensions): string {
+    let output = '';
+    let cursor = 0;
+    let mediaStart = findNextMediaAtRule(source, cursor);
+
+    while (mediaStart !== -1) {
+        output += source.slice(cursor, mediaStart);
+
+        const block = readMediaBlock(source, mediaStart);
+        if (!block) return output;
+
+        if (block.condition && mediaConditionMatches(block.condition, dimensions)) {
+            output += resolveMediaSource(block.body, dimensions);
+        }
+
+        cursor = block.endIndex;
+        mediaStart = findNextMediaAtRule(source, cursor);
+    }
+
+    output += source.slice(cursor);
+    return output;
+}
+
+export function parseMediaCondition(input: string): MediaCondition | undefined {
+    const match = /^\(?\s*(min-width|max-height)\s*:?\s*(\d+(?:\.\d+)?)\s*(?:cols?|columns?|rows?)?\s*\)?$/i.exec(input.trim());
+    if (!match) return undefined;
+
+    const feature = toMediaFeature(match[1]?.toLowerCase() ?? '');
+    const value = Number(match[2]);
+    if (!feature || !Number.isFinite(value)) return undefined;
+
+    return { feature, value };
+}
+
+export function mediaConditionMatches(condition: MediaCondition, dimensions: TerminalDimensions): boolean {
+    if (!Number.isFinite(dimensions.width) || !Number.isFinite(dimensions.height)) return false;
+
+    switch (condition.feature) {
+        case 'min-width':
+            return dimensions.width >= condition.value;
+        case 'max-height':
+            return dimensions.height <= condition.value;
+    }
+}
+
+function readMediaBlock(source: string, startIndex: number): MediaBlock | undefined {
+    const headerStart = startIndex + MEDIA_AT_RULE.length;
+    const blockStart = findOpeningBrace(source, headerStart);
+    if (blockStart === -1) return undefined;
+
+    const blockEnd = findMatchingBrace(source, blockStart);
+    if (blockEnd === -1) return undefined;
+
+    return {
+        condition: parseMediaCondition(source.slice(headerStart, blockStart)),
+        body: source.slice(blockStart + 1, blockEnd),
+        endIndex: blockEnd + 1,
+    };
+}
+
+function toMediaFeature(value: string): MediaFeature | undefined {
+    if (value === 'min-width' || value === 'max-height') return value;
+    return undefined;
+}
+
+function findNextMediaAtRule(source: string, startIndex: number): number {
+    for (let index = startIndex; index < source.length; index++) {
+        const skipped = skipIgnored(source, index);
+        if (skipped !== index) {
+            index = skipped;
+            continue;
+        }
+
+        if (source.startsWith(MEDIA_AT_RULE, index) && isMediaBoundary(source[index + MEDIA_AT_RULE.length])) {
+            return index;
+        }
+    }
+
+    return -1;
+}
+
+function findOpeningBrace(source: string, startIndex: number): number {
+    for (let index = startIndex; index < source.length; index++) {
+        const skipped = skipIgnored(source, index);
+        if (skipped !== index) {
+            index = skipped;
+            continue;
+        }
+
+        if (source[index] === '{') return index;
+        if (source[index] === '}') return -1;
+    }
+
+    return -1;
+}
+
+function findMatchingBrace(source: string, openIndex: number): number {
+    let depth = 0;
+
+    for (let index = openIndex; index < source.length; index++) {
+        const skipped = skipIgnored(source, index);
+        if (skipped !== index) {
+            index = skipped;
+            continue;
+        }
+
+        if (source[index] === '{') depth++;
+        if (source[index] === '}') {
+            depth--;
+            if (depth === 0) return index;
+        }
+    }
+
+    return -1;
+}
+
+function isMediaBoundary(char: string | undefined): boolean {
+    return char === undefined || /\s|\(/.test(char);
+}
+
+function skipIgnored(source: string, index: number): number {
+    const char = source[index];
+    const next = source[index + 1];
+
+    if (char === '"' || char === "'") return skipString(source, index);
+    if (char === '/' && next === '*') return skipBlockComment(source, index);
+    if (char === '/' && next === '/') return skipLineComment(source, index);
+
+    return index;
+}
+
+function skipString(source: string, startIndex: number): number {
+    const quote = source[startIndex];
+
+    for (let index = startIndex + 1; index < source.length; index++) {
+        if (source[index] === '\\') {
+            index++;
+            continue;
+        }
+
+        if (source[index] === quote) return index;
+    }
+
+    return source.length - 1;
+}
+
+function skipBlockComment(source: string, startIndex: number): number {
+    const endIndex = source.indexOf('*/', startIndex + 2);
+    return endIndex === -1 ? source.length - 1 : endIndex + 1;
+}
+
+function skipLineComment(source: string, startIndex: number): number {
+    const endIndex = source.indexOf('\n', startIndex + 2);
+    return endIndex === -1 ? source.length - 1 : endIndex;
+}


### PR DESCRIPTION
## Description

Adds size-aware media query support for `@termuijs/tss`. The new media helper resolves `@media min-width` and `@media max-height` blocks against terminal dimensions before loading the resulting TSS into `ThemeEngine`, keeping the existing flat selector matching behavior intact.

## Related Issue

Closes #313

## Which package(s)?

`@termuijs/tss`

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering). N/A, no widget changes.
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/shashank03-dev`

## Screenshots / Recordings (UI changes)

N/A. This is a library/API change in `@termuijs/tss`; terminal proof is from tests and typecheck.

## Notes for the Reviewer

Implemented:
- `packages/tss/src/media.ts` adds `resolveMediaSource`, `loadMediaStyles`, and media condition helpers for `min-width` and `max-height`.
- `packages/tss/src/media.test.ts` covers min-width apply/skip, max-height apply/skip, malformed media blocks, and unchanged non-media source.
- `packages/tss/src/index.ts` exports the new media API.

Verification:
- `bun vitest run packages/tss` -> 8 files passed, 48 tests passed.
- `env -u NO_COLOR TERM=xterm-256color bash -lc 'bun run build && bun vitest run && bun run typecheck'` -> build passed, 122 test files passed / 1136 tests passed, typecheck passed.

Environment note: this Codex shell defaults to `TERM=dumb`, which makes existing Unicode capability tests use ASCII fallback and fail when running bare `bun vitest run`. Rerunning under `TERM=xterm-256color` matches the repo's Unicode test expectations; the focused Unicode suites also pass under that environment.

Self-review: scope is clean and confined to the three files requested by the issue; no `bun.lock` or cross-package changes.
