### PR TITLE
test(tss): add Catppuccin theme 

### DIFF
--- a/packages/tss/src/named-themes.test.ts
+++ b/packages/tss/src/named-themes.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { defaultDark } from './tokens.js';
-import { getNamedTheme, highContrastTheme, NAMED_THEMES } from './named-themes.js';
+import {
+  getNamedTheme,
+  highContrastTheme,
+  catppuccinTheme,
+  NAMED_THEMES,
+} from './named-themes.js';
 
 describe('Named ThemeTokens', () => {
   it('registers highContrast in the named theme map', () => {
@@ -20,6 +25,26 @@ describe('Named ThemeTokens', () => {
       muted: '#b3b3b3',
       border: '#ffffff',
       highlight: '#1a1a1a',
+    });
+  });
+
+  it('registers catppuccin in the named theme map', () => {
+    expect(NAMED_THEMES.catppuccin).toBe(catppuccinTheme);
+    expect(getNamedTheme('catppuccin')).toBe(catppuccinTheme);
+  });
+
+  it('catppuccin exposes the official Catppuccin palette', () => {
+    expect(catppuccinTheme).toEqual({
+      bg: '#1e1e2e',
+      fg: '#cdd6f4',
+      primary: '#cba6f7',
+      secondary: '#f5c2e7',
+      success: '#a6e3a1',
+      warning: '#f9e2af',
+      error: '#f38ba8',
+      muted: '#585b70',
+      border: '#585b70',
+      highlight: '#313244',
     });
   });
 


### PR DESCRIPTION
## Description

This PR adds test coverage for the built-in `catppuccin` theme in `@termuijs/tss`.  
It verifies that the theme is correctly registered in `NAMED_THEMES` and validates official Catppuccin palette token values.

## Related Issue

Closes #320

## Which package(s)?

`@termuijs/tss`

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/86fed3e4-400c-4150-9449-85335be03b44`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

The Catppuccin theme implementation already existed in the current codebase, but corresponding test coverage was missing. This PR completes the remaining acceptance criteria by adding validation tests for the built-in theme.
