### PR TITLE
Bug "Validate benchmark JSON before processing"

### DIFF
--- a/scripts/compare-bench.mjs
+++ b/scripts/compare-bench.mjs
@@ -26,7 +26,20 @@ if (Number.isNaN(threshold) || !Number.isFinite(threshold) || threshold < 0) {
 
 const head = JSON.parse(readFileSync(headPath, 'utf8'));
 const main = JSON.parse(readFileSync(mainPath, 'utf8'));
+function validateBench(data, name) {
+    if (!data || typeof data !== 'object') {
+        console.error(`${name}: invalid benchmark file`);
+        process.exit(2);
+    }
 
+    if (!Array.isArray(data.results)) {
+        console.error(`${name}: missing results array`);
+        process.exit(2);
+    }
+}
+
+validateBench(head, 'head benchmark');
+validateBench(main, 'main benchmark');
 const byKey = (r) => `${r.cols}x${r.rows}`;
 const mainBySize = new Map(main.results.map((r) => [byKey(r), r]));
 const headSizes = new Set(head.results.map(byKey));


### PR DESCRIPTION
Fixes #430 

Summary

Add validation for benchmark JSON files before accessing the "results" array.

Problem

"compare-bench.mjs" assumes that both benchmark files contain a valid "results" array. When a benchmark file is malformed or missing the "results" field, the script throws a runtime error such as:

TypeError: Cannot read properties of undefined (reading 'map')

Changes

- Validate parsed benchmark data before processing.
- Ensure "results" exists and is an array.
- Exit with a descriptive error message when validation fails.

Type
-Bug 

Result

Before:

TypeError: Cannot read properties of undefined (reading 'map')

After:

head benchmark: missing results array

This improves error reporting and makes CI failures easier to understand when benchmark files are malformed.