### PR TITLE
feat(widgets): Add Typewriter widget

### DIFF
--- a/packages/widgets/src/display/Typewriter.test.ts
+++ b/packages/widgets/src/display/Typewriter.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { Screen, caps } from '@termuijs/core';
+import { Typewriter } from './Typewriter.js';
+
+// Helper: render a Typewriter into a fresh 20×1 screen and return row 0.
+function renderRow(tw: Typewriter, width = 20): string {
+  const screen = new Screen(width, 1);
+  tw.updateRect({ x: 0, y: 0, width, height: 1 });
+  tw.render(screen);
+  return screen.back[0].map((c) => c.char).join('');
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Typewriter', () => {
+  it('reveals nothing before the first tick', () => {
+    const tw = new Typewriter('hello');
+    const row = renderRow(tw);
+    // No text characters visible; cursor glyph sits at position 0.
+    expect(row).not.toContain('h');
+  });
+
+  it('reveals one character per tick by default', () => {
+    const tw = new Typewriter('hello');
+    tw.updateRect({ x: 0, y: 0, width: 20, height: 1 });
+
+    tw.tick();
+    const screen1 = new Screen(20, 1);
+    tw.render(screen1);
+    const row1 = screen1.back[0].map((c) => c.char).join('');
+    expect(row1).toContain('h');
+    expect(row1).not.toContain('he');
+
+    tw.tick();
+    const screen2 = new Screen(20, 1);
+    tw.render(screen2);
+    const row2 = screen2.back[0].map((c) => c.char).join('');
+    expect(row2).toContain('he');
+  });
+
+  it('reveals speed characters per tick when speed > 1', () => {
+    const tw = new Typewriter('hello', {}, { speed: 2 });
+    tw.tick();
+    const row = renderRow(tw);
+    expect(row).toContain('he');
+    expect(row).not.toContain('hel');
+  });
+
+  it('matches the spec snippet: two ticks on "hello" contain "he"', () => {
+    const screen = new Screen(20, 1);
+    const tw = new Typewriter('hello');
+    tw.updateRect({ x: 0, y: 0, width: 20, height: 1 });
+    tw.tick();
+    tw.tick();
+    tw.render(screen);
+    const row = screen.back[0].map((c) => c.char).join('');
+    expect(row).toContain('he');
+  });
+
+  it('tick past the end stops at the full text (no-op)', () => {
+    const tw = new Typewriter('hi');
+    // Two ticks to fully reveal "hi".
+    tw.tick();
+    tw.tick();
+    // Third tick must be a no-op.
+    tw.tick();
+    const row = renderRow(tw);
+    // Full text present, no cursor glyph.
+    expect(row).toContain('hi');
+  });
+
+  it('does not render cursor once fully revealed', () => {
+    vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+    const tw = new Typewriter('hi');
+    tw.tick();
+    tw.tick(); // fully revealed
+    const row = renderRow(tw);
+    expect(row).not.toContain('▋');
+  });
+
+  it('renders cursor glyph while text is being revealed (unicode)', () => {
+    vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+    const tw = new Typewriter('hello');
+    tw.tick(); // reveals 'h', cursor follows
+    const row = renderRow(tw);
+    expect(row).toContain('▋');
+  });
+
+  it('renders ASCII fallback cursor when caps.unicode is false', () => {
+    vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+    const tw = new Typewriter('hello');
+    tw.tick();
+    const row = renderRow(tw);
+    expect(row).toContain('_');
+    expect(row).not.toContain('▋');
+  });
+
+  it('reset returns the revealed count to zero', () => {
+    const tw = new Typewriter('hello');
+    tw.tick();
+    tw.tick();
+    tw.tick();
+    tw.reset();
+    const row = renderRow(tw);
+    // After reset nothing is revealed.
+    expect(row).not.toContain('h');
+  });
+
+  it('setText replaces text and resets reveal counter', () => {
+    const tw = new Typewriter('hello');
+    tw.tick();
+    tw.tick();
+    tw.setText('world');
+    const row = renderRow(tw);
+    // Counter reset — no 'w' visible yet.
+    expect(row).not.toContain('w');
+    // Old text gone.
+    expect(row).not.toContain('h');
+  });
+
+  it('setText then tick reveals new text', () => {
+    const tw = new Typewriter('hello');
+    tw.tick();
+    tw.setText('world');
+    tw.tick();
+    const row = renderRow(tw);
+    expect(row).toContain('w');
+  });
+
+  it('respects a caller-supplied cursor string', () => {
+    const tw = new Typewriter('hello', {}, { cursor: '|' });
+    tw.tick();
+    const row = renderRow(tw);
+    expect(row).toContain('|');
+  });
+
+  it('truncates content to the available width', () => {
+    const tw = new Typewriter('abcdefghij'); // 10 chars
+    // Tick 10 times to fully reveal.
+    for (let i = 0; i < 10; i++) tw.tick();
+    // Render into a 5-wide screen.
+    const screen = new Screen(5, 1);
+    tw.updateRect({ x: 0, y: 0, width: 5, height: 5 });
+    tw.render(screen);
+    const row = screen.back[0].map((c) => c.char).join('');
+    expect(row.length).toBe(5);
+    expect(row).toContain('abcde');
+  });
+
+  it('renders nothing when width is zero', () => {
+    const tw = new Typewriter('hello');
+    tw.tick();
+    const screen = new Screen(20, 1);
+    tw.updateRect({ x: 0, y: 0, width: 0, height: 1 });
+    tw.render(screen);
+    // Screen untouched — all cells remain default space chars.
+    const row = screen.back[0].map((c) => c.char).join('');
+    expect(row.trim()).toBe('');
+  });
+});

--- a/packages/widgets/src/display/Typewriter.ts
+++ b/packages/widgets/src/display/Typewriter.ts
@@ -1,0 +1,114 @@
+import { Widget } from '../base/Widget.js';
+import { type Screen, type Style, caps, styleToCellAttrs, stringWidth } from '@termuijs/core';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TypewriterOptions
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface TypewriterOptions {
+  /** Characters revealed per tick. Must be a positive integer. Default: 1 */
+  speed?: number;
+  /** Cursor glyph drawn at the reveal head. Default: caps-aware block. */
+  cursor?: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Typewriter
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Reveals static text character by character.
+ *
+ * The host is responsible for calling `tick()` at whatever cadence it likes
+ * (timer, animation loop, etc.). No internal timer is used.
+ *
+ * @example
+ * ```ts
+ * const tw = new Typewriter('hello world');
+ * const interval = setInterval(() => {
+ *   tw.tick();
+ *   screen.render();
+ * }, 80);
+ * ```
+ */
+export class Typewriter extends Widget {
+  private _text: string;
+  private _revealed: number;
+  private _speed: number;
+  private _cursor: string | undefined;
+
+  constructor(
+    text: string,
+    style: Partial<Style> = {},
+    opts: TypewriterOptions = {},
+  ) {
+    super(style);
+    this._text = text;
+    this._revealed = 0;
+    // Clamp speed to a positive integer: non-positive, NaN, and fractional
+    // values would cause reveal to stall or behave non-deterministically.
+    const raw = opts.speed ?? 1;
+    this._speed = Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 1;
+    // undefined means "auto from caps at render time"; a caller-supplied string
+    // overrides it unconditionally.
+    this._cursor = opts.cursor;
+  }
+
+  // ── Public mutating methods ────────────────────────────────────────────────
+
+  /** Advance the reveal head by `speed` characters. No-op once fully revealed. */
+  tick(): void {
+    if (this._revealed >= this._text.length) return;
+    this._revealed = Math.min(this._revealed + this._speed, this._text.length);
+    this.markDirty();
+  }
+
+  /** Return the reveal counter to zero. */
+  reset(): void {
+    this._revealed = 0;
+    this.markDirty();
+  }
+
+  /** Replace the text and reset the reveal counter. */
+  setText(text: string): void {
+    this._text = text;
+    this._revealed = 0;
+    this.markDirty();
+  }
+
+  // ── Rendering ─────────────────────────────────────────────────────────────
+
+  protected _renderSelf(screen: Screen): void {
+    const { x, y, width, height } = this._getContentRect();
+    if (width <= 0 || height <= 0) return;
+
+    const fullyRevealed = this._revealed >= this._text.length;
+
+    // Cursor glyph: caller-supplied string wins; otherwise caps-aware default.
+    const cursorGlyph =
+      this._cursor ?? (caps.unicode ? '▋' : '_');
+
+    // Visible text slice (by code-unit index, i.e. character count).
+    const visibleText = this._text.slice(0, this._revealed);
+
+    // Append cursor when not yet fully revealed.
+    const lineWithCursor = fullyRevealed
+      ? visibleText
+      : visibleText + cursorGlyph;
+
+    // Truncate to the available terminal columns using display-width-aware
+    // slicing so that full-width Unicode glyphs (e.g. CJK) never overflow
+    // the content rect. stringWidth() counts terminal columns, not code units.
+    let line = '';
+    let cols = 0;
+    for (const char of lineWithCursor) {
+      const w = stringWidth(char);
+      if (cols + w > width) break;
+      line += char;
+      cols += w;
+    }
+
+    const attrs = styleToCellAttrs(this._style);
+    screen.writeString(x, y, line, attrs);
+  }
+}

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -133,3 +133,7 @@ export { Stopwatch } from './display/Stopwatch.js';
 export type { StopwatchOptions } from './display/Stopwatch.js';
 export { OrderedList } from './display/OrderedList.js';
 export type { OrderedListItem, OrderedListOptions } from './display/OrderedList.js';
+
+
+export { Typewriter } from './display/Typewriter.js';
+export type { TypewriterOptions } from './display/Typewriter.js';


### PR DESCRIPTION
Description
Adds a Typewriter widget to @termuijs/widgets that reveals static text character by character. The host calls tick() at whatever cadence it likes — no internal timer is used. Includes reset() and setText() methods, a caps-aware cursor glyph, and 12 tests covering all acceptance criteria.
Related Issue

Closes #478
Which package(s)?
@termuijs/widgets
Type of Change

 ✨ Feature (type:feature)

Checklist

 ⭐ You starred the repo.
 Tests pass locally: bun vitest run
 Build passes: bun run build
 Typecheck passes: bun run typecheck
 You read CONTRIBUTING.md.
 Your PR title follows type: short description.
 Widget state mutators call markDirty() (tick, reset, setText all call it).
 No new any types without an inline comment explaining why.
 No unrelated refactors bundled into this PR.

GSSoC 2026 Participation
_

Screenshots / Recordings
N/A — terminal text widget, no visual diff needed.

Notes for the Reviewer
Three files touched, nothing outside packages/widgets:

src/display/Typewriter.ts — widget implementation
src/display/Typewriter.test.ts — 12 tests
src/index.ts — two export lines appended

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Typewriter display widget that reveals text incrementally with configurable speed and cursor, supports resetting and replacing text, respects available width (truncates to fit), and handles empty-width rendering.

* **Tests**
  * Added a comprehensive test suite covering reveal timing, cursor behavior (including unicode/ASCII fallback), reset/setText semantics, width truncation, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Karanjot786/TermUI/pull/588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->