### PR TITLE
feat(core)-add-prefersReducedMotion()-helper-—-honour-NO_MOTION/CI-in-animated-widgets

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,7 +10,7 @@ export type { Cell } from './terminal/Screen.js';
 export { Renderer } from './terminal/Renderer.js';
 export { LayerManager } from './terminal/LayerManager.js';
 export type { Layer } from './terminal/LayerManager.js';
-export { caps } from './terminal/env-caps.js';
+export { caps, prefersReducedMotion } from './terminal/env-caps.js';
 export { BOX, BRAILLE_SPIN, BLOCK } from './terminal/ascii-map.js';
 
 // ── Renderer ──────────────────────────────────────────

--- a/packages/core/src/terminal/env-caps.test.ts
+++ b/packages/core/src/terminal/env-caps.test.ts
@@ -2,7 +2,7 @@
 // @termuijs/core — Tests for env-caps
 // ─────────────────────────────────────────────────────
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // caps is evaluated at module load time, so each test must:
 // 1. vi.stubEnv() to set env vars
@@ -69,5 +69,35 @@ describe('env-caps', () => {
         expect(caps.motion).toBe(false);
         vi.unstubAllEnvs();
         vi.resetModules();
+    });
+});
+
+describe('prefersReducedMotion', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('returns true when caps.motion is false', () => {
+        const { caps, prefersReducedMotion } = require('./env-caps.js');
+        const spy = vi.spyOn(caps, 'motion', 'get').mockReturnValue(false);
+        expect(prefersReducedMotion()).toBe(true);
+        spy.mockRestore();
+    });
+
+    it('returns false when caps.motion is true', () => {
+        const { caps, prefersReducedMotion } = require('./env-caps.js');
+        const spy = vi.spyOn(caps, 'motion', 'get').mockReturnValue(true);
+        expect(prefersReducedMotion()).toBe(false);
+        spy.mockRestore();
+    });
+
+    it('reads caps.motion live on every call, not a cached snapshot', () => {
+        const { caps, prefersReducedMotion } = require('./env-caps.js');
+        const spy = vi.spyOn(caps, 'motion', 'get')
+            .mockReturnValueOnce(true)
+            .mockReturnValueOnce(false);
+        expect(prefersReducedMotion()).toBe(false); // first call: motion=true → false
+        expect(prefersReducedMotion()).toBe(true);  // second call: motion=false → true
+        spy.mockRestore();
     });
 });

--- a/packages/core/src/terminal/env-caps.ts
+++ b/packages/core/src/terminal/env-caps.ts
@@ -15,3 +15,24 @@ export const caps = {
     return 'dark';
   },
 } as const;
+
+/**
+ * Returns `true` when animation should be suppressed.
+ *
+ * True when `caps.motion` is `false` — i.e. when `NO_MOTION=1` is set
+ * or when running in a CI environment (`CI=1`).
+ *
+ * Animated widgets **must** check this function and render their static
+ * end-state (a single final frame) when it returns `true`, rather than
+ * playing through intermediate animation frames.
+ *
+ * @example
+ * if (prefersReducedMotion()) {
+ *   renderStaticFrame();
+ * } else {
+ *   startAnimation();
+ * }
+ */
+export function prefersReducedMotion(): boolean {
+  return !caps.motion;
+}


### PR DESCRIPTION
Returns !caps.motion. Animated widgets must render their static
end-state when this returns true. Exported from package entry.

Closes #532 