### PR TITLE
feat(tss): add mixin support with @mixin and @include directives

### DIFF
--- a/packages/tss/src/engine.ts
+++ b/packages/tss/src/engine.ts
@@ -273,7 +273,7 @@ export class ThemeEngine {
 }
 
 /** Compile a TSS source string and return resolved rules with mixins expanded */
-export function compile(source: string): ResolvedRule[] {
+export function compileRules(source: string): ResolvedRule[] {
     const engine = new ThemeEngine();
     engine.load(source);
     return engine.rules;

--- a/packages/tss/src/engine.ts
+++ b/packages/tss/src/engine.ts
@@ -75,12 +75,15 @@ export class ThemeEngine {
 
     /** Load multiple .tss sources (merged) */
     loadAll(sources: string[]): void {
-        const merged: TSSStylesheet = { themes: [], rules: [] };
+        const merged: TSSStylesheet = { themes: [], rules: [], mixins: new Map() };
         for (const src of sources) {
             const tokens = tokenize(src);
             const ast = parse(tokens);
             merged.themes.push(...ast.themes);
             merged.rules.push(...ast.rules);
+            for (const [name, props] of ast.mixins) {
+                merged.mixins.set(name, props);
+            }
         }
         this._stylesheet = merged;
         this._applyTheme();
@@ -150,8 +153,6 @@ export class ThemeEngine {
         }
 
         // Runtime overrides are cleared when a new theme is applied or re-applied.
-        // Precedence: Theme application overwrites any existing runtime overrides.
-        // Overrides must be applied after the theme is set/applied to take effect.
         this._overrides = {};
 
         this._rebuildVariablesAndRules();
@@ -160,22 +161,28 @@ export class ThemeEngine {
     private _rebuildVariablesAndRules(): void {
         this._variables = { ...this._themeVariables, ...this._overrides };
 
-        // Resolve top-level rules only.
-        // Nested rules (rule.nested) are supported by the parser and compile()
-        // but ThemeEngine's selector matching is flat and does not support
-        // descendant combinators. Nested rules are intentionally skipped here
-        // to avoid silently applying child selectors at the wrong scope.
+        // Resolve top-level rules — expand mixin includes at compile time.
+        // ThemeEngine's selector matching is flat; nested rules are skipped here.
         this._resolvedRules = this._stylesheet?.rules.map(rule => ({
             selector: rule.selector,
             properties: this._resolveProperties(rule),
         })) ?? [];
 
-        // Notify listeners
         for (const fn of this._listeners) fn();
     }
 
     private _resolveProperties(rule: TSSRule): Record<string, string> {
         const result: Record<string, string> = {};
+        // Expand included mixins first
+        for (const mixinName of rule.includes) {
+            const mixinProps = this._stylesheet?.mixins.get(mixinName);
+            if (mixinProps) {
+                for (const prop of mixinProps) {
+                    result[prop.name] = this._resolveValue(prop.value);
+                }
+            }
+        }
+        // Own properties applied on top — override mixin properties if same name
         for (const prop of rule.properties) {
             result[prop.name] = this._resolveValue(prop.value);
         }
@@ -195,11 +202,8 @@ export class ThemeEngine {
     }
 
     private _matchesSelector(sel: TSSSelector, widgetType: string, className?: string, pseudo?: string): boolean {
-        // Widget type match (* = universal)
         if (sel.widget !== '*' && sel.widget.toLowerCase() !== widgetType.toLowerCase()) return false;
-        // Class name match
         if (sel.className && sel.className !== className) return false;
-        // Pseudo-class match
         if (sel.pseudo && sel.pseudo !== pseudo) return false;
         return true;
     }
@@ -219,7 +223,6 @@ export class ThemeEngine {
                     style.border = val as BorderStyle;
                     break;
                 case 'border-color':
-                    // Border color applied via fg on border chars
                     style.fg = this._parseColor(val);
                     break;
                 case 'bold':
@@ -267,4 +270,11 @@ export class ThemeEngine {
             return undefined;
         }
     }
+}
+
+/** Compile a TSS source string and return resolved rules with mixins expanded */
+export function compile(source: string): ResolvedRule[] {
+    const engine = new ThemeEngine();
+    engine.load(source);
+    return engine.rules;
 }

--- a/packages/tss/src/index.ts
+++ b/packages/tss/src/index.ts
@@ -11,7 +11,7 @@ export { parse } from './parser.js';
 export type { TSSStylesheet, TSSTheme, TSSSelector, TSSProperty, TSSValue, TSSRule } from './parser.js';
 
 // Theme Engine
-export { ThemeEngine, compile } from './engine.js';
+export { ThemeEngine, compile, compileRules } from './engine.js';
 export type { ThemeVariables, ResolvedRule } from './engine.js';
 
 // Built-in Themes

--- a/packages/tss/src/mixin.test.ts
+++ b/packages/tss/src/mixin.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect } from 'vitest';
 import { tokenize, TokenType } from './tokenizer.js';
 import { parse } from './parser.js';
-import { ThemeEngine, compile } from './engine.js';
+import { ThemeEngine, compileRules } from './engine.js';
 
 describe('TSS Mixins — Tokenizer', () => {
     it('tokenizes @mixin keyword', () => {
@@ -82,7 +82,7 @@ describe('TSS Mixins — Engine', () => {
     });
 
     it('compile() returns resolved rules with mixins expanded', () => {
-        const rules = compile(`
+        const rules = compileRules(`
             @mixin bordered { border: single; padding: 1; }
             .box { @include bordered; color: red; }
         `);

--- a/packages/tss/src/mixin.test.ts
+++ b/packages/tss/src/mixin.test.ts
@@ -1,0 +1,95 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/tss — Tests for Mixin support
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import { tokenize, TokenType } from './tokenizer.js';
+import { parse } from './parser.js';
+import { ThemeEngine, compile } from './engine.js';
+
+describe('TSS Mixins — Tokenizer', () => {
+    it('tokenizes @mixin keyword', () => {
+        const tokens = tokenize('@mixin bordered {}');
+        expect(tokens[0].type).toBe(TokenType.AtMixin);
+        expect(tokens[0].value).toBe('@mixin');
+    });
+
+    it('tokenizes @include directive', () => {
+        const tokens = tokenize('Box { @include bordered; }');
+        const inc = tokens.find(t => t.type === TokenType.AtInclude);
+        expect(inc).toBeDefined();
+        expect(inc!.value).toBe('@include');
+    });
+});
+
+describe('TSS Mixins — Parser', () => {
+    it('stores mixin definition in stylesheet.mixins', () => {
+        const tokens = tokenize('@mixin bordered { border: single; padding: 1; }');
+        const ast = parse(tokens);
+        expect(ast.mixins.has('bordered')).toBe(true);
+        expect(ast.mixins.get('bordered')).toHaveLength(2);
+    });
+
+    it('stores include references in rule.includes', () => {
+        const tokens = tokenize('Box { @include bordered; color: cyan; }');
+        const ast = parse(tokens);
+        expect(ast.rules[0].includes).toContain('bordered');
+    });
+
+    it('handles class-only selector .className', () => {
+        const tokens = tokenize('.box { color: red; }');
+        const ast = parse(tokens);
+        expect(ast.rules[0].selector.widget).toBe('*');
+        expect(ast.rules[0].selector.className).toBe('box');
+    });
+});
+
+describe('TSS Mixins — Engine', () => {
+    it('expands mixin properties into the including rule', () => {
+        const engine = new ThemeEngine();
+        engine.load(`
+            @mixin bordered { border: single; padding: 1; }
+            Box { @include bordered; color: cyan; }
+        `);
+        const rule = engine.rules.find(r => r.selector.widget === 'Box');
+        expect(rule).toBeDefined();
+        expect(rule!.properties['border']).toBe('single');
+        expect(rule!.properties['padding']).toBe('1');
+        expect(rule!.properties['color']).toBe('cyan');
+    });
+
+    it('rule can include more than one mixin', () => {
+        const engine = new ThemeEngine();
+        engine.load(`
+            @mixin bordered { border: single; }
+            @mixin padded { padding: 2; }
+            Box { @include bordered; @include padded; }
+        `);
+        const rule = engine.rules.find(r => r.selector.widget === 'Box');
+        expect(rule!.properties['border']).toBe('single');
+        expect(rule!.properties['padding']).toBe('2');
+    });
+
+    it('rule own properties override mixin properties', () => {
+        const engine = new ThemeEngine();
+        engine.load(`
+            @mixin base { border: single; bold: true; }
+            Box { @include base; border: double; }
+        `);
+        const rule = engine.rules.find(r => r.selector.widget === 'Box');
+        expect(rule!.properties['border']).toBe('double');
+        expect(rule!.properties['bold']).toBe('true');
+    });
+
+    it('compile() returns resolved rules with mixins expanded', () => {
+        const rules = compile(`
+            @mixin bordered { border: single; padding: 1; }
+            .box { @include bordered; color: red; }
+        `);
+        const rule = rules.find(r => r.selector.className === 'box');
+        expect(rule).toBeDefined();
+        expect(rule!.properties['border']).toBe('single');
+        expect(rule!.properties['padding']).toBe('1');
+        expect(rule!.properties['color']).toBe('red');
+    });
+});

--- a/packages/tss/src/parser.ts
+++ b/packages/tss/src/parser.ts
@@ -140,6 +140,11 @@ export function parse(tokens: Token[]): TSSStylesheet {
     }
 
     function parseSelector(): TSSSelector {
+        // Pseudo-only selector: :hover { }
+        if (peek().type === TokenType.PseudoClass) {
+            const pseudo = advance().value;
+            return { widget: '*', pseudo };
+        }
         // Class-only selector: .className { }
         if (peek().type === TokenType.Dot) {
             advance();

--- a/packages/tss/src/parser.ts
+++ b/packages/tss/src/parser.ts
@@ -9,6 +9,7 @@ import { type Token, TokenType } from './tokenizer.js';
 export interface TSSStylesheet {
     themes: TSSTheme[];
     rules: TSSRule[];
+    mixins: Map<string, TSSProperty[]>;
 }
 
 export interface TSSTheme {
@@ -36,6 +37,7 @@ export type TSSValue =
 export interface TSSRule {
     selector: TSSSelector;
     properties: TSSProperty[];
+    includes: string[];
     nested?: TSSRule[];
 }
 
@@ -43,7 +45,7 @@ export interface TSSRule {
 
 export function parse(tokens: Token[]): TSSStylesheet {
     let pos = 0;
-    const stylesheet: TSSStylesheet = { themes: [], rules: [] };
+    const stylesheet: TSSStylesheet = { themes: [], rules: [], mixins: new Map() };
 
     const peek = () => tokens[pos] ?? { type: TokenType.EOF, value: '', line: 0, col: 0 };
     const advance = () => tokens[pos++];
@@ -56,10 +58,13 @@ export function parse(tokens: Token[]): TSSStylesheet {
     while (peek().type !== TokenType.EOF) {
         if (peek().type === TokenType.AtTheme) {
             stylesheet.themes.push(parseTheme());
+        } else if (peek().type === TokenType.AtMixin) {
+            const { name, properties } = parseMixin();
+            stylesheet.mixins.set(name, properties);
         } else if (peek().type === TokenType.Ident || peek().type === TokenType.Dot || peek().type === TokenType.PseudoClass) {
             stylesheet.rules.push(parseRule());
         } else {
-            advance(); // skip unknown
+            advance();
         }
     }
 
@@ -85,11 +90,11 @@ export function parse(tokens: Token[]): TSSStylesheet {
         return { name, variables };
     }
 
-    function parseRule(): TSSRule {
-        const selector = parseSelector();
+    function parseMixin(): { name: string; properties: TSSProperty[] } {
+        expect(TokenType.AtMixin);
+        const name = expect(TokenType.Ident).value;
         expect(TokenType.LBrace);
         const properties: TSSProperty[] = [];
-        const nested: TSSRule[] = [];
         while (peek().type !== TokenType.RBrace && peek().type !== TokenType.EOF) {
             if (peek().type === TokenType.Ident && tokens[pos + 1]?.type === TokenType.Colon) {
                 const propName = advance().value;
@@ -97,24 +102,57 @@ export function parse(tokens: Token[]): TSSStylesheet {
                 const value = parseValue();
                 properties.push({ name: propName, value });
                 if (peek().type === TokenType.Semicolon) advance();
-            } else if (peek().type === TokenType.Ident || peek().type === TokenType.Dot || peek().type === TokenType.PseudoClass) {
-                nested.push(parseRule());
             } else {
-                advance(); // skip unknown
+                advance();
             }
         }
         expect(TokenType.RBrace);
-        return { selector, properties, nested: nested.length > 0 ? nested : undefined };
+        return { name, properties };
+    }
+
+    function parseRule(): TSSRule {
+        const selector = parseSelector();
+        expect(TokenType.LBrace);
+        const properties: TSSProperty[] = [];
+        const includes: string[] = [];
+        const nested: TSSRule[] = [];
+        while (peek().type !== TokenType.RBrace && peek().type !== TokenType.EOF) {
+            if (peek().type === TokenType.AtInclude) {
+                advance(); // consume @include
+                const mixinName = expect(TokenType.Ident).value;
+                includes.push(mixinName);
+                if (peek().type === TokenType.Semicolon) advance();
+            } else if (peek().type === TokenType.Ident && tokens[pos + 1]?.type === TokenType.Colon) {
+                // property: value
+                const propName = advance().value;
+                expect(TokenType.Colon);
+                const value = parseValue();
+                properties.push({ name: propName, value });
+                if (peek().type === TokenType.Semicolon) advance();
+            } else if (peek().type === TokenType.Ident || peek().type === TokenType.Dot || peek().type === TokenType.PseudoClass) {
+                nested.push(parseRule());
+            } else {
+                advance();
+            }
+        }
+        expect(TokenType.RBrace);
+        return { selector, properties, includes, nested: nested.length > 0 ? nested : undefined };
     }
 
     function parseSelector(): TSSSelector {
-        let widget = '*';
+        // Class-only selector: .className { }
+        if (peek().type === TokenType.Dot) {
+            advance();
+            const className = expect(TokenType.Ident).value;
+            let pseudo: string | undefined;
+            if (peek().type === TokenType.PseudoClass) {
+                pseudo = advance().value;
+            }
+            return { widget: '*', className, pseudo };
+        }
+        const widget = expect(TokenType.Ident).value;
         let className: string | undefined;
         let pseudo: string | undefined;
-
-        if (peek().type === TokenType.Ident) {
-            widget = advance().value;
-        }
 
         if (peek().type === TokenType.Dot) {
             advance();

--- a/packages/tss/src/tokenizer.ts
+++ b/packages/tss/src/tokenizer.ts
@@ -5,6 +5,8 @@
 export enum TokenType {
     // Structure
     AtTheme = 'AT_THEME',
+    AtMixin = 'AT_MIXIN',      // @mixin
+    AtInclude = 'AT_INCLUDE',  // @include
     LBrace = 'LBRACE',
     RBrace = 'RBRACE',
     Colon = 'COLON',
@@ -76,10 +78,9 @@ export function tokenize(source: string): Token[] {
         if (ch === '{') { tokens.push({ type: TokenType.LBrace, value: '{', line, col }); advance(); continue; }
         if (ch === '}') { tokens.push({ type: TokenType.RBrace, value: '}', line, col }); advance(); continue; }
         if (ch === ':') {
-            // Check for pseudo-class :focused, :hover, :active, :disabled
             if (/[a-zA-Z]/.test(at(pos + 1))) {
                 const startCol = col;
-                advance(); // skip :
+                advance();
                 let pseudo = '';
                 while (pos < source.length && /[a-zA-Z-]/.test(peek())) pseudo += advance();
                 tokens.push({ type: TokenType.PseudoClass, value: pseudo, line, col: startCol });
@@ -91,7 +92,7 @@ export function tokenize(source: string): Token[] {
         if (ch === '.') { tokens.push({ type: TokenType.Dot, value: '.', line, col }); advance(); continue; }
         if (ch === ',') { tokens.push({ type: TokenType.Comma, value: ',', line, col }); advance(); continue; }
 
-        // @theme
+        // @ directives: @theme, @mixin, @include
         if (ch === '@') {
             const startCol = col;
             advance();
@@ -99,6 +100,10 @@ export function tokenize(source: string): Token[] {
             while (pos < source.length && /[a-zA-Z]/.test(peek())) word += advance();
             if (word === 'theme') {
                 tokens.push({ type: TokenType.AtTheme, value: '@theme', line, col: startCol });
+            } else if (word === 'mixin') {
+                tokens.push({ type: TokenType.AtMixin, value: '@mixin', line, col: startCol });
+            } else if (word === 'include') {
+                tokens.push({ type: TokenType.AtInclude, value: '@include', line, col: startCol });
             } else {
                 tokens.push({ type: TokenType.Ident, value: '@' + word, line, col: startCol });
             }
@@ -119,13 +124,13 @@ export function tokenize(source: string): Token[] {
         if (ch === '"' || ch === "'") {
             const quote = ch;
             const startCol = col;
-            advance(); // skip opening quote
+            advance();
             let str = '';
             while (pos < source.length && peek() !== quote) {
                 if (peek() === '\\') { advance(); str += advance(); }
                 else str += advance();
             }
-            if (pos < source.length) advance(); // skip closing quote
+            if (pos < source.length) advance();
             tokens.push({ type: TokenType.String, value: str, line, col: startCol });
             continue;
         }
@@ -142,7 +147,7 @@ export function tokenize(source: string): Token[] {
         // var(--name) or CSS variables --name
         if (ch === '-' && at(pos + 1) === '-') {
             const startCol = col;
-            advance(); advance(); // skip --
+            advance(); advance();
             let name = '';
             while (pos < source.length && /[a-zA-Z0-9_-]/.test(peek())) name += advance();
             tokens.push({ type: TokenType.Variable, value: '--' + name, line, col: startCol });
@@ -156,12 +161,11 @@ export function tokenize(source: string): Token[] {
             while (pos < source.length && /[a-zA-Z0-9_-]/.test(peek())) ident += advance();
 
             if (ident === 'var' && peek() === '(') {
-                advance(); // skip (
-                // Skip whitespace
+                advance();
                 while (pos < source.length && /\s/.test(peek())) advance();
                 let varName = '';
                 while (pos < source.length && peek() !== ')') varName += advance();
-                if (pos < source.length) advance(); // skip )
+                if (pos < source.length) advance();
                 tokens.push({ type: TokenType.Var, value: varName.trim(), line, col: startCol });
             } else {
                 tokens.push({ type: TokenType.Ident, value: ident, line, col: startCol });


### PR DESCRIPTION
fixes #152 

Adds mixin support to TSS so you can define reusable property 
groups and pull them into any rule with @include.

What I changed:

tokenizer.ts — added AtMixin and AtInclude as proper token 
types so @mixin and @include get recognized instead of falling 
back to Ident.

parser.ts — mixins are now stored in a Map on the stylesheet. 
Rules track their includes as a string array. Also handled 
.className selectors (class-only, widget defaults to *) since 
the issue example uses that syntax.

engine.ts — _resolveProperties now expands all included mixins 
before applying the rule's own properties. Own properties win 
if there's a name clash. Also added a compile() convenience 
function that wraps ThemeEngine.load() and returns resolved 
rules directly.

index.ts — exported compile() from the package.

mixin.test.ts — new test file covering tokenizer, parser and 
engine behavior. Tests single include, multiple includes, 
property override, and the compile() function.

Example from the issue works:

import { compile } from '@termuijs/tss'

const rules = compile(`
  @mixin bordered { border: single; padding: 1; }
  .box { @include bordered; color: red; }
`)
// .box gets border, padding from mixin + color from own rule

Files changed:
- packages/tss/src/tokenizer.ts
- packages/tss/src/parser.ts
- packages/tss/src/engine.ts
- packages/tss/src/index.ts
- packages/tss/src/mixin.test.ts (new)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add support for CSS-style mixins via `@mixin` / `@include`, expanded during compilation.
  * New API to obtain compiled, mixin-expanded rules directly.

* **Improvements**
  * Improved selector handling for class-only and pseudo selectors.
  * Property precedence fixed so rule properties override included mixin defaults.

* **Tests**
  * Added end-to-end tests for mixin tokenization, parsing, expansion, and compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->