### PR TITLE
feat(router): add forward navigation and multi-step go history tracking

### DIFF
--- a/packages/router/src/forward.test.ts
+++ b/packages/router/src/forward.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Router } from './router.js';
+
+const MinimalComponent = () => ({ type: 'text', props: {}, children: [] });
+
+describe('Router Forward Navigation', () => {
+    it('forward re-navigates after back', () => {
+        const router = new Router();
+        router.addRoutes([
+            { path: '/', component: MinimalComponent },
+            { path: '/next', component: MinimalComponent }
+        ]);
+
+        const navigateSpy = vi.fn();
+        router.events.on('navigate', navigateSpy);
+
+        router.push('/');
+        router.push('/next');
+        router.back();
+        
+        expect(router.currentPath).toBe('/');
+        router.forward();
+        
+        expect(router.currentPath).toBe('/next');
+        expect(navigateSpy).toHaveBeenCalled();
+    });
+
+    it('push clears the forward stack', () => {
+        const router = new Router();
+        router.addRoutes([
+            { path: '/', component: MinimalComponent },
+            { path: '/page1', component: MinimalComponent },
+            { path: '/page2', component: MinimalComponent }
+        ]);
+
+        router.push('/');
+        router.push('/page1');
+        router.back();
+        expect(router.canGoForward).toBe(true);
+
+        router.push('/page2');
+        expect(router.canGoForward).toBe(false);
+    });
+
+    it('canGoForward reflects forward entries', () => {
+        const router = new Router();
+        router.addRoutes([
+            { path: '/', component: MinimalComponent },
+            { path: '/page1', component: MinimalComponent }
+        ]);
+
+        expect(router.canGoForward).toBe(false);
+        router.push('/');
+        router.push('/page1');
+        router.back();
+        expect(router.canGoForward).toBe(true);
+    });
+
+    it('go(-1) goes back and go(1) goes forward', () => {
+        const router = new Router();
+        router.addRoutes([
+            { path: '/', component: MinimalComponent },
+            { path: '/home', component: MinimalComponent }
+        ]);
+
+        router.push('/');
+        router.push('/home');
+        
+        router.go(-1);
+        expect(router.currentPath).toBe('/');
+
+        router.go(1);
+        expect(router.currentPath).toBe('/home');
+    });
+
+    it('go past the boundary is a no-op', () => {
+        const router = new Router();
+        router.addRoutes([
+            { path: '/', component: MinimalComponent },
+            { path: '/dashboard', component: MinimalComponent }
+        ]);
+
+        router.push('/');
+        router.push('/dashboard');
+
+        expect(() => router.go(-100)).not.toThrow();
+        expect(router.currentPath).toBe('/dashboard');
+
+        expect(() => router.go(50)).not.toThrow();
+        expect(router.currentPath).toBe('/dashboard');
+    });
+});

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -38,6 +38,7 @@ export interface RouterOptions {
 export class Router {
     private _routes: Route[] = [];
     private _history: string[] = [];
+    private _forwardStack: string[] = [];
     private _currentMatch: RouteMatch | null = null;
     private _maxHistory: number;
     readonly events = new EventEmitter<RouterEvents>();
@@ -75,6 +76,10 @@ export class Router {
             this.events.emit('error', new Error(`No route found for path: ${path}`));
             return;
         }
+
+        // A new push(path) clears the forward stack
+        this._forwardStack = [];
+
         this._history.push(path);
         // Prevent unbounded history growth
         if (this._history.length > this._maxHistory) {
@@ -107,7 +112,13 @@ export class Router {
     /** Go back in history */
     back(): void {
         if (this._history.length <= 1) return;
-        this._history.pop();
+        
+        // back() pushes the popped path onto a forward stack
+        const poppedPath = this._history.pop();
+        if (poppedPath) {
+            this._forwardStack.push(poppedPath);
+        }
+
         const prevPath = this._history[this._history.length - 1];
         const match = prevPath ? matchRoute(prevPath, this._routes) : null;
         this._currentMatch = match;
@@ -118,6 +129,52 @@ export class Router {
         } else {
             this.events.emit('back', null);
         }
+    }
+
+    /** Move forward one step if a forward entry exists */
+    forward(): void {
+        if (this._forwardStack.length === 0) return;
+
+        const nextPath = this._forwardStack.pop();
+        if (!nextPath) return;
+
+        const match = matchRoute(nextPath, this._routes);
+        if (!match) {
+            this.events.emit('error', new Error(`No route found for forward path: ${nextPath}`));
+            return;
+        }
+
+        this._history.push(nextPath);
+        this._currentMatch = match;
+        unmountAll();
+        const screen = this._wrapScreen(match);
+        // forward() re-navigates to the most recent forward entry and emits navigate
+        this.events.emit('navigate', { match, screen });
+    }
+
+    /** Move delta steps: negative is back, positive is forward */
+    go(delta: number): void {
+        if (delta === 0) return;
+
+        if (delta < 0) {
+            const steps = Math.abs(delta);
+            // go(n) past either boundary is a no-op (clamped, no error)
+            if (steps >= this._history.length) return;
+            for (let i = 0; i < steps; i++) {
+                this.back();
+            }
+        } else {
+            // go(n) past either boundary is a no-op (clamped, no error)
+            if (delta > this._forwardStack.length) return;
+            for (let i = 0; i < delta; i++) {
+                this.forward();
+            }
+        }
+    }
+
+    /** Whether a forward entry exists */
+    get canGoForward(): boolean {
+        return this._forwardStack.length > 0;
     }
 
     /** Current route match */


### PR DESCRIPTION
## Description
This pull request implements browser-style forward navigation and multi-step history traversal utilities within the routing module. It adds support for tracking a forward history stack, undoing backward movements, checking forward availability, and navigating via absolute delta steps.

## Packages Affected
- `@termuijs/router`

## Type of Change
- [x] ✨ Feature (non-breaking change which adds functionality)
- [x] 🧪 Tests (adding missing tests or fixing existing tests)

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## GSSoC Participation Details
- **Contest Profile Link:** https://gssoc.girlscript.org/profile/3b9f326e-6c33-425b-a1c4-9a9a63a82956
- **Issue Linked:** Closes #494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added forward navigation to revisit routes after navigating back
  * Added relative history navigation to move multiple steps forward or backward
  * Added a status indicator to tell when forward navigation is available

* **Tests**
  * Added tests covering forward/back behavior, relative navigation limits, and no-op boundary handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->