### PR TITLE
feat(core): add mouse hit-grid and target dispatch

### DIFF
--- a/packages/core/src/terminal/LayerManager.test.ts
+++ b/packages/core/src/terminal/LayerManager.test.ts
@@ -1,0 +1,104 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/core — Tests for LayerManager
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { LayerManager } from './LayerManager.js';
+import { caps } from './env-caps.js';
+
+describe('LayerManager — Hit Testing', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('a single region hit-tests to its widget id', () => {
+        const lm = new LayerManager(20, 10);
+        lm.clearHitGrid();
+        lm.setHitRegion('btn', 2, 2, 5, 1, 0);
+
+        expect(lm.hitTest(3, 2)).toBe('btn');
+        expect(lm.hitTest(2, 2)).toBe('btn');
+        expect(lm.hitTest(6, 2)).toBe('btn');
+    });
+
+    it('two overlapping regions resolve to the higher z', () => {
+        const lm = new LayerManager(20, 10);
+        lm.clearHitGrid();
+
+        // Register lower z-index region first
+        lm.setHitRegion('bg', 0, 0, 10, 10, 0);
+
+        // Register higher z-index region overlapping it
+        lm.setHitRegion('dialog', 3, 3, 4, 4, 10);
+
+        expect(lm.hitTest(1, 1)).toBe('bg');
+        expect(lm.hitTest(4, 4)).toBe('dialog');
+        expect(lm.hitTest(3, 3)).toBe('dialog');
+        expect(lm.hitTest(6, 6)).toBe('dialog');
+        expect(lm.hitTest(7, 7)).toBe('bg');
+    });
+
+    it('equal z-index overlapping regions resolve to the last written region', () => {
+        const lm = new LayerManager(20, 10);
+        lm.clearHitGrid();
+
+        lm.setHitRegion('widgetA', 2, 2, 3, 3, 5);
+        lm.setHitRegion('widgetB', 3, 3, 3, 3, 5);
+
+        // Overlapping at (3, 3), (3, 4), (4, 3), (4, 4)
+        expect(lm.hitTest(2, 2)).toBe('widgetA');
+        expect(lm.hitTest(3, 3)).toBe('widgetB');
+        expect(lm.hitTest(4, 4)).toBe('widgetB');
+    });
+
+    it('a cell outside all regions returns null', () => {
+        const lm = new LayerManager(20, 10);
+        lm.clearHitGrid();
+        lm.setHitRegion('btn', 2, 2, 5, 1, 0);
+
+        expect(lm.hitTest(0, 0)).toBeNull();
+        expect(lm.hitTest(1, 2)).toBeNull();
+        expect(lm.hitTest(7, 2)).toBeNull();
+        expect(lm.hitTest(2, 3)).toBeNull();
+    });
+
+    it('out-of-bounds coordinates return null', () => {
+        const lm = new LayerManager(20, 10);
+        lm.clearHitGrid();
+        lm.setHitRegion('btn', 2, 2, 5, 1, 0);
+
+        expect(lm.hitTest(-1, 2)).toBeNull();
+        expect(lm.hitTest(20, 2)).toBeNull();
+        expect(lm.hitTest(2, -1)).toBeNull();
+        expect(lm.hitTest(2, 10)).toBeNull();
+    });
+
+    it('clearHitGrid removes all ownership', () => {
+        const lm = new LayerManager(20, 10);
+        lm.clearHitGrid();
+        lm.setHitRegion('btn', 2, 2, 5, 1, 0);
+
+        expect(lm.hitTest(3, 2)).toBe('btn');
+
+        lm.clearHitGrid();
+        expect(lm.hitTest(3, 2)).toBeNull();
+    });
+
+    it('resize reallocates the hit grids without affecting layer compositing', () => {
+        const lm = new LayerManager(20, 10);
+        lm.clearHitGrid();
+        lm.setHitRegion('btn', 2, 2, 5, 1, 0);
+
+        expect(lm.hitTest(3, 2)).toBe('btn');
+
+        lm.resize(30, 15);
+        expect(lm.cols).toBe(30);
+        expect(lm.rows).toBe(15);
+        // The old region is cleared after resize reallocation
+        expect(lm.hitTest(3, 2)).toBeNull();
+
+        // Write a new region within the new boundary and verify it works
+        lm.setHitRegion('btn-new', 25, 12, 2, 2, 5);
+        expect(lm.hitTest(26, 13)).toBe('btn-new');
+    });
+});

--- a/packages/core/src/terminal/LayerManager.test.ts
+++ b/packages/core/src/terminal/LayerManager.test.ts
@@ -4,7 +4,6 @@
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { LayerManager } from './LayerManager.js';
-import { caps } from './env-caps.js';
 
 describe('LayerManager — Hit Testing', () => {
     afterEach(() => {

--- a/packages/core/src/terminal/LayerManager.ts
+++ b/packages/core/src/terminal/LayerManager.ts
@@ -59,10 +59,13 @@ export class LayerManager {
     private _layers: Map<string, Layer> = new Map();
     private _cols: number;
     private _rows: number;
+    private _hitWidgetGrid!: (string | null)[][];
+    private _hitZGrid!: number[][];
 
     constructor(cols: number, rows: number) {
         this._cols = cols;
         this._rows = rows;
+        this._allocateHitGrids();
     }
 
     get cols(): number { return this._cols; }
@@ -236,6 +239,47 @@ export class LayerManager {
             layer.cells = this._createGrid();
             layer.dirtyRegion = null;
         }
+
+        this._allocateHitGrids();
+    }
+
+    /** Reset the hit grid. Call once at the start of each frame. */
+    clearHitGrid(): void {
+        this._allocateHitGrids();
+    }
+
+    /**
+     * Mark a rectangular region as owned by a widget at a given z-index.
+     * Higher z wins when regions overlap.
+     */
+    setHitRegion(widgetId: string, x: number, y: number, w: number, h: number, z?: number): void {
+        const zVal = z ?? 0;
+        const startX = Math.floor(x);
+        const startY = Math.floor(y);
+        const width = Math.floor(w);
+        const height = Math.floor(h);
+
+        for (let r = startY; r < startY + height; r++) {
+            if (r < 0 || r >= this._rows) continue;
+            for (let c = startX; c < startX + width; c++) {
+                if (c < 0 || c >= this._cols) continue;
+
+                if (zVal >= this._hitZGrid[r][c]) {
+                    this._hitWidgetGrid[r][c] = widgetId;
+                    this._hitZGrid[r][c] = zVal;
+                }
+            }
+        }
+    }
+
+    /** Return the topmost widget id at a cell, or null. */
+    hitTest(col: number, row: number): string | null {
+        const c = Math.floor(col);
+        const r = Math.floor(row);
+        if (c < 0 || c >= this._cols || r < 0 || r >= this._rows) {
+            return null;
+        }
+        return this._hitWidgetGrid[r][c];
     }
 
     /**
@@ -251,6 +295,24 @@ export class LayerManager {
             grid.push(row);
         }
         return grid;
+    }
+
+    /**
+     * Allocate parallel hit grid and z-index grid.
+     */
+    private _allocateHitGrids(): void {
+        this._hitWidgetGrid = [];
+        this._hitZGrid = [];
+        for (let r = 0; r < this._rows; r++) {
+            const widgetRow: (string | null)[] = [];
+            const zRow: number[] = [];
+            for (let c = 0; c < this._cols; c++) {
+                widgetRow.push(null);
+                zRow.push(-Infinity);
+            }
+            this._hitWidgetGrid.push(widgetRow);
+            this._hitZGrid.push(zRow);
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

Adds a per-frame cell-to-widget hit grid to `LayerManager` allowing mouse events to be cleanly dispatched to the topmost widget under the cursor. It maintains parallel ownership and z-index grids, resolves overlapping regions based on z-index (higher z wins), and clears/re-allocates grids automatically on new frames and resizing.

## Related Issue

Closes #467

## Which package(s)?

@termuijs/core

## Type of Change

- [x] ✨ Feature (`type:feature`)
- [x] 🧪 Tests (`type:testing`)

## Checklist

- [x] I have read the CONTRIBUTING guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## GSSoC 2026 Contributor Info

- **GSSoC 2026 Contributor:** Yes
- **GSSoC 2026 Contributor Profile:** https://gssoc.girlscript.org/profile/666f63ca-ed6a-4d0f-8ac8-1518b06ec839


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hit-testing to the terminal layer system: accurately reports which widget occupies a coordinate, respects z-index ordering, breaks ties by last write, returns null for out-of-bounds or empty cells, and updates correctly after resize or frame clears.

* **Tests**
  * Added comprehensive tests for hit-testing: overlapping regions, tie-breaking, boundaries, clears, and resize behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->