### PR TITLE
feat: add useAI hook for Anthropic and OpenAI streaming

### DIFF
--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -41,7 +41,9 @@
   },
   "peerDependencies": {
     "conf": "^10.2.0",
-    "commander": "^15.0.0"
+    "commander": "^15.0.0",
+    "openai": "^4.0.0",
+"@anthropic-ai/sdk": "^0.39.0"
   },
   "peerDependenciesMeta": {
     "conf": {
@@ -49,7 +51,9 @@
     },
     "commander": {
       "optional": true
-    }
+    },
+    "openai": { "optional": true },
+"@anthropic-ai/sdk": { "optional": true }
   },
   "keywords": [
     "terminal",

--- a/packages/adapters/src/ai/index.test.ts
+++ b/packages/adapters/src/ai/index.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useAI } from './index.js'
+
+// Mock node:module so we can control whether SDKs are "installed"
+vi.mock('node:module', async (importActual) => {
+  const actual = await importActual<typeof import('node:module')>()
+  return {
+    ...actual,
+    createRequire: () => (specifier: string) => {
+      if (specifier === 'openai') {
+        return {
+          default: class MockOpenAI {
+            chat = {
+              completions: {
+                create: vi.fn().mockImplementation(({ stream }: { stream?: boolean }) => {
+                  if (stream) {
+                    return (async function* () {
+                      yield { choices: [{ delta: { content: 'Hello' } }] }
+                      yield { choices: [{ delta: { content: ' World' } }] }
+                    })()
+                  }
+                  return Promise.resolve({
+                    choices: [{ message: { content: 'Hello World' } }],
+                  })
+                }),
+              },
+            }
+          },
+        }
+      }
+      if (specifier === '@anthropic-ai/sdk') {
+        return {
+          default: class MockAnthropic {
+            messages = {
+              create: vi.fn().mockResolvedValue({
+                content: [{ type: 'text', text: 'Hello World' }],
+              }),
+              stream: vi.fn().mockImplementation(() =>
+                (async function* () {
+                  yield { type: 'content_block_delta', delta: { type: 'text_delta', text: 'Hello' } }
+                  yield { type: 'content_block_delta', delta: { type: 'text_delta', text: ' World' } }
+                })()
+              ),
+            }
+          },
+        }
+      }
+      const err = new Error(`Cannot find module '${specifier}'`) as NodeJS.ErrnoException
+      err.code = 'MODULE_NOT_FOUND'
+      throw err
+    },
+  }
+})
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+describe('useAI', () => {
+  it('returns generate and chat functions', () => {
+    const ai = useAI('openai', { apiKey: 'test-key' })
+    expect(typeof ai.generate).toBe('function')
+    expect(typeof ai.chat).toBe('function')
+  })
+
+  it('generate calls OpenAI and returns text', async () => {
+    const ai = useAI('openai', { apiKey: 'test-key' })
+    const result = await ai.generate('Hello')
+    expect(result).toBe('Hello World')
+  })
+
+  it('generate calls Anthropic and returns text', async () => {
+    const ai = useAI('anthropic', { apiKey: 'test-key' })
+    const result = await ai.generate('Hello')
+    expect(result).toBe('Hello World')
+  })
+
+  it('chat streams tokens from OpenAI', async () => {
+    const ai = useAI('openai', { apiKey: 'test-key' })
+    const tokens: string[] = []
+    for await (const token of ai.chat([{ role: 'user', content: 'Hi' }])) {
+      tokens.push(token)
+    }
+    expect(tokens).toEqual(['Hello', ' World'])
+  })
+
+  it('chat streams tokens from Anthropic', async () => {
+    const ai = useAI('anthropic', { apiKey: 'test-key' })
+    const tokens: string[] = []
+    for await (const token of ai.chat([{ role: 'user', content: 'Hi' }])) {
+      tokens.push(token)
+    }
+    expect(tokens).toEqual(['Hello', ' World'])
+  })
+})

--- a/packages/adapters/src/ai/index.ts
+++ b/packages/adapters/src/ai/index.ts
@@ -1,0 +1,116 @@
+import { createRequire } from 'node:module'
+
+export type AIProvider = 'openai' | 'anthropic'
+
+export interface AIOptions {
+  apiKey: string
+}
+
+export interface AIMessage {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+export interface AIAdapter {
+  generate(prompt: string): Promise<string>
+  chat(messages: AIMessage[]): AsyncIterable<string>
+}
+
+function isModuleNotFound(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND'
+  )
+}
+
+function loadOpenAI() {
+  try {
+    const req = createRequire(import.meta.url)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mod = req('openai') as any
+    return 'default' in mod ? mod.default : mod
+  } catch (error) {
+    if (isModuleNotFound(error)) {
+      throw new Error(
+        'useAI() requires the optional peer dependency `openai`. Install it with: bun add openai'
+      )
+    }
+    throw error
+  }
+}
+
+function loadAnthropic() {
+  try {
+    const req = createRequire(import.meta.url)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mod = req('@anthropic-ai/sdk') as any
+    return 'default' in mod ? mod.default : mod
+  } catch (error) {
+    if (isModuleNotFound(error)) {
+      throw new Error(
+        'useAI() requires the optional peer dependency `@anthropic-ai/sdk`. Install it with: bun add @anthropic-ai/sdk'
+      )
+    }
+    throw error
+  }
+}
+
+export function useAI(provider: AIProvider, options: AIOptions): AIAdapter {
+  return {
+    async generate(prompt: string): Promise<string> {
+      if (provider === 'openai') {
+        const OpenAI = loadOpenAI()
+        const client = new OpenAI({ apiKey: options.apiKey })
+        const response = await client.chat.completions.create({
+          model: 'gpt-4o-mini',
+          messages: [{ role: 'user', content: prompt }],
+        })
+        return response.choices[0]?.message?.content ?? ''
+      }
+
+      const Anthropic = loadAnthropic()
+      const client = new Anthropic({ apiKey: options.apiKey })
+      const response = await client.messages.create({
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 1024,
+        messages: [{ role: 'user', content: prompt }],
+      })
+      const block = response.content[0]
+      return block.type === 'text' ? block.text : ''
+    },
+
+    async *chat(messages: AIMessage[]): AsyncIterable<string> {
+      if (provider === 'openai') {
+        const OpenAI = loadOpenAI()
+        const client = new OpenAI({ apiKey: options.apiKey })
+        const stream = await client.chat.completions.create({
+          model: 'gpt-4o-mini',
+          messages,
+          stream: true,
+        })
+        for await (const chunk of stream) {
+          const token = chunk.choices[0]?.delta?.content
+          if (token) yield token
+        }
+        return
+      }
+
+      const Anthropic = loadAnthropic()
+      const client = new Anthropic({ apiKey: options.apiKey })
+      const stream = await client.messages.stream({
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 1024,
+        messages,
+      })
+      for await (const event of stream) {
+        if (
+          event.type === 'content_block_delta' &&
+          event.delta.type === 'text_delta'
+        ) {
+          yield event.delta.text
+        }
+      }
+    },
+  }
+}

--- a/packages/adapters/src/ai/index.ts
+++ b/packages/adapters/src/ai/index.ts
@@ -32,7 +32,7 @@ function loadOpenAI() {
     const mod = req('openai') as any
     return 'default' in mod ? mod.default : mod
   } catch (error) {
-    if (isModuleNotFound(error)) {
+    if (isModuleNotFound(error, 'openai')) {
       throw new Error(
         'useAI() requires the optional peer dependency `openai`. Install it with: bun add openai'
       )
@@ -48,7 +48,7 @@ function loadAnthropic() {
     const mod = req('@anthropic-ai/sdk') as any
     return 'default' in mod ? mod.default : mod
   } catch (error) {
-    if (isModuleNotFound(error)) {
+    if (isModuleNotFound(error, '@anthropic-ai/sdk')) {
       throw new Error(
         'useAI() requires the optional peer dependency `@anthropic-ai/sdk`. Install it with: bun add @anthropic-ai/sdk'
       )

--- a/packages/adapters/src/ai/index.ts
+++ b/packages/adapters/src/ai/index.ts
@@ -16,11 +16,12 @@ export interface AIAdapter {
   chat(messages: AIMessage[]): AsyncIterable<string>
 }
 
-function isModuleNotFound(error: unknown): boolean {
+function isModuleNotFound(error: unknown, moduleName: string): boolean {
   return (
     error instanceof Error &&
     'code' in error &&
-    (error as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND'
+    (error as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND' &&
+    error.message.includes(moduleName)
   )
 }
 

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -2,3 +2,7 @@ export { useCommander } from './commander/index.js'
 export type { CommanderResult } from './commander/index.js' 
 export { useConf } from './conf/index.js'
 export type { SetConfValue, UseConfResult } from './conf/index.js'
+
+export { useAI } from './ai/index.js'
+
+export type {AIAdapter,AIMessage,AIOptions, AIProvider,} from './ai/index.js'


### PR DESCRIPTION
Closes #87

## Changes

* Added `useAI()` hook supporting `openai` and `anthropic` providers
* Added `generate(prompt)` returning `Promise<string>`
* Added `chat(messages)` returning `AsyncIterable<string>` for token streaming
* Added optional peer dependencies: `openai` and `@anthropic-ai/sdk`
* Added helpful error messages when SDKs are not installed
* Added mocked tests for SDK streaming responses
* Exported `useAI` and related types from `packages/adapters/src/index.ts`

## Validation

* All tests passing (13/13)
* Typecheck passing across the workspace


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public AI adapter hook (useAI) and related types, supporting OpenAI and Anthropic with generate() text responses and chat() real-time streaming.

* **Tests**
  * Added tests validating generate() outputs and chat() streaming behavior for both providers.

* **Chores**
  * Package manifest updated to declare the OpenAI and Anthropic SDKs as optional peer dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->