### PR TITLE
feat: add git-client example

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "termui",
-      "dependencies": {
-        "commander": "^15.0.0",
-      },
       "devDependencies": {
         "@types/bun": "latest",
         "@types/node": "^25.2.3",
@@ -59,6 +56,17 @@
         "@termuijs/core": "workspace:*",
         "@termuijs/jsx": "workspace:*",
         "@termuijs/ui": "workspace:*",
+        "@termuijs/widgets": "workspace:*",
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3",
+      },
+    },
+    "examples/git-client": {
+      "name": "@termuijs/example-git-client",
+      "version": "0.1.0",
+      "dependencies": {
+        "@termuijs/core": "workspace:*",
         "@termuijs/widgets": "workspace:*",
       },
       "devDependencies": {
@@ -277,6 +285,7 @@
       "dependencies": {
         "@termuijs/core": "workspace:*",
         "@termuijs/jsx": "workspace:*",
+        "@termuijs/motion": "workspace:*",
         "@termuijs/widgets": "workspace:*",
       },
       "devDependencies": {
@@ -450,6 +459,8 @@
     "@termuijs/example-dashboard": ["@termuijs/example-dashboard@workspace:examples/dashboard"],
 
     "@termuijs/example-forms": ["@termuijs/example-forms@workspace:examples/forms-and-validation"],
+
+    "@termuijs/example-git-client": ["@termuijs/example-git-client@workspace:examples/git-client"],
 
     "@termuijs/example-jsx-dashboard": ["@termuijs/example-jsx-dashboard@workspace:examples/jsx-dashboard"],
 

--- a/examples/git-client/package.json
+++ b/examples/git-client/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@termuijs/example-git-client",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Git client example app",
+  "type": "module",
+  "scripts": {
+    "start": "bun src/index.tsx",
+    "dev": "bun --watch src/index.tsx",
+    "build": "echo 'no build needed'"
+  },
+  "dependencies": {
+    "@termuijs/core": "workspace:*",
+    "@termuijs/widgets": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  },
+  "engines": {
+    "bun": ">=1.3.0"
+  }
+}

--- a/examples/git-client/src/index.tsx
+++ b/examples/git-client/src/index.tsx
@@ -1,0 +1,191 @@
+import { App, type KeyEvent } from '@termuijs/core';
+import {
+    Box,
+    Text,
+    Widget,
+    List,
+    DiffView,
+    type ListItem,
+    type DiffLine,
+} from '@termuijs/widgets';
+
+class GitClientExample extends Widget {
+    private fileList: List;
+    private statusText: Text;
+
+    constructor() {
+        super({
+            flexDirection: 'column',
+            padding: 1,
+            gap: 1,
+        });
+
+        const title = new Text(' Git Client Example ', {
+            bold: true,
+            fg: { type: 'named', name: 'cyan' },
+        });
+
+        const files: ListItem[] = [
+            { label: 'src/index.tsx', value: 'index' },
+            { label: 'src/App.tsx', value: 'app' },
+            { label: 'README.md', value: 'readme' },
+            { label: 'package.json', value: 'package' },
+        ];
+
+        const diffLines: DiffLine[] = [
+            {
+                type: 'context',
+                content: 'function App() {',
+                lineNo: 1,
+            },
+            {
+                type: 'remove',
+                content: 'console.log("old version");',
+                lineNo: 2,
+            },
+            {
+                type: 'add',
+                content: 'console.log("new version");',
+                lineNo: 2,
+            },
+            {
+                type: 'context',
+                content: '}',
+                lineNo: 3,
+            },
+        ];
+
+        const contentRow = new Box({
+            flexDirection: 'row',
+            gap: 2,
+            flexGrow: 1,
+        });
+
+        const leftPanel = new Box({
+            flexDirection: 'column',
+            width: 30,
+            border: 'single',
+        });
+
+        leftPanel.addChild(
+            new Text(' Staged Files ', {
+                bold: true,
+            }),
+        );
+
+        this.fileList = new List(files);
+
+        leftPanel.addChild(this.fileList);
+
+        const rightPanel = new Box({
+            flexDirection: 'column',
+            flexGrow: 1,
+            border: 'single',
+        });
+
+        rightPanel.addChild(
+            new Text(' Diff Preview ', {
+                bold: true,
+            }),
+        );
+
+        const diffView = new DiffView({
+            lines: diffLines,
+        });
+
+        rightPanel.addChild(diffView);
+
+        contentRow.addChild(leftPanel);
+        contentRow.addChild(rightPanel);
+
+        const commitBox = new Box({
+            flexDirection: 'column',
+            border: 'single',
+            height: 4,
+        });
+
+        commitBox.addChild(
+            new Text(' Commit Message ', {
+                bold: true,
+            }),
+        );
+
+        commitBox.addChild(
+            new Text('feat: initial git-client example'),
+        );
+
+        this.statusText = new Text(
+            'Controls: ↑ ↓ navigate | Enter select | q quit',
+            {
+                dim: true,
+            },
+        );
+
+        this.addChild(title);
+        this.addChild(contentRow);
+        this.addChild(commitBox);
+        this.addChild(this.statusText);
+
+        this.fileList.isFocused = true;
+    }
+
+    handleKey(event: KeyEvent): boolean {
+        if (event.key === 'q' || (event.ctrl && event.key === 'c')) {
+            return false;
+        }
+
+        if (event.key === 'up') {
+            this.fileList.selectPrev();
+            return true;
+        }
+
+        if (event.key === 'down') {
+            this.fileList.selectNext();
+            return true;
+        }
+
+        if (event.key === 'enter') {
+            const item = this.fileList.selectedItem;
+
+            if (item) {
+                this.statusText.setContent(
+                    `Selected: ${item.label}  |  Press q to quit`,
+                );
+            }
+
+            return true;
+        }
+
+        return true;
+    }
+
+    protected _renderSelf(): void {}
+}
+
+async function main() {
+    const exampleApp = new GitClientExample();
+
+    const app = new App(exampleApp, {
+        fullscreen: true,
+        title: 'Git Client Example',
+        fps: 30,
+    });
+
+    app.events.on('key', (event) => {
+        const shouldContinue = exampleApp.handleKey(event);
+
+        if (!shouldContinue) {
+            app.exit(0);
+        }
+
+        app.requestRender();
+    });
+
+    const exitCode = await app.mount();
+    process.exit(exitCode);
+}
+
+main().catch((err) => {
+    console.error('Error:', err);
+    process.exit(1);
+});

--- a/examples/git-client/tsconfig.json
+++ b/examples/git-client/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "jsx": "react-jsx",
+    "jsxImportSource": "@termuijs/jsx"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Description

This PR adds a Git Client example application using @termuijs/widgets. It demonstrates a simple staging and diff UI similar to a lightweight git interface.

The app includes a staged files list, diff preview panel, and commit message section with keyboard navigation support.

## Related Issue

Closes #342

## Which package(s)?

@termuijs/example-git-client

## Type of Change

- [x] ✨ Feature (`type:feature`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: https://gssoc.girlscript.org/profile/anchallll02

## Screenshots / Recordings (UI changes)

Terminal UI shows:
- Left panel: staged files list
- Right panel: diff preview
- Bottom panel: commit message section
- Keyboard navigation using arrow keys and enter

## Notes for the Reviewer

This example is self-contained under `examples/git-client/` and does not modify any core packages.