### PR TITLE
feat(jsx): add useForceUpdate hook

### DIFF
--- a/packages/jsx/src/hooks/useForceUpdate.test.ts
+++ b/packages/jsx/src/hooks/useForceUpdate.test.ts
@@ -1,0 +1,79 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/jsx — Tests for useForceUpdate hook
+// ─────────────────────────────────────────────────────
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+    createFiber, setCurrentFiber, clearCurrentFiber,
+    setRequestRender, runEffects, destroyFiber,
+} from '../hooks.js';
+import { useForceUpdate } from './useForceUpdate.js';
+
+function renderWithFiber<T>(fiber: ReturnType<typeof createFiber>, fn: () => T): T {
+    setCurrentFiber(fiber);
+    const result = fn();
+    clearCurrentFiber();
+    runEffects(fiber);
+    return result;
+}
+
+describe('useForceUpdate', () => {
+    beforeEach(() => {
+        setRequestRender(() => {});
+    });
+
+    afterEach(() => {
+        clearCurrentFiber();
+    });
+
+    it('returns a function', () => {
+        const fiber = createFiber();
+        const forceUpdate = renderWithFiber(fiber, () => useForceUpdate());
+        expect(typeof forceUpdate).toBe('function');
+        destroyFiber(fiber);
+    });
+
+    it('calling the function marks fiber as dirty', () => {
+        const fiber = createFiber();
+        fiber.isDirty = false;
+
+        const forceUpdate = renderWithFiber(fiber, () => useForceUpdate());
+        forceUpdate();
+
+        expect(fiber.isDirty).toBe(true);
+        destroyFiber(fiber);
+    });
+
+    it('returned function identity stays stable across re-renders', () => {
+        const fiber = createFiber();
+
+        const first = renderWithFiber(fiber, () => useForceUpdate());
+        const second = renderWithFiber(fiber, () => useForceUpdate());
+
+        expect(first).toBe(second);
+        destroyFiber(fiber);
+    });
+
+    it('each call marks fiber dirty again', () => {
+        const fiber = createFiber();
+        const forceUpdate = renderWithFiber(fiber, () => useForceUpdate());
+
+        fiber.isDirty = false;
+        forceUpdate();
+        expect(fiber.isDirty).toBe(true);
+
+        fiber.isDirty = false;
+        forceUpdate();
+        expect(fiber.isDirty).toBe(true);
+
+        destroyFiber(fiber);
+    });
+
+    it('the function takes no arguments and returns nothing', () => {
+        const fiber = createFiber();
+        const forceUpdate = renderWithFiber(fiber, () => useForceUpdate());
+
+        const result = forceUpdate();
+        expect(result).toBeUndefined();
+        destroyFiber(fiber);
+    });
+});

--- a/packages/jsx/src/hooks/useForceUpdate.ts
+++ b/packages/jsx/src/hooks/useForceUpdate.ts
@@ -1,0 +1,20 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/jsx — useForceUpdate hook
+// ─────────────────────────────────────────────────────
+import { useState, useCallback } from '../hooks.js';
+
+/**
+ * useForceUpdate — returns a stable function that forces the component to re-render.
+ *
+ * ```tsx
+ * const forceUpdate = useForceUpdate();
+ * forceUpdate(); // triggers a re-render
+ * ```
+ */
+export function useForceUpdate(): () => void {
+    const [, setState] = useState(0);
+
+    return useCallback(() => {
+        setState((n) => n + 1);
+    }, []);
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -86,6 +86,10 @@ export { useSyncExternalStore } from './hooks/useSyncExternalStore.js';
 export { useHover } from './hooks/useHover.js';
 export { useElementSize } from './hooks/useElementSize.js';
 export type { ElementSize } from './hooks/useElementSize.js';
+<<<<<<< HEAD
 export { useDebounce } from './hooks/useDebounce.js';
 export { useTerminalSize } from './hooks/useTerminalSize.js';
 export type { TerminalSize } from './hooks/useTerminalSize.js';
+=======
+export { useForceUpdate } from './hooks/useForceUpdate.js';
+>>>>>>> 3b1178b (feat(jsx): export useForceUpdate from index)

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -86,10 +86,7 @@ export { useSyncExternalStore } from './hooks/useSyncExternalStore.js';
 export { useHover } from './hooks/useHover.js';
 export { useElementSize } from './hooks/useElementSize.js';
 export type { ElementSize } from './hooks/useElementSize.js';
-<<<<<<< HEAD
 export { useDebounce } from './hooks/useDebounce.js';
 export { useTerminalSize } from './hooks/useTerminalSize.js';
 export type { TerminalSize } from './hooks/useTerminalSize.js';
-=======
 export { useForceUpdate } from './hooks/useForceUpdate.js';
->>>>>>> 3b1178b (feat(jsx): export useForceUpdate from index)


### PR DESCRIPTION
## feat(jsx): add useForceUpdate hook

Closes #447

---

### 📌 Summary

Adds a `useForceUpdate` hook to `@termuijs/jsx` that returns a stable function which forces the component to re-render.

---

### ✅ What's implemented

- Returns a function, not a value
- Calling the function changes the backing state
- Each call produces a new state value so the render is not skipped
- The returned function identity stays stable across re-renders
- The function takes no arguments and returns nothing
- The backing state value is never exposed to the caller

---

### 📂 Files Changed

- `packages/jsx/src/hooks/useForceUpdate.ts` — hook implementation
- `packages/jsx/src/hooks/useForceUpdate.test.ts` — vitest tests
- `packages/jsx/src/index.ts` — added export

---

### 🧪 Testing

```
bun vitest run packages/jsx ✅
bun run typecheck ✅
bun run build ✅
```

All 5 test cases pass:
- Returns a function ✅
- Calling the function marks fiber as dirty ✅
- Function identity stays stable across re-renders ✅
- Each call marks fiber dirty again ✅
- Function takes no arguments and returns nothing ✅

---

### ⭐ Checklist

- [x] Starred the repo
- [x] Change confined to `packages/jsx`
- [x] `bun.lock` not modified
- [x] All tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new useForceUpdate hook to trigger component re-renders.
* **Breaking Changes**
  * Removed useDebounce and useTerminalSize hooks and related type exports.
* **Tests**
  * Added a test suite validating useForceUpdate behavior (returns a callable that triggers re-render, remains stable across renders, and behaves consistently on repeated calls).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->