### PR TITLE
docs(store): add store guide to README

### DIFF
--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -124,7 +124,7 @@ The store uses a selective subscription pattern (Zustand-like). When components 
 ---
 
 ### 2. Create
-To create a state store, call `createStore` with a `StateCreator` function (which receives `set` and `get` functions) or a initial state object. The returned object is a hook that can be invoked inside components, and it also exposes helper methods on itself for access outside the component lifecycle.
+To create a state store, call `createStore` with a `StateCreator` function (which receives `set` and `get` functions) or an initial state object. The returned object is a hook that can be invoked inside components, and it also exposes helper methods on itself for access outside the component lifecycle.
 
 - **`getState()`**: Retrieves the current state of the store without initiating a subscription. Helpful inside event handlers or timers.
 - **`setState()`**: Updates the state. You can pass a partial state object to merge, or a function that receives the current state and returns a partial update.

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -114,6 +114,215 @@ const useDataStore = createStore((set) => ({
 
 Full docs at [www.termui.io/docs/store/overview](https://www.termui.io/docs/store/overview).
 
+## Store Guide
+
+### 1. Overview
+The `@termuijs/store` package provides global, reactive state management designed specifically for terminal environments. In TermUI apps, rendering happens in a terminal grid via ANSI escape sequences rather than a browser DOM. This makes efficient re-renders critical. 
+
+The store uses a selective subscription pattern (Zustand-like). When components consume state via the store hook, they can specify a selector function. The component will only trigger a terminal cell refresh when the selected slice of state changes, preventing unnecessary frame re-draws. Use the store for managing shared state (e.g., application configuration, active user sessions, CLI navigation menus, and cached API responses) across decoupled components.
+
+---
+
+### 2. Create
+To create a state store, call `createStore` with a `StateCreator` function (which receives `set` and `get` functions) or a initial state object. The returned object is a hook that can be invoked inside components, and it also exposes helper methods on itself for access outside the component lifecycle.
+
+- **`getState()`**: Retrieves the current state of the store without initiating a subscription. Helpful inside event handlers or timers.
+- **`setState()`**: Updates the state. You can pass a partial state object to merge, or a function that receives the current state and returns a partial update.
+
+```typescript
+import { createStore, SetState, GetState, StateCreator, UseStore } from '@termuijs/store';
+
+interface AppState {
+    theme: string;
+    loading: boolean;
+    setTheme: (theme: string) => void;
+    toggleLoading: () => void;
+}
+
+const creator: StateCreator<AppState> = (set, get) => ({
+    theme: 'dark',
+    loading: false,
+    setTheme: (theme) => set({ theme }),
+    toggleLoading: () => {
+        const currentLoading = get().loading;
+        set({ loading: !currentLoading });
+    },
+});
+
+// Create the store hook
+const useAppStore: UseStore<AppState> = createStore(creator);
+
+// Accessing state outside of components
+const state = useAppStore.getState();
+console.log('Current theme:', state.theme);
+
+// Mutating state outside of components
+useAppStore.setState({ theme: 'light' });
+useAppStore.setState((state) => ({ loading: !state.loading }));
+```
+
+---
+
+### 3. Selectors
+Selectors allow components to subscribe only to the specific slices of the state they care about. In addition, you can create computed properties or batch multiple state changes together to minimize UI redraw passes.
+
+- **`Selector`**: A function that maps the full state to a slice of state.
+- **`Computed`**: A memoized selector that caches the derived value and only notifies its subscribers when the computed value actually changes.
+- **`batch()`**: Groups multiple `setState` calls so that only a single terminal reconciler pass executes, rather than one per update.
+
+```typescript
+import { createStore, batch, Selector, Computed, UseStore } from '@termuijs/store';
+
+interface CounterState {
+    count: number;
+    step: number;
+    increment: () => void;
+}
+
+const useCounterStore: UseStore<CounterState> = createStore((set) => ({
+    count: 0,
+    step: 1,
+    increment: () => set((s) => ({ count: s.count + s.step })),
+}));
+
+// 1. Selector usage
+const selectCount: Selector<CounterState, number> = (state) => state.count;
+// Inside a component: const count = useCounterStore(selectCount);
+
+// 2. Computed values (memoized derived state)
+const doubleCountComputed: Computed<number> = useCounterStore.computed(
+    (state) => state.count * 2
+);
+const currentDouble = doubleCountComputed.get();
+const unsubscribeComputed = doubleCountComputed.subscribe((value) => {
+    // Fired only when the derived value changes
+});
+
+// 3. Batching multiple updates
+batch(() => {
+    useCounterStore.setState({ count: 10 });
+    useCounterStore.setState({ step: 2 });
+}); // Triggers a single render pass
+```
+
+---
+
+### 4. Slices
+As store states grow complex, they can be broken down into modular, independent files or objects and composed together using the `slices` helper and the `SliceDef` type. Each slice creator function receives the full store's `set` and `get` functions, enabling cross-slice reads and actions.
+
+```typescript
+import { createStore, slices, SliceDef, UseStore } from '@termuijs/store';
+
+interface UserSlice {
+    username: string;
+    setUsername: (name: string) => void;
+}
+
+interface SettingsSlice {
+    theme: string;
+    setTheme: (theme: string) => void;
+}
+
+type CombinedState = UserSlice & SettingsSlice;
+
+// Define slices using SliceDef
+const createUserSlice: SliceDef<UserSlice, CombinedState> = (set) => ({
+    username: 'Guest',
+    setUsername: (name) => set({ username: name }),
+});
+
+const createSettingsSlice: SliceDef<SettingsSlice, CombinedState> = (set) => ({
+    theme: 'dark',
+    setTheme: (theme) => set({ theme }),
+});
+
+// Compose the combined store
+const useStore: UseStore<CombinedState> = createStore(
+    slices<CombinedState>({
+        user: createUserSlice,
+        settings: createSettingsSlice,
+    })
+);
+```
+
+---
+
+### 5. Persist
+State can be automatically persisted to and rehydrated from disk via the `persist` options in the store configuration.
+
+- **`PersistOptions`**: Configures the key name, target filepath, and debounce time for disk writes.
+  - `key`: The config key name (stored under standard OS application directories, e.g., `%APPDATA%` on Windows).
+  - `file`: Direct absolute or relative file path to save the state.
+  - `debounceMs`: Time in milliseconds to debounce file writes during frequent updates (default is `100`).
+
+```typescript
+import { createStore, PersistOptions, StoreOptions, UseStore } from '@termuijs/store';
+
+interface ConfigState {
+    theme: string;
+    saveLocation: string;
+}
+
+const persistOptions: PersistOptions = {
+    key: 'app-config',       // Automatically maps to OS-specific config folder
+    // file: 'custom-config.json', // Or specify a file path
+    debounceMs: 200,         // Debounces disk writes (default is 100ms)
+};
+
+const storeOptions: StoreOptions<ConfigState> = {
+    persist: persistOptions,
+};
+
+const useConfigStore: UseStore<ConfigState> = createStore(
+    {
+        theme: 'dark',
+        saveLocation: '/usr/bin',
+    },
+    storeOptions
+);
+```
+
+---
+
+### 6. Middleware
+Store updates can be processed, transformed, or logged by using middlewares. A middleware interceptor runs every time state is set.
+
+- **`Middleware`**: Intercepts `prevState` and `update`, and can invoke `next(transformedUpdate)` to execute the state transition.
+- **`logger`**: A built-in middleware exported from `@termuijs/store` that logs previous and next states to the console/terminal.
+
+```typescript
+import { createStore, Middleware, logger, StoreOptions, UseStore } from '@termuijs/store';
+
+interface CounterState {
+    count: number;
+    increment: () => void;
+}
+
+// Custom middleware to cap updates
+const maxLimitMiddleware: Middleware<CounterState> = (prevState, update, next) => {
+    const nextUpdate = { ...update };
+    if (nextUpdate.count !== undefined && nextUpdate.count > 100) {
+        nextUpdate.count = 100;
+    }
+    next(nextUpdate);
+};
+
+const options: StoreOptions<CounterState> = {
+    middleware: [
+        maxLimitMiddleware,
+        logger, // Logs transition: Previous State -> Next State
+    ],
+};
+
+const useCounterStore: UseStore<CounterState> = createStore(
+    (set) => ({
+        count: 0,
+        increment: () => set((s) => ({ count: s.count + 1 })),
+    }),
+    options
+);
+```
+
 ## License
 
 MIT


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

Adds a comprehensive in-repo Store Guide to the `@termuijs/store` package README.md. The guide covers store creation, selectors, slices, state persistence, and middleware, using code blocks that match the real exported API.

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #528 

## Which package(s)?

`@termuijs/store`

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->


- 📝 Docs (`type:docs`)


## Checklist

-  ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
-  Tests pass locally: `bun vitest run`
-  Build passes: `bun run build`
-  Typecheck passes: `bun run typecheck`
-  You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
-  Your PR title follows `type: short description`.
-  No new `any` types without an inline comment explaining why.
-  No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/901726b7-d593-41ba-b695-a4b8000cb3ff`

## Screenshots / Recordings (UI changes)

N/A (Documentation changes only)

## Notes for the Reviewer

- The guide is appended to the packages/store/README.md under a clear heading `## Store Guide`.
- All six required sections (Overview, Create, Selectors, Slices, Persist, Middleware) are present in the specified order.
- Every imported symbol in code blocks is validated against the package's exports in packages/store/src/index.ts.
- Checked that `bun run typecheck` and `bun vitest run` pass successfully with no source code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Store Guide explaining global reactive state management: store creation patterns, accessing/updating state outside components, selectors (including computed/memoized values and batching), composing state via slices, persisting state to disk with persistence options, and configuring middleware (including the built-in logger and a custom middleware example). Existing API, usage, installation, and license info remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->