### PR TITLE
feat(ui): add RadioGroup widget with keyboard navigation and disabled option support

### DIFF
--- a/packages/ui/src/RadioGroup.test.ts
+++ b/packages/ui/src/RadioGroup.test.ts
@@ -1,0 +1,158 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/ui — Tests for RadioGroup widget
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Screen, createKeyEvent } from '@termuijs/core';
+import { RadioGroup } from './RadioGroup.js';
+
+const OPTIONS = [
+    { label: 'Dark', value: 'dark' },
+    { label: 'Light', value: 'light' },
+    { label: 'System', value: 'system' },
+];
+
+const OPTIONS_WITH_DISABLED = [
+    { label: 'Dark', value: 'dark' },
+    { label: 'High Contrast', value: 'high-contrast', disabled: true },
+    { label: 'Light', value: 'light' },
+];
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('RadioGroup', () => {
+    // ── 1. Default selection ───────────────────────────
+
+    it('uses defaultValue as initial selection', () => {
+        const radio = new RadioGroup({
+            options: OPTIONS,
+            defaultValue: 'light',
+        });
+        expect(radio.selectedValue).toBe('light');
+        expect(radio.focusedIndex).toBe(1);
+    });
+
+    it('falls back to first enabled option when no defaultValue given', () => {
+        const radio = new RadioGroup({ options: OPTIONS });
+        expect(radio.selectedValue).toBe('dark');
+        expect(radio.focusedIndex).toBe(0);
+    });
+
+    it('ignores defaultValue that matches a disabled option and picks first enabled', () => {
+        const radio = new RadioGroup({
+            options: OPTIONS_WITH_DISABLED,
+            defaultValue: 'high-contrast',
+        });
+        // high-contrast is disabled, so should fall back to first enabled (dark)
+        expect(radio.selectedValue).toBe('dark');
+    });
+
+    // ── 2. Arrow-key navigation ────────────────────────
+
+    it('selectNext moves focus to the next option', () => {
+        const radio = new RadioGroup({ options: OPTIONS, defaultValue: 'dark' });
+        radio.selectNext();
+        expect(radio.focusedIndex).toBe(1);
+    });
+
+    it('selectPrev moves focus to the previous option', () => {
+        const radio = new RadioGroup({ options: OPTIONS, defaultValue: 'light' });
+        radio.selectPrev();
+        expect(radio.focusedIndex).toBe(0);
+    });
+
+    it('selectNext does not go past the last option', () => {
+        const radio = new RadioGroup({ options: OPTIONS, defaultValue: 'system' });
+        radio.selectNext();
+        expect(radio.focusedIndex).toBe(2); // stays at last
+    });
+
+    it('selectPrev does not go before the first option', () => {
+        const radio = new RadioGroup({ options: OPTIONS, defaultValue: 'dark' });
+        radio.selectPrev();
+        expect(radio.focusedIndex).toBe(0); // stays at first
+    });
+
+    it('handleKey up/down moves focus', () => {
+        const radio = new RadioGroup({ options: OPTIONS, defaultValue: 'dark' });
+        radio.handleKey(createKeyEvent({ key: 'down', ctrl: false, shift: false, alt: false, raw: Buffer.alloc(0) }));
+        expect(radio.focusedIndex).toBe(1);
+        radio.handleKey(createKeyEvent({ key: 'up', ctrl: false, shift: false, alt: false, raw: Buffer.alloc(0) }));
+        expect(radio.focusedIndex).toBe(0);
+    });
+
+    // ── 3. onChange fires on Enter confirm ─────────────
+
+    it('onChange fires when a new option is confirmed with enter', () => {
+        const onChange = vi.fn();
+        const radio = new RadioGroup({ options: OPTIONS, defaultValue: 'dark', onChange });
+
+        radio.selectNext(); // move focus to 'light'
+        radio.handleKey(createKeyEvent({ key: 'enter', ctrl: false, shift: false, alt: false, raw: Buffer.alloc(0) }));
+
+        expect(onChange).toHaveBeenCalledOnce();
+        expect(onChange).toHaveBeenCalledWith('light');
+        expect(radio.selectedValue).toBe('light');
+    });
+
+    it('onChange does not fire when confirming the already-selected option', () => {
+        const onChange = vi.fn();
+        const radio = new RadioGroup({ options: OPTIONS, defaultValue: 'dark', onChange });
+
+        // confirm without moving — value unchanged
+        radio.confirm();
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    // ── 4. Disabled options skipped during navigation ──
+
+    it('selectNext skips disabled options', () => {
+        const radio = new RadioGroup({
+            options: OPTIONS_WITH_DISABLED,
+            defaultValue: 'dark',
+        });
+        radio.selectNext(); // index 1 is disabled → should land on index 2 (light)
+        expect(radio.focusedIndex).toBe(2);
+    });
+
+    it('confirm does nothing on a disabled option', () => {
+        const onChange = vi.fn();
+        // Manually force focus onto the disabled item by navigating backwards
+        // from 'light' (index 2) to check confirm guard.
+        const radio = new RadioGroup({
+            options: OPTIONS_WITH_DISABLED,
+            defaultValue: 'light',
+            onChange,
+        });
+        // focusedIndex is 2 (light). Move prev — skips index 1 (disabled) → lands on 0
+        radio.selectPrev();
+        expect(radio.focusedIndex).toBe(0); // skipped disabled correctly
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    // ── 5. Render output ───────────────────────────────
+
+    it('renders selected option with (o) marker', () => {
+        const radio = new RadioGroup({ options: OPTIONS, defaultValue: 'dark' });
+        const screen = new Screen(40, OPTIONS.length);
+        radio.updateRect({ x: 0, y: 0, width: 40, height: OPTIONS.length });
+        radio.render(screen);
+
+        const row0 = screen.back[0]!.map((c) => c.char).join('');
+        expect(row0).toContain('(o)');
+        expect(row0).toContain('Dark');
+    });
+
+    it('renders unselected options with ( ) marker', () => {
+        const radio = new RadioGroup({ options: OPTIONS, defaultValue: 'dark' });
+        const screen = new Screen(40, OPTIONS.length);
+        radio.updateRect({ x: 0, y: 0, width: 40, height: OPTIONS.length });
+        radio.render(screen);
+
+        const row1 = screen.back[1]!.map((c) => c.char).join('');
+        expect(row1).toContain('( )');
+        expect(row1).toContain('Light');
+    });
+});

--- a/packages/ui/src/RadioGroup.ts
+++ b/packages/ui/src/RadioGroup.ts
@@ -1,0 +1,177 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/ui — RadioGroup widget
+//
+// Renders a list of options where only one is selectable
+// at a time. Up/down arrow keys move the cursor; Enter
+// confirms the selection and fires onChange.
+// ─────────────────────────────────────────────────────
+
+import { Widget } from '@termuijs/widgets';
+import {
+    type Screen,
+    type KeyEvent,
+    mergeStyles,
+    defaultStyle,
+    styleToCellAttrs,
+    caps,
+} from '@termuijs/core';
+
+export interface RadioGroupOption {
+    label: string;
+    value: string;
+    disabled?: boolean;
+}
+
+export interface RadioGroupOptions {
+    options: Array<RadioGroupOption>;
+    defaultValue?: string;
+    onChange?: (value: string) => void;
+}
+
+/**
+ * RadioGroup — renders a vertical list of mutually exclusive options.
+ *
+ * Example output (unicode):
+ *   (o) Dark
+ *   ( ) Light
+ *   ( ) System
+ */
+export class RadioGroup extends Widget {
+    private _options: RadioGroupOption[];
+    private _selectedValue: string;
+    private _focusedIndex: number;
+
+    /** Fires whenever the confirmed selection changes. */
+    onChange?: (value: string) => void;
+
+    focusable = true;
+
+    constructor(config: RadioGroupOptions) {
+        super(
+            mergeStyles(defaultStyle(), {
+                height: Math.max(config.options.length, 1),
+            })
+        );
+
+        this._options = config.options;
+        this.onChange = config.onChange;
+
+        // Determine initial selection
+        const defaultIndex = config.defaultValue !== undefined
+            ? config.options.findIndex((o) => o.value === config.defaultValue)
+            : -1;
+
+        // If defaultValue matched a non-disabled option use it; otherwise pick
+        // the first enabled option (or index 0 as a safe fallback).
+        if (defaultIndex >= 0 && !config.options[defaultIndex]?.disabled) {
+            this._selectedValue = config.options[defaultIndex]!.value;
+            this._focusedIndex = defaultIndex;
+        } else {
+            const firstEnabled = config.options.findIndex((o) => !o.disabled);
+            this._focusedIndex = firstEnabled >= 0 ? firstEnabled : 0;
+            this._selectedValue = config.options[this._focusedIndex]?.value ?? '';
+        }
+    }
+
+    // ── Accessors ─────────────────────────────────────
+
+    /** The value of the currently confirmed selection. */
+    get selectedValue(): string {
+        return this._selectedValue;
+    }
+
+    /** The index currently under the keyboard cursor. */
+    get focusedIndex(): number {
+        return this._focusedIndex;
+    }
+
+    // ── Navigation ────────────────────────────────────
+
+    /** Move cursor to the next enabled option. */
+    selectNext(): void {
+        let n = this._focusedIndex + 1;
+        while (n < this._options.length && this._options[n]?.disabled) n++;
+        if (n < this._options.length) {
+            this._focusedIndex = n;
+            this.markDirty();
+        }
+    }
+
+    /** Move cursor to the previous enabled option. */
+    selectPrev(): void {
+        let n = this._focusedIndex - 1;
+        while (n >= 0 && this._options[n]?.disabled) n--;
+        if (n >= 0) {
+            this._focusedIndex = n;
+            this.markDirty();
+        }
+    }
+
+    /** Confirm the focused option and fire onChange. */
+    confirm(): void {
+        const option = this._options[this._focusedIndex];
+        if (!option || option.disabled) return;
+        if (option.value === this._selectedValue) return; // nothing changed
+        this._selectedValue = option.value;
+        this.markDirty();
+        this.onChange?.(this._selectedValue);
+    }
+
+    // ── Key handling ──────────────────────────────────
+
+    handleKey(event: KeyEvent): void {
+        switch (event.key) {
+            case 'up':
+                this.selectPrev();
+                break;
+            case 'down':
+                this.selectNext();
+                break;
+            case 'enter':
+                this.confirm();
+                break;
+        }
+    }
+
+    // ── Rendering ─────────────────────────────────────
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width, height } = this._rect;
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this.style);
+
+        for (let i = 0; i < this._options.length && i < height; i++) {
+            const option = this._options[i]!;
+            const isFocused = i === this._focusedIndex;
+            const isSelected = option.value === this._selectedValue;
+
+            // "(o) Label"  — selected
+            // "( ) Label"  — unselected
+            // ASCII fallbacks for NO_UNICODE environments
+            const radio = isSelected
+                ? (caps.unicode ? '(o)' : '(*)')
+                : (caps.unicode ? '( )' : '( )');
+
+            const cursor = isFocused
+                ? (caps.unicode ? '❯ ' : '> ')
+                : '  ';
+
+            const text = `${cursor}${radio} ${option.label}`;
+
+            screen.writeString(
+                x,
+                y + i,
+                text.slice(0, width),
+                {
+                    ...attrs,
+                    bold: isFocused,
+                    dim: option.disabled === true,
+                    fg: option.disabled
+                        ? { type: 'named' as const, name: 'brightBlack' as const }
+                        : attrs.fg,
+                }
+            );
+        }
+    }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -141,3 +141,6 @@ export type { MultilineTextInputOptions } from './MultilineTextInput.js';
 
 export { Stepper } from './Stepper.js';
 export type { StepperOptions } from './Stepper.js';
+
+export { RadioGroup } from './RadioGroup.js';
+export type { RadioGroupOption, RadioGroupOptions } from './RadioGroup.js';


### PR DESCRIPTION
## Description
Implements the `RadioGroup` widget at `packages/ui/src/RadioGroup.ts`
and exports it from `packages/ui/src/index.ts` as specified in #[issue number].

## Type of Change
- [x] New feature

## Related Issue
Fixes #30 

## Changes Made
- Added `RadioGroup.ts` at `packages/ui/src/RadioGroup.ts`
- Widget accepts `options: Array<{ label: string, value: string }>` 
  and optional `defaultValue?: string`
- Renders `(o) Option` for selected and `( ) Option` for unselected
- Up/down arrow keys navigate options, Enter confirms selection
- Disabled options render dimmed and are skipped during keyboard navigation
- Fires `onChange(value: string)` and calls `this.markDirty()` on every change
- Exported from `packages/ui/src/index.ts`
- Added `RadioGroup.test.ts` with 4 tests:
  - Default selection renders correctly
  - Arrow key navigation works
  - `onChange` fires on selection change
  - Disabled option is skipped during navigation

## Implementation Notes
- Followed keyboard and render patterns from `Select.ts` as suggested
- Disabled options use dimmed rendering and are excluded from arrow navigation loop

## Testing
- [x] All 4 required tests passing
- [x] Manual testing completed
- [x] No console errors or warnings

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] Exported from `packages/ui/src/index.ts`
- [x] `.test.ts` includes all 4 required test cases
- [x] Followed patterns from `Select.ts`
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a RadioGroup UI widget for choosing a single option from a vertical list. Supports keyboard navigation (arrow keys), customizable default selection, disabled options, and change event callbacks.

* **Tests**
  * Added tests covering default selection, focus/keyboard navigation, skipping disabled options, confirming selections, and onChange firing only when selection actually changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->