### PR TITLE
feat(ui): add Stepper widget

### DIFF
--- a/packages/ui/src/Stepper.test.ts
+++ b/packages/ui/src/Stepper.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Stepper } from './Stepper.js';
+
+// Mock caps for unicode support
+vi.mock('@termuijs/core', async () => {
+    const actual = await vi.importActual('@termuijs/core');
+    return {
+        ...actual,
+        caps: {
+            unicode: true,
+        },
+    };
+});
+
+describe('Stepper', () => {
+    it('renders all step labels', () => {
+        const stepper = new Stepper(['Step 1', 'Step 2', 'Step 3']);
+        expect(stepper.activeStep).toBe(0);
+    });
+
+    it('setActiveStep changes active step', () => {
+        const stepper = new Stepper(['One', 'Two', 'Three']);
+        const markDirtySpy = vi.spyOn(stepper, 'markDirty');
+        
+        stepper.setActiveStep(1);
+        expect(stepper.activeStep).toBe(1);
+        expect(markDirtySpy).toHaveBeenCalled();
+    });
+
+    it('setActiveStep does nothing for invalid index', () => {
+        const stepper = new Stepper(['One', 'Two']);
+        stepper.setActiveStep(5);
+        expect(stepper.activeStep).toBe(0);
+        
+        stepper.setActiveStep(-1);
+        expect(stepper.activeStep).toBe(0);
+    });
+
+    it('uses custom colors from options', () => {
+        const stepper = new Stepper(['A', 'B'], undefined, {
+            completedColor: { type: 'named', name: 'blue' },
+            activeColor: { type: 'named', name: 'red' },
+            pendingColor: { type: 'named', name: 'white' },
+        });
+        
+        expect(stepper.activeStep).toBe(0);
+    });
+
+    it('uses custom connector character', () => {
+        const stepper = new Stepper(['X', 'Y', 'Z'], undefined, {
+            connectorChar: '→',
+        });
+        
+        expect(stepper.activeStep).toBe(0);
+    });
+});

--- a/packages/ui/src/Stepper.ts
+++ b/packages/ui/src/Stepper.ts
@@ -1,0 +1,81 @@
+import { Widget } from '@termuijs/widgets';
+import { type Style, type Screen, mergeStyles, defaultStyle, styleToCellAttrs, caps } from '@termuijs/core';
+
+export interface StepperOptions {
+    completedColor?: Style['fg'];
+    activeColor?: Style['fg'];
+    pendingColor?: Style['fg'];
+    connectorChar?: string;
+}
+
+export class Stepper extends Widget {
+    private _labels: string[];
+    private _activeStep: number = 0;
+    private _completedColor: Style['fg'];
+    private _activeColor: Style['fg'];
+    private _pendingColor: Style['fg'];
+    private _connectorChar: string;
+
+    constructor(labels: string[], style?: Partial<Style>, opts?: StepperOptions) {
+        super(mergeStyles(defaultStyle(), style ?? {}));
+        this._labels = labels;
+        this._completedColor = opts?.completedColor ?? { type: 'named', name: 'green' };
+        this._activeColor = opts?.activeColor ?? { type: 'named', name: 'yellow' };
+        this._pendingColor = opts?.pendingColor ?? { type: 'named', name: 'brightBlack' };
+        this._connectorChar = opts?.connectorChar ?? (caps.unicode ? '─' : '-');
+    }
+
+    get activeStep(): number { return this._activeStep; }
+
+    setActiveStep(index: number): void {
+        if (index >= 0 && index < this._labels.length) {
+            this._activeStep = index;
+            this.markDirty();
+        }
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width, height } = this._rect;
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this.style);
+        let col = x;
+
+        for (let i = 0; i < this._labels.length; i++) {
+            const label = this._labels[i];
+            let stepText: string;
+            let color: Style['fg'];
+
+            if (i < this._activeStep) {
+                // Completed step - show checkmark
+                const checkmark = caps.unicode ? '✓' : 'v';
+                stepText = `${checkmark} ${label}`;
+                color = this._completedColor;
+            } else if (i === this._activeStep) {
+                // Active step
+                stepText = `${i + 1} ${label}`;
+                color = this._activeColor;
+            } else {
+                // Pending step
+                stepText = `${i + 1} ${label}`;
+                color = this._pendingColor;
+            }
+
+            const isActive = i === this._activeStep;
+            screen.writeString(col, y, stepText, {
+                ...attrs,
+                fg: color,
+                bold: isActive,
+                dim: !isActive && i > this._activeStep,
+            });
+
+            col += stepText.length;
+
+            // Add connector between steps (not after the last one)
+            if (i < this._labels.length - 1) {
+                screen.writeString(col, y, this._connectorChar, { ...attrs, dim: true });
+                col++;
+            }
+        }
+    }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -110,5 +110,5 @@ export { MultilineTextInput } from './MultilineTextInput.js';
 export type { MultilineTextInputOptions } from './MultilineTextInput.js';
 
 
-export { Stepper } from ./Stepper.js;
-export type { StepperOptions } from ./Stepper.js;
+export { Stepper } from './Stepper.js';
+export type { StepperOptions } from './Stepper.js';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -109,3 +109,6 @@ export type { WizardStep, WizardOptions } from './Wizard.js';
 export { MultilineTextInput } from './MultilineTextInput.js';
 export type { MultilineTextInputOptions } from './MultilineTextInput.js';
 
+
+export { Stepper } from ./Stepper.js;
+export type { StepperOptions } from ./Stepper.js;


### PR DESCRIPTION
Closes #271

## Changes
- Added Stepper widget to `@termuijs/ui`
- Displays numbered steps with completed (✓), active, and pending states
- Customizable colors (completedColor, activeColor, pendingColor)
- Customizable connector character
- ASCII fallback when unicode not supported

## Testing
- ✅ `bun vitest run packages/ui/src/Stepper.test.ts` - 5/5 passed
- ✅ `bun run typecheck` - No errors
- ✅ No changes to `bun.lock`

## Files Changed
- `packages/ui/src/Stepper.ts` - Widget implementation
- `packages/ui/src/Stepper.test.ts` - Test suite
- `packages/ui/src/index.ts` - Added exports