### PR TITLE
feat(quick): add stack and spacer layout builders

### DIFF
--- a/packages/quick/src/index.test.ts
+++ b/packages/quick/src/index.test.ts
@@ -24,3 +24,34 @@ describe('quick – index exports batch from @termuijs/store', () => {
         expect(typeof (mod as any).batch).toBe('function');
     });
 });
+
+describe('quick – layout stack', () => {
+    it('returns a Widget and stacks children vertically', async () => {
+        const mod = await import('./index.js');
+        const widget = mod.stack('a', 'b');
+        expect(widget.style.flexDirection).toBe('column');
+        expect(widget.style.flexGrow).toBe(0);
+        expect(widget.children.length).toBe(2);
+    });
+
+    it('accepts string children', async () => {
+        const mod = await import('./index.js');
+        const widget = mod.stack('a');
+        expect(widget.children.length).toBe(1);
+    });
+});
+
+describe('quick – layout spacer', () => {
+    it('returns a growing Widget', async () => {
+        const mod = await import('./index.js');
+        const widget = mod.spacer();
+        expect(widget.style.flexGrow).toBe(1);
+    });
+
+    it('returns a fixed-height Widget', async () => {
+        const mod = await import('./index.js');
+        const widget = mod.spacer(2);
+        expect(widget.style.height).toBe(2);
+        expect(widget.style.flexGrow).toBe(0);
+    });
+});

--- a/packages/quick/src/index.test.ts
+++ b/packages/quick/src/index.test.ts
@@ -39,6 +39,27 @@ describe('quick – layout stack', () => {
         const widget = mod.stack('a');
         expect(widget.children.length).toBe(1);
     });
+
+    it('renders children vertically with correct layout', async () => {
+        const { Screen, computeLayout } = await import('@termuijs/core');
+        const mod = await import('./index.js');
+        const screen = new Screen(20, 10);
+        const widget = mod.stack('a', 'b', 'c');
+        
+        const node = widget.getLayoutNode();
+        computeLayout(node, 20, 10);
+        widget.syncLayout(node);
+        
+        widget.render(screen);
+        
+        const row0 = screen.back[0].map(c => c.char).join('');
+        const row1 = screen.back[1].map(c => c.char).join('');
+        const row2 = screen.back[2].map(c => c.char).join('');
+        
+        expect(row0).toContain('a');
+        expect(row1).toContain('b');
+        expect(row2).toContain('c');
+    });
 });
 
 describe('quick – layout spacer', () => {

--- a/packages/quick/src/index.ts
+++ b/packages/quick/src/index.ts
@@ -6,7 +6,7 @@
 export { app, AppBuilder } from './app.js';
 
 // ── Layout ────────────────────────────────────────────
-export { row, col, grid, toWidget } from './layout.js';
+export { row, col, grid, stack, spacer, toWidget } from './layout.js';
 export type { LayoutChild } from './layout.js';
 
 // ── Widget Shorthands ─────────────────────────────────

--- a/packages/quick/src/layout.ts
+++ b/packages/quick/src/layout.ts
@@ -101,3 +101,25 @@ export function grid(rows: number, cols: number, items: LayoutChild[]): Widget {
 
     return container;
 }
+
+/**
+ * Vertical stack, children top-to-bottom, sized to content rather than
+ * growing to fill. Use when col()'s flexGrow is too greedy.
+ */
+export function stack(...children: LayoutChild[]): Widget {
+    const box = new Box({
+        flexDirection: 'column',
+    });
+    for (const child of children) {
+        box.addChild(toWidget(child));
+    }
+    return box;
+}
+
+/**
+ * Flexible empty gap. Grows to fill free space and pushes siblings apart.
+ * Optional fixed size in cells.
+ */
+export function spacer(size?: number): Widget {
+    return new Box(size !== undefined ? { height: size } : { flexGrow: 1 });
+}


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

This PR implements the `stack()` and `spacer()` layout builders in `@termuijs/quick` as outlined in the issue specification. `stack` provides a vertical, non-growing column shorthand by wrapping a `Box`, and `spacer` provides a flexible gap (or fixed-height gap if `size` is provided).

## Related Issue

Closes #511

## Which package(s)?

`@termuijs/quick`

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/08cd7fd2-53b3-4999-a636-7be9d1d94640`

## Screenshots / Recordings (UI changes)

<!-- I am attaching screenshots showing the passing unit tests for `bun vitest run packages/quick` and `bun run typecheck`, as well as a visual confirmation of the new layouts rendering correctly in the terminal. -->

- bun run typecheck
<img width="1934" height="1302" alt="typechek" src="https://github.com/user-attachments/assets/ec7fd577-b662-4b28-ae1f-f03139daa47d" />



- bun vitest run packages/quick 
<img width="1922" height="1290" alt="vitest_package_quick_check" src="https://github.com/user-attachments/assets/1cd859e9-38dd-4959-bb55-569d17f6fb24" />


## Notes for the Reviewer

Followed the reference pattern from `col()` and `row()` using `Box` and `toWidget`. Includes full test coverage in `index.test.ts` for all acceptance criteria.

@srinadhtadikonda Could you please review this for GSSoC 2026?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "stack" — a vertical layout container that sizes to its content.
  * Added "spacer" — a spacing element that either expands to fill space or uses a fixed height when specified.

* **Tests**
  * Added tests validating stack and spacer behaviors, including orientation, sizing, and child rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->