### PR TITLE
feat(core): add mouse double-click and drag synthesis

### DIFF
--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -52,7 +52,9 @@ export function createKeyEvent(base: {
 /**
  * Mouse event types.
  */
-export type MouseEventType = 'mousedown' | 'mouseup' | 'mousemove' | 'scroll';
+export type MouseEventType =
+    | 'mousedown' | 'mouseup' | 'mousemove' | 'scroll'
+    | 'dblclick' | 'drag' | 'dragend';
 export type MouseButton = 'left' | 'middle' | 'right' | 'none';
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,8 @@ export { RenderHook } from './renderer/render-hook.js';
 export { InputParser } from './input/InputParser.js';
 export { ESCAPE_SEQUENCES, CTRL_KEYS, SPECIAL_KEYS } from './input/KeyMap.js';
 export { parseMouseEvent, isMouseSequence } from './input/MouseParser.js';
+export { MouseGestures } from './input/MouseGestures.js';
+export type { MouseGesturesOptions } from './input/MouseGestures.js';
 export { ChordMatcher } from './input/ChordMatcher.js';
 export type { ChordMatcherOptions, Chord } from './input/ChordMatcher.js';
 

--- a/packages/core/src/input/MouseGestures.test.ts
+++ b/packages/core/src/input/MouseGestures.test.ts
@@ -1,0 +1,153 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/core — Tests for MouseGestures
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi } from 'vitest';
+import { MouseGestures } from './MouseGestures.js';
+import type { MouseEvent } from '../events/types.js';
+
+describe('MouseGestures', () => {
+    it('synthesizes double-click within window', () => {
+        vi.useFakeTimers();
+        const g = new MouseGestures({ doubleClickMs: 300 });
+        const down: MouseEvent = { x: 1, y: 1, button: 'left', type: 'mousedown' };
+
+        expect(g.feed({ ...down })).toEqual([]);
+        vi.advanceTimersByTime(150);
+
+        const out = g.feed({ ...down });
+        expect(out).toEqual([
+            { x: 1, y: 1, button: 'left', type: 'dblclick' }
+        ]);
+
+        vi.useRealTimers();
+    });
+
+    it('does not synthesize double-click outside window', () => {
+        vi.useFakeTimers();
+        const g = new MouseGestures({ doubleClickMs: 300 });
+        const down: MouseEvent = { x: 1, y: 1, button: 'left', type: 'mousedown' };
+
+        expect(g.feed({ ...down })).toEqual([]);
+        vi.advanceTimersByTime(350);
+
+        const out = g.feed({ ...down });
+        expect(out).toEqual([]);
+
+        vi.useRealTimers();
+    });
+
+    it('does not synthesize double-click if position is different', () => {
+        vi.useFakeTimers();
+        const g = new MouseGestures({ doubleClickMs: 300 });
+        
+        expect(g.feed({ x: 1, y: 1, button: 'left', type: 'mousedown' })).toEqual([]);
+        vi.advanceTimersByTime(100);
+
+        const out = g.feed({ x: 1, y: 2, button: 'left', type: 'mousedown' });
+        expect(out).toEqual([]);
+
+        vi.useRealTimers();
+    });
+
+    it('does not synthesize double-click if button is different', () => {
+        vi.useFakeTimers();
+        const g = new MouseGestures({ doubleClickMs: 300 });
+        
+        expect(g.feed({ x: 1, y: 1, button: 'left', type: 'mousedown' })).toEqual([]);
+        vi.advanceTimersByTime(100);
+
+        const out = g.feed({ x: 1, y: 1, button: 'right', type: 'mousedown' });
+        expect(out).toEqual([]);
+
+        vi.useRealTimers();
+    });
+
+    it('resets double click state after synthesis (no triple-click double click)', () => {
+        vi.useFakeTimers();
+        const g = new MouseGestures({ doubleClickMs: 300 });
+        const down: MouseEvent = { x: 1, y: 1, button: 'left', type: 'mousedown' };
+
+        expect(g.feed({ ...down })).toEqual([]);
+        vi.advanceTimersByTime(100);
+
+        expect(g.feed({ ...down })).toEqual([
+            { x: 1, y: 1, button: 'left', type: 'dblclick' }
+        ]);
+        vi.advanceTimersByTime(100);
+
+        // Third click should not trigger another double-click
+        expect(g.feed({ ...down })).toEqual([]);
+        vi.advanceTimersByTime(100);
+
+        // Fourth click should trigger a second double-click
+        expect(g.feed({ ...down })).toEqual([
+            { x: 1, y: 1, button: 'left', type: 'dblclick' }
+        ]);
+
+        vi.useRealTimers();
+    });
+
+    it('synthesizes drag on move with button held', () => {
+        const g = new MouseGestures();
+        
+        // Start press
+        expect(g.feed({ x: 1, y: 1, button: 'left', type: 'mousedown' })).toEqual([]);
+
+        // Move mouse
+        const drag1 = g.feed({ x: 2, y: 2, button: 'left', type: 'mousemove' });
+        expect(drag1).toEqual([
+            { x: 2, y: 2, button: 'left', type: 'drag' }
+        ]);
+
+        const drag2 = g.feed({ x: 3, y: 3, button: 'left', type: 'mousemove' });
+        expect(drag2).toEqual([
+            { x: 3, y: 3, button: 'left', type: 'drag' }
+        ]);
+    });
+
+    it('does not synthesize drag on move with button none / if not pressed', () => {
+        const g = new MouseGestures();
+
+        // Move mouse without prior mousedown
+        const drag1 = g.feed({ x: 2, y: 2, button: 'none', type: 'mousemove' });
+        expect(drag1).toEqual([]);
+    });
+
+    it('synthesizes dragend on release after drag', () => {
+        const g = new MouseGestures();
+
+        // Down -> Move -> Up
+        expect(g.feed({ x: 1, y: 1, button: 'left', type: 'mousedown' })).toEqual([]);
+        expect(g.feed({ x: 2, y: 2, button: 'left', type: 'mousemove' })).toEqual([
+            { x: 2, y: 2, button: 'left', type: 'drag' }
+        ]);
+        expect(g.feed({ x: 2, y: 2, button: 'left', type: 'mouseup' })).toEqual([
+            { x: 2, y: 2, button: 'left', type: 'dragend' }
+        ]);
+    });
+
+    it('does not synthesize dragend on release if there was no drag', () => {
+        const g = new MouseGestures();
+
+        // Down -> Up (simple click)
+        expect(g.feed({ x: 1, y: 1, button: 'left', type: 'mousedown' })).toEqual([]);
+        expect(g.feed({ x: 1, y: 1, button: 'left', type: 'mouseup' })).toEqual([]);
+    });
+
+    it('does not mutate input event objects', () => {
+        const g = new MouseGestures();
+        const event: MouseEvent = { x: 1, y: 1, button: 'left', type: 'mousedown' };
+        Object.freeze(event); // freeze to ensure no mutation can occur without throwing
+
+        expect(() => g.feed(event)).not.toThrow();
+
+        const move: MouseEvent = { x: 2, y: 2, button: 'left', type: 'mousemove' };
+        Object.freeze(move);
+        expect(() => g.feed(move)).not.toThrow();
+
+        const up: MouseEvent = { x: 2, y: 2, button: 'left', type: 'mouseup' };
+        Object.freeze(up);
+        expect(() => g.feed(up)).not.toThrow();
+    });
+});

--- a/packages/core/src/input/MouseGestures.ts
+++ b/packages/core/src/input/MouseGestures.ts
@@ -1,0 +1,84 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/core — Mouse gestures synthesizer
+// ─────────────────────────────────────────────────────
+
+import type { MouseEvent, MouseButton } from '../events/types.js';
+
+export interface MouseGesturesOptions {
+    /** Max ms between two clicks to count as a double-click. Default 300. */
+    doubleClickMs?: number;
+}
+
+export class MouseGestures {
+    private doubleClickMs: number;
+    private lastMouseDown: { x: number; y: number; button: MouseButton; time: number } | null = null;
+    private activeDragButton: MouseButton | null = null;
+    private wasDragging = false;
+
+    constructor(opts?: MouseGesturesOptions) {
+        this.doubleClickMs = opts?.doubleClickMs ?? 300;
+    }
+
+    /**
+     * Feed a raw MouseEvent. Returns synthesized events to emit
+     * (may be empty). Does not mutate the input event.
+     */
+    feed(event: MouseEvent): MouseEvent[] {
+        const synthesized: MouseEvent[] = [];
+
+        if (event.type === 'mousedown') {
+            const now = Date.now();
+            if (
+                this.lastMouseDown &&
+                this.lastMouseDown.x === event.x &&
+                this.lastMouseDown.y === event.y &&
+                this.lastMouseDown.button === event.button &&
+                now - this.lastMouseDown.time <= this.doubleClickMs
+            ) {
+                synthesized.push({
+                    x: event.x,
+                    y: event.y,
+                    button: event.button,
+                    type: 'dblclick',
+                });
+                // Reset so a third consecutive fast click doesn't trigger another double click
+                this.lastMouseDown = null;
+            } else {
+                this.lastMouseDown = {
+                    x: event.x,
+                    y: event.y,
+                    button: event.button,
+                    time: now,
+                };
+            }
+
+            this.activeDragButton = event.button;
+            this.wasDragging = false;
+        } else if (event.type === 'mousemove') {
+            if (this.activeDragButton !== null) {
+                this.wasDragging = true;
+                synthesized.push({
+                    x: event.x,
+                    y: event.y,
+                    button: this.activeDragButton,
+                    type: 'drag',
+                });
+            }
+        } else if (event.type === 'mouseup') {
+            if (this.activeDragButton !== null) {
+                if (this.wasDragging) {
+                    synthesized.push({
+                        x: event.x,
+                        y: event.y,
+                        button: event.button,
+                        type: 'dragend',
+                    });
+                }
+                this.activeDragButton = null;
+                this.wasDragging = false;
+            }
+        }
+
+        return synthesized;
+    }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

Implements a stateful mouse gesture synthesizer (`MouseGestures`) in `@termuijs/core` that translates the raw stream of mouse events into synthesized `dblclick`, `drag`, and `dragend` events. The implementation is purely additive, dependency-free, and ensures that the fed input events are never mutated.

## Related Issue

Closes #460

## Which package(s)?

`@termuijs/core`

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise. (Be sure to star the repo if you haven't yet!)
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: https://gssoc.girlscript.org/profile/47aab18d-1c76-4f80-b3c2-24dc44764bb8

## Screenshots / Recordings (UI changes)

*No visual UI changes were made as this is a non-visual, core input processing utility.*

## Notes for the Reviewer

- **State Machine Implementation**: The `MouseGestures` utility tracks the last `mousedown` to synthesize `dblclick` events using the provided `doubleClickMs` timeout, resetting state upon trigger to prevent accidental triple-click multi-triggers.
- **Drag Synthesis**: Tracks the active drag button when a `mousedown` occurs and yields `drag` events on subsequent `mousemove` events. Once `mouseup` occurs, if a drag was active, a `dragend` is synthesized.
- **Event Preservation**: Feed is completely non-mutating; new objects are constructed for synthesized events while input coordinates/buttons are correctly preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mouse gesture synthesis capabilities including double-click, drag, and dragend detection with configurable double-click timing window

* **Tests**
  * Added comprehensive test suite covering double-click synthesis, drag tracking, and event handling edge cases

* **Style**
  * Reformatted type declaration for improved readability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Karanjot786/TermUI/pull/587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->