### PR TITLE
feat(motion): add spring presets

### DIFF
--- a/packages/motion/src/index.ts
+++ b/packages/motion/src/index.ts
@@ -2,8 +2,17 @@
 // @termuijs/motion — Terminal Animations
 // ─────────────────────────────────────────────────────
 // Spring physics
-export { stepSpring, animateSpring, SPRING_PRESETS } from './spring.js';
-export type { SpringConfig, SpringState } from './spring.js';
+export {
+    stepSpring,
+    animateSpring,
+    SPRING_PRESETS,
+    springPreset,
+} from './spring.js';
+export type {
+    SpringConfig,
+    SpringState,
+    SpringPresetName,
+} from './spring.js';
 // Transitions & easings
 export { transition, fadeIn, fadeOut, slideIn, typewriter, pulse, easings } from './transitions.js';
 export type { TransitionOptions, EasingFn } from './transitions.js';

--- a/packages/motion/src/spring-presets.test.ts
+++ b/packages/motion/src/spring-presets.test.ts
@@ -33,9 +33,10 @@ describe('animateSpring preset support', () => {
 
     it('accepts a preset name', () => {
         const onFrame = vi.fn();
-
+    
         expect(() => {
-            animateSpring(0, 1, 'stiff', onFrame);
+            const cancel = animateSpring(0, 1, 'stiff', onFrame);
+            cancel();
         }).not.toThrow();
     });
 

--- a/packages/motion/src/spring-presets.test.ts
+++ b/packages/motion/src/spring-presets.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { caps } from '@termuijs/core';
+import {
+    SPRING_PRESETS,
+    springPreset,
+    animateSpring,
+} from './spring.js';
+
+describe('springPreset', () => {
+    it('returns config for a named preset', () => {
+        expect(springPreset('gentle')).toEqual(SPRING_PRESETS.gentle);
+    });
+
+    it('returns a copy not the shared object', () => {
+        const preset = springPreset('gentle');
+
+        preset.tension = 999;
+
+        expect(SPRING_PRESETS.gentle.tension).not.toBe(999);
+    });
+
+    it('unknown preset falls back to default', () => {
+        expect(
+            springPreset('unknown' as any),
+        ).toEqual(SPRING_PRESETS.default);
+    });
+});
+
+describe('animateSpring preset support', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('accepts a preset name', () => {
+        const onFrame = vi.fn();
+
+        expect(() => {
+            animateSpring(0, 1, 'stiff', onFrame);
+        }).not.toThrow();
+    });
+
+    it('no-motion path jumps to target', () => {
+        vi.spyOn(caps, 'motion', 'get').mockReturnValue(false);
+
+        const onFrame = vi.fn();
+        const onComplete = vi.fn();
+
+        animateSpring(
+            0,
+            100,
+            'gentle',
+            onFrame,
+            onComplete,
+        );
+
+        expect(onFrame).toHaveBeenCalledWith(100);
+        expect(onComplete).toHaveBeenCalled();
+    });
+});

--- a/packages/motion/src/spring.ts
+++ b/packages/motion/src/spring.ts
@@ -16,6 +16,14 @@ export interface SpringConfig {
     precision: number;
 }
 
+export type SpringPresetName =
+    | 'default'
+    | 'gentle'
+    | 'wobbly'
+    | 'stiff'
+    | 'slow'
+    | 'molasses';
+
 export const SPRING_PRESETS: Record<string, SpringConfig> = {
     default: { tension: 170, friction: 26, mass: 1, precision: 0.01 },
     gentle: { tension: 120, friction: 14, mass: 1, precision: 0.01 },
@@ -24,6 +32,12 @@ export const SPRING_PRESETS: Record<string, SpringConfig> = {
     slow: { tension: 280, friction: 60, mass: 1, precision: 0.01 },
     molasses: { tension: 280, friction: 120, mass: 1, precision: 0.01 },
 };
+
+export function springPreset(name: SpringPresetName): SpringConfig {
+    return {
+        ...(SPRING_PRESETS[name] ?? SPRING_PRESETS.default),
+    };
+}
 
 export interface SpringState {
     value: number;
@@ -66,7 +80,7 @@ export function stepSpring(state: SpringState, config: SpringConfig, dt: number)
 export function animateSpring(
     from: number,
     to: number,
-    config: Partial<SpringConfig>,
+    config: Partial<SpringConfig> | SpringPresetName,
     onFrame: (value: number) => void,
     onComplete?: () => void,
 ): () => void {
@@ -76,7 +90,16 @@ export function animateSpring(
         return () => {};
     }
 
-    const cfg = { ...SPRING_PRESETS.default, ...config };
+    const resolvedConfig =
+        typeof config === 'string'
+            ? springPreset(config as SpringPresetName)
+            : config;
+
+    const cfg = {
+        ...SPRING_PRESETS.default,
+        ...resolvedConfig,
+    };
+
     let state: SpringState = { value: from, velocity: 0, target: to, done: false };
     let lastTime = Date.now();
 

--- a/packages/motion/src/spring.ts
+++ b/packages/motion/src/spring.ts
@@ -24,7 +24,7 @@ export type SpringPresetName =
     | 'slow'
     | 'molasses';
 
-export const SPRING_PRESETS: Record<string, SpringConfig> = {
+export const SPRING_PRESETS: Record<SpringPresetName, SpringConfig> = {
     default: { tension: 170, friction: 26, mass: 1, precision: 0.01 },
     gentle: { tension: 120, friction: 14, mass: 1, precision: 0.01 },
     wobbly: { tension: 180, friction: 12, mass: 1, precision: 0.01 },
@@ -92,7 +92,7 @@ export function animateSpring(
 
     const resolvedConfig =
         typeof config === 'string'
-            ? springPreset(config as SpringPresetName)
+            ? springPreset(config)
             : config;
 
     const cfg = {


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

Adds support for named spring presets in animateSpring and introduces a springPreset() helper for retrieving preset configurations. Also adds test coverage for preset resolution, copy behavior, fallback handling, and no-motion execution.

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #491 

## Which package(s)?

@termuijs/motion

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)
N/A (No UI changes)
<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->

**Summary**

- Added SpringPresetName type.
- Added springPreset() helper returning a fresh copy of preset configurations.
- Updated animateSpring() to accept either a preset name or a partial spring configuration.
- Preserved existing config merge behavior with defaults.
- Added tests covering:
- named preset lookup
- fresh-copy behavior
- preset-name support in animateSpring
- unknown preset fallback
- no-motion path behavior

**Verification**

- bun vitest run packages/motion
- bun run typecheck
<br>
Both commands pass successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * animateSpring now accepts named spring presets (e.g., "gentle") as well as custom configs.
  * Added a helper to retrieve spring presets with automatic fallback to the default.
  * Preset values returned are immutable to avoid mutating shared presets.

* **Tests**
  * Added tests validating preset resolution, immutability, preset-name usage in animateSpring, and behavior when motion is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->