### PR TITLE
feat(jsx): add useFocusWithin hook

### DIFF
--- a/packages/jsx/src/hooks/useFocusWithin.test.ts
+++ b/packages/jsx/src/hooks/useFocusWithin.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createFiber, setCurrentFiber, clearCurrentFiber, setRequestRender, type Fiber } from '../hooks.js';
+import { FocusContext } from '../focus-context.js';
+import { useFocusWithin } from './useFocusWithin.js';
+
+describe('useFocusWithin', () => {
+    let fiber: Fiber;
+
+    beforeEach(() => {
+        fiber = createFiber();
+        setRequestRender(() => {});
+        setCurrentFiber(fiber);
+    });
+
+    afterEach(() => {
+        clearCurrentFiber();
+    });
+
+    it('returns false when nothing is focused', () => {
+        fiber.contextValues.set(FocusContext._id, {
+            focused: null,
+            focus: vi.fn(),
+            blur: vi.fn(),
+        });
+        const isFocusedWithin = useFocusWithin({ ids: ['id1', 'id2'] });
+        expect(isFocusedWithin).toBe(false);
+    });
+
+    it('returns true when the focused id is in ids', () => {
+        fiber.contextValues.set(FocusContext._id, {
+            focused: 'id1',
+            focus: vi.fn(),
+            blur: vi.fn(),
+        });
+        const isFocusedWithin = useFocusWithin({ ids: ['id1', 'id2'] });
+        expect(isFocusedWithin).toBe(true);
+    });
+
+    it('returns false when the focused id is not in ids', () => {
+        fiber.contextValues.set(FocusContext._id, {
+            focused: 'id3',
+            focus: vi.fn(),
+            blur: vi.fn(),
+        });
+        const isFocusedWithin = useFocusWithin({ ids: ['id1', 'id2'] });
+        expect(isFocusedWithin).toBe(false);
+    });
+
+    it('returns false when ids list is empty', () => {
+        fiber.contextValues.set(FocusContext._id, {
+            focused: 'id1',
+            focus: vi.fn(),
+            blur: vi.fn(),
+        });
+        const isFocusedWithin = useFocusWithin({ ids: [] });
+        expect(isFocusedWithin).toBe(false);
+    });
+
+    it('updates when the focused id changes', () => {
+        const mockContext = {
+            focused: 'id1',
+            focus: vi.fn(),
+            blur: vi.fn(),
+        };
+        fiber.contextValues.set(FocusContext._id, mockContext);
+
+        let isFocusedWithin = useFocusWithin({ ids: ['id1', 'id2'] });
+        expect(isFocusedWithin).toBe(true);
+
+        // Simulate context update
+        mockContext.focused = 'id3';
+
+        // Reset the hookIndex to simulate a rerender of the same component
+        fiber.hookIndex = 0;
+        isFocusedWithin = useFocusWithin({ ids: ['id1', 'id2'] });
+        expect(isFocusedWithin).toBe(false);
+    });
+});

--- a/packages/jsx/src/hooks/useFocusWithin.ts
+++ b/packages/jsx/src/hooks/useFocusWithin.ts
@@ -1,0 +1,28 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/jsx — useFocusWithin
+//
+// Hook that reports whether focus currently lies on
+// any element in a given list of IDs.
+// ─────────────────────────────────────────────────────
+
+import { useContext } from '../context.js';
+import { FocusContext } from '../focus-context.js';
+
+export interface UseFocusWithinOptions {
+    /** List of focusable element IDs to check against */
+    ids: string[];
+}
+
+/**
+ * useFocusWithin — check if focus is within a list of IDs.
+ */
+export function useFocusWithin(opts: UseFocusWithinOptions): boolean {
+    const ctx = useContext(FocusContext);
+    const focusedId = ctx?.focused;
+    if (!focusedId) {
+        return false;
+    }
+    return opts?.ids?.includes(focusedId) ?? false;
+}
+
+

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -1,4 +1,4 @@
-﻿// ─────────────────────────────────────────────────────
+// ─────────────────────────────────────────────────────
 // @termuijs/jsx — Public API
 // ─────────────────────────────────────────────────────
 
@@ -55,6 +55,8 @@ export { useFocusManager } from './hooks/useFocusManager.js';
 export type { UseFocusManagerResult } from './hooks/useFocusManager.js';
 export { useFocus } from './hooks/useFocus.js';
 export type { UseFocusOptions, UseFocusResult } from './hooks/useFocus.js';
+export { useFocusWithin } from './hooks/useFocusWithin.js';
+export type { UseFocusWithinOptions } from './hooks/useFocusWithin.js';
 export { useFocusTrap } from './hooks/useFocusTrap.js';
 export { useKeyboardNavigation } from './hooks/useKeyboardNavigation.js';
 export type { KeyboardNavigationOptions, KeyboardNavigationResult } from './hooks/useKeyboardNavigation.js';


### PR DESCRIPTION
## Description

Adds the `useFocusWithin` hook to the `@termuijs/jsx` package. It allows components to dynamically determine whether the currently focused element lies within a specified list of IDs.

## Related Issue

Closes #452

## Which package(s)?

`@termuijs/jsx`

## Type of Change

- [x] ✨ Feature (`type:feature`)
- [x] 🧪 Tests (`type:testing`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/Nicks-19` <!-- Update this link with your exact GSSoC profile URL -->

## Notes for the Reviewer

The implementation consumes `FocusContext` directly, ensuring a clean and lightweight check that reactively updates whenever the focused ID changes, without adding state overhead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `useFocusWithin` hook, enabling developers to check whether focus is currently within a specified set of element IDs. The hook returns a boolean value indicating the focus state.

* **Tests**
  * Added comprehensive test suite for `useFocusWithin` covering edge cases including when focus is absent, when focus is present but outside specified IDs, and when the ID set is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->