### PR TITLE
feat(ui): add ThemeSwitcher widget

### DIFF
--- a/packages/ui/src/ThemeSwitcher.test.ts
+++ b/packages/ui/src/ThemeSwitcher.test.ts
@@ -3,7 +3,20 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi } from 'vitest';
+import { Screen } from '@termuijs/core';
 import { ThemeSwitcher } from './ThemeSwitcher.js';
+
+function rowText(screen: Screen, row: number): string {
+    return screen.back[row].map(c => c.char ?? ' ').join('').trim();
+}
+
+function renderSwitcher(ts: ThemeSwitcher): Screen {
+    const themes = ts.themes;
+    const screen = new Screen(20, themes.length + 2);
+    ts.updateRect({ x: 0, y: 0, width: 20, height: themes.length + 2 });
+    ts.render(screen);
+    return screen;
+}
 
 describe('ThemeSwitcher', () => {
     it('initializes with activeTheme="default" and correct selectedIndex', () => {
@@ -47,5 +60,37 @@ describe('ThemeSwitcher', () => {
         ts.confirm();
         expect(onChange).toHaveBeenCalledWith(ts.themes[1]);
         expect(ts.activeTheme).toBe(ts.themes[1]);
+    });
+
+    it('syncs activeTheme to first theme when provided activeTheme is not in list', () => {
+        const ts = new ThemeSwitcher({ themes: ['light', 'dark'], activeTheme: 'invalid' });
+        expect(ts.selectedIndex).toBe(0);
+        expect(ts.activeTheme).toBe('light');
+    });
+
+    it('renders theme names in output', () => {
+        const ts = new ThemeSwitcher({ themes: ['light', 'dark'] });
+        const screen = renderSwitcher(ts);
+        const row0 = rowText(screen, 1);
+        const row1 = rowText(screen, 2);
+        expect(row0).toContain('Light');
+        expect(row1).toContain('Dark');
+    });
+
+    it('renders selection marker on the selected row', () => {
+        const ts = new ThemeSwitcher({ themes: ['light', 'dark'] });
+        ts.selectNext();
+        const screen = renderSwitcher(ts);
+        const row1 = rowText(screen, 2);
+        expect(row1).toMatch(/[>▸]/);
+    });
+
+    it('renders active marker after confirm', () => {
+        const ts = new ThemeSwitcher({ themes: ['light', 'dark'] });
+        ts.selectNext();
+        ts.confirm();
+        const screen = renderSwitcher(ts);
+        const row1 = rowText(screen, 2);
+        expect(row1).toMatch(/[*●]/);
     });
 });

--- a/packages/ui/src/ThemeSwitcher.test.ts
+++ b/packages/ui/src/ThemeSwitcher.test.ts
@@ -3,7 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi } from 'vitest';
-import { Screen } from '@termuijs/core';
+import { Screen, caps } from '@termuijs/core';
 import { ThemeSwitcher } from './ThemeSwitcher.js';
 
 function rowText(screen: Screen, row: number): string {
@@ -92,5 +92,44 @@ describe('ThemeSwitcher', () => {
         const screen = renderSwitcher(ts);
         const row1 = rowText(screen, 2);
         expect(row1).toMatch(/[*●]/);
+    });
+
+    it('applies bold and custom/active color styling to selected and active items', () => {
+        const ts = new ThemeSwitcher({ 
+            themes: ['light', 'dark'], 
+            activeTheme: 'light',
+            activeColor: { type: 'named', name: 'green' } 
+        });
+        const screen = renderSwitcher(ts);
+
+        // 'light' (active and selected) should have bold styling and green foreground color
+        expect(screen.back[1][1].bold).toBe(true);
+        expect(screen.back[1][1].fg).toEqual({ type: 'named', name: 'green' });
+
+        // 'dark' (neither active nor selected) should not be bold and not green
+        expect(screen.back[2][1].bold).toBe(false);
+        expect(screen.back[2][1].fg).not.toEqual({ type: 'named', name: 'green' });
+    });
+
+    it('uses unicode markers when caps.unicode is true', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+        const ts = new ThemeSwitcher({ themes: ['light', 'dark'] });
+        const screen = renderSwitcher(ts);
+        
+        const row1 = rowText(screen, 1);
+        expect(row1).toContain('●▸ Light');
+        
+        vi.restoreAllMocks();
+    });
+
+    it('uses ASCII markers when caps.unicode is false', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+        const ts = new ThemeSwitcher({ themes: ['light', 'dark'] });
+        const screen = renderSwitcher(ts);
+        
+        const row1 = rowText(screen, 1);
+        expect(row1).toContain('*> Light');
+        
+        vi.restoreAllMocks();
     });
 });

--- a/packages/ui/src/ThemeSwitcher.test.ts
+++ b/packages/ui/src/ThemeSwitcher.test.ts
@@ -1,0 +1,51 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/ui — Tests for ThemeSwitcher component
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi } from 'vitest';
+import { ThemeSwitcher } from './ThemeSwitcher.js';
+
+describe('ThemeSwitcher', () => {
+    it('initializes with activeTheme="default" and correct selectedIndex', () => {
+        const ts = new ThemeSwitcher();
+        expect(ts.activeTheme).toBe('default');
+        expect(ts.selectedIndex).toBe(0);
+    });
+
+    it('custom themes lists are supported', () => {
+        const themes = ['light', 'dark'];
+        const ts = new ThemeSwitcher({ themes, activeTheme: 'dark' });
+        expect(ts.themes).toEqual(themes);
+        expect(ts.activeTheme).toBe('dark');
+        expect(ts.selectedIndex).toBe(1);
+    });
+
+    it('selectNext increments selectedIndex', () => {
+        const ts = new ThemeSwitcher();
+        ts.selectNext();
+        expect(ts.selectedIndex).toBe(1);
+    });
+
+    it('selectPrev decrements selectedIndex', () => {
+        const ts = new ThemeSwitcher();
+        ts.selectNext();
+        ts.selectPrev();
+        expect(ts.selectedIndex).toBe(0);
+    });
+
+    it('selectNext at last stays at last', () => {
+        const ts = new ThemeSwitcher({ themes: ['a', 'b'] });
+        ts.selectNext(); // 1
+        ts.selectNext(); // stays at 1
+        expect(ts.selectedIndex).toBe(1);
+    });
+
+    it('confirm calls onChange callback with selected theme', () => {
+        const onChange = vi.fn();
+        const ts = new ThemeSwitcher({ onChange });
+        ts.selectNext(); // select second theme
+        ts.confirm();
+        expect(onChange).toHaveBeenCalledWith(ts.themes[1]);
+        expect(ts.activeTheme).toBe(ts.themes[1]);
+    });
+});

--- a/packages/ui/src/ThemeSwitcher.ts
+++ b/packages/ui/src/ThemeSwitcher.ts
@@ -1,0 +1,147 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/ui — ThemeSwitcher widget
+//
+// A list-based widget to display and switch between different themes.
+// - Keyboard navigable (Up/Down or K/J)
+// - Emits onChange(themeName) when a theme is confirmed via Enter/Space
+// ─────────────────────────────────────────────────────
+
+import { Widget } from '@termuijs/widgets';
+import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, caps } from '@termuijs/core';
+
+export interface ThemeSwitcherOptions {
+    themes?: string[];
+    activeTheme?: string;
+    onChange?: (theme: string) => void;
+    activeColor?: Style['fg'];
+}
+
+export class ThemeSwitcher extends Widget {
+    private _themes: string[];
+    private _activeTheme: string;
+    private _selectedIndex: number;
+    private _onChange?: (theme: string) => void;
+    private _activeColor: Style['fg'];
+    focusable = true;
+
+    constructor(options: ThemeSwitcherOptions = {}) {
+        const themes = options.themes ?? [
+            'default',
+            'cyberpunk',
+            'nord',
+            'dracula',
+            'gruvbox',
+            'catppuccin',
+            'solarized',
+            'tokyo-night',
+            'highContrast'
+        ];
+
+        super(mergeStyles(defaultStyle(), { border: 'single', height: themes.length + 2 }));
+
+        this._themes = themes;
+        this._activeTheme = options.activeTheme ?? 'default';
+        this._selectedIndex = this._themes.indexOf(this._activeTheme);
+        if (this._selectedIndex === -1) {
+            this._selectedIndex = 0;
+        }
+        this._onChange = options.onChange;
+        this._activeColor = options.activeColor ?? { type: 'named', name: 'cyan' };
+    }
+
+    get activeTheme(): string {
+        return this._activeTheme;
+    }
+
+    set activeTheme(theme: string) {
+        if (this._activeTheme === theme) return;
+        this._activeTheme = theme;
+        const idx = this._themes.indexOf(theme);
+        if (idx !== -1) {
+            this._selectedIndex = idx;
+        }
+        this.markDirty();
+    }
+
+    get themes(): string[] {
+        return this._themes;
+    }
+
+    get selectedIndex(): number {
+        return this._selectedIndex;
+    }
+
+    selectNext(): void {
+        if (this._selectedIndex < this._themes.length - 1) {
+            this._selectedIndex++;
+            this.markDirty();
+        }
+    }
+
+    selectPrev(): void {
+        if (this._selectedIndex > 0) {
+            this._selectedIndex--;
+            this.markDirty();
+        }
+    }
+
+    confirm(): void {
+        const theme = this._themes[this._selectedIndex];
+        if (theme) {
+            this._activeTheme = theme;
+            this._onChange?.(theme);
+            this.markDirty();
+        }
+    }
+
+    handleKey(event: KeyEvent): void {
+        switch (event.key) {
+            case 'up':
+            case 'k':
+                this.selectPrev();
+                break;
+            case 'down':
+            case 'j':
+                this.selectNext();
+                break;
+            case 'enter':
+            case 'space':
+                this.confirm();
+                break;
+        }
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const rect = this._getContentRect();
+        const { x, y, width, height } = rect;
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this._style);
+
+        for (let i = 0; i < this._themes.length; i++) {
+            if (i >= height) break;
+
+            const themeName = this._themes[i];
+            const isSelected = i === this._selectedIndex;
+            const isActive = themeName === this._activeTheme;
+
+            let prefix = '  ';
+            if (isActive && isSelected) {
+                prefix = caps.unicode ? '●▸' : '*>';
+            } else if (isActive) {
+                prefix = caps.unicode ? '● ' : '* ';
+            } else if (isSelected) {
+                prefix = caps.unicode ? ' ▸' : ' >';
+            }
+
+            const formattedName = themeName.charAt(0).toUpperCase() + themeName.slice(1);
+            const lineText = `${prefix} ${formattedName}`;
+
+            screen.writeString(x, y + i, lineText.slice(0, width), {
+                ...attrs,
+                fg: isSelected ? this._activeColor : attrs.fg,
+                bold: isSelected || isActive,
+            });
+        }
+    }
+}

--- a/packages/ui/src/ThemeSwitcher.ts
+++ b/packages/ui/src/ThemeSwitcher.ts
@@ -43,7 +43,7 @@ export class ThemeSwitcher extends Widget {
         this._activeTheme = options.activeTheme ?? 'default';
         this._selectedIndex = this._themes.indexOf(this._activeTheme);
         if (this._selectedIndex === -1) {
-            this._activeTheme = this._themes[0] ?? 'default';
+            this._activeTheme = this._themes[0] ?? '';
             this._selectedIndex = 0;
         }
         this._onChange = options.onChange;

--- a/packages/ui/src/ThemeSwitcher.ts
+++ b/packages/ui/src/ThemeSwitcher.ts
@@ -43,6 +43,7 @@ export class ThemeSwitcher extends Widget {
         this._activeTheme = options.activeTheme ?? 'default';
         this._selectedIndex = this._themes.indexOf(this._activeTheme);
         if (this._selectedIndex === -1) {
+            this._activeTheme = this._themes[0] ?? 'default';
             this._selectedIndex = 0;
         }
         this._onChange = options.onChange;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -147,3 +147,5 @@ export type { StepperOptions } from './Stepper.js';
 
 export { RadioGroup } from './RadioGroup.js';
 export type { RadioGroupOption, RadioGroupOptions } from './RadioGroup.js';
+export { ThemeSwitcher } from './ThemeSwitcher.js';
+export type { ThemeSwitcherOptions } from './ThemeSwitcher.js';


### PR DESCRIPTION
This PR adds the ThemeSwitcher widget in packages/ui to list and switch between themes.
It adds ThemeSwitcher.test.ts containing 6 test cases.
It exports ThemeSwitcher and ThemeSwitcherOptions from index.ts.

Closes #324

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Theme Switcher widget with keyboard navigation (Up/Down, K/J), confirmable selection (Enter/Space), selection/active markers, bolded active/selected rows, configurable active color, onChange callback, and syncing of active theme/selection.

* **Tests**
  * Expanded test coverage for initialization, navigation bounds, confirmation, rendering, styling (bold/active color), and marker variations (Unicode vs ASCII).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->