### PR TITLE
feat(widgets): add Masonry widget

### DIFF
--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -71,6 +71,7 @@ export { Center } from './layout/Center.js';
 export type { CenterOptions } from './layout/Center.js';
 export { Card } from './layout/Card.js';
 export type { CardOptions } from './layout/Card.js';
+// Masonry removed: module not present in this package
 export { Columns } from './layout/Columns.js';
 export type { ColumnsOptions } from './layout/Columns.js';
 

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -71,7 +71,8 @@ export { Center } from './layout/Center.js';
 export type { CenterOptions } from './layout/Center.js';
 export { Card } from './layout/Card.js';
 export type { CardOptions } from './layout/Card.js';
-// Masonry removed: module not present in this package
+export { Masonry } from './layout/Masonry.js';
+export type { MasonryOptions } from './layout/Masonry.js';
 export { Columns } from './layout/Columns.js';
 export type { ColumnsOptions } from './layout/Columns.js';
 

--- a/packages/widgets/src/layout/Masonry.test.ts
+++ b/packages/widgets/src/layout/Masonry.test.ts
@@ -1,13 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
-import { Masonry } from './Masonry';
-import { Widget } from '../base/Widget';
+import { Masonry } from './Masonry.js';
+import { Widget } from '../base/Widget.js';
 
-// Helper: create a mock widget with a fixed preferredHeight
+// Helper: create a real widget with a fixed preferredHeight
 function makeWidget(height: number): Widget {
-  const w = {
-    preferredHeight: height,
-    rect: null,
-  } as unknown as Widget;
+  const w = new Widget({});
+  w.preferredHeight = height;
   return w;
 }
 
@@ -21,7 +19,7 @@ describe('Masonry', () => {
     ];
 
     const masonry = new Masonry(children, {}, { columns: 2 });
-    (masonry as any).rect = { x: 0, y: 0, width: 80, height: 24 };
+    masonry.updateRect({ x: 0, y: 0, width: 80, height: 24 });
 
     // children 0 and 2 should be in column 0 (x=0)
     expect(children[0].rect?.x).toBe(0);
@@ -40,7 +38,7 @@ describe('Masonry', () => {
     ];
 
     const masonry = new Masonry(children, {}, { columns: 2 });
-    (masonry as any).rect = { x: 0, y: 0, width: 80, height: 24 };
+    masonry.updateRect({ x: 0, y: 0, width: 80, height: 24 });
 
     // child 2 should go to column 1 (x=40) because col 1 is shorter
     expect(children[2].rect?.x).toBe(40);

--- a/packages/widgets/src/layout/Masonry.test.ts
+++ b/packages/widgets/src/layout/Masonry.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Masonry } from './Masonry';
+import { Widget } from '../base/Widget';
+
+// Helper: create a mock widget with a fixed preferredHeight
+function makeWidget(height: number): Widget {
+  const w = {
+    preferredHeight: height,
+    rect: null,
+  } as unknown as Widget;
+  return w;
+}
+
+describe('Masonry', () => {
+  it('distributes 4 children across 2 columns', () => {
+    const children = [
+      makeWidget(3), // col 0
+      makeWidget(3), // col 1
+      makeWidget(3), // col 0
+      makeWidget(3), // col 1
+    ];
+
+    const masonry = new Masonry(children, {}, { columns: 2 });
+    (masonry as any).rect = { x: 0, y: 0, width: 80, height: 24 };
+
+    // children 0 and 2 should be in column 0 (x=0)
+    expect(children[0].rect?.x).toBe(0);
+    expect(children[2].rect?.x).toBe(0);
+
+    // children 1 and 3 should be in column 1 (x=40)
+    expect(children[1].rect?.x).toBe(40);
+    expect(children[3].rect?.x).toBe(40);
+  });
+
+  it('puts next item in shorter column when one is taller', () => {
+    const children = [
+      makeWidget(10), // col 0 — tall
+      makeWidget(2),  // col 1 — short
+      makeWidget(2),  // should go to col 1 (shorter)
+    ];
+
+    const masonry = new Masonry(children, {}, { columns: 2 });
+    (masonry as any).rect = { x: 0, y: 0, width: 80, height: 24 };
+
+    // child 2 should go to column 1 (x=40) because col 1 is shorter
+    expect(children[2].rect?.x).toBe(40);
+  });
+
+  it('setChildren triggers markDirty', () => {
+    const masonry = new Masonry([], {}, { columns: 2 });
+    const spy = vi.spyOn(masonry, 'markDirty');
+
+    masonry.setChildren([makeWidget(1)]);
+
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/packages/widgets/src/layout/Masonry.ts
+++ b/packages/widgets/src/layout/Masonry.ts
@@ -1,5 +1,5 @@
 import { Widget } from '../base/Widget.js';
-import { type Style } from '@termuijs/core';
+import { type Screen, type Style } from '@termuijs/core';
 
 export interface MasonryOptions {
   /** Number of columns. Default: 2 */
@@ -9,52 +9,47 @@ export interface MasonryOptions {
 }
 
 export class Masonry extends Widget {
-  protected _children: Widget[];
   private _columns: number;
   private _gap: number;
 
   constructor(
     children: Widget[],
     style?: Partial<Style>,
-    opts?: MasonryOptions
+    opts?: MasonryOptions,
   ) {
     super(style);
     this._columns = opts?.columns ?? 2;
     this._gap = opts?.gap ?? 0;
-    this._children = [];
     this.setChildren(children);
   }
 
   setChildren(children: Widget[]): void {
-    this._children = children;
+    this.clearChildren();
+    for (const child of children) this.addChild(child);
     this._layout();
     this.markDirty();
   }
 
-  protected _renderSelf(): string {
-    return '';
+  override syncLayout(): void {
+    super.syncLayout();
+    this._layout();
   }
 
+  protected _renderSelf(_screen: Screen): void {}
+
   private _layout(): void {
-    const totalWidth = this.rect?.width ?? 80;
+    const totalWidth = this.rect.width || 80;
     const colWidth = Math.floor(totalWidth / this._columns);
     const colHeights = new Array<number>(this._columns).fill(0);
 
-    for (const child of this._children) {
-      // Find the shortest column
+    for (const child of this.children) {
       const col = colHeights.indexOf(Math.min(...colHeights));
       const x = col * colWidth;
       const y = colHeights[col];
-      const height = child.rect?.height ?? 1;
+      const height = (child as any).preferredHeight ?? (child.rect.height || 1);
 
-      // Use child's setRect if available; otherwise fall back to any-assignment
-      if (typeof (child as any).setRect === 'function') {
-        (child as any).setRect({ x, y, width: colWidth, height });
-      } else {
-        (child as any).rect = { x, y, width: colWidth, height };
-      }
+      child.updateRect({ x, y, width: colWidth, height });
 
-      // Advance that column's height
       colHeights[col] += height + this._gap;
     }
   }

--- a/packages/widgets/src/layout/Masonry.ts
+++ b/packages/widgets/src/layout/Masonry.ts
@@ -1,0 +1,61 @@
+import { Widget } from '../base/Widget.js';
+import { type Style } from '@termuijs/core';
+
+export interface MasonryOptions {
+  /** Number of columns. Default: 2 */
+  columns?: number;
+  /** Vertical gap between items. Default: 0 */
+  gap?: number;
+}
+
+export class Masonry extends Widget {
+  protected _children: Widget[];
+  private _columns: number;
+  private _gap: number;
+
+  constructor(
+    children: Widget[],
+    style?: Partial<Style>,
+    opts?: MasonryOptions
+  ) {
+    super(style);
+    this._columns = opts?.columns ?? 2;
+    this._gap = opts?.gap ?? 0;
+    this._children = [];
+    this.setChildren(children);
+  }
+
+  setChildren(children: Widget[]): void {
+    this._children = children;
+    this._layout();
+    this.markDirty();
+  }
+
+  protected _renderSelf(): string {
+    return '';
+  }
+
+  private _layout(): void {
+    const totalWidth = this.rect?.width ?? 80;
+    const colWidth = Math.floor(totalWidth / this._columns);
+    const colHeights = new Array<number>(this._columns).fill(0);
+
+    for (const child of this._children) {
+      // Find the shortest column
+      const col = colHeights.indexOf(Math.min(...colHeights));
+      const x = col * colWidth;
+      const y = colHeights[col];
+      const height = child.rect?.height ?? 1;
+
+      // Use child's setRect if available; otherwise fall back to any-assignment
+      if (typeof (child as any).setRect === 'function') {
+        (child as any).setRect({ x, y, width: colWidth, height });
+      } else {
+        (child as any).rect = { x, y, width: colWidth, height };
+      }
+
+      // Advance that column's height
+      colHeights[col] += height + this._gap;
+    }
+  }
+}


### PR DESCRIPTION
Closes #277

Adds a Masonry (waterfall/pinterest-style) layout widget that arranges children into equal-width columns,
placing each new item in the shortest column to minimize total height.

Features:
- Configurable number of columns (default: 2)
- Configurable vertical gap between items (default: 0)
- Automatically distributes children to shortest column
- Type-checked and follows existing layout widget patterns