### PR TITLE
feat(jsx): add useEventCallback hook

### DIFF
--- a/packages/jsx/src/hooks/useEventCallback.test.ts
+++ b/packages/jsx/src/hooks/useEventCallback.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+    createFiber,
+    setCurrentFiber,
+    clearCurrentFiber,
+} from '../hooks.js';
+import { useEventCallback } from './useEventCallback.js';
+
+describe('useEventCallback', () => {
+    let fiber = createFiber();
+
+    beforeEach(() => {
+        fiber = createFiber();
+        setCurrentFiber(fiber);
+    });
+
+    afterEach(() => {
+        clearCurrentFiber();
+    });
+
+    it('keeps a stable identity across re-renders', () => {
+        const callback1 = useEventCallback(() => 'first');
+
+        fiber.hookIndex = 0;
+
+        const callback2 = useEventCallback(() => 'second');
+
+        expect(callback1).toBe(callback2);
+    });
+
+    it('calls the latest callback instead of a stale one', () => {
+        useEventCallback(() => 'first');
+
+        fiber.hookIndex = 0;
+
+        const callback = useEventCallback(() => 'second');
+
+        expect(callback()).toBe('second');
+    });
+
+    it('passes arguments through unchanged', () => {
+        const callback = useEventCallback(
+            (a: number, b: number) => a + b,
+        );
+
+        expect(callback(2, 3)).toBe(5);
+    });
+
+    it('passes return values through unchanged', () => {
+        const callback = useEventCallback(
+            (name: string) => `Hello ${name}`,
+        );
+
+        expect(callback('Srushti')).toBe('Hello Srushti');
+    });
+
+    it('works with callbacks of any arity', () => {
+        const callback = useEventCallback(
+            (a: number, b: number, c: number) => a + b + c,
+        );
+
+        expect(callback(1, 2, 3)).toBe(6);
+    });
+});

--- a/packages/jsx/src/hooks/useEventCallback.ts
+++ b/packages/jsx/src/hooks/useEventCallback.ts
@@ -1,0 +1,17 @@
+import { useRef, useCallback } from '../hooks.js';
+
+export function useEventCallback<
+    Args extends unknown[],
+    Return,
+>(
+    callback: (...args: Args) => Return,
+): (...args: Args) => Return {
+    const callbackRef = useRef(callback);
+
+    callbackRef.current = callback;
+
+    return useCallback(
+        (...args: Args) => callbackRef.current(...args),
+        [],
+    );
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -92,3 +92,4 @@ export { useDebounce } from './hooks/useDebounce.js';
 export { useTerminalSize } from './hooks/useTerminalSize.js';
 export type { TerminalSize } from './hooks/useTerminalSize.js';
 export { useForceUpdate } from './hooks/useForceUpdate.js';
+export { useEventCallback } from './hooks/useEventCallback.js';


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description
Adds a new useEventCallback hook to @termuijs/jsx that provides a stable callback identity across re-renders while always invoking the latest callback implementation. Added tests covering stable identity, latest callback usage, argument forwarding, return values, and support for callbacks with varying arity.
<!-- What does this PR do? 1 to 3 sentences. -->

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #448 

## Which package(s)?
@termuijs/jsx
<!-- Example: @termuijs/core, @termuijs/widgets, website. -->

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)
N/A (hook implementation only)
<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

- Added useEventCallback hook to @termuijs/jsx
- Uses a ref to always call the latest callback implementation
- Returns a stable function identity across re-renders
- Added tests for:
- stable callback identity
- latest callback invocation
- argument forwarding
- return value forwarding
- support for callbacks of varying arity

**Verification:**

- bun vitest run packages/jsx
- bun run build
- bun run typecheck

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `useEventCallback` hook to the package. This new utility provides stable event callbacks that maintain their identity across re-renders while ensuring the latest function logic is always executed. Supports callbacks of any arity with proper argument passing and return value preservation.

* **Tests**
  * Introduced comprehensive test suite for callback stability and behavior verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Karanjot786/TermUI/pull/586?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->