### PR TITLE
feat(widgets): add SplitPane widget

### DIFF
--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -77,6 +77,8 @@ export { Card } from './layout/Card.js';
 export type { CardOptions } from './layout/Card.js';
 export { Columns } from './layout/Columns.js';
 export type { ColumnsOptions } from './layout/Columns.js';
+export { SplitPane } from './layout/SplitPane.js';
+export type { SplitPaneOptions } from './layout/SplitPane.js';
 
 // ── Feedback Widgets ──────────────────────────────────
 export { ProgressBar } from './feedback/ProgressBar.js';

--- a/packages/widgets/src/layout/SplitPane.test.ts
+++ b/packages/widgets/src/layout/SplitPane.test.ts
@@ -1,0 +1,107 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for SplitPane layout
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { SplitPane } from './SplitPane.js';
+import { Box } from '../display/Box.js';
+import { Screen, computeLayout, caps, type KeyEvent } from '@termuijs/core';
+
+function shiftKey(key: string): KeyEvent {
+    return {
+        key,
+        shift: true,
+        ctrl: false,
+        alt: false,
+        raw: Buffer.alloc(0),
+        stopPropagation: () => {},
+        preventDefault: () => {},
+    };
+}
+
+describe('SplitPane layout', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('left pane renders at expected width for ratio=0.5', () => {
+        const left = new Box();
+        const right = new Box();
+        const pane = new SplitPane(left, right, { width: 40, height: 10 }, { ratio: 0.5 });
+
+        const node = pane.getLayoutNode();
+        computeLayout(node, 40, 10);
+        pane.syncLayout();
+
+        expect(left.rect.width).toBe(20);
+        expect(right.rect.width).toBe(19);
+        expect(left.rect.x).toBe(0);
+        expect(right.rect.x).toBe(21);
+    });
+
+    it('shift+right moves divider right by 1 cell', () => {
+        const left = new Box();
+        const right = new Box();
+        const pane = new SplitPane(left, right, { width: 40, height: 10 }, { ratio: 0.5 });
+
+        const node = pane.getLayoutNode();
+        computeLayout(node, 40, 10);
+        pane.syncLayout();
+
+        expect(left.rect.width).toBe(20);
+
+        pane.handleKey(shiftKey('right'));
+        pane.syncLayout();
+
+        expect(left.rect.width).toBe(21);
+        expect(right.rect.x).toBe(22);
+    });
+
+    it('ratio does not exceed 1 - minSize/totalWidth', () => {
+        const left = new Box();
+        const right = new Box();
+        const pane = new SplitPane(left, right, { width: 40, height: 10 }, { ratio: 0.5, minSize: 5 });
+
+        const node = pane.getLayoutNode();
+        computeLayout(node, 40, 10);
+        pane.syncLayout();
+
+        const maxRatio = 1 - 5 / 40;
+        pane.setRatio(1);
+
+        expect(pane.getRatio()).toBeLessThanOrEqual(maxRatio);
+        expect(right.rect.width).toBeGreaterThanOrEqual(5);
+    });
+
+    it('renders ASCII divider when caps.unicode is false', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+
+        const left = new Box();
+        const right = new Box();
+        const pane = new SplitPane(left, right, { width: 10, height: 3 }, { ratio: 0.5 });
+
+        const node = pane.getLayoutNode();
+        computeLayout(node, 10, 3);
+        pane.syncLayout();
+
+        const screen = new Screen(10, 3);
+        pane.render(screen);
+
+        expect(screen.back[0][5].char).toBe('|');
+    });
+
+    it('setRatio triggers markDirty', () => {
+        const left = new Box();
+        const right = new Box();
+        const pane = new SplitPane(left, right, { width: 40, height: 10 });
+
+        const node = pane.getLayoutNode();
+        computeLayout(node, 40, 10);
+        pane.syncLayout();
+
+        const markDirtySpy = vi.spyOn(pane, 'markDirty');
+        pane.setRatio(0.6);
+
+        expect(markDirtySpy).toHaveBeenCalled();
+    });
+});

--- a/packages/widgets/src/layout/SplitPane.ts
+++ b/packages/widgets/src/layout/SplitPane.ts
@@ -1,0 +1,115 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — SplitPane layout widget
+// ─────────────────────────────────────────────────────
+
+import { type Screen, type Style, type KeyEvent, caps, styleToCellAttrs } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export interface SplitPaneOptions {
+    /** Horizontal split ratio for the left pane (0–1, default: 0.5) */
+    ratio?: number;
+    /** Minimum width in cells for each pane (default: 1) */
+    minSize?: number;
+}
+
+/**
+ * SplitPane — two-pane horizontal layout with a draggable divider.
+ *
+ * The left pane occupies columns [0, leftWidth − 1], the divider sits at
+ * leftWidth, and the right pane occupies [leftWidth + 1, totalWidth − 1].
+ * Use shift+left / shift+right to resize when focused.
+ */
+export class SplitPane extends Widget {
+    private _ratio: number;
+    private readonly _minSize: number;
+
+    constructor(
+        left: Widget,
+        right: Widget,
+        style: Partial<Style> = {},
+        opts: SplitPaneOptions = {},
+    ) {
+        super(style);
+        this._ratio = opts.ratio ?? 0.5;
+        this._minSize = opts.minSize ?? 1;
+        this.focusable = true;
+        this.addChild(left);
+        this.addChild(right);
+    }
+
+    getRatio(): number {
+        return this._ratio;
+    }
+
+    setRatio(ratio: number): void {
+        const totalWidth = this._getContentRect().width;
+        this._ratio = totalWidth > 0 ? this._clampRatio(ratio, totalWidth) : ratio;
+        this.markDirty();
+    }
+
+    handleKey(event: KeyEvent): void {
+        if (!event.shift) return;
+
+        const totalWidth = this._getContentRect().width;
+        if (totalWidth <= 0) return;
+
+        const step = 1 / totalWidth;
+        if (event.key === 'left') {
+            this.setRatio(this._ratio - step);
+        } else if (event.key === 'right') {
+            this.setRatio(this._ratio + step);
+        }
+    }
+
+    override syncLayout(): void {
+        super.syncLayout();
+        this._positionChildren();
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const content = this._getContentRect();
+        const { x, y, width, height } = content;
+        if (width <= 0 || height <= 0) return;
+
+        const leftWidth = Math.floor(this._ratio * width);
+        const dividerX = x + leftWidth;
+        const dividerChar = caps.unicode ? '│' : '|';
+        const attrs = styleToCellAttrs(this._style);
+
+        for (let row = 0; row < height; row++) {
+            screen.setCell(dividerX, y + row, { char: dividerChar, ...attrs });
+        }
+    }
+
+    private _clampRatio(ratio: number, totalWidth: number): number {
+        const minRatio = this._minSize / totalWidth;
+        const maxRatio = 1 - this._minSize / totalWidth;
+        return Math.max(minRatio, Math.min(maxRatio, ratio));
+    }
+
+    private _positionChildren(): void {
+        const left = this._children[0];
+        const right = this._children[1];
+        if (!left || !right) return;
+
+        const content = this._getContentRect();
+        const totalWidth = content.width;
+        if (totalWidth <= 0) return;
+
+        const leftWidth = Math.floor(this._ratio * totalWidth);
+
+        left.updateRect({
+            x: content.x,
+            y: content.y,
+            width: leftWidth,
+            height: content.height,
+        });
+
+        right.updateRect({
+            x: content.x + leftWidth + 1,
+            y: content.y,
+            width: Math.max(0, totalWidth - leftWidth - 1),
+            height: content.height,
+        });
+    }
+}


### PR DESCRIPTION
## Description
Adds a `SplitPane` widget to `@termuijs/widgets` that renders two resizable panes side by side with a keyboard-movable divider.

## Type of Change
- [x] New feature

## Related Issue
Closes #275

## What's Changed
- [x] Created `packages/widgets/src/layout/SplitPane.ts`
- [x] Created `packages/widgets/src/layout/SplitPane.test.ts`
- [x] Exported `SplitPane` and `SplitPaneOptions` from `packages/widgets/src/index.ts`
- [x] Left pane occupies `ratio` of available width, right pane takes the rest
- [x] Divider character renders between panes using `caps.unicode` with ASCII fallback `|`
- [x] `shift+left` / `shift+right` move divider by 1 cell
- [x] Ratio clamped so neither pane goes below `minSize`
- [x] `setRatio()` calls `markDirty()`
- [x] `handleKey` uses lowercase `event.key`
- [x] Only `packages/widgets` was modified

## Tests
- [x] Left pane renders at expected width for ratio=0.5
- [x] shift+right moves divider right by 1 cell
- [x] Ratio does not exceed 1 - minSize/totalWidth
- [x] setRatio triggers markDirty
- [x] caps.unicode divider renders correctly

## Verification
- [x] `bun vitest run packages/widgets` passes - 541/541 
- [x] `bun run typecheck` passes 
- [x] `bun run build` passes 
- [x] Only `packages/widgets` modified 
- [x] `bun.lock` unchanged 
- [x] Repo starred 

Closes #275