### PR TITLE
feat(store): add store reset to initial state

### DIFF
--- a/packages/store/src/reset.test.ts
+++ b/packages/store/src/reset.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createStore } from './store.js';
+
+describe('store reset', () => {
+    it('getInitialState returns the creation snapshot', () => {
+        const useStore = createStore(() => ({
+            count: 0,
+        }));
+
+        useStore.setState({ count: 10 });
+
+        expect(useStore.getInitialState()).toEqual({
+            count: 0,
+        });
+    });
+
+    it('reset restores changed values', () => {
+        const useStore = createStore(() => ({
+            count: 0,
+        }));
+
+        useStore.setState({ count: 20 });
+
+        expect(useStore.getState().count).toBe(20);
+
+        useStore.reset();
+
+        expect(useStore.getState().count).toBe(0);
+    });
+
+    it('reset keeps action functions callable', () => {
+        interface CounterStore {
+            count: number;
+            increment: () => void;
+        }
+
+        const useStore = createStore<CounterStore>((set) => ({
+            count: 0,
+            increment: () =>
+                set((s) => ({
+                    count: s.count + 1,
+                })),
+        }));
+
+        useStore.getState().increment();
+
+        expect(useStore.getState().count).toBe(1);
+
+        useStore.reset();
+
+        useStore.getState().increment();
+
+        expect(useStore.getState().count).toBe(1);
+    });
+
+    it('getInitialState returns a safe copy', () => {
+        const useStore = createStore(() => ({
+            count: 0,
+        }));
+    
+        const initial = useStore.getInitialState();
+    
+        initial.count = 999;
+    
+        expect(useStore.getInitialState()).toEqual({
+            count: 0,
+        });
+    
+        expect(useStore.getState().count).toBe(0);
+    });
+
+    it('reset notifies subscribers once', () => {
+        const useStore = createStore(() => ({
+            count: 0,
+        }));
+
+        const listener = vi.fn();
+
+        useStore.subscribe(listener);
+
+        useStore.setState({ count: 5 });
+
+        listener.mockClear();
+
+        useStore.reset();
+
+        expect(listener).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -137,6 +137,11 @@ export interface Store<T> {
     destroy(): void;
     /** Create a memoized selector — subscribers are notified only when the derived value changes */
     computed<U>(selector: Selector<T, U>): Computed<U>;
+    /** Restore state to the value captured at creation */
+    reset(): void;
+    
+    /** Read the state captured at creation */
+    getInitialState(): T;
 }
 
 // ── Store Implementation ──
@@ -314,6 +319,23 @@ export function createStore<T extends object>(
     state = typeof creator === 'function'
         ? (creator as StateCreator<T>)(setState, getState)
         : { ...(creator as any) } as T;
+    
+    // Capture initial state BEFORE persist rehydration
+    const initialState = structuredClone(
+        Object.fromEntries(
+            Object.entries(state).filter(
+                ([, value]) => typeof value !== 'function',
+            ),
+        ),
+    ) as Partial<T>;
+    
+    const getInitialState = (): T => {
+        return structuredClone(initialState) as T;
+    };
+    
+    const reset = (): void => {
+        setState(structuredClone(initialState) as Partial<T>);
+    };
 
     // Rehydrate saved state if persist file exists
     if (persistFilePath) {
@@ -354,7 +376,7 @@ export function createStore<T extends object>(
         };
     };
 
-    const store: Store<T> = { getState, setState, subscribe, destroy, computed };
+    const store: Store<T> = { getState, setState, subscribe, destroy, computed, reset, getInitialState };
 
     // Create the hook function
     function useStore(): T;
@@ -384,6 +406,8 @@ export function createStore<T extends object>(
     (useStore as any).subscribe = subscribe;
     (useStore as any).destroy = destroy;
     (useStore as any).computed = computed;
+    (useStore as any).reset = reset;
+    (useStore as any).getInitialState = getInitialState;
 
     return useStore as UseStore<T>;
 }
@@ -398,4 +422,6 @@ export interface UseStore<T> {
     subscribe(listener: Listener<T>): () => void;
     destroy(): void;
     computed<U>(selector: Selector<T, U>): Computed<U>;
+    reset(): void;
+    getInitialState(): T;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

Adds support for reset() and getInitialState() in @termuijs/store.
The store now captures an immutable snapshot of its initial state immediately after creation and before persistence rehydration. reset() restores state using the existing update pipeline, preserving action functions and subscriber notifications.

<!-- What does this PR do? 1 to 3 sentences. -->

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #490 

## Which package(s)?

<!-- Example: @termuijs/core, @termuijs/widgets, website. -->

## Type of Change
@termuijs/store
<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)
N/A (store feature and tests only)
<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

- Added reset() and getInitialState() to Store<T> and UseStore<T>
- Captured initial state before persistence rehydration
- Reused setState() for reset behavior to preserve notifications and persistence handling
- Preserved action functions after reset
- Added tests covering:
- creation snapshot retrieval
- state restoration
- action preservation
- subscriber notifications
- safe-copy behavior

**Verification:**

- bun vitest run packages/store
- bun run typecheck

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Store API now includes `reset()` method to restore all state values back to their initial state
  * Store API now includes `getInitialState()` method to safely retrieve a snapshot of the initial state

* **Tests**
  * Added comprehensive test suite for store reset functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->