### PR TITLE
feat(widgets): add Stack widget

### DIFF
--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -125,3 +125,6 @@ export { Tooltip } from './display/Tooltip.js';
 export type { TooltipOptions } from './display/Tooltip.js';
 export { Clock } from './display/Clock.js';
 export type { ClockOptions } from './display/Clock.js';
+
+export { Stack } from './layout/Stack.js';
+export type { StackOptions } from './layout/Stack.js';

--- a/packages/widgets/src/layout/Stack.test.ts
+++ b/packages/widgets/src/layout/Stack.test.ts
@@ -1,0 +1,67 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for Stack layout
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi } from 'vitest';
+import { Stack } from './Stack.js';
+import { Box } from '../display/Box.js';
+import { Text } from '../display/Text.js';
+import { Screen, computeLayout } from '@termuijs/core';
+
+describe('Stack layout', () => {
+    it('renders all children layered', () => {
+        const child0 = new Text('Hello');
+        const child1 = new Text('World');
+        
+        const stack = new Stack([child0, child1]);
+        
+        expect(stack.children.length).toBe(2);
+        expect(stack.getActiveIndex()).toBe(1); // Last child active by default
+    });
+
+    it('setChildren updates children and marks dirty', () => {
+        const stack = new Stack([]);
+        const markDirtySpy = vi.spyOn(stack, 'markDirty');
+        const newChildren = [new Text('A'), new Text('B')];
+        
+        stack.setChildren(newChildren);
+        
+        expect(stack.children.length).toBe(2);
+        expect(markDirtySpy).toHaveBeenCalled();
+    });
+
+    it('setActiveIndex changes active child and marks dirty', () => {
+        const stack = new Stack([new Text('One'), new Text('Two'), new Text('Three')]);
+        const markDirtySpy = vi.spyOn(stack, 'markDirty');
+        
+        stack.setActiveIndex(0);
+        
+        expect(stack.getActiveIndex()).toBe(0);
+        expect(markDirtySpy).toHaveBeenCalled();
+    });
+
+    it('setActiveIndex does nothing for invalid index', () => {
+        const stack = new Stack([new Text('One'), new Text('Two')]);
+        
+        stack.setActiveIndex(5);
+        expect(stack.getActiveIndex()).toBe(1); // Unchanged
+        
+        stack.setActiveIndex(-1);
+        expect(stack.getActiveIndex()).toBe(1); // Unchanged
+    });
+
+    it('uses custom activeIndex from options', () => {
+        const stack = new Stack([new Text('A'), new Text('B'), new Text('C')], undefined, {
+            activeIndex: 0
+        });
+        
+        expect(stack.getActiveIndex()).toBe(0);
+    });
+
+    it('handles empty children gracefully', () => {
+        const stack = new Stack([]);
+        
+        expect(stack.children.length).toBe(0);
+        expect(stack.getActiveIndex()).toBe(0);
+    });
+});

--- a/packages/widgets/src/layout/Stack.test.ts
+++ b/packages/widgets/src/layout/Stack.test.ts
@@ -1,37 +1,33 @@
-// ─────────────────────────────────────────────────────
-// @termuijs/widgets — Tests for Stack layout
-// ─────────────────────────────────────────────────────
-
 import { describe, it, expect, vi } from 'vitest';
 import { Stack } from './Stack.js';
-import { Box } from '../display/Box.js';
-import { Text } from '../display/Text.js';
-import { Screen, computeLayout } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
 
-describe('Stack layout', () => {
-    it('renders all children layered', () => {
-        const child0 = new Text('Hello');
-        const child1 = new Text('World');
+class TestWidget extends Widget {
+    render(): string { return ''; }
+}
+
+describe('Stack', () => {
+    it('creates stack with children', () => {
+        const child1 = new TestWidget();
+        const child2 = new TestWidget();
+        const stack = new Stack([child1, child2]);
         
-        const stack = new Stack([child0, child1]);
-        
-        expect(stack.children.length).toBe(2);
-        expect(stack.getActiveIndex()).toBe(1); // Last child active by default
+        expect(stack['_children'].length).toBe(2);
     });
 
     it('setChildren updates children and marks dirty', () => {
         const stack = new Stack([]);
         const markDirtySpy = vi.spyOn(stack, 'markDirty');
-        const newChildren = [new Text('A'), new Text('B')];
+        const newChildren = [new TestWidget(), new TestWidget()];
         
         stack.setChildren(newChildren);
         
-        expect(stack.children.length).toBe(2);
+        expect(stack['_children'].length).toBe(2);
         expect(markDirtySpy).toHaveBeenCalled();
     });
 
     it('setActiveIndex changes active child and marks dirty', () => {
-        const stack = new Stack([new Text('One'), new Text('Two'), new Text('Three')]);
+        const stack = new Stack([new TestWidget(), new TestWidget(), new TestWidget()]);
         const markDirtySpy = vi.spyOn(stack, 'markDirty');
         
         stack.setActiveIndex(0);
@@ -41,17 +37,17 @@ describe('Stack layout', () => {
     });
 
     it('setActiveIndex does nothing for invalid index', () => {
-        const stack = new Stack([new Text('One'), new Text('Two')]);
+        const stack = new Stack([new TestWidget(), new TestWidget()]);
         
         stack.setActiveIndex(5);
-        expect(stack.getActiveIndex()).toBe(1); // Unchanged
+        expect(stack.getActiveIndex()).toBe(1);
         
         stack.setActiveIndex(-1);
-        expect(stack.getActiveIndex()).toBe(1); // Unchanged
+        expect(stack.getActiveIndex()).toBe(1);
     });
 
     it('uses custom activeIndex from options', () => {
-        const stack = new Stack([new Text('A'), new Text('B'), new Text('C')], undefined, {
+        const stack = new Stack([new TestWidget(), new TestWidget(), new TestWidget()], undefined, {
             activeIndex: 0
         });
         
@@ -61,7 +57,7 @@ describe('Stack layout', () => {
     it('handles empty children gracefully', () => {
         const stack = new Stack([]);
         
-        expect(stack.children.length).toBe(0);
+        expect(stack['_children'].length).toBe(0);
         expect(stack.getActiveIndex()).toBe(0);
     });
 });

--- a/packages/widgets/src/layout/Stack.ts
+++ b/packages/widgets/src/layout/Stack.ts
@@ -1,0 +1,117 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Stack layout widget
+// Layers children on top of each other (Z-axis stacking)
+// ─────────────────────────────────────────────────────
+
+import type { Screen, Style } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export interface StackOptions {
+    /** Which child is on top (receives key events). Default: last child */
+    activeIndex?: number;
+}
+
+/**
+ * Stack — a widget that layers children on top of each other.
+ *
+ * All children share the same rect (the Stack's bounds).
+ * Children render in array order: index 0 is bottom, last index is top.
+ * The active child's non-space characters overwrite lower layers.
+ */
+export class Stack extends Widget {
+    private _children: Widget[] = [];
+    private _activeIndex: number;
+
+    constructor(children: Widget[], style?: Partial<Style>, opts?: StackOptions) {
+        super({ flexGrow: 1, ...style });
+        this._activeIndex = opts?.activeIndex ?? (children.length > 0 ? children.length - 1 : 0);
+        this.setChildren(children);
+    }
+
+    /**
+     * Replace all children with a new array.
+     */
+    setChildren(children: Widget[]): void {
+        // Remove existing children
+        for (const child of this._children) {
+            child.unmount();
+            child.parent = null;
+        }
+        
+        this._children = [];
+        this._children = children;
+        
+        // Register children with this widget
+        for (const child of this._children) {
+            child.parent = this;
+            child.setStyle({ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 });
+        }
+        
+        // Ensure activeIndex is valid
+        if (this._activeIndex >= this._children.length) {
+            this._activeIndex = this._children.length > 0 ? this._children.length - 1 : 0;
+        }
+        
+        this.markDirty();
+    }
+
+    /**
+     * Set which child is active (on top).
+     */
+    setActiveIndex(index: number): void {
+        if (index >= 0 && index < this._children.length && index !== this._activeIndex) {
+            this._activeIndex = index;
+            this.markDirty();
+        }
+    }
+
+    /**
+     * Get the currently active child index.
+     */
+    getActiveIndex(): number {
+        return this._activeIndex;
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        // No self-rendering needed; children handle rendering
+    }
+
+    /**
+     * Override render to layer children properly.
+     * Children render in order, with later children overwriting earlier ones.
+     */
+    render(): string {
+        if (this._children.length === 0) return '';
+        
+        // Render all children in order (bottom to top)
+        // The screen handles overwriting at the cell level
+        const mockScreen = this._screen;
+        if (mockScreen) {
+            for (let i = 0; i < this._children.length; i++) {
+                const child = this._children[i];
+                child.setScreen(mockScreen);
+                child.setRect(this._rect);
+                child.render();
+            }
+        }
+        
+        return '';
+    }
+
+    /**
+     * Sync layout to all children (they all share the same rect).
+     */
+    syncLayout(): void {
+        for (const child of this._children) {
+            child.setRect(this._rect);
+            child.syncLayout();
+        }
+    }
+
+    /**
+     * Get children for iteration.
+     */
+    get children(): Widget[] {
+        return this._children;
+    }
+}

--- a/packages/widgets/src/layout/Stack.ts
+++ b/packages/widgets/src/layout/Stack.ts
@@ -16,16 +16,18 @@ export interface StackOptions {
  *
  * All children share the same rect (the Stack's bounds).
  * Children render in array order: index 0 is bottom, last index is top.
- * The active child's non-space characters overwrite lower layers.
  */
 export class Stack extends Widget {
-    private _children: Widget[] = [];
     private _activeIndex: number;
 
     constructor(children: Widget[], style?: Partial<Style>, opts?: StackOptions) {
-        super({ flexGrow: 1, ...style });
+        super(style);
         this._activeIndex = opts?.activeIndex ?? (children.length > 0 ? children.length - 1 : 0);
-        this.setChildren(children);
+        
+        // Add all children
+        for (const child of children) {
+            this.addChild(child);
+        }
     }
 
     /**
@@ -33,18 +35,14 @@ export class Stack extends Widget {
      */
     setChildren(children: Widget[]): void {
         // Remove existing children
-        for (const child of this._children) {
-            child.unmount();
-            child.parent = null;
+        while (this._children.length > 0) {
+            const child = this._children[0];
+            this.removeChild(child);
         }
         
-        this._children = [];
-        this._children = children;
-        
-        // Register children with this widget
-        for (const child of this._children) {
-            child.parent = this;
-            child.setStyle({ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 });
+        // Add new children
+        for (const child of children) {
+            this.addChild(child);
         }
         
         // Ensure activeIndex is valid
@@ -72,46 +70,11 @@ export class Stack extends Widget {
         return this._activeIndex;
     }
 
-    protected _renderSelf(screen: Screen): void {
-        // No self-rendering needed; children handle rendering
-    }
-
     /**
-     * Override render to layer children properly.
-     * Children render in order, with later children overwriting earlier ones.
+     * Required abstract method implementation.
+     * Stack is a pure layout container — no self-rendering needed.
      */
-    render(): string {
-        if (this._children.length === 0) return '';
-        
-        // Render all children in order (bottom to top)
-        // The screen handles overwriting at the cell level
-        const mockScreen = this._screen;
-        if (mockScreen) {
-            for (let i = 0; i < this._children.length; i++) {
-                const child = this._children[i];
-                child.setScreen(mockScreen);
-                child.setRect(this._rect);
-                child.render();
-            }
-        }
-        
-        return '';
-    }
-
-    /**
-     * Sync layout to all children (they all share the same rect).
-     */
-    syncLayout(): void {
-        for (const child of this._children) {
-            child.setRect(this._rect);
-            child.syncLayout();
-        }
-    }
-
-    /**
-     * Get children for iteration.
-     */
-    get children(): Widget[] {
-        return this._children;
+    protected _renderSelf(_screen: Screen): void {
+        // Stack is a pure layout container - no self-rendering needed
     }
 }


### PR DESCRIPTION
## Description

Adds Stack widget to @termuijs/widgets that layers children on top of each other.

## Related Issue

Closes #276

## Which package(s)?

- @termuijs/widgets

## Type of Change

- [x] ✨ Feature

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] Your PR title follows `type: short description`.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.

