### PR TITLE
feat(ui): add ScalePrompt widget

### DIFF
--- a/packages/ui/src/ScalePrompt.test.ts
+++ b/packages/ui/src/ScalePrompt.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Screen, createKeyEvent } from '@termuijs/core';
+import { ScalePrompt } from './ScalePrompt.js';
+
+function renderScalePrompt(prompt: ScalePrompt, width = 40, height = 3): Screen {
+    const screen = new Screen(width, height);
+
+    prompt.updateRect({
+        x: 0,
+        y: 0,
+        width,
+        height,
+    });
+
+    prompt.render(screen);
+
+    return screen;
+}
+
+describe('ScalePrompt', () => {
+    it('renders default 5 numbers', () => {
+        const prompt = new ScalePrompt();
+        const screen = renderScalePrompt(prompt);
+
+        const rendered = screen.back[0].map((cell) => cell.char).join('');
+
+        expect(rendered).toContain('[1]');
+        expect(rendered).toContain('2');
+        expect(rendered).toContain('3');
+        expect(rendered).toContain('4');
+        expect(rendered).toContain('5');
+    });
+
+    it('right key moves active right', () => {
+        const prompt = new ScalePrompt();
+
+        prompt.handleKey(createKeyEvent({
+            key: 'right',
+            ctrl: false,
+            alt: false,
+            shift: false,
+            raw: Buffer.from('right'),
+        }));
+
+        expect(prompt.getValue()).toBe(2);
+
+        const screen = renderScalePrompt(prompt);
+        const rendered = screen.back[0].map((cell) => cell.char).join('');
+
+        expect(rendered).toContain('1 [2] 3 4 5');
+    });
+
+    it('left key does not go below 1', () => {
+        const prompt = new ScalePrompt();
+
+        prompt.handleKey(createKeyEvent({
+            key: 'left',
+            ctrl: false,
+            alt: false,
+            shift: false,
+            raw: Buffer.from('left'),
+        }));
+
+        expect(prompt.getValue()).toBe(1);
+
+        const screen = renderScalePrompt(prompt);
+        const rendered = screen.back[0].map((cell) => cell.char).join('');
+
+        expect(rendered).toContain('[1]');
+    });
+
+    it('enter fires onSelect with current value', () => {
+        const onSelect = vi.fn();
+        const prompt = new ScalePrompt(undefined, { onSelect, max: 5 });
+
+        prompt.handleKey(createKeyEvent({
+            key: 'right',
+            ctrl: false,
+            alt: false,
+            shift: false,
+            raw: Buffer.from('right'),
+        }));
+        prompt.handleKey(createKeyEvent({
+            key: 'right',
+            ctrl: false,
+            alt: false,
+            shift: false,
+            raw: Buffer.from('right'),
+        }));
+        prompt.handleKey(createKeyEvent({
+            key: 'enter',
+            ctrl: false,
+            alt: false,
+            shift: false,
+            raw: Buffer.from('enter'),
+        }));
+
+        expect(onSelect).toHaveBeenCalledTimes(1);
+        expect(onSelect).toHaveBeenCalledWith(3);
+    });
+});

--- a/packages/ui/src/ScalePrompt.ts
+++ b/packages/ui/src/ScalePrompt.ts
@@ -1,0 +1,101 @@
+import { Widget } from '@termuijs/widgets';
+import { type Color, type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs } from '@termuijs/core';
+
+export interface ScalePromptOptions {
+    max?: number;
+    question?: string;
+    endLabels?: [string, string];
+    activeColor?: Color;
+    onSelect?: (value: number) => void;
+}
+
+export class ScalePrompt extends Widget {
+    private _max: number;
+    private _value: number;
+    private _question?: string;
+    private _endLabels?: [string, string];
+    private _activeColor: Color;
+    private _onSelect?: (value: number) => void;
+
+    focusable = true;
+
+    constructor(style?: Partial<Style>, opts: ScalePromptOptions = {}) {
+        super(mergeStyles(defaultStyle(), { height: 3, flexGrow: 1, ...style }));
+
+        this._max = Math.max(1, Math.floor(opts.max ?? 5));
+        this._value = 1;
+        this._question = opts.question;
+        this._endLabels = opts.endLabels;
+        this._activeColor = opts.activeColor ?? { type: 'named', name: 'cyan' };
+        this._onSelect = opts.onSelect;
+    }
+
+    getValue(): number {
+        return this._value;
+    }
+
+    private _setValue(value: number): void {
+        const nextValue = Math.max(1, Math.min(this._max, value));
+
+        if (nextValue === this._value) return;
+
+        this._value = nextValue;
+        this.markDirty();
+    }
+
+    handleKey(event: KeyEvent): void {
+        switch (event.key) {
+            case 'left':
+                this._setValue(this._value - 1);
+                break;
+
+            case 'right':
+                this._setValue(this._value + 1);
+                break;
+
+            case 'enter':
+                this._onSelect?.(this._value);
+                break;
+        }
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width, height } = this._rect;
+
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this.style);
+        let row = 0;
+
+        if (this._question) {
+            screen.writeString(x, y + row, this._question.slice(0, width), attrs);
+            row++;
+        }
+
+        if (row < height) {
+            const numbers: string[] = [];
+
+            for (let i = 1; i <= this._max; i++) {
+                numbers.push(i === this._value ? `[${i}]` : String(i));
+            }
+
+            screen.writeString(
+                x,
+                y + row,
+                numbers.join(' ').slice(0, width),
+                { ...attrs, fg: this._activeColor }
+            );
+            row++;
+        }
+
+        if (row < height && this._endLabels) {
+            const [leftLabel, rightLabel] = this._endLabels;
+            const leftText = leftLabel.slice(0, width);
+            const rightText = rightLabel.slice(0, width);
+            const rightX = x + Math.max(0, width - rightText.length);
+
+            screen.writeString(x, y + row, leftText, attrs);
+            screen.writeString(rightX, y + row, rightText, attrs);
+        }
+    }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -117,6 +117,9 @@ export type { AppShellOptions } from './AppShell.js';
 export { Pagination } from './Pagination.js';
 export type { PaginationOptions } from './Pagination.js';
 
+export { ScalePrompt } from './ScalePrompt.js';
+export type { ScalePromptOptions } from './ScalePrompt.js';
+
 export { SearchableSelect } from './SearchableSelect.js';
 export { Toggle } from './Toggle.js';
 export type { ToggleOptions } from './Toggle.js';


### PR DESCRIPTION
## Summary

Adds a new `ScalePrompt` widget to `@termuijs/ui`.

The widget renders a Likert-style scale with keyboard navigation and selection support.

## Features

* configurable scale size
* active value highlighting
* left/right keyboard navigation
* clamped selection bounds
* enter-to-select behavior
* optional endpoint labels

## Changes Made

* Added `packages/ui/src/ScalePrompt.ts`
* Added `packages/ui/src/ScalePrompt.test.ts`
* Exported `ScalePrompt` from `packages/ui/src/index.ts`

## Validation

Verified with:

```bash id="x8m3qt"
bun vitest run packages/ui
bun run typecheck
```

All tests pass successfully.

Closes #259


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a ScalePrompt component for interactive scale selection via keyboard (defaults to 1–5, configurable max). Optionally shows a question line, end labels, and active-color styling; exposes a method to read the current value and invokes a selection callback.

* **Tests**
  * Added tests covering rendering, keyboard navigation, boundary behavior, and selection callback invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->