### PR TITLE
feat(widgets): add AreaChart widget

### DIFF
--- a/packages/widgets/src/data/AreaChart.test.ts
+++ b/packages/widgets/src/data/AreaChart.test.ts
@@ -1,0 +1,65 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for AreaChart widget
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { caps, Screen } from '@termuijs/core';
+import { AreaChart } from './AreaChart.js';
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+function renderAreaChart(
+    data: number[],
+    opts: import('./AreaChart.js').AreaChartOptions = {},
+    cols = 40,
+    rows = 10,
+): Screen {
+    const widget = new AreaChart({}, opts);
+    widget.setData(data);
+    const screen = new Screen(cols, rows);
+    widget.updateRect({ x: 0, y: 0, width: cols, height: rows });
+    widget.render(screen);
+    return screen;
+}
+
+function countCharInGrid(screen: Screen, ch: string): number {
+    let total = 0;
+    for (const row of screen.back) {
+        for (const cell of row) {
+            if (cell.char === ch) total++;
+        }
+    }
+    return total;
+}
+
+describe('AreaChart', () => {
+    it('renders without error for 3-value dataset', () => {
+        expect(() => renderAreaChart([10, 50, 90], {}, 20, 8)).not.toThrow();
+    });
+
+    it('empty dataset renders safely', () => {
+        const screen = renderAreaChart([], {}, 20, 8);
+        const total = screen.back.reduce((acc, row) => acc + row.filter((cell) => cell.char !== ' ').length, 0);
+        expect(total).toBe(0);
+    });
+
+    it('setData triggers markDirty', () => {
+        const widget = new AreaChart();
+        widget.clearDirty();
+
+        widget.setData([10, 20, 30]);
+
+        expect(widget.isDirty).toBe(true);
+    });
+
+    it('uses # in ASCII fallback when caps.unicode is false', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+
+        const screen = renderAreaChart([10, 50, 90], {}, 20, 8);
+
+        expect(countCharInGrid(screen, '#')).toBeGreaterThan(0);
+        expect(screen.back.flat().some((cell) => /[⠁-⣿]/.test(cell.char))).toBe(false);
+    });
+});

--- a/packages/widgets/src/data/AreaChart.ts
+++ b/packages/widgets/src/data/AreaChart.ts
@@ -1,0 +1,209 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — AreaChart widget
+// ─────────────────────────────────────────────────────
+
+import { type Screen, type Style, type Color, styleToCellAttrs, caps, stringWidth, BRAILLE_DOTS, BRAILLE_OFFSET } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export interface AreaChartOptions {
+    xLabel?: string;
+    yLabel?: string;
+    lineColor?: Color;
+    fillColor?: Color;
+    showLine?: boolean;
+}
+
+type CanvasLayer = 'fill' | 'line';
+
+interface BrailleCell {
+    fillBits: number;
+    lineBits: number;
+}
+
+class BrailleCanvas {
+    private _cellWidth: number;
+    private _cellHeight: number;
+    private _cells: BrailleCell[];
+
+    constructor(width: number, height: number) {
+        this._cellWidth = Math.max(1, Math.ceil(width / 2));
+        this._cellHeight = Math.max(1, Math.ceil(height / 4));
+        this._cells = Array.from({ length: this._cellWidth * this._cellHeight }, () => ({
+            fillBits: 0,
+            lineBits: 0,
+        }));
+    }
+
+    drawPixel(x: number, y: number, layer: CanvasLayer = 'fill'): void {
+        if (x < 0 || y < 0) return;
+
+        const cellX = Math.floor(x / 2);
+        const cellY = Math.floor(y / 4);
+        if (cellX < 0 || cellY < 0 || cellX >= this._cellWidth || cellY >= this._cellHeight) return;
+
+        const dotRow = y % 4;
+        const dotCol = x % 2;
+        const dotBits = BRAILLE_DOTS[dotRow];
+        if (!dotBits) return;
+
+        const bit = dotCol === 0 ? dotBits[0] : dotBits[1];
+        const cell = this._cells[cellY * this._cellWidth + cellX];
+        if (!cell) return;
+
+        if (layer === 'line') {
+            cell.lineBits |= bit;
+        } else {
+            cell.fillBits |= bit;
+        }
+    }
+
+    drawLine(x0: number, y0: number, x1: number, y1: number, layer: CanvasLayer = 'line'): void {
+        let cx = x0;
+        let cy = y0;
+        const dx = Math.abs(x1 - x0);
+        const dy = Math.abs(y1 - y0);
+        const sx = x0 < x1 ? 1 : -1;
+        const sy = y0 < y1 ? 1 : -1;
+        let err = dx - dy;
+
+        while (true) {
+            this.drawPixel(cx, cy, layer);
+            if (cx === x1 && cy === y1) break;
+
+            const e2 = err * 2;
+            if (e2 > -dy) {
+                err -= dy;
+                cx += sx;
+            }
+            if (e2 < dx) {
+                err += dx;
+                cy += sy;
+            }
+        }
+    }
+
+    render(
+        screen: Screen,
+        x: number,
+        y: number,
+        fillColor: Color,
+        lineColor: Color,
+        attrs: ReturnType<typeof styleToCellAttrs>,
+        asciiFallback: boolean,
+    ): void {
+        for (let cy = 0; cy < this._cellHeight; cy++) {
+            for (let cx = 0; cx < this._cellWidth; cx++) {
+                const cell = this._cells[cy * this._cellWidth + cx];
+                if (!cell) continue;
+
+                const unionBits = cell.fillBits | cell.lineBits;
+                if (unionBits === 0) continue;
+
+                const char = asciiFallback
+                    ? '#'
+                    : String.fromCharCode(BRAILLE_OFFSET + unionBits);
+
+                const fg = cell.lineBits !== 0 ? lineColor : fillColor;
+                screen.setCell(x + cx, y + cy, { char, ...attrs, fg });
+            }
+        }
+    }
+}
+
+export class AreaChart extends Widget {
+    private _data: number[] = [];
+    private _xLabel: string;
+    private _yLabel: string;
+    private _lineColor: Color;
+    private _fillColor: Color;
+    private _showLine: boolean;
+
+    constructor(style: Partial<Style> = {}, opts: AreaChartOptions = {}) {
+        super(style);
+        this._xLabel = opts.xLabel ?? '';
+        this._yLabel = opts.yLabel ?? '';
+        this._lineColor = opts.lineColor ?? { type: 'named', name: 'cyan' };
+        this._fillColor = opts.fillColor ?? { type: 'named', name: 'brightBlack' };
+        this._showLine = opts.showLine ?? true;
+    }
+
+    setData(values: number[]): void {
+        this._data = values;
+        this.markDirty();
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const rect = this._getContentRect();
+        const { x, y, width, height } = rect;
+
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this._style);
+        const topLabelRows = this._yLabel ? 1 : 0;
+        const bottomLabelRows = this._xLabel ? 1 : 0;
+        const plotY = y + topLabelRows;
+        const plotHeight = height - topLabelRows - bottomLabelRows;
+
+        if (this._yLabel) {
+            screen.writeString(x, y, this._yLabel.slice(0, width), attrs);
+        }
+
+        if (this._xLabel) {
+            const labelWidth = stringWidth(this._xLabel);
+            const labelX = x + Math.max(0, width - labelWidth);
+            screen.writeString(labelX, y + height - 1, this._xLabel.slice(0, width), attrs);
+        }
+
+        if (plotHeight <= 0 || this._data.length === 0) return;
+
+        const min = Math.min(...this._data);
+        const max = Math.max(...this._data);
+        const range = max - min || 1;
+
+        const pixelWidth = width * 2;
+        const pixelHeight = plotHeight * 4;
+        const fillCanvas = new BrailleCanvas(pixelWidth, pixelHeight);
+        const lineCanvas = new BrailleCanvas(pixelWidth, pixelHeight);
+
+        const sampleValueAt = (pixelX: number): number => {
+            if (this._data.length === 1) return this._data[0] ?? min;
+
+            const position = (pixelX / Math.max(1, pixelWidth - 1)) * (this._data.length - 1);
+            const leftIndex = Math.floor(position);
+            const rightIndex = Math.min(this._data.length - 1, leftIndex + 1);
+            const t = position - leftIndex;
+            const left = this._data[leftIndex] ?? min;
+            const right = this._data[rightIndex] ?? left;
+            return left + (right - left) * t;
+        };
+
+        let previousX: number | null = null;
+        let previousY: number | null = null;
+
+        for (let pixelX = 0; pixelX < pixelWidth; pixelX++) {
+            const value = sampleValueAt(pixelX);
+            const normalized = (value - min) / range;
+            const lineY = Math.max(0, Math.min(pixelHeight - 1, Math.round((1 - normalized) * (pixelHeight - 1))));
+
+            for (let pixelY = lineY; pixelY < pixelHeight; pixelY++) {
+                fillCanvas.drawPixel(pixelX, pixelY, 'fill');
+            }
+
+            if (this._showLine) {
+                if (previousX !== null && previousY !== null) {
+                    lineCanvas.drawLine(previousX, previousY, pixelX, lineY, 'line');
+                } else {
+                    lineCanvas.drawPixel(pixelX, lineY, 'line');
+                }
+            }
+
+            previousX = pixelX;
+            previousY = lineY;
+        }
+
+        fillCanvas.render(screen, x, plotY, this._fillColor, this._lineColor, attrs, !caps.unicode);
+        if (this._showLine) {
+            lineCanvas.render(screen, x, plotY, this._fillColor, this._lineColor, attrs, !caps.unicode);
+        }
+    }
+}

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -91,6 +91,8 @@ export { Sidebar } from './data/Sidebar.js';
 export type { SidebarItem, SidebarOptions } from './data/Sidebar.js';
 export { LineChart } from './data/LineChart.js';
 export type { LineChartOptions } from './data/LineChart.js';
+export { AreaChart } from './data/AreaChart.js';
+export type { AreaChartOptions } from './data/AreaChart.js';
 export { HeatMap } from './data/HeatMap.js';
 export type { HeatMapOptions } from './data/HeatMap.js';
 export { Definition } from './data/Definition.js';


### PR DESCRIPTION
## Summary

Adds a new `AreaChart` widget to `@termuijs/widgets`.

The widget renders a line chart with a filled area beneath the line using the repository BrailleCanvas rendering system.

## Features

* line chart rendering
* filled area rendering
* unicode braille rendering
* ASCII fallback support
* configurable colors
* optional line visibility

## Changes Made

* Added `packages/widgets/src/data/AreaChart.ts`
* Added `packages/widgets/src/data/AreaChart.test.ts`
* Exported `AreaChart` from `packages/widgets/src/index.ts`

## Validation

Verified with:

```bash id="x8m3qt"
bun vitest run packages/widgets
bun run typecheck
```

All tests pass successfully.

Closes #244


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced AreaChart widget for displaying numeric data series with customizable fill and line colors, optional line visibility, and configurable x/y axis labels.

* **Tests**
  * Added test coverage for AreaChart widget validating rendering without errors, empty dataset handling, state management updates, and character rendering with both Unicode and ASCII modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->