### PR TITLE
Feat qrcode widget

### DIFF
--- a/packages/widgets/src/display/QRCode.test.ts
+++ b/packages/widgets/src/display/QRCode.test.ts
@@ -1,29 +1,45 @@
-import { describe, it, expect, vi } from 'vitest';
-import { QRCode } from './QRCode.js';
-import { caps } from '@termuijs/core';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { QRCodePattern } from './QRCode.js';
+import { caps, Screen } from '@termuijs/core';
 
-describe('QRCode widget', () => {
+function bufferToString(screen: Screen): string {
+    return screen.back.map(row => row.map(cell => cell.char).join('')).join('\n');
+}
+
+describe('QRCodePattern widget', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
 
     it('renders without error for a short string', () => {
-        const qr = new QRCode('hello');
-        const out = qr.render();
+        const qr = new QRCodePattern('hello');
+        const screen = new Screen(21, 21);
+        qr.updateRect({ x: 0, y: 0, width: 21, height: 21 });
+
+        qr.render(screen);
+        const out = bufferToString(screen);
 
         expect(out).toContain('\n');
         expect(out.length).toBeGreaterThan(10);
     });
 
     it('setData updates QR code', () => {
-        const qr = new QRCode('a');
-        const first = qr.render();
+        const qr = new QRCodePattern('a');
+        const screen = new Screen(21, 21);
+        qr.updateRect({ x: 0, y: 0, width: 21, height: 21 });
+
+        qr.render(screen);
+        const first = bufferToString(screen);
 
         qr.setData('b');
-        const second = qr.render();
+        qr.render(screen);
+        const second = bufferToString(screen);
 
         expect(first).not.toBe(second);
     });
 
     it('setData triggers markDirty', () => {
-        const qr = new QRCode('a');
+        const qr = new QRCodePattern('a');
 
         const spy = vi.spyOn(qr, 'markDirty' as any);
 
@@ -35,8 +51,11 @@ describe('QRCode widget', () => {
     it('ASCII fallback uses # for dark modules', () => {
         vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
 
-        const qr = new QRCode('test');
-        const out = qr.render();
+        const qr = new QRCodePattern('test');
+        const screen = new Screen(21, 21);
+        qr.updateRect({ x: 0, y: 0, width: 21, height: 21 });
+        qr.render(screen);
+        const out = bufferToString(screen);
 
         expect(out).toContain('#');
     });

--- a/packages/widgets/src/display/QRCode.test.ts
+++ b/packages/widgets/src/display/QRCode.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { QRCode } from './QRCode.js';
+import { caps } from '@termuijs/core';
+
+describe('QRCode widget', () => {
+
+    it('renders without error for a short string', () => {
+        const qr = new QRCode('hello');
+        const out = qr.render();
+
+        expect(out).toContain('\n');
+        expect(out.length).toBeGreaterThan(10);
+    });
+
+    it('setData updates QR code', () => {
+        const qr = new QRCode('a');
+        const first = qr.render();
+
+        qr.setData('b');
+        const second = qr.render();
+
+        expect(first).not.toBe(second);
+    });
+
+    it('setData triggers markDirty', () => {
+        const qr = new QRCode('a');
+
+        const spy = vi.spyOn(qr, 'markDirty' as any);
+
+        qr.setData('new');
+
+        expect(spy).toHaveBeenCalled();
+    });
+
+    it('ASCII fallback uses # for dark modules', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+
+        const qr = new QRCode('test');
+        const out = qr.render();
+
+        expect(out).toContain('#');
+    });
+});

--- a/packages/widgets/src/display/QRCode.ts
+++ b/packages/widgets/src/display/QRCode.ts
@@ -1,14 +1,21 @@
 import { Widget } from '../base/Widget.js';
-import { type Style, caps } from '@termuijs/core';
+import { type Screen, type Style, caps, styleToCellAttrs } from '@termuijs/core';
 
-export interface QRCodeOptions {
-    errorCorrectionLevel?: 'L' | 'M' | 'Q' | 'H';
+export interface QRCodePatternOptions {
     darkChar?: string;
     lightChar?: string;
 }
 
+export interface QRCodeOptions extends QRCodePatternOptions {
+    errorCorrectionLevel?: 'L' | 'M' | 'Q' | 'H';
+}
+
 const SIZE = 21;
 
+/**
+ * Decorative QR-style pattern generator.
+ * This widget is intentionally not a scannable QR code.
+ */
 function hashString(str: string): number {
     let hash = 0;
     for (let i = 0; i < str.length; i++) {
@@ -17,11 +24,11 @@ function hashString(str: string): number {
     return hash;
 }
 
-export class QRCode extends Widget {
+export class QRCodePattern extends Widget {
     private data: string;
-    private opts: QRCodeOptions;
+    private opts: QRCodePatternOptions;
 
-    constructor(data: string, style?: Partial<Style>, opts?: QRCodeOptions) {
+    constructor(data: string, style?: Partial<Style>, opts?: QRCodePatternOptions) {
         super(style);
         this.data = data;
         this.opts = opts ?? {};
@@ -53,32 +60,36 @@ export class QRCode extends Widget {
         return border || center ? dark : light;
     }
 
-  protected _renderSelf(): string {
-    const dark = caps.unicode ? (this.opts.darkChar ?? '█') : '#';
-    const light = caps.unicode ? (this.opts.lightChar ?? ' ') : ' ';
+    protected _renderSelf(screen: Screen): void {
+        const contentRect = this._getContentRect();
+        const { x: baseX, y: baseY, width, height } = contentRect;
+        if (width <= 0 || height <= 0) return;
 
-    const hash = hashString(this.data);
+        const dark = caps.unicode ? (this.opts.darkChar ?? '█') : '#';
+        const light = caps.unicode ? (this.opts.lightChar ?? ' ') : ' ';
+        const attrs = styleToCellAttrs(this._style);
+        const hash = hashString(this.data);
 
-    let out = '';
+        const drawWidth = Math.min(SIZE, width);
+        const drawHeight = Math.min(SIZE, height);
 
-    for (let y = 0; y < SIZE; y++) {
-        for (let x = 0; x < SIZE; x++) {
+        for (let row = 0; row < drawHeight; row++) {
+            for (let col = 0; col < drawWidth; col++) {
+                let char: string;
 
-            let char: string;
+                if (this.isFinder(col, row)) {
+                    char = this.renderFinder(col, row);
+                } else {
+                    const bitIndex = (col * row + hash) % 32;
+                    const bit = (hash >> bitIndex) & 1;
+                    char = bit ? dark : light;
+                }
 
-            if (this.isFinder(x, y)) {
-                char = this.renderFinder(x, y);
-            } else {
-                const bitIndex = (x * y + hash) % 32;
-                const bit = (hash >> bitIndex) & 1;
-                char = bit ? dark : light;
+                screen.writeString(baseX + col, baseY + row, char, attrs);
             }
-
-            out += char;
         }
-        out += '\n';
-    }
-
-    return out;
     }
 }
+
+
+export const QRCode = QRCodePattern;

--- a/packages/widgets/src/display/QRCode.ts
+++ b/packages/widgets/src/display/QRCode.ts
@@ -1,0 +1,84 @@
+import { Widget } from '../base/Widget.js';
+import { type Style, caps } from '@termuijs/core';
+
+export interface QRCodeOptions {
+    errorCorrectionLevel?: 'L' | 'M' | 'Q' | 'H';
+    darkChar?: string;
+    lightChar?: string;
+}
+
+const SIZE = 21;
+
+function hashString(str: string): number {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+        hash = (hash * 31 + str.charCodeAt(i)) >>> 0;
+    }
+    return hash;
+}
+
+export class QRCode extends Widget {
+    private data: string;
+    private opts: QRCodeOptions;
+
+    constructor(data: string, style?: Partial<Style>, opts?: QRCodeOptions) {
+        super(style);
+        this.data = data;
+        this.opts = opts ?? {};
+    }
+
+    setData(data: string): void {
+        this.data = data;
+        this.markDirty();
+    }
+
+    private isFinder(x: number, y: number): boolean {
+        const inTopLeft = x < 7 && y < 7;
+        const inTopRight = x > SIZE - 8 && y < 7;
+        const inBottomLeft = x < 7 && y > SIZE - 8;
+
+        return inTopLeft || inTopRight || inBottomLeft;
+    }
+
+    private renderFinder(x: number, y: number): string {
+        const dark = caps.unicode ? (this.opts.darkChar ?? '█') : '#';
+        const light = caps.unicode ? (this.opts.lightChar ?? ' ') : ' ';
+
+        const dx = x % 7;
+        const dy = y % 7;
+
+        const border = dx === 0 || dx === 6 || dy === 0 || dy === 6;
+        const center = dx >= 2 && dx <= 4 && dy >= 2 && dy <= 4;
+
+        return border || center ? dark : light;
+    }
+
+  protected _renderSelf(): string {
+    const dark = caps.unicode ? (this.opts.darkChar ?? '█') : '#';
+    const light = caps.unicode ? (this.opts.lightChar ?? ' ') : ' ';
+
+    const hash = hashString(this.data);
+
+    let out = '';
+
+    for (let y = 0; y < SIZE; y++) {
+        for (let x = 0; x < SIZE; x++) {
+
+            let char: string;
+
+            if (this.isFinder(x, y)) {
+                char = this.renderFinder(x, y);
+            } else {
+                const bitIndex = (x * y + hash) % 32;
+                const bit = (hash >> bitIndex) & 1;
+                char = bit ? dark : light;
+            }
+
+            out += char;
+        }
+        out += '\n';
+    }
+
+    return out;
+    }
+}

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -69,8 +69,6 @@ export { ScrollView } from './layout/ScrollView.js';
 export type { ScrollViewOptions } from './layout/ScrollView.js';
 export { Center } from './layout/Center.js';
 export type { CenterOptions } from './layout/Center.js';
-export { Fill } from './layout/Fill.js';
-export type { FillOptions } from './layout/Fill.js';
 export { Card } from './layout/Card.js';
 export type { CardOptions } from './layout/Card.js';
 export { Columns } from './layout/Columns.js';
@@ -128,5 +126,5 @@ export type { TooltipOptions } from './display/Tooltip.js';
 export { Clock } from './display/Clock.js';
 export type { ClockOptions } from './display/Clock.js';
 
-export { QRCode } from './display/QRCode.js';
-export type { QRCodeOptions } from './display/QRCode.js';
+export { QRCodePattern, QRCode } from './display/QRCode.js';
+export type { QRCodePatternOptions, QRCodeOptions } from './display/QRCode.js';

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -69,6 +69,8 @@ export { ScrollView } from './layout/ScrollView.js';
 export type { ScrollViewOptions } from './layout/ScrollView.js';
 export { Center } from './layout/Center.js';
 export type { CenterOptions } from './layout/Center.js';
+export { Fill } from './layout/Fill.js';
+export type { FillOptions } from './layout/Fill.js';
 export { Card } from './layout/Card.js';
 export type { CardOptions } from './layout/Card.js';
 export { Columns } from './layout/Columns.js';
@@ -125,3 +127,6 @@ export { Tooltip } from './display/Tooltip.js';
 export type { TooltipOptions } from './display/Tooltip.js';
 export { Clock } from './display/Clock.js';
 export type { ClockOptions } from './display/Clock.js';
+
+export { QRCode } from './display/QRCode.js';
+export type { QRCodeOptions } from './display/QRCode.js';


### PR DESCRIPTION
## Description

Adds a new `QRCode` widget to `@termuijs/widgets` that renders QR-style terminal output using block characters with Unicode support and ASCII fallback. The widget supports updating data through `setData()` and triggers `markDirty()` when content changes.

## Related Issue

Closes #273

## Which package(s)?

* @termuijs/widgets

## Type of Change

* [x] ✨ Feature (`type:feature`)
* [x] 🧪 Tests (`type:testing`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read `CONTRIBUTING.md`.
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

      You are a GSSoC 2026 contributor.

* Your GSSoC profile: `https://gssoc.girlscript.org/profile/e28902d6-ac09-4030-a305-38827f21efb0`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

* Added `QRCode.ts` and `QRCode.test.ts`.
* Exported the widget from `packages/widgets/src/index.ts`.
* Implemented Unicode block rendering with ASCII fallback support.
* Added tests for rendering, updates, `markDirty()`, and fallback behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New QRCode display widget: renders a fixed-size QR-like pattern with configurable dark/light characters and Unicode or ASCII output, and updates immediately when its content changes.
  * Deterministic rendering so the same content produces the same visual pattern and it adapts to available display space.

* **Tests**
  * Added unit tests covering initial render, runtime content updates, and ASCII fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Karanjot786/TermUI/pull/583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->