### PR TITLE
feat(ui): add TreeSelect widget with single and multi selection (closes #483)

### DIFF
--- a/packages/ui/src/TreeSelect.test.ts
+++ b/packages/ui/src/TreeSelect.test.ts
@@ -1,0 +1,99 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/ui — Tests for TreeSelect component
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Screen, caps } from '@termuijs/core';
+import { TreeSelect } from './TreeSelect.js';
+
+const ROOTS = [
+    {
+        label: 'src',
+        value: 's',
+        expanded: true,
+        children: [
+            { label: 'a.ts', value: 'a' },
+            { label: 'b.ts', value: 'b' },
+        ],
+    },
+    { label: 'lib', value: 'l' },
+];
+
+describe('TreeSelect', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('down moves cursor and renders highlight', () => {
+        const screen = new Screen(30, 6);
+        const ts = new TreeSelect(ROOTS);
+        ts.updateRect({ x: 0, y: 0, width: 30, height: 6 });
+
+        ts.handleKey({ key: 'down' } as any);
+        ts.render(screen);
+
+        expect(screen.back[1].some(cell => cell.bold)).toBe(true);
+        expect(screen.back[0].some(cell => cell.bold)).toBe(false);
+    });
+
+    it('space selects cursor node', () => {
+        const screen = new Screen(30, 6);
+        const ts = new TreeSelect(ROOTS);
+        ts.updateRect({ x: 0, y: 0, width: 30, height: 6 });
+
+        ts.handleKey({ key: 'space' } as any);
+        expect(ts.selectedValues).toEqual(['s']);
+    });
+
+    it('single mode replaces prior selection', () => {
+        const ts = new TreeSelect(ROOTS, { multiple: false });
+
+        ts.handleKey({ key: 'space' } as any);
+        expect(ts.selectedValues).toEqual(['s']);
+
+        ts.handleKey({ key: 'down' } as any);
+        ts.handleKey({ key: 'space' } as any);
+        expect(ts.selectedValues).toEqual(['a']);
+    });
+
+    it('multi mode accumulates selections', () => {
+        const ts = new TreeSelect(ROOTS, { multiple: true });
+
+        ts.handleKey({ key: 'space' } as any);
+        ts.handleKey({ key: 'down' } as any);
+        ts.handleKey({ key: 'space' } as any);
+
+        expect(ts.selectedValues).toContain('s');
+        expect(ts.selectedValues).toContain('a');
+        expect(ts.selectedValues).toHaveLength(2);
+    });
+
+    it('ASCII fallback markers render when caps.unicode is false', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+
+        const screen = new Screen(30, 6);
+        const ts = new TreeSelect(ROOTS);
+        ts.updateRect({ x: 0, y: 0, width: 30, height: 6 });
+
+        ts.handleKey({ key: 'space' } as any);
+        ts.render(screen);
+
+        const rendered = screen.back
+            .map(row => row.map(cell => cell.char).join(''))
+            .join('\n');
+
+        expect(rendered).toContain('v ');
+        expect(rendered).toContain('* ');
+        expect(rendered).toContain('o ');
+    });
+
+    it('navigates nested nodes with down and space in multi mode', () => {
+        const roots = [{ label: 'src', value: 's', expanded: true, children: [{ label: 'a.ts', value: 'a' }] }];
+        const screen = new Screen(30, 6);
+        const ts = new TreeSelect(roots, { multiple: true });
+        ts.updateRect({ x: 0, y: 0, width: 30, height: 6 });
+        ts.handleKey({ key: 'down' } as any);
+        ts.handleKey({ key: 'space' } as any);
+        expect(ts.selectedValues).toContain('a');
+    });
+});

--- a/packages/ui/src/TreeSelect.test.ts
+++ b/packages/ui/src/TreeSelect.test.ts
@@ -6,6 +6,11 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { Screen, caps } from '@termuijs/core';
 import { TreeSelect } from './TreeSelect.js';
 
+// KeyEvent stub — tests only need the `key` field; cast avoids importing the full KeyEvent type
+function key(k: string) {
+    return { key: k } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+}
+
 const ROOTS = [
     {
         label: 'src',
@@ -29,7 +34,7 @@ describe('TreeSelect', () => {
         const ts = new TreeSelect(ROOTS);
         ts.updateRect({ x: 0, y: 0, width: 30, height: 6 });
 
-        ts.handleKey({ key: 'down' } as any);
+        ts.handleKey(key('down'));
         ts.render(screen);
 
         expect(screen.back[1].some(cell => cell.bold)).toBe(true);
@@ -41,27 +46,27 @@ describe('TreeSelect', () => {
         const ts = new TreeSelect(ROOTS);
         ts.updateRect({ x: 0, y: 0, width: 30, height: 6 });
 
-        ts.handleKey({ key: 'space' } as any);
+        ts.handleKey(key('space'));
         expect(ts.selectedValues).toEqual(['s']);
     });
 
     it('single mode replaces prior selection', () => {
         const ts = new TreeSelect(ROOTS, { multiple: false });
 
-        ts.handleKey({ key: 'space' } as any);
+        ts.handleKey(key('space'));
         expect(ts.selectedValues).toEqual(['s']);
 
-        ts.handleKey({ key: 'down' } as any);
-        ts.handleKey({ key: 'space' } as any);
+        ts.handleKey(key('down'));
+        ts.handleKey(key('space'));
         expect(ts.selectedValues).toEqual(['a']);
     });
 
     it('multi mode accumulates selections', () => {
         const ts = new TreeSelect(ROOTS, { multiple: true });
 
-        ts.handleKey({ key: 'space' } as any);
-        ts.handleKey({ key: 'down' } as any);
-        ts.handleKey({ key: 'space' } as any);
+        ts.handleKey(key('space'));
+        ts.handleKey(key('down'));
+        ts.handleKey(key('space'));
 
         expect(ts.selectedValues).toContain('s');
         expect(ts.selectedValues).toContain('a');
@@ -75,7 +80,7 @@ describe('TreeSelect', () => {
         const ts = new TreeSelect(ROOTS);
         ts.updateRect({ x: 0, y: 0, width: 30, height: 6 });
 
-        ts.handleKey({ key: 'space' } as any);
+        ts.handleKey(key('space'));
         ts.render(screen);
 
         const rendered = screen.back
@@ -92,8 +97,8 @@ describe('TreeSelect', () => {
         const screen = new Screen(30, 6);
         const ts = new TreeSelect(roots, { multiple: true });
         ts.updateRect({ x: 0, y: 0, width: 30, height: 6 });
-        ts.handleKey({ key: 'down' } as any);
-        ts.handleKey({ key: 'space' } as any);
+        ts.handleKey(key('down'));
+        ts.handleKey(key('space'));
         expect(ts.selectedValues).toContain('a');
     });
 });

--- a/packages/ui/src/TreeSelect.ts
+++ b/packages/ui/src/TreeSelect.ts
@@ -1,0 +1,191 @@
+// TreeSelect — expandable tree with single or multi selection
+import { Widget } from '@termuijs/widgets';
+import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, caps } from '@termuijs/core';
+
+export interface TreeSelectNode {
+    label: string;
+    value: string;
+    children?: TreeSelectNode[];
+    expanded?: boolean;
+}
+
+export interface TreeSelectOptions {
+    multiple?: boolean;
+    activeColor?: Style['fg'];
+    onChange?: (values: string[]) => void;
+}
+
+export class TreeSelect extends Widget {
+    private _roots: TreeSelectNode[];
+    private _cursorIndex = 0;
+    private _selected = new Set<string>();
+    private _multiple: boolean;
+    private _activeColor: Style['fg'];
+    private _onChange?: (values: string[]) => void;
+    focusable = true;
+
+    constructor(roots: TreeSelectNode[], options: TreeSelectOptions = {}) {
+        super(mergeStyles(defaultStyle(), { flexGrow: 1 }));
+        this._roots = roots;
+        this._multiple = options.multiple ?? false;
+        this._activeColor = options.activeColor ?? { type: 'named', name: 'cyan' };
+        this._onChange = options.onChange;
+    }
+
+    get selectedValues(): string[] {
+        return [...this._selected];
+    }
+
+    private _flatten(): { node: TreeSelectNode; depth: number; path: number[]; hasChildren: boolean }[] {
+        const result: { node: TreeSelectNode; depth: number; path: number[]; hasChildren: boolean }[] = [];
+        const walk = (nodes: TreeSelectNode[], depth: number, path: number[]) => {
+            for (let i = 0; i < nodes.length; i++) {
+                const node = nodes[i];
+                const hasChildren = (node.children?.length ?? 0) > 0;
+                result.push({ node, depth, path: [...path, i], hasChildren });
+                if (hasChildren && node.expanded) walk(node.children!, depth + 1, [...path, i]);
+            }
+        };
+        walk(this._roots, 0, []);
+        return result;
+    }
+
+    selectNext(): void {
+        const f = this._flatten();
+        if (this._cursorIndex < f.length - 1) {
+            this._cursorIndex++;
+            this.markDirty();
+        }
+    }
+
+    selectPrev(): void {
+        if (this._cursorIndex > 0) {
+            this._cursorIndex--;
+            this.markDirty();
+        }
+    }
+
+    expand(): void {
+        const f = this._flatten();
+        const it = f[this._cursorIndex];
+        if (it?.hasChildren && !it.node.expanded) {
+            it.node.expanded = true;
+            this.markDirty();
+        }
+    }
+
+    collapse(): void {
+        const f = this._flatten();
+        const it = f[this._cursorIndex];
+        if (!it) return;
+
+        if (it.hasChildren && it.node.expanded) {
+            it.node.expanded = false;
+            this.markDirty();
+            return;
+        }
+
+        if (it.depth > 0) {
+            const parentPath = it.path.slice(0, -1);
+            const parentIdx = f.findIndex(entry => _pathsEqual(entry.path, parentPath));
+            if (parentIdx >= 0) {
+                this._cursorIndex = parentIdx;
+                this.markDirty();
+            }
+        }
+    }
+
+    toggleSelection(): void {
+        const f = this._flatten();
+        const it = f[this._cursorIndex];
+        if (!it) return;
+
+        const value = it.node.value;
+        const previous = this.selectedValues;
+
+        if (this._multiple) {
+            if (this._selected.has(value)) {
+                this._selected.delete(value);
+            } else {
+                this._selected.add(value);
+            }
+        } else if (this._selected.has(value)) {
+            this._selected.clear();
+        } else {
+            this._selected.clear();
+            this._selected.add(value);
+        }
+
+        this.markDirty();
+        const next = this.selectedValues;
+        if (!_valuesEqual(previous, next)) {
+            this._onChange?.(next);
+        }
+    }
+
+    handleKey(event: KeyEvent): void {
+        switch (event.key) {
+            case 'down':
+                this.selectNext();
+                break;
+            case 'up':
+                this.selectPrev();
+                break;
+            case 'right':
+                this.expand();
+                break;
+            case 'left':
+                this.collapse();
+                break;
+            case 'space':
+                this.toggleSelection();
+                break;
+        }
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width, height } = this._rect;
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this.style);
+        const flat = this._flatten();
+        const expandCollapsed = caps.unicode ? '▶ ' : '> ';
+        const expandExpanded = caps.unicode ? '▼ ' : 'v ';
+        const selectedMarker = caps.unicode ? '● ' : '* ';
+        const unselectedMarker = caps.unicode ? '○ ' : 'o ';
+
+        for (let i = 0; i < flat.length && i < height; i++) {
+            const it = flat[i];
+            const active = i === this._cursorIndex;
+            const indent = '  '.repeat(it.depth);
+            const expandIcon = it.hasChildren
+                ? (it.node.expanded ? expandExpanded : expandCollapsed)
+                : '  ';
+            const selectIcon = this._selected.has(it.node.value) ? selectedMarker : unselectedMarker;
+            const line = `${indent}${expandIcon}${selectIcon}${it.node.label}`;
+            screen.writeString(x, y + i, line.slice(0, width), {
+                ...attrs,
+                fg: active ? this._activeColor : attrs.fg,
+                bold: active,
+            });
+        }
+    }
+}
+
+function _pathsEqual(a: number[], b: number[]): boolean {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i]) return false;
+    }
+    return true;
+}
+
+function _valuesEqual(a: string[], b: string[]): boolean {
+    if (a.length !== b.length) return false;
+    const sortedA = [...a].sort();
+    const sortedB = [...b].sort();
+    for (let i = 0; i < sortedA.length; i++) {
+        if (sortedA[i] !== sortedB[i]) return false;
+    }
+    return true;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -158,3 +158,6 @@ export { RadioGroup } from './RadioGroup.js';
 export type { RadioGroupOption, RadioGroupOptions } from './RadioGroup.js';
 export { ThemeSwitcher } from './ThemeSwitcher.js';
 export type { ThemeSwitcherOptions } from './ThemeSwitcher.js';
+
+export { TreeSelect } from './TreeSelect.js';
+export type { TreeSelectNode, TreeSelectOptions } from './TreeSelect.js';


### PR DESCRIPTION
## Summary
Implements the `TreeSelect` widget for `@termuijs/ui` per the full spec in issue #483.

## Changes
- **`packages/ui/src/TreeSelect.ts`** — new widget extending `Widget`
- **`packages/ui/src/TreeSelect.test.ts`** — 6 test cases covering all acceptance criteria
- **`packages/ui/src/index.ts`** — exports `TreeSelect`, `TreeSelectNode`, `TreeSelectOptions`

## Behavior
- `up`/`down` move cursor through visible nodes
- `left`/`right` collapse/expand parent nodes
- `space` toggles selection — single mode replaces, multi mode accumulates
- `caps.unicode` markers with ASCII fallbacks: `▶`/`>`, `▼`/`v`, `●`/`*`, `○`/`o`
- `markDirty()` called on cursor, expand/collapse, and selection changes
- `selectedValues` getter and `onChange` callback on selection change
- `focusable = true`

## Tests (6)
1. Down moves cursor and renders highlight
2. Space selects cursor node
3. Single mode replaces prior selection
4. Multi mode accumulates selections
5. ASCII fallback markers render when `caps.unicode` is false
6. Nested navigation using exact import pattern from spec

## Verification
- `bun vitest run packages/ui` — 172 passed (26 files)
- `bun run typecheck` — passed
- `bun.lock` — unchanged

Closes #483

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TreeSelect — an interactive, keyboard-navigable tree list with expandable nodes, depth-aware rendering, and configurable single- or multi-selection; exposes current selected values and invokes change callbacks only on real changes.

* **Tests**
  * Added a test suite validating keyboard navigation, selection semantics for single vs. multi modes, nested selection, Unicode vs ASCII rendering fallbacks, and mock cleanup after each test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->