### PR TITLE
feat: add Accordion widget

### DIFF
--- a/packages/ui/src/Accordion.test.ts
+++ b/packages/ui/src/Accordion.test.ts
@@ -1,0 +1,118 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/ui — Tests for Accordion widget
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Screen, caps } from '@termuijs/core';
+import { Accordion } from './Accordion.js';
+
+const makeAccordion = (multi = false) => new Accordion([
+    { title: 'Section 1', body: 'Body 1' },
+    { title: 'Section 2', body: 'Body 2\nMore 2' },
+    { title: 'Section 3', body: 'Body 3' },
+], {}, { multi });
+
+describe('Accordion', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('all section titles render', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+
+        const accordion = makeAccordion();
+        accordion.updateRect({ x: 0, y: 0, width: 30, height: 10 });
+
+        const screen = new Screen(30, 10);
+        accordion.render(screen);
+
+        const rendered = screen.back.map(row => row.map(c => c.char).join('')).join('\n');
+
+        expect(rendered).toContain('▶ Section 1');
+        expect(rendered).toContain('▶ Section 2');
+        expect(rendered).toContain('▶ Section 3');
+    });
+
+    it('enter opens the focused section', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+
+        const accordion = makeAccordion();
+        accordion.updateRect({ x: 0, y: 0, width: 30, height: 10 });
+
+        accordion.handleKey({ key: 'enter', ctrl: false, alt: false } as any);
+
+        const screen = new Screen(30, 10);
+        accordion.render(screen);
+
+        const renderedLines = screen.back.map(row => row.map(c => c.char).join('').trim());
+
+        expect(renderedLines[0]).toContain('▼ Section 1');
+        expect(renderedLines[1]).toContain('Body 1');
+        expect(renderedLines[2]).toContain('▶ Section 2');
+    });
+
+    it('opening section 2 closes section 1 in single mode', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+
+        const accordion = makeAccordion();
+        accordion.updateRect({ x: 0, y: 0, width: 30, height: 10 });
+
+        accordion.openSection(0);
+        
+        let screen = new Screen(30, 10);
+        accordion.render(screen);
+        let renderedLines = screen.back.map(row => row.map(c => c.char).join('').trim());
+        expect(renderedLines[0]).toContain('▼ Section 1');
+        expect(renderedLines[1]).toContain('Body 1');
+
+        accordion.openSection(1);
+
+        screen = new Screen(30, 10);
+        accordion.render(screen);
+        renderedLines = screen.back.map(row => row.map(c => c.char).join('').trim());
+
+        expect(renderedLines[0]).toContain('▶ Section 1');
+        expect(renderedLines[1]).toContain('▼ Section 2');
+        expect(renderedLines[2]).toContain('Body 2');
+        expect(renderedLines[3]).toContain('More 2');
+    });
+
+    it('multi mode allows two sections open', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+
+        const accordion = makeAccordion(true);
+        accordion.updateRect({ x: 0, y: 0, width: 30, height: 15 });
+
+        accordion.openSection(0);
+        accordion.openSection(1);
+
+        const screen = new Screen(30, 15);
+        accordion.render(screen);
+        const renderedLines = screen.back.map(row => row.map(c => c.char).join('').trim());
+
+        expect(renderedLines[0]).toContain('▼ Section 1');
+        expect(renderedLines[1]).toContain('Body 1');
+        expect(renderedLines[2]).toContain('▼ Section 2');
+        expect(renderedLines[3]).toContain('Body 2');
+        expect(renderedLines[4]).toContain('More 2');
+        expect(renderedLines[5]).toContain('▶ Section 3');
+    });
+
+    it('up/down move focus', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+
+        const accordion = makeAccordion();
+        
+        accordion.handleKey({ key: 'down', ctrl: false, alt: false } as any);
+        expect((accordion as any)._focusIndex).toBe(1);
+
+        accordion.handleKey({ key: 'down', ctrl: false, alt: false } as any);
+        expect((accordion as any)._focusIndex).toBe(2);
+
+        accordion.handleKey({ key: 'down', ctrl: false, alt: false } as any);
+        expect((accordion as any)._focusIndex).toBe(2);
+
+        accordion.handleKey({ key: 'up', ctrl: false, alt: false } as any);
+        expect((accordion as any)._focusIndex).toBe(1);
+    });
+});

--- a/packages/ui/src/Accordion.ts
+++ b/packages/ui/src/Accordion.ts
@@ -1,0 +1,157 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/ui — Accordion widget
+//
+// A collapsible vertical section widget with keyboard focus,
+// support for single/multi-open modes, and toggle event fires.
+// ─────────────────────────────────────────────────────
+
+import { Widget } from '@termuijs/widgets';
+import {
+    type Style,
+    type Screen,
+    type KeyEvent,
+    mergeStyles,
+    defaultStyle,
+    styleToCellAttrs,
+    caps
+} from '@termuijs/core';
+
+export interface AccordionItem {
+    title: string;
+    body: string;
+}
+
+export interface AccordionOptions {
+    /** Allow multiple sections open at once. Default: false (one at a time) */
+    multi?: boolean;
+    onToggle?: (index: number, open: boolean) => void;
+}
+
+export class Accordion extends Widget {
+    private _items: AccordionItem[] = [];
+    private _multi = false;
+    private _onToggle?: (index: number, open: boolean) => void;
+    private _focusIndex = 0;
+    private _openSet: Set<number> = new Set();
+
+    focusable = true;
+
+    constructor(items: AccordionItem[], style: Partial<Style> = {}, opts: AccordionOptions = {}) {
+        super(mergeStyles(defaultStyle(), style));
+        this._items = items;
+        this._multi = opts?.multi ?? false;
+        this._onToggle = opts?.onToggle;
+    }
+
+    setItems(items: AccordionItem[]): void {
+        this._items = items;
+        this._focusIndex = Math.min(this._focusIndex, Math.max(0, items.length - 1));
+        const keysToDelete: number[] = [];
+        for (const idx of this._openSet) {
+            if (idx >= items.length) {
+                keysToDelete.push(idx);
+            }
+        }
+        for (const key of keysToDelete) {
+            this._openSet.delete(key);
+        }
+        this.markDirty();
+    }
+
+    openSection(index: number): void {
+        if (index < 0 || index >= this._items.length) return;
+        if (this._openSet.has(index)) return;
+
+        if (!this._multi) {
+            for (const openIdx of Array.from(this._openSet)) {
+                this._openSet.delete(openIdx);
+                this._onToggle?.(openIdx, false);
+            }
+        }
+
+        this._openSet.add(index);
+        this._onToggle?.(index, true);
+        this.markDirty();
+    }
+
+    closeSection(index: number): void {
+        if (index < 0 || index >= this._items.length) return;
+        if (!this._openSet.has(index)) return;
+
+        this._openSet.delete(index);
+        this._onToggle?.(index, false);
+        this.markDirty();
+    }
+
+    handleKey(event: KeyEvent): void {
+        if (this._items.length === 0) return;
+        const key = event.key?.toLowerCase();
+
+        switch (key) {
+            case 'up':
+                if (this._focusIndex > 0) {
+                    this._focusIndex--;
+                    this.markDirty();
+                }
+                break;
+            case 'down':
+                if (this._focusIndex < this._items.length - 1) {
+                    this._focusIndex++;
+                    this.markDirty();
+                }
+                break;
+            case 'enter':
+            case 'space': {
+                const isOpened = this._openSet.has(this._focusIndex);
+                if (isOpened) {
+                    this.closeSection(this._focusIndex);
+                } else {
+                    this.openSection(this._focusIndex);
+                }
+                break;
+            }
+        }
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const rect = this._getContentRect();
+        const { x, y, width, height } = rect;
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this.style);
+        let currentY = y;
+
+        for (let i = 0; i < this._items.length; i++) {
+            if (currentY >= y + height) break;
+
+            const item = this._items[i];
+            const isOpen = this._openSet.has(i);
+            const isFocused = i === this._focusIndex;
+
+            // 1. Render Title Bar
+            const indicator = isOpen ? (caps.unicode ? '▼ ' : 'v ') : (caps.unicode ? '▶ ' : '> ');
+            const titleText = `${indicator}${item.title}`;
+            const titleAttrs = {
+                ...attrs,
+                fg: isFocused ? ({ type: 'named' as const, name: 'cyan' as const }) : attrs.fg,
+                bold: isFocused
+            };
+
+            const paddedTitle = titleText.padEnd(width).slice(0, width);
+            screen.writeString(x, currentY, paddedTitle, titleAttrs);
+            currentY++;
+
+            // 2. Render Body content if open
+            if (isOpen) {
+                const bodyLines = item.body.split('\n');
+                for (const line of bodyLines) {
+                    if (currentY >= y + height) break;
+
+                    const indentedLine = `  ${line}`;
+                    screen.writeString(x, currentY, indentedLine.padEnd(width).slice(0, width), attrs);
+                    currentY++;
+                }
+            }
+        }
+    }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -95,6 +95,9 @@ export type { DatePickerOptions } from './DatePicker.js';
 export { ColorPicker } from './ColorPicker.js';
 export type { ColorPickerOptions } from './ColorPicker.js';
 
+export { Accordion } from './Accordion.js';
+export type { AccordionOptions, AccordionItem } from './Accordion.js';
+
 export { AppShell } from './AppShell.js';
 export type { AppShellOptions } from './AppShell.js';
 export { Pagination } from './Pagination.js';


### PR DESCRIPTION
## Description

Adds a new keyboard-navigable and collapsible `Accordion` widget to `@termuijs/ui`. It supports both standard single-open vertical stacks (collapsing inactive panels) and concurrent multi-panel stacks (`multi: true`), with custom title bars, open/closed visual indicators, and toggle events.

## Related Issue

Closes #265

## Which package(s)?

@termuijs/ui

## Type of Change

- [x] ✨ Feature (`type:feature`)
- [x] 🧪 Tests (`type:testing`)

## Checklist

- [x] I have read the CONTRIBUTING guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## GSSoC 2026 Contributor Info

- **GSSoC 2026 Contributor:** Yes
- **GSSoC 2026 Contributor Profile:** https://gssoc.girlscript.org/profile/666f63ca-ed6a-4d0f-8ac8-1518b06ec839
