### PR TITLE
feat(testing): add frameSerializer, queryByText, and queryByType

### DIFF
--- a/packages/testing/src/frame-serializer.test.ts
+++ b/packages/testing/src/frame-serializer.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { formatFrame, frameSerializer } from './frame-serializer.js';
+
+describe('formatFrame', () => {
+  it('pads rows to equal width and draws a border', () => {
+    const result = formatFrame(['ab', 'c']);
+    expect(result).toBe('┌──┐\n│ab│\n│c │\n└──┘');
+  });
+
+  it('handles a single row', () => {
+    const result = formatFrame(['hello']);
+    expect(result).toBe('┌─────┐\n│hello│\n└─────┘');
+  });
+
+  it('handles empty frame without throwing', () => {
+    const result = formatFrame([]);
+    expect(result).toBe('┌┐\n└┘');
+  });
+
+  it('produces deterministic output for same input', () => {
+    const frame = ['foo', 'ba'];
+    expect(formatFrame(frame)).toBe(formatFrame(frame));
+  });
+});
+
+describe('frameSerializer', () => {
+  it('accepts a string[] frame', () => {
+    expect(frameSerializer.test(['hello', 'world'])).toBe(true);
+  });
+
+  it('accepts an empty string[]', () => {
+    expect(frameSerializer.test([])).toBe(true);
+  });
+
+  it('rejects non-array values', () => {
+    expect(frameSerializer.test('hello')).toBe(false);
+    expect(frameSerializer.test(42)).toBe(false);
+    expect(frameSerializer.test(null)).toBe(false);
+    expect(frameSerializer.test(undefined)).toBe(false);
+    expect(frameSerializer.test({ frame: [] })).toBe(false);
+  });
+
+  it('rejects array with non-string values', () => {
+    expect(frameSerializer.test([1, 2, 3])).toBe(false);
+    expect(frameSerializer.test(['ok', 42])).toBe(false);
+  });
+
+  it('serialize produces stable deterministic output', () => {
+    const frame = ['ab', 'c'];
+    expect(frameSerializer.serialize(frame)).toBe(frameSerializer.serialize(frame));
+  });
+
+  it('can be passed to expect.addSnapshotSerializer without error', () => {
+    expect(() => expect.addSnapshotSerializer(frameSerializer)).not.toThrow();
+  });
+});

--- a/packages/testing/src/frame-serializer.ts
+++ b/packages/testing/src/frame-serializer.ts
@@ -4,17 +4,22 @@
  * expect.addSnapshotSerializer.
  */
 
+import { stringWidth } from '@termuijs/core';
+
 /** Format a frame as a bordered grid string. */
 export function formatFrame(frame: string[]): string {
   if (frame.length === 0) {
     return '┌┐\n└┘';
   }
 
-  const width = Math.max(...frame.map((row) => row.length));
+  const width = Math.max(...frame.map((row) => stringWidth(row)));
 
   const top    = '┌' + '─'.repeat(width) + '┐';
   const bottom = '└' + '─'.repeat(width) + '┘';
-  const rows   = frame.map((row) => '│' + row.padEnd(width, ' ') + '│');
+  const rows   = frame.map((row) => {
+    const pad = Math.max(0, width - stringWidth(row));
+    return '│' + row + ' '.repeat(pad) + '│';
+  });
 
   return [top, ...rows, bottom].join('\n');
 }

--- a/packages/testing/src/frame-serializer.ts
+++ b/packages/testing/src/frame-serializer.ts
@@ -1,0 +1,37 @@
+/**
+ * A Vitest snapshot serializer that renders a frame (the string[] from
+ * lastFrame()) as a bordered grid. Register in a setup file or pass to
+ * expect.addSnapshotSerializer.
+ */
+
+/** Format a frame as a bordered grid string. */
+export function formatFrame(frame: string[]): string {
+  if (frame.length === 0) {
+    return '┌┐\n└┘';
+  }
+
+  const width = Math.max(...frame.map((row) => row.length));
+
+  const top    = '┌' + '─'.repeat(width) + '┐';
+  const bottom = '└' + '─'.repeat(width) + '┘';
+  const rows   = frame.map((row) => '│' + row.padEnd(width, ' ') + '│');
+
+  return [top, ...rows, bottom].join('\n');
+}
+
+/** Vitest snapshot serializer for terminal frames. */
+export const frameSerializer: {
+  test(value: unknown): boolean;
+  serialize(value: string[]): string;
+} = {
+  test(value: unknown): boolean {
+    return (
+      Array.isArray(value) &&
+      value.every((item) => typeof item === 'string')
+    );
+  },
+
+  serialize(value: string[]): string {
+    return formatFrame(value);
+  },
+};

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -9,3 +9,4 @@ export type { Fixture, TestInstance, TestRenderOptions } from './render.js';
 // ── Virtual Clock ──
 export { createVirtualClock } from './virtual-clock.js';
 export type { VirtualClock } from '@termuijs/motion';
+export { frameSerializer, formatFrame } from './frame-serializer.js';

--- a/packages/testing/src/render.test.tsx
+++ b/packages/testing/src/render.test.tsx
@@ -211,7 +211,8 @@ describe("render harness", () => {
       }).not.toThrow()
     })
   })
-describe("createFixture", () => {
+    
+  describe("createFixture", () => {
     it("applies default size when rendering without options", () => {
       const fixture = createFixture({ width: 40, height: 10 })
 

--- a/packages/testing/src/render.test.tsx
+++ b/packages/testing/src/render.test.tsx
@@ -211,8 +211,7 @@ describe("render harness", () => {
       }).not.toThrow()
     })
   })
-
-  describe("createFixture", () => {
+describe("createFixture", () => {
     it("applies default size when rendering without options", () => {
       const fixture = createFixture({ width: 40, height: 10 })
 
@@ -254,6 +253,53 @@ describe("render harness", () => {
       expect(() => {
         fixture.cleanup()
       }).not.toThrow()
+    })
+  })
+
+  describe("queryByText", () => {
+    it("returns null on a miss", () => {
+      const screen = render(<Hello />)
+
+      expect(screen.queryByText("Missing")).toBeNull()
+    })
+
+    it("returns the widget on a hit", () => {
+      const screen = render(<Hello />)
+
+      const result = screen.queryByText("Hello")
+
+      expect(result).not.toBeNull()
+    })
+
+    it("does not throw on a miss", () => {
+      const screen = render(<Hello />)
+
+      expect(() => screen.queryByText("NotHere")).not.toThrow()
+    })
+  })
+
+  describe("queryByType", () => {
+    it("returns the first instance of a type", () => {
+      const screen = render(<MultiText />)
+
+      const result = screen.queryByType(Text)
+
+      expect(result).not.toBeNull()
+      expect(result instanceof Text).toBe(true)
+    })
+
+    it("returns null when no instance exists", () => {
+      const screen = render(<MultiText />)
+
+      const result = screen.queryByType(FakeWidget)
+
+      expect(result).toBeNull()
+    })
+
+    it("does not throw when no instance exists", () => {
+      const screen = render(<MultiText />)
+
+      expect(() => screen.queryByType(FakeWidget)).not.toThrow()
     })
   })
 })

--- a/packages/testing/src/render.test.tsx
+++ b/packages/testing/src/render.test.tsx
@@ -211,7 +211,7 @@ describe("render harness", () => {
       }).not.toThrow()
     })
   })
-    
+
   describe("createFixture", () => {
     it("applies default size when rendering without options", () => {
       const fixture = createFixture({ width: 40, height: 10 })

--- a/packages/testing/src/render.ts
+++ b/packages/testing/src/render.ts
@@ -45,6 +45,18 @@ export interface TestInstance {
     getAllByType<T extends Widget>(type: new (...args: any[]) => T): T[];
 
     /**
+     * Find the first widget whose text content includes the given string.
+     * Returns null instead of throwing when nothing matches.
+     */
+    queryByText(text: string): Widget | null;
+
+    /**
+     * Find the first widget of a specific type (by constructor).
+     * Returns null instead of throwing when nothing matches.
+     */
+    queryByType<T extends Widget>(type: new (...args: any[]) => T): T | null;
+
+    /**
      * Simulate a key press event. This dispatches to useInput handlers.
      */
     fireKey(key: string, modifiers?: { ctrl?: boolean; shift?: boolean; alt?: boolean }): void;
@@ -277,6 +289,21 @@ export function render(element: VNode, options: TestRenderOptions = {}): TestIns
 
         getAllByType<T extends Widget>(type: new (...args: any[]) => T): T[] {
             return walkWidgets(container, (w) => w instanceof type) as T[];
+        },
+
+        queryByText(text: string): Widget | null {
+            const matches = walkWidgets(container, (w) => {
+                if (w instanceof Text) {
+                    return getTextContent(w).includes(text);
+                }
+                return false;
+            });
+            return matches.length > 0 ? matches[0] : null;
+        },
+
+        queryByType<T extends Widget>(type: new (...args: any[]) => T): T | null {
+            const matches = walkWidgets(container, (w) => w instanceof type) as T[];
+            return matches.length > 0 ? matches[0] : null;
         },
 
         fireKey(key: string, modifiers?: { ctrl?: boolean; shift?: boolean; alt?: boolean }): void {


### PR DESCRIPTION
Closes #506
Closes #505

## What I did
Added two features to `packages/testing` as specified in the issues.

## Changes
- `packages/testing/src/frame-serializer.ts` — new file implementing `frameSerializer` and `formatFrame`
- `packages/testing/src/frame-serializer.test.ts` — 10 tests covering all acceptance criteria  
- `packages/testing/src/render.ts` — added `queryByText` and `queryByType` to `TestInstance`
- `packages/testing/src/render.test.tsx` — 6 new tests for query helpers
- `packages/testing/src/index.ts` — exported `frameSerializer` and `formatFrame`

## Test results
- ✅ frame-serializer.test.ts (10 passed)
- ✅ render.test.tsx (22 passed)
- ✅ virtual-clock.test.ts (13 passed)
- ✅ bun run typecheck — all packages pass

## Checklist
- [x] Change confined to `packages/testing` only
- [x] `bun.lock` has no unrelated changes
- [x] All tests pass
- [x] Repo starred ⭐

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Testing renderer gains non-throwing search helpers to find text or widget types in the rendered tree.
  * Frame-formatting utilities and a snapshot serializer added to produce consistent, bordered frame output.

* **Tests**
  * New tests cover search helpers and frame formatting/serialization: empty cases, input validation, padding/width normalization, deterministic output, and serializer registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->