### PR TITLE
feat(repeat,yoyo

### DIFF
--- a/packages/motion/src/index.ts
+++ b/packages/motion/src/index.ts
@@ -8,8 +8,8 @@ export type { SpringConfig, SpringState } from './spring.js';
 export { transition, fadeIn, fadeOut, slideIn, typewriter, pulse, easings } from './transitions.js';
 export type { TransitionOptions, EasingFn } from './transitions.js';
 // Sequencing
-export { sequence, parallel } from './sequence.js';
-export type { AnimationRunner, SequenceStep, AnimatableValue } from './sequence.js';
+export { sequence, parallel, repeat } from './sequence.js';
+export type { AnimationRunner, SequenceStep, AnimatableValue, RepeatOptions } from './sequence.js';
 export { stagger } from './stagger.js';
 // Shared interval timer pool
 export { subscribe as timerPoolSubscribe, unsubscribeAll as timerPoolUnsubscribeAll } from './timer-pool.js';

--- a/packages/motion/src/repeat.test.ts
+++ b/packages/motion/src/repeat.test.ts
@@ -111,4 +111,20 @@ describe('repeat()', () => {
     expect(directions).toEqual(['forward', 'reverse', 'forward', 'reverse']);
     expect(doneSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('yoyo falls back to original runner when reverse is missing', () => {
+    const directions: string[] = [];
+    const forwardRunner = vi.fn((done) => {
+      directions.push('forward');
+      done();
+      return () => {};
+    }) as AnimationRunner;
+
+    const doneSpy = vi.fn();
+    const repeated = repeat(forwardRunner, { count: 4, yoyo: true });
+    repeated(doneSpy);
+
+    expect(directions).toEqual(['forward', 'forward', 'forward', 'forward']);
+    expect(doneSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/motion/src/repeat.test.ts
+++ b/packages/motion/src/repeat.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+import { repeat, type AnimationRunner } from './sequence.js';
+
+describe('repeat()', () => {
+  it('runs the runner count times', () => {
+    let calls = 0;
+    const runner: AnimationRunner = (done) => {
+      calls++;
+      done();
+      return () => {};
+    };
+
+    const doneSpy = vi.fn();
+    const repeated = repeat(runner, { count: 3 });
+    repeated(doneSpy);
+
+    expect(calls).toBe(3);
+    expect(doneSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('default count runs once', () => {
+    let calls = 0;
+    const runner: AnimationRunner = (done) => {
+      calls++;
+      done();
+      return () => {};
+    };
+
+    const doneSpy = vi.fn();
+    const repeated = repeat(runner);
+    repeated(doneSpy);
+
+    expect(calls).toBe(1);
+    expect(doneSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancel stops further passes', () => {
+    let calls = 0;
+    let triggerDone: (() => void) | null = null;
+    const cancelSpy = vi.fn();
+
+    const runner: AnimationRunner = (done) => {
+      calls++;
+      triggerDone = done;
+      return cancelSpy;
+    };
+
+    const doneSpy = vi.fn();
+    const repeated = repeat(runner, { count: 3 });
+    const cancel = repeated(doneSpy);
+
+    expect(calls).toBe(1);
+    expect(cancelSpy).not.toHaveBeenCalled();
+
+    cancel();
+
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+    expect(doneSpy).not.toHaveBeenCalled();
+
+    if (triggerDone) {
+      (triggerDone as () => void)();
+    }
+    expect(calls).toBe(1);
+  });
+
+  it('infinite loop does not call done', () => {
+    let calls = 0;
+    let cancel: (() => void) | null = null;
+
+    const runner: AnimationRunner = (done) => {
+      calls++;
+      if (calls === 5) {
+        if (cancel) cancel();
+      } else {
+        done();
+      }
+      return () => {};
+    };
+
+    const doneSpy = vi.fn();
+    const repeated = repeat(runner, { count: Infinity });
+    cancel = repeated(doneSpy);
+
+    expect(calls).toBe(5);
+    expect(doneSpy).not.toHaveBeenCalled();
+  });
+
+  it('yoyo alternates direction each pass', () => {
+    const directions: string[] = [];
+
+    const forwardRunner = vi.fn((done) => {
+      directions.push('forward');
+      done();
+      return () => {};
+    });
+
+    const reverseRunner = vi.fn((done) => {
+      directions.push('reverse');
+      done();
+      return () => {};
+    });
+
+    const runner = Object.assign(forwardRunner, {
+      reverse: reverseRunner,
+    }) as AnimationRunner;
+
+    const doneSpy = vi.fn();
+    const repeated = repeat(runner, { count: 4, yoyo: true });
+    repeated(doneSpy);
+
+    expect(directions).toEqual(['forward', 'reverse', 'forward', 'reverse']);
+    expect(doneSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/motion/src/sequence.ts
+++ b/packages/motion/src/sequence.ts
@@ -89,7 +89,11 @@ export function repeat(
   runner: AnimationRunner,
   options?: RepeatOptions,
 ): AnimationRunner {
-  const count = options?.count ?? 1
+  const rawCount = options?.count ?? 1;
+  if (rawCount !== Infinity && !(typeof rawCount === 'number' && Number.isInteger(rawCount) && rawCount >= 0)) {
+    throw new TypeError(`repeat count must be a non-negative integer or Infinity, got ${rawCount}`);
+  }
+  const count = rawCount
   const yoyo = options?.yoyo ?? false
 
   return (done: () => void) => {

--- a/packages/motion/src/sequence.ts
+++ b/packages/motion/src/sequence.ts
@@ -76,3 +76,52 @@ export function parallel(
     cancellers.forEach(c => c())
   }
 }
+
+export interface RepeatOptions {
+  /** Number of passes. Use Infinity for an endless loop. Default 1. */
+  count?: number
+
+  /** Reverse direction on every other pass. Default false. */
+  yoyo?: boolean
+}
+
+export function repeat(
+  runner: AnimationRunner,
+  options?: RepeatOptions,
+): AnimationRunner {
+  const count = options?.count ?? 1
+  const yoyo = options?.yoyo ?? false
+
+  return (done: () => void) => {
+    if (count <= 0) {
+      done()
+      return () => {}
+    }
+
+    let cancelled = false
+    let cancelCurrent: () => void = () => {}
+
+    function runNext(index: number) {
+      if (cancelled || index >= count) {
+        if (!cancelled) done()
+        return
+      }
+
+      // If a reversed runner is supplied, use it on odd passes.
+      // Otherwise fall back to the original runner.
+      const reverseRunner = (runner as { reverse?: AnimationRunner }).reverse
+      const currentRunner = yoyo && index % 2 === 1 && reverseRunner
+        ? reverseRunner
+        : runner
+
+      cancelCurrent = currentRunner(() => runNext(index + 1))
+    }
+
+    runNext(0)
+
+    return () => {
+      cancelled = true
+      cancelCurrent()
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds a `repeat()` wrapper for `AnimationRunner` in `@termuijs/motion`.

The wrapper supports fixed repetition counts, infinite looping via `count: Infinity`, cancellation of active/future passes, and optional yoyo behavior that alternates between forward and reversed runners. Added comprehensive tests covering all required repeat scenarios.

## Related Issue

Closes #492

## Which package(s)?

* @termuijs/motion

## Type of Change

* [x] ✨ Feature (`type:feature`)
* [x] 🧪 Tests (`type:testing`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md](https://chatgpt.com/g/g-p-6a1c81640ef4819180e1541a1faf22fa-oss-termui/c/CONTRIBUTING.md)`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: https://gssoc.girlscript.org/profile/YOUR_PROFILE_ID`](https://gssoc.girlscript.org/profile/42e0e4bf-0550-4021-a19c-29f6f92ca35d

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

### Changes

* Added `RepeatOptions` interface.
* Added `repeat(runner, options)` implementation in `packages/motion/src/sequence.ts`.
* Exported `repeat` and `RepeatOptions` from `packages/motion/src/index.ts`.
* Added `repeat.test.ts` covering:

  * runs the runner count times
  * default count runs once
  * cancel stops further passes
  * infinite loop does not call done
  * yoyo alternates direction each pass

### Implementation Notes

* Mirrors the recursive control flow used by `sequence()`.
* Uses the same `cancelled` and `cancelCurrent` pattern for cancellation.
* Starts no timers and acts as a pure wrapper around existing runners.
* For yoyo mode, a reversed runner is used when supplied; otherwise execution falls back to the original runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repeat helper to run animations multiple times with configurable count and optional yoyo (alternate direction) behavior.

* **Tests**
  * Added comprehensive tests covering counts, default behavior, cancellation, infinite runs, and yoyo edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->