### PR TITLE
feat(jsx): add useDebounce hook 

### DIFF
--- a/packages/jsx/src/hooks/useDebounce.test.ts
+++ b/packages/jsx/src/hooks/useDebounce.test.ts
@@ -1,0 +1,106 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/jsx — Tests for useDebounce hook
+// ─────────────────────────────────────────────────────
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+    createFiber, setCurrentFiber, clearCurrentFiber,
+    setRequestRender, runEffects, destroyFiber,
+} from '../hooks.js';
+import { useDebounce } from './useDebounce.js';
+
+function renderWithFiber<T>(fiber: ReturnType<typeof createFiber>, fn: () => T): T {
+    setCurrentFiber(fiber);
+    const result = fn();
+    clearCurrentFiber();
+    runEffects(fiber);
+    return result;
+}
+
+describe('useDebounce', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        setRequestRender(() => {});
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        clearCurrentFiber();
+    });
+
+    it('returns updated value after delayMs ms of no new input', () => {
+        const fiber = createFiber();
+
+        // First render with initial value
+        let debounced = renderWithFiber(fiber, () => useDebounce('hello', 300));
+        expect(debounced).toBe('hello');
+
+        // Simulate re-render with new value
+        debounced = renderWithFiber(fiber, () => useDebounce('world', 300));
+
+        // Before delay — should still be old value
+        expect(debounced).toBe('hello');
+
+        // Advance past delay
+        vi.advanceTimersByTime(300);
+
+        // Now re-render to pick up new state
+        debounced = renderWithFiber(fiber, () => useDebounce('world', 300));
+        expect(debounced).toBe('world');
+
+        destroyFiber(fiber);
+    });
+
+    it('does NOT update while new inputs arrive faster than delayMs', () => {
+        const fiber = createFiber();
+
+        // Initial render
+        renderWithFiber(fiber, () => useDebounce('a', 300));
+
+        // Rapid updates before delay elapses
+        renderWithFiber(fiber, () => useDebounce('b', 300));
+        vi.advanceTimersByTime(100);
+
+        renderWithFiber(fiber, () => useDebounce('c', 300));
+        vi.advanceTimersByTime(100);
+
+        renderWithFiber(fiber, () => useDebounce('d', 300));
+        vi.advanceTimersByTime(100);
+
+        // Only 300ms has passed since last update — should not have settled
+        let debounced = renderWithFiber(fiber, () => useDebounce('d', 300));
+        expect(debounced).toBe('a');
+
+        // Now let the full delay elapse
+        vi.advanceTimersByTime(300);
+        debounced = renderWithFiber(fiber, () => useDebounce('d', 300));
+        expect(debounced).toBe('d');
+
+        destroyFiber(fiber);
+    });
+
+    it('resets the timer when delayMs changes', () => {
+        const fiber = createFiber();
+
+        // Initial render
+        renderWithFiber(fiber, () => useDebounce('hello', 300));
+
+        // Change value
+        renderWithFiber(fiber, () => useDebounce('world', 300));
+        vi.advanceTimersByTime(200);
+
+        // Change delayMs — should reset the timer
+        renderWithFiber(fiber, () => useDebounce('world', 500));
+        vi.advanceTimersByTime(300);
+
+        // 300ms elapsed after delayMs change but new delay is 500ms — not settled yet
+        let debounced = renderWithFiber(fiber, () => useDebounce('world', 500));
+        expect(debounced).toBe('hello');
+
+        // Advance remaining 200ms
+        vi.advanceTimersByTime(200);
+        debounced = renderWithFiber(fiber, () => useDebounce('world', 500));
+        expect(debounced).toBe('world');
+
+        destroyFiber(fiber);
+    });
+});

--- a/packages/jsx/src/hooks/useDebounce.ts
+++ b/packages/jsx/src/hooks/useDebounce.ts
@@ -1,0 +1,37 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/jsx — useDebounce hook
+// ─────────────────────────────────────────────────────
+import { useState, useEffect, useRef } from '../hooks.js';
+
+/**
+ * useDebounce — debounce a changing value.
+ *
+ * Returns the last stable value after delayMs ms of no new input.
+ *
+ * ```tsx
+ * const debouncedSearch = useDebounce(searchTerm, 300);
+ * ```
+ */
+export function useDebounce<T>(value: T, delayMs: number): T {
+    const [debouncedValue, setDebouncedValue] = useState<T>(value);
+    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        if (timerRef.current !== null) {
+            clearTimeout(timerRef.current);
+        }
+        timerRef.current = setTimeout(() => {
+            setDebouncedValue(value);
+            timerRef.current = null;
+        }, delayMs);
+
+        return () => {
+            if (timerRef.current !== null) {
+                clearTimeout(timerRef.current);
+                timerRef.current = null;
+            }
+        };
+    }, [value, delayMs]);
+
+    return debouncedValue;
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -82,3 +82,4 @@ export { useSyncExternalStore } from './hooks/useSyncExternalStore.js';
 export { useHover } from './hooks/useHover.js';
 export { useElementSize } from './hooks/useElementSize.js';
 export type { ElementSize } from './hooks/useElementSize.js';
+export { useDebounce } from './hooks/useDebounce.js';


### PR DESCRIPTION
## feat(jsx): add useDebounce hook

Closes #283

---

### 📌 Summary

Adds a `useDebounce` hook to `@termuijs/jsx` that debounces a changing value, returning the last stable value after the delay has elapsed without an update.

---

### ✅ What's implemented

- Returns the last stable value after `delayMs` ms of no new input
- Does NOT update while new inputs arrive faster than `delayMs`
- Changing `delayMs` resets the timer
- Cleanup on unmount cancels any pending timer

---

### 📂 Files Changed

- `packages/jsx/src/hooks/useDebounce.ts` — hook implementation
- `packages/jsx/src/hooks/useDebounce.test.ts` — vitest tests
- `packages/jsx/src/index.ts` — added export

---

### 🧪 Testing

```
bun vitest run packages/jsx ✅
bun run typecheck ✅
bun run build ✅
```

All 3 test cases pass:
- Returns updated value after `delayMs` ms of no new input ✅
- Does NOT update while inputs arrive faster than `delayMs` ✅
- Changing `delayMs` resets the timer ✅

---

### ⭐ Checklist

- [x] Starred the repo
- [x] Change confined to `packages/jsx`
- [x] `bun.lock` not modified
- [x] All tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `useDebounce` hook for delaying value updates until after a specified delay period with no further changes. Useful for optimizing performance in input fields and search functionality.

* **Tests**
  * Added comprehensive test suite verifying debounce delay behavior, rapid input handling, and dynamic delay configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->