### PR TITLE
feat(jsx): add useTerminalSize hook

### DIFF
--- a/packages/jsx/src/hooks/useTerminalSize.test.ts
+++ b/packages/jsx/src/hooks/useTerminalSize.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+    createFiber,
+    setCurrentFiber,
+    clearCurrentFiber,
+    runEffects,
+    destroyFiber,
+    type Fiber,
+} from '../hooks.js';
+
+import { EventEmitter } from '@termuijs/core';
+import { setCurrentApp } from '../runtime.js';
+import { useTerminalSize } from './useTerminalSize.js';
+
+describe('useTerminalSize', () => {
+    let fiber: Fiber;
+
+    beforeEach(() => {
+        fiber = createFiber();
+        setCurrentFiber(fiber);
+    });
+
+    afterEach(() => {
+        clearCurrentFiber();
+        setCurrentApp(null);
+    });
+
+    function createApp(cols = 80, rows = 24) {
+        return {
+            terminal: {
+                cols,
+                rows,
+            },
+            events: new EventEmitter(),
+        };
+    }
+
+    it('returns safe defaults when no app is mounted', () => {
+        setCurrentApp(null);
+
+        const size = useTerminalSize();
+
+        expect(size).toEqual({
+            cols: 0,
+            rows: 0,
+        });
+    });
+
+    it('returns current terminal size', () => {
+        const app = createApp(120, 40);
+
+        setCurrentApp(app as any);
+
+        const size = useTerminalSize();
+
+        expect(size).toEqual({
+            cols: 120,
+            rows: 40,
+        });
+    });
+
+    it('updates when resize event is emitted', () => {
+        const app = createApp(80, 24);
+
+        setCurrentApp(app as any);
+
+        useTerminalSize();
+        runEffects(fiber);
+
+        app.events.emit('resize', {
+            cols: 100,
+            rows: 50,
+        });
+
+        const stateHook = fiber.hooks.find(
+            (h: any) => h?.value?.cols !== undefined,
+        );
+
+        expect(stateHook?.value).toEqual({
+            cols: 100,
+            rows: 50,
+        });
+    });
+
+    it('removes subscription on unmount', () => {
+        const app = createApp();
+
+        setCurrentApp(app as any);
+
+        useTerminalSize();
+        runEffects(fiber);
+
+        expect(app.events.hasListeners('resize')).toBe(true);
+
+        destroyFiber(fiber);
+
+        expect(app.events.hasListeners('resize')).toBe(false);
+    });
+});

--- a/packages/jsx/src/hooks/useTerminalSize.ts
+++ b/packages/jsx/src/hooks/useTerminalSize.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect } from '../hooks.js';
+import { getCurrentApp } from '../runtime.js';
+
+export interface TerminalSize {
+    cols: number;
+    rows: number;
+}
+
+export function useTerminalSize(): TerminalSize {
+    const app = getCurrentApp();
+
+    const [size, setSize] = useState<TerminalSize>({
+        cols: app?.terminal?.cols ?? 0,
+        rows: app?.terminal?.rows ?? 0,
+    });
+
+    useEffect(() => {
+        const currentApp = getCurrentApp();
+
+        if (!currentApp) {
+            return;
+        }
+
+        const handleResize = ({
+            cols,
+            rows,
+        }: {
+            cols: number;
+            rows: number;
+        }) => {
+            setSize({ cols, rows });
+        };
+
+        const unsubscribe =
+            currentApp.events.on('resize', handleResize);
+
+        return () => {
+            unsubscribe();
+        };
+    }, []);
+
+    return size;
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -87,3 +87,5 @@ export { useHover } from './hooks/useHover.js';
 export { useElementSize } from './hooks/useElementSize.js';
 export type { ElementSize } from './hooks/useElementSize.js';
 export { useDebounce } from './hooks/useDebounce.js';
+export { useTerminalSize } from './hooks/useTerminalSize.js';
+export type { TerminalSize } from './hooks/useTerminalSize.js';


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

Adds a new useTerminalSize hook to @termuijs/jsx that exposes the current terminal dimensions and automatically updates when the terminal is resized. The hook subscribes to app resize events, cleans up subscriptions on unmount, and provides safe default values when no app is mounted.

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #451 

## Which package(s)?
@termuijs/jsx
<!-- Example: @termuijs/core, @termuijs/widgets, website. -->

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)
N/A (hook implementation only)
<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->

- Added useTerminalSize hook with cols and rows support.
- Reads the initial terminal size from the current app.
- Subscribes to app resize events and updates state accordingly.
- Cleans up the resize subscription on unmount.
- Returns safe defaults when no app is mounted.
- Added tests covering default values, initial size, resize updates, and cleanup behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hook to read and monitor terminal dimensions (cols/rows), updating in real time when the terminal is resized.
  * The hook and its TerminalSize type are now publicly exported.

* **Tests**
  * Added a test suite covering defaults, initial values, resize updates, and cleanup of resize listeners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->