### PR TITLE
feat(dev-server): add error overlay

### DIFF
--- a/packages/dev-server/src/error-overlay.test.ts
+++ b/packages/dev-server/src/error-overlay.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { Screen } from '@termuijs/core';
+import { parseErrorStack, ErrorOverlay } from './error-overlay.js';
+
+describe('error-overlay stack trace parsing', () => {
+    it('correctly parses standard runtime error stacks', () => {
+        const rawTrace = `
+TypeError: Cannot read properties of undefined (reading 'foo')
+    at renderSelf (D:/OpenSource/TermUI/TermUI/packages/widgets/src/display/Clock.ts:40:15)
+    at render (D:/OpenSource/TermUI/TermUI/packages/widgets/src/base/Widget.ts:182:14)
+    at runMicrotasks (<anonymous>)
+    at processTicksAndRejections (node:internal/process/task_queues:95:5)
+`;
+
+        const parsed = parseErrorStack(rawTrace);
+        expect(parsed.name).toBe('TypeError');
+        expect(parsed.message).toBe("Cannot read properties of undefined (reading 'foo')");
+        expect(parsed.file).toBe('D:/OpenSource/TermUI/TermUI/packages/widgets/src/display/Clock.ts');
+        expect(parsed.line).toBe(40);
+        expect(parsed.column).toBe(15);
+        expect(parsed.rawStack.length).toBe(4);
+    });
+
+    it('filters out node_modules and framework internals', () => {
+        const rawTrace = `
+Error: Render failed
+    at renderSelf (D:/OpenSource/TermUI/TermUI/node_modules/some-lib/index.js:5:10)
+    at renderSelf (D:/OpenSource/TermUI/TermUI/packages/widgets/src/display/Clock.ts:25:8)
+    at bun:wrap (bun:wrap:12:4)
+`;
+
+        const parsed = parseErrorStack(rawTrace);
+        expect(parsed.file).toBe('D:/OpenSource/TermUI/TermUI/packages/widgets/src/display/Clock.ts');
+        expect(parsed.line).toBe(25);
+    });
+});
+
+describe('ErrorOverlay rendering', () => {
+    it('writes parsed details correctly into the screen buffer', () => {
+        const rawTrace = `
+ReferenceError: x is not defined
+    at D:/OpenSource/TermUI/TermUI/src/index.ts:12:4
+`;
+        const screen = new Screen(80, 20);
+        const overlay = new ErrorOverlay(rawTrace);
+        overlay.render(screen);
+
+        const textOutput = screen.back.map(row => row.map(c => c.char).join('')).join('\n');
+
+        expect(textOutput).toContain('DEV-SERVER RUNTIME / COMPILE ERROR');
+        expect(textOutput).toContain('ReferenceError:');
+        expect(textOutput).toContain('x is not defined');
+        expect(textOutput).toContain('Location: D:/OpenSource/TermUI/TermUI/src/index.ts:12:4');
+        expect(textOutput).toContain('Watching for changes...');
+    });
+});

--- a/packages/dev-server/src/error-overlay.ts
+++ b/packages/dev-server/src/error-overlay.ts
@@ -1,0 +1,206 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/dev-server — Full-screen Error Overlay
+// ─────────────────────────────────────────────────────
+
+import { Screen, type LayoutNode, type RootWidget, stripAnsi, createLayoutNode, defaultStyle } from '@termuijs/core';
+
+export interface ParsedError {
+    name: string;
+    message: string;
+    file?: string;
+    line?: number;
+    column?: number;
+    rawStack: string[];
+}
+
+/**
+ * Parse standard Node/Bun error stack traces from stderr.
+ */
+export function parseErrorStack(rawStderr: string): ParsedError {
+    const cleanStderr = stripAnsi(rawStderr);
+    const lines = cleanStderr.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+
+    let name = 'Error';
+    let message = 'An unknown error occurred';
+    let file: string | undefined;
+    let line: number | undefined;
+    let column: number | undefined;
+    const rawStack: string[] = [];
+
+    let errorHeaderLine = '';
+    for (const l of lines) {
+        if (l.startsWith('at ') || l.startsWith('at') || l.includes('    at')) {
+            rawStack.push(l.replace(/^\s*at\s+/, 'at '));
+        } else if (!errorHeaderLine && (l.includes('Error:') || l.includes('Exception:') || l.match(/^[A-Z][a-zA-Z0-9]*Error:/))) {
+            errorHeaderLine = l;
+        } else if (!errorHeaderLine) {
+            // Fallback to first line that isn't a code frame or compiler visual guide
+            if (!l.includes(' | ') && !l.includes('^')) {
+                errorHeaderLine = l;
+            }
+        }
+    }
+
+    if (errorHeaderLine) {
+        const colonIdx = errorHeaderLine.indexOf(':');
+        if (colonIdx >= 0) {
+            name = errorHeaderLine.slice(0, colonIdx).trim();
+            message = errorHeaderLine.slice(colonIdx + 1).trim();
+        } else {
+            message = errorHeaderLine;
+        }
+    }
+
+    const stackRegex = /at\s+(?:.+?\s+\()?(.*?):(\d+):(\d+)\)?/;
+    for (const l of rawStack) {
+        const match = l.match(stackRegex);
+        if (match) {
+            const filePath = match[1];
+            // Filter out node_modules, Node/Bun internals, and anonymous wrappers
+            if (
+                !filePath.includes('node_modules') &&
+                !filePath.startsWith('node:') &&
+                !filePath.includes('bun:wrap') &&
+                !filePath.includes('<anonymous>')
+            ) {
+                file = filePath;
+                line = parseInt(match[2], 10);
+                column = parseInt(match[3], 10);
+                break;
+            }
+        }
+    }
+
+    // Fallback to the first available stack frame if no user-land frame matched
+    if (!file && rawStack.length > 0) {
+        const match = rawStack[0].match(stackRegex);
+        if (match) {
+            file = match[1];
+            line = parseInt(match[2], 10);
+            column = parseInt(match[3], 10);
+        }
+    }
+
+    return { name, message, file, line, column, rawStack };
+}
+
+/**
+ * ErrorOverlay widget which displays full-screen application crashes.
+ */
+export class ErrorOverlay implements RootWidget {
+    readonly id: string;
+    private _error: ParsedError;
+    private _dirty = true;
+
+    constructor(rawStderr: string) {
+        this.id = `error_overlay_${Math.random().toString(36).substring(2, 7)}`;
+        this._error = parseErrorStack(rawStderr);
+    }
+
+    get error(): ParsedError {
+        return this._error;
+    }
+
+    getLayoutNode(): LayoutNode {
+        return createLayoutNode(this.id, defaultStyle(), []);
+    }
+
+    get isDirty(): boolean {
+        return this._dirty;
+    }
+
+    clearDirty(): void {
+        this._dirty = false;
+    }
+
+    markDirty(): void {
+        this._dirty = true;
+    }
+
+    render(screen: Screen): void {
+        const { cols, rows } = screen;
+        if (cols <= 0 || rows <= 0) return;
+
+        // Clear screen with a consistent background
+        for (let y = 0; y < rows; y++) {
+            for (let x = 0; x < cols; x++) {
+                screen.setCell(x, y, {
+                    char: ' ',
+                    fg: { type: 'named', name: 'white' },
+                    bg: { type: 'named', name: 'black' },
+                });
+            }
+        }
+
+        // 1. Draw top banner
+        const bannerText = '  ❌ DEV-SERVER RUNTIME / COMPILE ERROR  ';
+        screen.writeString(0, 0, bannerText.padEnd(cols, ' '), {
+            fg: { type: 'named', name: 'white' },
+            bg: { type: 'named', name: 'red' },
+            bold: true,
+        });
+
+        // 2. Draw error header (Name: message)
+        let currentLine = 2;
+        screen.writeString(2, currentLine, `${this._error.name}:`, {
+            fg: { type: 'named', name: 'red' },
+            bold: true,
+        });
+        screen.writeString(2 + this._error.name.length + 2, currentLine, this._error.message, {
+            fg: { type: 'named', name: 'white' },
+            bold: true,
+        });
+        currentLine += 2;
+
+        // 3. Draw primary error location
+        if (this._error.file) {
+            const locText = `Location: ${this._error.file}:${this._error.line ?? 0}:${this._error.column ?? 0}`;
+            screen.writeString(2, currentLine, locText, {
+                fg: { type: 'named', name: 'yellow' },
+            });
+            currentLine += 2;
+        }
+
+        // 4. Draw stack trace header
+        screen.writeString(2, currentLine, 'Stack Trace:', {
+            fg: { type: 'named', name: 'brightBlack' },
+            underline: true,
+        });
+        currentLine += 1;
+
+        // 5. Draw visible stack trace frames
+        const maxTraceLines = rows - currentLine - 3;
+        const visibleTrace = this._error.rawStack.slice(0, Math.max(0, maxTraceLines));
+        for (const line of visibleTrace) {
+            const isInternal =
+                line.includes('node_modules') ||
+                line.includes('node:') ||
+                line.includes('bun:wrap') ||
+                line.includes('<anonymous>');
+
+            const style = isInternal
+                ? { fg: { type: 'named' as const, name: 'brightBlack' as const } }
+                : { fg: { type: 'named' as const, name: 'white' as const } };
+
+            screen.writeString(4, currentLine, line.slice(0, cols - 6), style);
+            currentLine++;
+        }
+
+        if (this._error.rawStack.length > visibleTrace.length) {
+            screen.writeString(
+                4,
+                currentLine,
+                `... and ${this._error.rawStack.length - visibleTrace.length} more frames`,
+                { fg: { type: 'named', name: 'brightBlack' } }
+            );
+        }
+
+        // 6. Draw bottom footer
+        const footerText = '  🔄 Watching for changes... (Save a file to auto-reload)  ';
+        screen.writeString(0, rows - 1, footerText.padEnd(cols, ' '), {
+            fg: { type: 'named', name: 'black' },
+            bg: { type: 'named', name: 'brightBlack' },
+            bold: true,
+        });
+    }
+}

--- a/packages/dev-server/src/index.ts
+++ b/packages/dev-server/src/index.ts
@@ -5,3 +5,5 @@ export { FileWatcher } from './watcher.js';
 export type { FileChange, WatcherEvents } from './watcher.js';
 export { DevTools } from './devtools.js';
 export type { WidgetNode, PerfMetrics } from './devtools.js';
+export { ErrorOverlay, parseErrorStack } from './error-overlay.js';
+export type { ParsedError } from './error-overlay.js';

--- a/packages/dev-server/src/server.test.ts
+++ b/packages/dev-server/src/server.test.ts
@@ -8,7 +8,12 @@ function createMockSubprocess() {
         exitCode: null,
         signalCode: null,
         killed: false,
-        exited: Promise.resolve(0)
+        exited: Promise.resolve(0),
+        stderr: {
+            getReader: vi.fn(() => ({
+                read: vi.fn(() => Promise.resolve({ done: true, value: undefined }))
+            }))
+        }
     };
 }
 

--- a/packages/dev-server/src/server.ts
+++ b/packages/dev-server/src/server.ts
@@ -10,8 +10,10 @@
 import { resolve } from 'node:path';
 import { existsSync } from 'node:fs';
 import type { Subprocess } from 'bun';
+import { App } from '@termuijs/core';
 import { FileWatcher, type FileChange } from './watcher.js';
 import { DevTools } from './devtools.js';
+import { ErrorOverlay } from './error-overlay.js';
 
 export interface DevServerOptions {
     /** Project root directory */
@@ -30,7 +32,7 @@ export interface DevServerOptions {
     debounce?: number;
 }
 
-type ChildSubprocess = Subprocess<'pipe', 'inherit', 'inherit'>;
+type ChildSubprocess = Subprocess<'pipe', 'inherit', 'pipe'>;
 
 export class DevServer {
     private _watcher: FileWatcher;
@@ -46,6 +48,7 @@ export class DevServer {
     private _bunFlags: string[];
     private _debounce: number;
     private _reloadTimer: ReturnType<typeof setTimeout> | null = null;
+    private _errorApp: App | null = null;
 
     constructor(options: DevServerOptions) {
         this._rootDir = resolve(options.rootDir);
@@ -112,6 +115,7 @@ export class DevServer {
     /** Stop the dev server — kills child process and stops watching */
     stop(): void {
         this._running = false;
+        this._hideErrorOverlay();
         this._killChild();
         this._watcher.stop();
         if (this._reloadTimer) {
@@ -130,13 +134,16 @@ export class DevServer {
     private _spawnChild(): void {
         if (!this._entryFile) return;
 
+        // Ensure any active error overlay is cleaned up before spawning the new child process
+        this._hideErrorOverlay();
+
         try {
             const child = Bun.spawn({
                 cmd: ['bun', ...this._bunFlags, this._entryFile],
                 cwd: this._rootDir,
                 stdin: 'pipe',
                 stdout: 'inherit',
-                stderr: 'inherit',
+                stderr: 'pipe',
                 ipc: (msg: unknown) => {
                     const m = msg as { type?: string; event?: string; data?: unknown };
                     if (m?.type === 'devtools' && m.event) {
@@ -150,9 +157,27 @@ export class DevServer {
                     TERMUI_DEV: '1',
                     NODE_ENV: 'development',
                 },
+            // Assert type to specify that stdin and stderr are piped for handling DevTools & crash overlays
             }) as ChildSubprocess;
 
             this._child = child;
+
+            let stderrBuffer = '';
+            (async () => {
+                try {
+                    const reader = child.stderr.getReader();
+                    const decoder = new TextDecoder();
+                    while (true) {
+                        const { done, value } = await reader.read();
+                        if (done) break;
+                        const chunk = decoder.decode(value);
+                        stderrBuffer += chunk;
+                        process.stderr.write(chunk);
+                    }
+                } catch {
+                    // Ignored
+                }
+            })();
 
             // Track exit asynchronously via the exited promise.
             // child.exited resolves with the exit code; it does not reject.
@@ -164,6 +189,10 @@ export class DevServer {
                     const time = new Date().toLocaleTimeString();
                     console.log(`  ❌ [${time}] Process exited (code: ${exitCode}, signal: ${signal})`);
                     this._devtools.logEvent('crash', `exit code ${exitCode}`);
+
+                    if (exitCode !== 0 && stderrBuffer.trim().length > 0) {
+                        this._showErrorOverlay(stderrBuffer);
+                    }
                 }
                 this._child = null;
             });
@@ -212,6 +241,9 @@ export class DevServer {
     private _handleChange(change: FileChange): void {
         const time = new Date().toLocaleTimeString();
         const icon = change.type === 'tss' ? '🎨' : change.type === 'config' ? '⚙️' : '📝';
+        
+        this._hideErrorOverlay();
+        
         console.log(`  ${icon} [${time}] ${change.filename} changed — reloading...`);
 
         this._devtools.logEvent('reload', `${change.type}: ${change.filename}`);
@@ -248,6 +280,29 @@ export class DevServer {
                 }
             }, 100);
         }, this._debounce);
+    }
+
+    private _showErrorOverlay(rawStderr: string): void {
+        this._hideErrorOverlay();
+        const overlay = new ErrorOverlay(rawStderr);
+        this._errorApp = new App(overlay, {
+            fullscreen: true,
+            title: 'TermUI Dev Server - Error',
+            fps: 10,
+            skipFallback: true,
+        });
+        this._errorApp.mount().catch(() => {});
+    }
+
+    private _hideErrorOverlay(): void {
+        if (this._errorApp) {
+            try {
+                this._errorApp.unmount();
+            } catch {
+                // Ignore
+            }
+            this._errorApp = null;
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Adds a full-screen error overlay to `@termuijs/dev-server` that displays uncaught render/runtime errors and stack traces when the child application crashes.

The implementation captures stderr output from the spawned process, renders diagnostic information through a dedicated `ErrorOverlay`, and automatically clears the overlay when the application reloads successfully.

## Related Issue

Closes #327

## Which package(s)?

@termuijs/dev-server

## Type of Change

* [x] ✨ Feature (`type:feature`)
* [x] 🧪 Tests (`type:testing`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md](https://chatgpt.com/g/g-p-6a1c81640ef4819180e1541a1faf22fa/c/CONTRIBUTING.md)`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/42e0e4bf-0550-4021-a19c-29f6f92ca35d`

## Screenshots / Recordings (UI changes)

N/A (dev-server infrastructure change)

## Notes for the Reviewer

### Summary

* Added `ErrorOverlay` component for displaying runtime/render errors.
* Captures stderr output from spawned child processes.
* Automatically displays stack traces when the child process exits with a non-zero code.
* Clears the overlay on reloads and server shutdown.
* Added test coverage for overlay behavior and updated server mocks to support piped stderr streams.

### Verification

* `bun vitest run packages/dev-server` ✅
* `bun run typecheck` ✅

### Files Added

* `packages/dev-server/src/error-overlay.ts`
* `packages/dev-server/src/error-overlay.test.ts`

### Files Modified

* `packages/dev-server/src/index.ts`
* `packages/dev-server/src/server.ts`
* `packages/dev-server/src/server.test.ts`

`server.ts` was modified because the overlay must be integrated into the dev-server lifecycle. The implementation captures stderr from the spawned child process, detects non-zero exits, and mounts/unmounts the overlay accordingly.

`server.test.ts` was updated only to extend the existing subprocess mock with `stderr.getReader()`, which became necessary after piping stderr in production code. Without this change, the existing server tests fail because the mock no longer matches the runtime API.

`index.ts` was updated to export the new ErrorOverlay API as required by the issue.
