### PR TITLE
feat(testing): add createFixture helper

### DIFF
--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -3,8 +3,8 @@
 // ─────────────────────────────────────────────────────
 
 // ── Render ──
-export { render } from './render.js';
-export type { TestInstance, TestRenderOptions } from './render.js';
+export { createFixture, render } from './render.js';
+export type { Fixture, TestInstance, TestRenderOptions } from './render.js';
 
 // ── Virtual Clock ──
 export { createVirtualClock } from './virtual-clock.js';

--- a/packages/testing/src/render.test.tsx
+++ b/packages/testing/src/render.test.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @termuijs/jsx */
 
-import { describe, it, expect } from "vitest"
-import { render } from "./render.js"
+import { describe, it, expect, vi } from "vitest"
+import { createFixture, render } from "./render.js"
 import { Text, Box, Widget } from "@termuijs/widgets"
 import { useInput, useState } from "@termuijs/jsx"
 
@@ -208,6 +208,51 @@ describe("render harness", () => {
 
       expect(() => {
         server.fireKey("+")
+      }).not.toThrow()
+    })
+  })
+
+  describe("createFixture", () => {
+    it("applies default size when rendering without options", () => {
+      const fixture = createFixture({ width: 40, height: 10 })
+
+      const screen = fixture.render(<Hello />)
+
+      expect(screen.screen.cols).toBe(40)
+      expect(screen.screen.rows).toBe(10)
+
+      fixture.cleanup()
+    })
+
+    it("allows per-call options to override defaults", () => {
+      const fixture = createFixture({ width: 40, height: 10 })
+
+      const screen = fixture.render(<Hello />, { width: 20, height: 5 })
+
+      expect(screen.screen.cols).toBe(20)
+      expect(screen.screen.rows).toBe(5)
+
+      fixture.cleanup()
+    })
+
+    it("unmounts every tracked instance during cleanup", () => {
+      const fixture = createFixture()
+      const first = fixture.render(<Label text="First" />)
+      const second = fixture.render(<Label text="Second" />)
+      const firstUnmount = vi.spyOn(first, "unmount")
+      const secondUnmount = vi.spyOn(second, "unmount")
+
+      fixture.cleanup()
+
+      expect(firstUnmount).toHaveBeenCalledOnce()
+      expect(secondUnmount).toHaveBeenCalledOnce()
+    })
+
+    it("allows cleanup before any renders", () => {
+      const fixture = createFixture()
+
+      expect(() => {
+        fixture.cleanup()
       }).not.toThrow()
     })
   })

--- a/packages/testing/src/render.ts
+++ b/packages/testing/src/render.ts
@@ -87,6 +87,16 @@ export interface TestRenderOptions {
     height?: number;
 }
 
+/**
+ * A scoped render helper for tests that share default render options.
+ */
+export interface Fixture {
+    /** Render a tree with the fixture defaults; tracked for auto-unmount. */
+    render(element: VNode, options?: TestRenderOptions): TestInstance;
+    /** Unmount every instance this fixture created. Call in afterEach. */
+    cleanup(): void;
+}
+
 // ── Helpers ──
 
 /** Recursively walk a widget tree, collecting matching widgets */
@@ -365,4 +375,27 @@ export function render(element: VNode, options: TestRenderOptions = {}): TestIns
     };
 
     return instance;
+}
+
+/**
+ * Create a render fixture with default options merged into every render().
+ * Tracks each TestInstance so cleanup() unmounts them all.
+ */
+export function createFixture(defaults: TestRenderOptions = {}): Fixture {
+    const instances: TestInstance[] = [];
+
+    return {
+        render(element: VNode, options: TestRenderOptions = {}): TestInstance {
+            const instance = render(element, { ...defaults, ...options });
+            instances.push(instance);
+            return instance;
+        },
+
+        cleanup(): void {
+            for (const instance of instances) {
+                instance.unmount();
+            }
+            instances.length = 0;
+        },
+    };
 }


### PR DESCRIPTION
## Summary
- add a `Fixture` interface and `createFixture(defaults?)` helper for scoped test rendering
- export the helper and type from the testing package
- cover default options, per-call overrides, tracked cleanup, and empty cleanup behavior

Closes #507

## Verification
- `bun vitest run packages/testing`
- `bun run build`
- `bun vitest run`
- `bun run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Extended the testing package API with `createFixture()` function and `Fixture` interface. Developers can now create reusable test fixtures with configurable default render options that are automatically merged with per-call options, with built-in instance tracking and convenient one-call cleanup of all rendered test instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->