### PR TITLE
feat: add retry with exponential backoff to useFetch

### DIFF
--- a/packages/data/src/hooks.ts
+++ b/packages/data/src/hooks.ts
@@ -326,6 +326,12 @@ export function useWebSocket(url: string): UseWebSocketReturn {
 
 export interface UseFetchOptions {
     staleTime?: number;
+
+    /** Max retry attempts after the first failure. Default 0. */
+    retry?: number;
+
+    /** Base backoff in ms. Delay = retryDelay * 2 ** attempt */
+    retryDelay?: number;
 }
 
 export interface UseFetchResult<T> {
@@ -342,6 +348,9 @@ export interface UseFetchResult<T> {
  */
 export function useFetch<T = any>(url: string, options?: UseFetchOptions): UseFetchResult<T> {
     const staleTime = options?.staleTime ?? 0;
+    const retry = options?.retry ?? 0;
+    const retryDelay = options?.retryDelay ?? 300;
+    const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const [data, setData] = useState<T | null>(() => {
         if (isFresh(url)) {
@@ -354,42 +363,86 @@ export function useFetch<T = any>(url: string, options?: UseFetchOptions): UseFe
     const [loading, setLoading] = useState<boolean>(() => !isFresh(url));
 
     useEffect(() => {
+        let isMounted = true;
+
+        /**
+         * Clear any pending retry timer.
+         * Used to cancel scheduled retry attempts during cleanup or when a
+         * request succeeds to avoid leaking timers.
+         */
+        const clearRetryTimer = () => {
+            if (retryTimerRef.current !== null) {
+                clearTimeout(retryTimerRef.current);
+                retryTimerRef.current = null;
+            }
+        };
+
         if (isFresh(url)) {
             const entry = getCache<T>(url);
             if (entry) {
-                setData(entry.data);
-                setError(null);
-                setLoading(false);
-                return;
+                if (isMounted) {
+                    clearRetryTimer();
+                    setData(entry.data);
+                    setError(null);
+                    setLoading(false);
+                }
+                return () => {
+                    isMounted = false;
+                    clearRetryTimer();
+                };
             }
         }
 
-        let mounted = true;
         setLoading(true);
 
-        fetchShared<T>(url, () => fetch(url)
-            .then(res => {
-                if (!res.ok) throw new Error(`HTTP Error ${res.status}`);
-                return res.json() as Promise<T>;
+        /**
+         * Attempt the fetch and, on failure, schedule a retry using
+         * exponential backoff. `attempt` is zero-based and controls the
+         * backoff multiplier `retryDelay * 2 ** attempt`.
+         */
+        const fetchWithRetry = (attempt: number) => {
+            fetchShared<T>(url, () => fetch(url)
+                .then(res => {
+                    if (!res.ok) throw new Error(`HTTP Error ${res.status}`);
+                    return res.json() as Promise<T>;
+                })
+            )
+            .then(json => {
+                if (!isMounted) return;
+                clearRetryTimer();
+                setCache(url, json, staleTime);
+                setData(json);
+                setError(null);
+                setLoading(false);
             })
-        )
-        .then(json => {
-            if (!mounted) return;
-            setCache(url, json, staleTime);
-            setData(json);
-            setError(null);
-            setLoading(false);
-        })
-        .catch(err => {
-            if (!mounted) return;
-            setError(err instanceof Error ? err : new Error(String(err)));
-            setLoading(false);
-        });
+            .catch(err => {
+                if (!isMounted) return;
+
+                if (attempt < retry) {
+                    clearRetryTimer();
+                    retryTimerRef.current = setTimeout(() => {
+                        retryTimerRef.current = null;
+
+                        if (!isMounted) return;
+
+                        fetchWithRetry(attempt + 1);
+                    }, retryDelay * 2 ** attempt);
+                    return;
+                }
+
+                clearRetryTimer();
+                setError(err instanceof Error ? err : new Error(String(err)));
+                setLoading(false);
+            });
+        };
+
+        fetchWithRetry(0);
 
         return () => {
-            mounted = false;
+            isMounted = false;
+            clearRetryTimer();
         };
-    }, [url, staleTime]);
+    }, [url, staleTime, retry, retryDelay]);
 
     return { data, error, loading };
 }

--- a/packages/data/src/useFetch-retry.test.tsx
+++ b/packages/data/src/useFetch-retry.test.tsx
@@ -1,0 +1,136 @@
+/** @jsxImportSource @termuijs/jsx */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from '@termuijs/testing';
+import { useFetch, type UseFetchOptions, type UseFetchResult } from './hooks.js';
+
+let hookResult: UseFetchResult<unknown> | null = null;
+
+function response(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    });
+}
+
+function TestComponent({
+    url,
+    options,
+}: {
+    url: string;
+    options?: UseFetchOptions;
+}) {
+    hookResult = useFetch<unknown>(url, options);
+    return null;
+}
+
+async function settle(): Promise<void> {
+    await vi.advanceTimersByTimeAsync(0);
+}
+
+describe('useFetch retry behavior', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        hookResult = null;
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+        hookResult = null;
+    });
+
+    it('retries the configured number of times', async () => {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('request failed'));
+
+        render(<TestComponent url="https://example.com/retry-count" options={{ retry: 2, retryDelay: 100 }} />);
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(100);
+        await settle();
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+        await vi.advanceTimersByTimeAsync(200);
+        await settle();
+
+        expect(fetchSpy).toHaveBeenCalledTimes(3);
+        expect(hookResult?.loading).toBe(false);
+        expect(hookResult?.data).toBeNull();
+        expect(hookResult?.error).toBeInstanceOf(Error);
+    });
+
+    it('succeeds when a retry resolves', async () => {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch');
+        fetchSpy
+            .mockRejectedValueOnce(new Error('request failed'))
+            .mockResolvedValueOnce(response({ status: 'ok' }));
+
+        render(<TestComponent url="https://example.com/retry-success" options={{ retry: 1, retryDelay: 100 }} />);
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(100);
+        await settle();
+
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        expect(hookResult?.loading).toBe(false);
+        expect(hookResult?.data).toEqual({ status: 'ok' });
+        expect(hookResult?.error).toBeNull();
+    });
+
+    it('sets error after retries are exhausted', async () => {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('request failed'));
+
+        render(<TestComponent url="https://example.com/retry-exhausted" options={{ retry: 1, retryDelay: 50 }} />);
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(50);
+        await settle();
+
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        expect(hookResult?.loading).toBe(false);
+        expect(hookResult?.data).toBeNull();
+        expect(hookResult?.error).toBeInstanceOf(Error);
+    });
+
+    it('default makes a single attempt', async () => {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('request failed'));
+
+        render(<TestComponent url="https://example.com/default-attempt" />);
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(1000);
+        await settle();
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(hookResult?.loading).toBe(false);
+        expect(hookResult?.data).toBeNull();
+        expect(hookResult?.error).toBeInstanceOf(Error);
+    });
+
+    it('clears pending timers on unmount', async () => {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('request failed'));
+        const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+
+        const { unmount } = render(
+            <TestComponent url="https://example.com/unmount-cleanup" options={{ retry: 2, retryDelay: 100 }} />,
+        );
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+        await settle();
+
+        unmount();
+
+        expect(clearTimeoutSpy).toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1000);
+        await settle();
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/data/src/useFetch.test.ts
+++ b/packages/data/src/useFetch.test.ts
@@ -7,6 +7,7 @@ vi.mock("@termuijs/jsx", () => ({
     typeof initial === "function" ? initial() : initial,
     vi.fn(),
   ],
+  useRef: (initial: unknown) => ({ current: initial }),
   useEffect: (cb: () => void) => cb(),
   useInterval: vi.fn(),
 }));


### PR DESCRIPTION
## Description

Adds configurable retry support with exponential backoff to `useFetch`. Failed requests now retry up to the configured limit using `retryDelay * 2 ** attempt`, while preserving existing cache behavior, shared request deduplication, and cleanup safeguards.

## Related Issue

Closes #501

## Which package(s)?

@termuijs/data

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [x] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A – no UI changes.

## Notes for the Reviewer

* Added `retry` and `retryDelay` options to `useFetch`.
* Implemented exponential backoff using `retryDelay * 2 ** attempt`.
* Preserved existing cache and shared-request behavior.
* Added cleanup for pending retry timers on unmount.
* Added dedicated retry tests covering:

  * configured retry counts
  * successful retry recovery
  * retry exhaustion
  * default single-attempt behavior
  * timer cleanup on unmount
* Added a minimal `useRef` mock to the existing `useFetch.test.ts` setup because `useFetch` now uses a timer ref for retry management.
* No changes outside `packages/data`.
* Added JSDoc comments for the new retry helper functions to satisfy repository docstring coverage requirements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Data fetching hook now supports configurable retries (retry, retryDelay) with exponential backoff and default single-attempt behavior.

* **Tests**
  * Added tests covering retry attempts, backoff timing, eventual success vs exhausted retries, and cleanup of pending retry timers on unmount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->