### PR TITLE
feat(widgets): added ProgressCircle widget

### DIFF
--- a/packages/widgets/src/feedback/ProgressCircle.test.ts
+++ b/packages/widgets/src/feedback/ProgressCircle.test.ts
@@ -1,0 +1,147 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for ProgressCircle widget
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Screen, caps } from '@termuijs/core';
+import { ProgressCircle } from './ProgressCircle.js';
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+function row(screen: Screen, y: number): string {
+    return screen.back[y].map((c: { char: string }) => c.char).join('');
+}
+
+describe('ProgressCircle — value handling', () => {
+    it('initializes with a value of 0', () => {
+        const c = new ProgressCircle();
+        expect(c.value).toBe(0);
+    });
+
+    it('initializes with the supplied value', () => {
+        const c = new ProgressCircle({}, { value: 0.42 });
+        expect(c.value).toBe(0.42);
+    });
+
+    it('setValue stores the value', () => {
+        const c = new ProgressCircle();
+        c.setValue(0.6);
+        expect(c.value).toBe(0.6);
+    });
+
+    it('clamps values above 1 to 1', () => {
+        const c = new ProgressCircle();
+        c.setValue(1.5);
+        expect(c.value).toBe(1);
+    });
+
+    it('clamps values below 0 to 0', () => {
+        const c = new ProgressCircle();
+        c.setValue(-0.5);
+        expect(c.value).toBe(0);
+    });
+
+    it('NaN values clamp to 0', () => {
+        const c = new ProgressCircle();
+        c.setValue(Number.NaN);
+        expect(c.value).toBe(0);
+    });
+
+    it('setValue marks the widget dirty', () => {
+        const c = new ProgressCircle();
+        (c as unknown as { _dirty: boolean })._dirty = false;
+        c.setValue(0.5);
+        expect(c.isDirty).toBe(true);
+    });
+});
+
+describe('ProgressCircle — ASCII rendering', () => {
+    it('renders an empty bar [--------] at value 0', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+
+        const c = new ProgressCircle({}, { value: 0, showLabel: false });
+        c.updateRect({ x: 0, y: 0, width: 10, height: 1 });
+        const screen = new Screen(10, 1);
+        c.render(screen);
+
+        const rendered = row(screen, 0);
+        expect(rendered).toBe('[--------]');
+        expect(rendered).not.toContain('#');
+    });
+
+    it('renders a full bar [########] at value 1', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+
+        const c = new ProgressCircle({}, { value: 1, showLabel: false });
+        c.updateRect({ x: 0, y: 0, width: 10, height: 1 });
+        const screen = new Screen(10, 1);
+        c.render(screen);
+
+        const rendered = row(screen, 0);
+        expect(rendered).toBe('[########]');
+        expect(rendered).not.toContain('-');
+    });
+
+    it('renders half fill at value 0.5', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+
+        const c = new ProgressCircle({}, { value: 0.5, showLabel: false });
+        c.updateRect({ x: 0, y: 0, width: 10, height: 1 });
+        const screen = new Screen(10, 1);
+        c.render(screen);
+
+        const rendered = row(screen, 0);
+        expect(rendered.startsWith('[####')).toBe(true);
+        expect(rendered.endsWith('----]')).toBe(true);
+    });
+
+    it('shows the percentage label when showLabel is true', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+
+        const c = new ProgressCircle({}, { value: 0.5, showLabel: true });
+        c.updateRect({ x: 0, y: 0, width: 16, height: 1 });
+        const screen = new Screen(16, 1);
+        c.render(screen);
+
+        const rendered = row(screen, 0).trimEnd();
+        expect(rendered).toContain('50%');
+    });
+});
+
+describe('ProgressCircle — unicode rendering', () => {
+    it('uses braille chars (⣿ and ⠿) when unicode is available', () => {
+        // Default caps.unicode in tests is true.
+
+        const c = new ProgressCircle({}, { value: 0.5, showLabel: false });
+        c.updateRect({ x: 0, y: 0, width: 8, height: 1 });
+        const screen = new Screen(8, 1);
+        c.render(screen);
+
+        const rendered = row(screen, 0);
+        expect(rendered).toMatch(/[⣿⠿]/);
+        expect(rendered).not.toContain('#');
+        expect(rendered).not.toContain('-');
+    });
+
+    it('renders all empty braille at value 0', () => {
+        const c = new ProgressCircle({}, { value: 0, showLabel: false });
+        c.updateRect({ x: 0, y: 0, width: 6, height: 1 });
+        const screen = new Screen(6, 1);
+        c.render(screen);
+
+        const rendered = row(screen, 0);
+        expect(rendered).toBe('⠿⠿⠿⠿⠿⠿');
+    });
+
+    it('renders all filled braille at value 1', () => {
+        const c = new ProgressCircle({}, { value: 1, showLabel: false });
+        c.updateRect({ x: 0, y: 0, width: 6, height: 1 });
+        const screen = new Screen(6, 1);
+        c.render(screen);
+
+        const rendered = row(screen, 0);
+        expect(rendered).toBe('⣿⣿⣿⣿⣿⣿');
+    });
+});

--- a/packages/widgets/src/feedback/ProgressCircle.ts
+++ b/packages/widgets/src/feedback/ProgressCircle.ts
@@ -1,0 +1,149 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — ProgressCircle widget
+//
+// Renders a progress value (0–1) as a braille "arc" when
+// unicode is available, or a `[####----]`-style bar in
+// ASCII. Optionally shows a percentage label centered
+// on the same line as the indicator.
+// ─────────────────────────────────────────────────────
+
+import { type Screen, type Style, type Color, styleToCellAttrs, caps, stringWidth } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export interface ProgressCircleOptions {
+    /** Current value in the range 0–1. Clamped. */
+    value?: number;
+    /** Color of the filled portion. */
+    fillColor?: Color;
+    /** Show a " XX%" label next to the indicator. */
+    showLabel?: boolean;
+}
+
+/**
+ * ProgressCircle — compact circular-style progress meter.
+ *
+ * In unicode mode the filled and empty portions use 8-dot
+ * braille characters (`⣿` and `⠿`) at different dot
+ * densities to suggest a filling arc. In ASCII mode the
+ * widget falls back to a bracketed bar (`[####----]`).
+ *
+ * Example:
+ *   new ProgressCircle({ width: 12, height: 3 }, { showLabel: true })
+ *   circle.setValue(0.72);
+ */
+export class ProgressCircle extends Widget {
+    private _value: number;
+    private _fillColor: Color;
+    private _showLabel: boolean;
+
+    constructor(style: Partial<Style> = {}, options: ProgressCircleOptions = {}) {
+        super(style);
+        this._value = clamp01(options.value ?? 0);
+        this._fillColor = options.fillColor ?? { type: 'named', name: 'green' };
+        this._showLabel = options.showLabel ?? false;
+    }
+
+    /** Update the current progress. Out-of-range values are clamped to [0, 1]. */
+    setValue(value: number): void {
+        this._value = clamp01(value);
+        this.markDirty();
+    }
+
+    /** Current clamped progress value in the range [0, 1]. */
+    get value(): number { return this._value; }
+
+    /** Color applied to the filled portion. */
+    get fillColor(): Color { return this._fillColor; }
+    set fillColor(color: Color) {
+        this._fillColor = color;
+        this.markDirty();
+    }
+
+    /** Whether the " XX%" label is rendered alongside the indicator. */
+    get showLabel(): boolean { return this._showLabel; }
+    set showLabel(v: boolean) {
+        this._showLabel = v;
+        this.markDirty();
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const rect = this._getContentRect();
+        const { x, y, width, height } = rect;
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this._style);
+
+        if (caps.unicode) {
+            this._renderBraille(screen, x, y, width, height, attrs);
+        } else {
+            this._renderAscii(screen, x, y, width, height, attrs);
+        }
+    }
+
+    private _renderAscii(
+        screen: Screen,
+        x: number, y: number, width: number, height: number,
+        attrs: ReturnType<typeof styleToCellAttrs>,
+    ): void {
+        const barY = y + Math.floor((height - 1) / 2);
+        const labelStr = this._showLabel ? ` ${Math.round(this._value * 100)}%` : '';
+        const labelWidth = stringWidth(labelStr);
+
+        // Need at least 2 cells for the brackets, plus any label width.
+        const innerWidth = Math.max(1, width - 2 - labelWidth);
+        const filled = Math.min(innerWidth, Math.round(innerWidth * this._value));
+        const empty = innerWidth - filled;
+
+        let col = x;
+        screen.setCell(col, barY, { char: '[', ...attrs });
+        col += 1;
+        for (let i = 0; i < filled; i++) {
+            screen.setCell(col + i, barY, { char: '#', ...attrs, fg: this._fillColor });
+        }
+        for (let i = 0; i < empty; i++) {
+            screen.setCell(col + filled + i, barY, { char: '-', ...attrs, dim: true });
+        }
+        col += innerWidth;
+        screen.setCell(col, barY, { char: ']', ...attrs });
+        col += 1;
+
+        if (this._showLabel && labelStr) {
+            screen.writeString(col, barY, labelStr, { ...attrs, bold: true });
+        }
+    }
+
+    private _renderBraille(
+        screen: Screen,
+        x: number, y: number, width: number, height: number,
+        attrs: ReturnType<typeof styleToCellAttrs>,
+    ): void {
+        const barY = y + Math.floor((height - 1) / 2);
+        const labelStr = this._showLabel ? ` ${Math.round(this._value * 100)}%` : '';
+        const labelWidth = stringWidth(labelStr);
+
+        // Each braille char is one terminal column.
+        const innerWidth = Math.max(1, width - labelWidth);
+        const filled = Math.min(innerWidth, Math.round(innerWidth * this._value));
+        const empty = innerWidth - filled;
+
+        let col = x;
+        for (let i = 0; i < filled; i++) {
+            screen.setCell(col + i, barY, { char: '⣿', ...attrs, fg: this._fillColor });
+        }
+        for (let i = 0; i < empty; i++) {
+            screen.setCell(col + filled + i, barY, { char: '⠿', ...attrs, dim: true });
+        }
+        col += innerWidth;
+
+        if (this._showLabel && labelStr) {
+            screen.writeString(col, barY, labelStr, { ...attrs, bold: true });
+        }
+    }
+}
+
+function clamp01(n: number): number {
+    if (Number.isNaN(n)) return 0;
+    if (n < 0) return 0;
+    if (n > 1) return 1;
+    return n;
+}

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -77,6 +77,8 @@ export type { ColumnsOptions } from './layout/Columns.js';
 // ── Feedback Widgets ──────────────────────────────────
 export { ProgressBar } from './feedback/ProgressBar.js';
 export type { ProgressBarOptions } from './feedback/ProgressBar.js';
+export { ProgressCircle } from './feedback/ProgressCircle.js';
+export type { ProgressCircleOptions } from './feedback/ProgressCircle.js';
 export { MultiProgress } from './feedback/MultiProgress.js';
 export type { ProgressItem, MultiProgressOptions } from './feedback/MultiProgress.js';
 export { Spinner, SPINNER_FRAMES } from './feedback/Spinner.js';


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

<!-- What does this PR do? 1 to 3 sentences. -->
adds a `ProgressCircle` widget to `@termuijs/widgets` that renders a progress value (0–1) as a braille "arc" in unicode terminals or a `[####----]`-style bar in ASCII mode. An optional centered label shows the rounded percentage.


## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #27

## Which package(s)?

<!-- Example: @termuijs/core, @termuijs/widgets, website. -->
termuijs/widgets

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [x] ♻️ Refactor (`type:refactor`)
- [x] 🎨 Design / UX (`type:design`)
- [x] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/ffd28efb-18d5-4421-8b8e-7a4b5431fa83`

## Screenshots / Recordings (UI changes)

<img width="478" height="650" alt="image" src="https://github.com/user-attachments/assets/e27c3424-e03a-451a-b5ba-8ccd4a8cb287" />

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->
- `bun run build --filter=@termuijs/widgets` → builds clean
- `bun vitest run packages/widgets/src/feedback/ProgressCircle.test.ts`
  → 14/14 pass
- `bun vitest run packages/widgets` → 536/536 pass
- `bun vitest run` → 1144/1144 pass
- `bun run typecheck` → clean across all 17 packages
