### PR TITLE
[Feature] cursor position parser

### DIFF
--- a/packages/core/src/input/InputParser.test.ts
+++ b/packages/core/src/input/InputParser.test.ts
@@ -16,7 +16,10 @@ function createParser() {
 }
 
 describe('InputParser', () => {
-    afterEach(() => { vi.restoreAllMocks(); });
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
 
     it('parses regular ASCII character "a"', () => {
         const { stdin, handler } = createParser();
@@ -106,6 +109,58 @@ describe('InputParser', () => {
         const { stdin, handler } = createParser();
         sendKey(stdin, '\x1bx');
         expect(handler).toHaveBeenCalledWith(expect.objectContaining({ key: 'x', alt: true }));
+    });
+
+    it('resolves cursor position reports with correct row/col', async () => {
+        const stdin = createMockStdin();
+        const parser = new InputParser(stdin);
+        parser.start();
+
+        const positionPromise = parser.requestCursorPosition();
+        sendKey(stdin, '\x1b[12;34R');
+
+        await expect(positionPromise).resolves.toEqual({ row: 12, col: 34 });
+    });
+
+    it('rejects cursor position request after timeout', async () => {
+        vi.useFakeTimers();
+        const stdin = createMockStdin();
+        const parser = new InputParser(stdin);
+        parser.start();
+
+        const positionPromise = parser.requestCursorPosition(200);
+        vi.advanceTimersByTime(201);
+
+        await expect(positionPromise).rejects.toThrow('Cursor position request timed out');
+    });
+
+    it('does not emit a key event for cursor position reports', async () => {
+        const stdin = createMockStdin();
+        const parser = new InputParser(stdin);
+        const keyHandler = vi.fn();
+        parser.onKey(keyHandler);
+        parser.start();
+
+        const positionPromise = parser.requestCursorPosition();
+        sendKey(stdin, '\x1b[5;7R');
+
+        await expect(positionPromise).resolves.toEqual({ row: 5, col: 7 });
+        expect(keyHandler).not.toHaveBeenCalled();
+    });
+
+    it('resolves two pending cursor position requests', async () => {
+        const stdin = createMockStdin();
+        const parser = new InputParser(stdin);
+        parser.start();
+
+        const first = parser.requestCursorPosition();
+        const second = parser.requestCursorPosition();
+        sendKey(stdin, '\x1b[8;9R');
+
+        await expect(Promise.all([first, second])).resolves.toEqual([
+            { row: 8, col: 9 },
+            { row: 8, col: 9 },
+        ]);
     });
 
     it('processes rapid multi-byte input correctly', () => {

--- a/packages/core/src/input/InputParser.ts
+++ b/packages/core/src/input/InputParser.ts
@@ -8,6 +8,11 @@ import { ESCAPE_SEQUENCES, CTRL_KEYS, SPECIAL_KEYS } from './KeyMap.js';
 import { parseMouseEvent, isMouseSequence } from './MouseParser.js';
 import { EventEmitter } from '../events/EventEmitter.js';
 
+export interface CursorPosition {
+    row: number;
+    col: number;
+}
+
 interface InputEvents {
     key: KeyEvent;
     mouse: MouseEvent;
@@ -23,6 +28,11 @@ export class InputParser {
     private _handler: ((data: Buffer) => void) | null = null;
     private _escapeTimeout: ReturnType<typeof setTimeout> | null = null;
     private _escapeBuffer = '';
+    private _cursorRequests: Array<{
+        resolve: (position: CursorPosition) => void;
+        reject: (error: Error) => void;
+        timeout: ReturnType<typeof setTimeout>;
+    }> = [];
 
     constructor(stdin: NodeJS.ReadStream) {
         this._stdin = stdin;
@@ -36,6 +46,20 @@ export class InputParser {
     /** Subscribe to mouse events */
     onMouse(handler: (event: MouseEvent) => void): () => void {
         return this._events.on('mouse', handler);
+    }
+
+    requestCursorPosition(timeoutMs = 200): Promise<CursorPosition> {
+        return new Promise<CursorPosition>((resolve, reject) => {
+            const timeout = setTimeout(() => {
+                const idx = this._cursorRequests.findIndex((item) => item.reject === reject);
+                if (idx !== -1) {
+                    this._cursorRequests.splice(idx, 1);
+                }
+                reject(new Error('Cursor position request timed out'));
+            }, timeoutMs);
+
+            this._cursorRequests.push({ resolve, reject, timeout });
+        });
     }
 
     /** Start listening for input */
@@ -175,6 +199,22 @@ export class InputParser {
                 }, 100);
                 return;
             }
+        }
+
+        // Cursor position report
+        const cursorMatch = seq.match(/^\x1b\[(\d+);(\d+)R$/);
+        if (cursorMatch) {
+            const row = parseInt(cursorMatch[1], 10);
+            const col = parseInt(cursorMatch[2], 10);
+            const position = { row, col };
+
+            for (const request of this._cursorRequests) {
+                clearTimeout(request.timeout);
+                request.resolve(position);
+            }
+            this._cursorRequests = [];
+            this._escapeBuffer = '';
+            return;
         }
 
         // Check known escape sequences

--- a/packages/core/src/utils/ansi.ts
+++ b/packages/core/src/utils/ansi.ts
@@ -25,6 +25,8 @@ export function moveDown(n = 1): string { return `${CSI}${n}B`; }
 export function moveRight(n = 1): string { return `${CSI}${n}C`; }
 export function moveLeft(n = 1): string { return `${CSI}${n}D`; }
 
+export const requestCursorPosition = `${CSI}6n`;
+
 // ── Screen Control ──────────────────────────────────
 
 export const clearScreen = `${CSI}2J`;


### PR DESCRIPTION
## Fixes #463

### Summary

Adds cursor position report (DSR 6n) support to `packages/core`.

### Changes

* Added `requestCursorPosition` ANSI constant (`\x1b[6n`)
* Added `CursorPosition` interface
* Added `InputParser.requestCursorPosition()` with timeout support
* Parsed CSI cursor position reports (`\x1b[row;colR`)
* Resolved all pending requests from the next report
* Prevented cursor position reports from leaking into key events
* Added tests for:

  * Successful cursor position parsing
  * Timeout rejection
  * No key event emission
  * Multiple pending request resolution

### Validation

* ✅ `bun vitest run packages/core`
* ✅ `bun run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added terminal cursor position reporting. Applications can now request the current cursor position and receive row and column coordinates. Includes timeout handling for requests without responses, and ensures cursor position queries do not interfere with regular key input processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->