### PR TITLE
feat: add json-explorer example

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -127,6 +127,18 @@
         "typescript": "^5.9.3",
       },
     },
+    "examples/json-explorer": {
+      "name": "@termuijs/example-json-explorer",
+      "version": "0.1.0",
+      "dependencies": {
+        "@termuijs/core": "workspace:*",
+        "@termuijs/ui": "workspace:*",
+        "@termuijs/widgets": "workspace:*",
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3",
+      },
+    },
     "examples/jsx-dashboard": {
       "name": "@termuijs/example-jsx-dashboard",
       "version": "0.1.0",
@@ -562,9 +574,6 @@
 
     "@termuijs/example-auth-flow": ["@termuijs/example-auth-flow@workspace:examples/auth-flow"],
 
-    "@termuijs/example-cli-wrapper-live": ["@termuijs/example-cli-wrapper-live@workspace:examples/cli-wrapper-live"],
-
-    "@termuijs/example-dashboard": ["@termuijs/example-dashboard@workspace:examples/dashboard"],
     "@termuijs/example-calculator": ["@termuijs/example-calculator@workspace:examples/calculator"],
 
     "@termuijs/example-chat-app": ["@termuijs/example-chat-app@workspace:examples/chat-app"],
@@ -579,9 +588,9 @@
 
     "@termuijs/example-git-client": ["@termuijs/example-git-client@workspace:examples/git-client"],
 
-    "@termuijs/example-jsx-dashboard": ["@termuijs/example-jsx-dashboard@workspace:examples/jsx-dashboard"],
+    "@termuijs/example-json-explorer": ["@termuijs/example-json-explorer@workspace:examples/json-explorer"],
 
-    "@termuijs/example-multi-screen-router": ["@termuijs/example-multi-screen-router@workspace:examples/multi-screen-router"],
+    "@termuijs/example-jsx-dashboard": ["@termuijs/example-jsx-dashboard@workspace:examples/jsx-dashboard"],
 
     "@termuijs/example-kanban": ["@termuijs/example-kanban@workspace:examples/kanban-board"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -127,18 +127,6 @@
         "typescript": "^5.9.3",
       },
     },
-    "examples/json-explorer": {
-      "name": "@termuijs/example-json-explorer",
-      "version": "0.1.0",
-      "dependencies": {
-        "@termuijs/core": "workspace:*",
-        "@termuijs/ui": "workspace:*",
-        "@termuijs/widgets": "workspace:*",
-      },
-      "devDependencies": {
-        "typescript": "^5.9.3",
-      },
-    },
     "examples/jsx-dashboard": {
       "name": "@termuijs/example-jsx-dashboard",
       "version": "0.1.0",
@@ -587,8 +575,6 @@
     "@termuijs/example-forms": ["@termuijs/example-forms@workspace:examples/forms-and-validation"],
 
     "@termuijs/example-git-client": ["@termuijs/example-git-client@workspace:examples/git-client"],
-
-    "@termuijs/example-json-explorer": ["@termuijs/example-json-explorer@workspace:examples/json-explorer"],
 
     "@termuijs/example-jsx-dashboard": ["@termuijs/example-jsx-dashboard@workspace:examples/jsx-dashboard"],
 

--- a/examples/json-explorer/src/index.tsx
+++ b/examples/json-explorer/src/index.tsx
@@ -1,0 +1,177 @@
+// examples/json-explorer/src/index.tsx
+import * as fs from 'node:fs';
+import { App, type KeyEvent } from '@termuijs/core';
+import { Box, Text, Widget, JSONView, ScrollView } from '@termuijs/widgets';
+import { FilePicker } from '@termuijs/ui';
+
+// ---------------------------------------------------------------------------
+// Fallback sample data shown when user dismisses the FilePicker
+// ---------------------------------------------------------------------------
+const SAMPLE_DATA = {
+    name: 'json-explorer',
+    version: '0.1.0',
+    description: 'Browse any JSON file as a collapsible tree',
+    author: {
+        name: 'TermUI contributor',
+        email: 'contributor@example.com',
+    },
+    features: ['collapsible tree', 'scroll support', 'file picker'],
+    stats: {
+        nodes: 42,
+        depth: 5,
+        nullable: null,
+        active: true,
+    },
+    tags: ['terminal', 'json', 'tui'],
+};
+
+// ---------------------------------------------------------------------------
+// App
+// ---------------------------------------------------------------------------
+type AppState = 'picking' | 'browsing';
+
+class JsonExplorerApp extends Widget {
+    private state: AppState = 'picking';
+    private picker: FilePicker;
+    private scrollView: ScrollView;
+    private jsonView: JSONView;
+    private statusBar: Box;
+    private statusText: Text;
+    private titleText: Text;
+    private mainArea: Box;
+
+    constructor() {
+        super({ flexDirection: 'column', flexGrow: 1 });
+
+        // ── Header ──────────────────────────────────────────────────────────
+        const header = new Box({ height: 3, border: 'single' });
+        this.titleText = new Text(
+            '  JSON Explorer  —  pick a .json file to browse',
+            { bold: true, fg: { type: 'named', name: 'cyan' } },
+        );
+        header.addChild(this.titleText);
+
+        // ── Main area: either FilePicker or ScrollView+JSONView ─────────────
+        this.mainArea = new Box({ flexGrow: 1, border: 'single' });
+
+        this.jsonView = new JSONView(SAMPLE_DATA, { flexGrow: 1 });
+        this.scrollView = new ScrollView({ flexGrow: 1 });
+        this.scrollView.addChild(this.jsonView);
+
+        this.picker = new FilePicker({
+            startPath: process.cwd(),
+            filter: (entry) => entry.isDirectory || entry.name.endsWith('.json'),
+        });
+        this.mainArea.addChild(this.picker);   // start in picking state
+
+        // ── Status bar ──────────────────────────────────────────────────────
+        this.statusBar = new Box({ height: 3, border: 'single' });
+        this.statusText = new Text(
+            '  [enter] select file   [esc] use sample data   [q] quit',
+        );
+        this.statusBar.addChild(this.statusText);
+
+        this.addChild(header);
+        this.addChild(this.mainArea);
+        this.addChild(this.statusBar);
+    }
+
+    // ── Switch from FilePicker to JSON tree view ──────────────────────────
+    private showJson(data: unknown, label: string): void {
+        this.titleText.setText(`  ${label}`);
+        this.jsonView.setData(data);
+        this.mainArea.clearChildren();
+        this.mainArea.addChild(this.scrollView);
+        this.statusText.setText(
+            '  [↑↓] scroll   [enter] expand/collapse   [q] quit',
+        );
+        this.state = 'browsing';
+        this.markDirty();
+    }
+
+    private loadFile(filePath: string): void {
+        try {
+            const raw = fs.readFileSync(filePath, 'utf8');
+            const data = JSON.parse(raw) as unknown;
+            this.showJson(data, filePath);
+        } catch (err) {
+            this.showJson(
+                { error: 'Failed to parse JSON', file: filePath, detail: String(err) },
+                `Parse error — ${filePath}`,
+            );
+        }
+    }
+
+    // ── Key routing ──────────────────────────────────────────────────────
+    handleKey(event: KeyEvent): boolean {
+        // q or Ctrl+C always quits
+        if (event.key === 'q' || (event.ctrl && event.key === 'c')) {
+            return false;
+        }
+
+        if (this.state === 'picking') {
+            // esc → skip file picker, use sample data
+            if (event.key === 'escape') {
+                this.showJson(SAMPLE_DATA, 'sample data');
+                return true;
+            }
+            // enter on a .json file → load it
+            if (event.key === 'enter' || event.key === 'return') {
+                const selected = this.picker.getSelected?.();
+                if (selected && !selected.isDirectory && selected.name.endsWith('.json')) {
+                    this.loadFile(selected.path);
+                    return true;
+                }
+            }
+            this.picker.handleKey(event);
+            return true;
+        }
+
+        // Browsing state
+        switch (event.key) {
+            case 'up':
+                this.scrollView.scrollBy(-1);
+                break;
+            case 'down':
+                this.scrollView.scrollBy(1);
+                break;
+            case 'enter':
+            case 'return':
+                this.jsonView.handleKey(event);
+                break;
+            default:
+                this.jsonView.handleKey(event);
+        }
+        this.markDirty();
+        return true;
+    }
+
+    protected _renderSelf(): void {}
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap — matches file-manager pattern exactly
+// ---------------------------------------------------------------------------
+async function main() {
+    const explorerApp = new JsonExplorerApp();
+
+    const app = new App(explorerApp, {
+        fullscreen: true,
+        title: 'JSON Explorer',
+        fps: 30,
+    });
+
+    app.events.on('key', (event: KeyEvent) => {
+        const shouldContinue = explorerApp.handleKey(event);
+        if (!shouldContinue) app.exit(0);
+        app.requestRender();
+    });
+
+    const exitCode = await app.mount();
+    process.exit(exitCode);
+}
+
+main().catch((err) => {
+    console.error('Error:', err);
+    process.exit(1);
+});

--- a/examples/json-explorer/src/package.json
+++ b/examples/json-explorer/src/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "@termuijs/example-json-explorer",
+    "version": "0.1.0",
+    "private": true,
+    "type": "module",
+    "description": "JSON explorer example app — browse any JSON file as a collapsible tree",
+    "scripts": {
+        "start": "bun src/index.tsx",
+        "dev": "bun --watch src/index.tsx",
+        "build": "echo 'no build needed'",
+        "typecheck": "tsc --noEmit"
+    },
+    "dependencies": {
+        "@termuijs/core": "workspace:*",
+        "@termuijs/widgets": "workspace:*",
+        "@termuijs/ui": "workspace:*"
+    },
+    "devDependencies": {
+        "typescript": "^5.9.3"
+    },
+    "engines": {
+        "bun": ">=1.3.0"
+    }
+}

--- a/examples/json-explorer/src/tsconfig.json
+++ b/examples/json-explorer/src/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "dist",
+        "rootDir": "src",
+        "jsx": "react-jsx",
+        "jsxImportSource": "@termuijs/jsx"
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Adds a json-explorer example that:

- Opens a JSON file using FilePicker
- Displays JSON using JSONView
- Supports scrolling via ScrollView
- Supports node expand/collapse
- Falls back to sample JSON
- Supports q and Ctrl+C to quit

Closes #521

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a JSON explorer example application with interactive file browsing, keyboard-driven navigation (scrolling, selection, expanding), and JSON parsing with error handling for invalid files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->