### PR TITLE
feat(widgets): add OrderedList widget

### DIFF
--- a/packages/widgets/src/display/OrderedList.test.ts
+++ b/packages/widgets/src/display/OrderedList.test.ts
@@ -1,0 +1,106 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for OrderedList widget
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi } from 'vitest';
+import { OrderedList, type OrderedListItem } from './OrderedList.js';
+import { Screen } from '@termuijs/core';
+
+function makeList(
+    items: OrderedListItem[],
+    opts?: ConstructorParameters<typeof OrderedList>[2],
+    width = 40,
+    height = 20,
+): OrderedList {
+    const list = new OrderedList(items, {}, opts);
+    list.updateRect({ x: 0, y: 0, width, height });
+    return list;
+}
+
+function renderList(list: OrderedList, width = 40, height = 20): Screen {
+    const screen = new Screen(width, height);
+    list.updateRect({ x: 0, y: 0, width, height });
+    list.render(screen);
+    return screen;
+}
+
+function rowText(screen: Screen, row: number): string {
+    let line = '';
+    for (let col = 0; col < screen.cols; col++) {
+        line += screen.back[row]?.[col]?.char ?? ' ';
+    }
+    return line.trimEnd();
+}
+
+describe('OrderedList', () => {
+
+    describe('1. Arabic numerals (default style)', () => {
+        it('renders 1., 2., 3. prefixes for a 3-item list', () => {
+            const items: OrderedListItem[] = [
+                { text: 'Alpha' },
+                { text: 'Beta' },
+                { text: 'Gamma' },
+            ];
+            const list = makeList(items);
+            const screen = renderList(list);
+
+            expect(rowText(screen, 0)).toContain('1.');
+            expect(rowText(screen, 0)).toContain('Alpha');
+            expect(rowText(screen, 1)).toContain('2.');
+            expect(rowText(screen, 1)).toContain('Beta');
+            expect(rowText(screen, 2)).toContain('3.');
+            expect(rowText(screen, 2)).toContain('Gamma');
+        });
+    });
+
+    describe('2. Nested items', () => {
+        it('renders nested item with indent and restarts numbering from 1.', () => {
+            const items: OrderedListItem[] = [
+                {
+                    text: 'Parent',
+                    children: [{ text: 'Child' }],
+                },
+            ];
+            const list = makeList(items, { indent: 3 });
+            const screen = renderList(list);
+
+            const row0 = rowText(screen, 0);
+            const row1 = rowText(screen, 1);
+
+            expect(row0).toContain('1.');
+            expect(row0).toContain('Parent');
+            expect(row1).toMatch(/^\s+/);
+            expect(row1).toContain('1.');
+            expect(row1).toContain('Child');
+        });
+    });
+
+    describe('3. Alpha style', () => {
+        it('renders a., b. prefixes with style: "a."', () => {
+            const items: OrderedListItem[] = [
+                { text: 'First' },
+                { text: 'Second' },
+            ];
+            const list = makeList(items, { style: 'a.' });
+            const screen = renderList(list);
+
+            expect(rowText(screen, 0)).toContain('a.');
+            expect(rowText(screen, 0)).toContain('First');
+            expect(rowText(screen, 1)).toContain('b.');
+            expect(rowText(screen, 1)).toContain('Second');
+        });
+    });
+
+    describe('4. setItems triggers markDirty', () => {
+        it('calls markDirty when setItems is called', () => {
+            const items: OrderedListItem[] = [{ text: 'Item' }];
+            const list = makeList(items);
+
+            const spy = vi.spyOn(list as any, 'markDirty');
+            list.setItems([{ text: 'New Item' }]);
+
+            expect(spy).toHaveBeenCalledOnce();
+        });
+    });
+
+});

--- a/packages/widgets/src/display/OrderedList.test.ts
+++ b/packages/widgets/src/display/OrderedList.test.ts
@@ -91,7 +91,26 @@ describe('OrderedList', () => {
         });
     });
 
-    describe('4. setItems triggers markDirty', () => {
+    describe('4. Roman style', () => {
+        it('renders i., ii., iii. prefixes with style: "i."', () => {
+            const items: OrderedListItem[] = [
+                { text: 'Alpha' },
+                { text: 'Beta' },
+                { text: 'Gamma' },
+            ];
+            const list = makeList(items, { style: 'i.' });
+            const screen = renderList(list);
+
+            expect(rowText(screen, 0)).toContain('i.');
+            expect(rowText(screen, 0)).toContain('Alpha');
+            expect(rowText(screen, 1)).toContain('ii.');
+            expect(rowText(screen, 1)).toContain('Beta');
+            expect(rowText(screen, 2)).toContain('iii.');
+            expect(rowText(screen, 2)).toContain('Gamma');
+        });
+    });
+
+    describe('6. setItems triggers markDirty', () => {
         it('calls markDirty when setItems is called', () => {
             const items: OrderedListItem[] = [{ text: 'Item' }];
             const list = makeList(items);

--- a/packages/widgets/src/display/OrderedList.ts
+++ b/packages/widgets/src/display/OrderedList.ts
@@ -1,0 +1,118 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — OrderedList widget
+// ─────────────────────────────────────────────────────
+import {
+    type Screen,
+    type Style,
+    styleToCellAttrs,
+    truncate,
+} from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export interface OrderedListItem {
+    text: string;
+    /** Nested items */
+    children?: OrderedListItem[];
+}
+
+export interface OrderedListOptions {
+    /** Indent width per level. Default: 3 */
+    indent?: number;
+    /** Numbering style: '1.' for arabic, 'a.' for lowercase alpha, 'i.' for lowercase roman. Default: '1.' */
+    style?: '1.' | 'a.' | 'i.';
+}
+
+interface FlatRow {
+    text: string;
+    prefix: string;
+    depth: number;
+}
+
+function toAlpha(n: number): string {
+    return String.fromCharCode(96 + n);
+}
+
+function toRoman(n: number): string {
+    const vals = [1000,900,500,400,100,90,50,40,10,9,5,4,1];
+    const syms = ['m','cm','d','cd','c','xc','l','xl','x','ix','v','iv','i'];
+    let result = '';
+    for (let i = 0; i < vals.length; i++) {
+        while (n >= vals[i]) {
+            result += syms[i];
+            n -= vals[i];
+        }
+    }
+    return result;
+}
+
+function getPrefix(index: number, style: '1.' | 'a.' | 'i.'): string {
+    switch (style) {
+        case 'a.': return toAlpha(index) + '.';
+        case 'i.': return toRoman(index) + '.';
+        default:   return index + '.';
+    }
+}
+
+function flattenItems(
+    items: OrderedListItem[],
+    depth: number,
+    style: '1.' | 'a.' | 'i.',
+    out: FlatRow[],
+): void {
+    for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        out.push({
+            text: item.text,
+            prefix: getPrefix(i + 1, style),
+            depth,
+        });
+        if (item.children && item.children.length > 0) {
+            flattenItems(item.children, depth + 1, style, out);
+        }
+    }
+}
+
+/**
+ * OrderedList — renders a numbered list with optional nesting.
+ */
+export class OrderedList extends Widget {
+    private _items: OrderedListItem[];
+    private _opts: Required<OrderedListOptions>;
+
+    constructor(
+        items: OrderedListItem[],
+        style: Partial<Style> = {},
+        opts: OrderedListOptions = {},
+    ) {
+        super(style);
+        this._items = items;
+        this._opts = {
+            indent: opts.indent ?? 3,
+            style: opts.style ?? '1.',
+        };
+    }
+
+    setItems(items: OrderedListItem[]): void {
+        this._items = items;
+        this.markDirty();
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const rect = this._getContentRect();
+        const { x, y, width, height } = rect;
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this._style);
+        const rows: FlatRow[] = [];
+        flattenItems(this._items, 0, this._opts.style, rows);
+
+        const visibleCount = Math.min(rows.length, height);
+        for (let i = 0; i < visibleCount; i++) {
+            const { text, prefix, depth } = rows[i];
+            const indentStr = ' '.repeat(this._opts.indent * depth);
+            let line = `${indentStr}${prefix} ${text}`;
+            line = truncate(line, width);
+            screen.writeString(x, y + i, line, attrs);
+        }
+    }
+}

--- a/packages/widgets/src/display/OrderedList.ts
+++ b/packages/widgets/src/display/OrderedList.ts
@@ -29,7 +29,13 @@ interface FlatRow {
 }
 
 function toAlpha(n: number): string {
-    return String.fromCharCode(96 + n);
+    let result = '';
+    while (n > 0) {
+        n--;
+        result = String.fromCharCode(97 + (n % 26)) + result;
+        n = Math.floor(n / 26);
+    }
+    return result || 'a';
 }
 
 function toRoman(n: number): string {
@@ -87,7 +93,7 @@ export class OrderedList extends Widget {
         super(style);
         this._items = items;
         this._opts = {
-            indent: opts.indent ?? 3,
+            indent: Math.max(0, opts.indent ?? 3),
             style: opts.style ?? '1.',
         };
     }

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -158,3 +158,5 @@ export { Timer } from './display/Timer.js';
 export type { TimerOptions } from './display/Timer.js';
 export { Stopwatch } from './display/Stopwatch.js';
 export type { StopwatchOptions } from './display/Stopwatch.js';
+export { OrderedList } from './display/OrderedList.js';
+export type { OrderedListItem, OrderedListOptions } from './display/OrderedList.js';


### PR DESCRIPTION
## feat(widgets): add OrderedList widget

Closes #269

---

### 📌 Summary

Adds an `OrderedList` widget to `@termuijs/widgets` that renders a numbered list with optional nesting.

---

### ✅ What's implemented

- Arabic numerals (`1.`, `2.`, `3.`) — default style
- Lowercase alpha (`a.`, `b.`, `c.`) via `style: 'a.'`
- Lowercase roman numerals (`i.`, `ii.`, `iii.`) via `style: 'i.'`
- Nested items with configurable `indent` width (default: 3)
- Nested items restart numbering from `1.` at each level
- `setItems()` updates the list and calls `markDirty()`

---

### 📂 Files Changed

- `packages/widgets/src/display/OrderedList.ts` — widget implementation
- `packages/widgets/src/display/OrderedList.test.ts` — vitest tests
- `packages/widgets/src/index.ts` — added exports

---

### 🧪 Testing

```
bun vitest run packages/widgets ✅
bun run typecheck ✅
bun run build ✅
```

All 4 test cases pass:
- 3-item list renders `1.`, `2.`, `3.` prefixes ✅
- Nested item renders at indent + `1.` prefix ✅  
- Style `a.` renders `a.`, `b.` prefixes ✅
- `setItems()` triggers `markDirty` ✅

---

### ⭐ Checklist

- [x] Starred the repo
- [x] Change confined to `packages/widgets`
- [x] `bun.lock` not modified
- [x] All tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OrderedList widget to render ordered lists with nesting, indentation, and support for styles: Arabic (1.), lowercase letters (a.), and lowercase Roman (i.).
  * Public setItems method to replace list contents and refresh the rendered output.

* **Tests**
  * Added Vitest coverage validating rendering, nesting behavior, numbering styles, and update/refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->