### PR TITLE
feat(ui): add BasicAuthPrompt widget

### DIFF
--- a/packages/ui/src/BasicAuthPrompt.test.ts
+++ b/packages/ui/src/BasicAuthPrompt.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect } from "vitest";
+import { BasicAuthPrompt } from "./BasicAuthPrompt";
+import { createElement, useRef } from "@termuijs/jsx";
+import { render } from "@termuijs/testing";
+
+describe("BasicAuthPrompt", () => {
+    it("updates username on keypress", () => {
+        const input = new BasicAuthPrompt();
+        input.handleKey({
+            key: "x",
+            ctrl: false,
+            shift: false,
+            alt: false,
+            raw: Buffer.from("x"),
+            stopPropagation: () => {},
+            preventDefault: () => {},
+        });
+        input.handleKey({
+            key: "y",
+            ctrl: false,
+            shift: false,
+            alt: false,
+            raw: Buffer.from("y"),
+            stopPropagation: () => {},
+            preventDefault: () => {},
+        });
+
+        expect(input.getCredentials()).toEqual({
+            username: "xy",
+            password: "",
+        });
+    });
+    it("enter switches active field", () => {
+        const input = new BasicAuthPrompt();
+        input.handleKey({
+            key: "m",
+            ctrl: false,
+            shift: false,
+            alt: false,
+            raw: Buffer.from("m"),
+            stopPropagation: () => {},
+            preventDefault: () => {},
+        });
+        input.handleKey({
+            key: "enter",
+            ctrl: false,
+            shift: false,
+            alt: false,
+            raw: Buffer.alloc(0),
+            stopPropagation: () => {},
+            preventDefault: () => {},
+        });
+        input.handleKey({
+            key: "1",
+            ctrl: false,
+            shift: false,
+            alt: false,
+            raw: Buffer.from("1"),
+            stopPropagation: () => {},
+            preventDefault: () => {},
+        });
+
+        expect(input.getCredentials()).toEqual({
+            username: "m",
+            password: "1",
+        });
+    });
+    it("submits credentials on enter from password field", () => {
+        let result = null;
+        const input = new BasicAuthPrompt(
+            {},
+            {
+                onSubmit: (cred) => {
+                    result = cred;
+                },
+            },
+        );
+        input.handleKey({
+            key: "m",
+            ctrl: false,
+            shift: false,
+            alt: false,
+            raw: Buffer.from("m"),
+            stopPropagation: () => {},
+            preventDefault: () => {},
+        });
+        input.handleKey({
+            key: "enter",
+            ctrl: false,
+            shift: false,
+            alt: false,
+            raw: Buffer.alloc(0),
+            stopPropagation: () => {},
+            preventDefault: () => {},
+        });
+        input.handleKey({
+            key: "1",
+            ctrl: false,
+            shift: false,
+            alt: false,
+            raw: Buffer.from("1"),
+            stopPropagation: () => {},
+            preventDefault: () => {},
+        });
+        input.handleKey({
+            key: "enter",
+            ctrl: false,
+            shift: false,
+            alt: false,
+            raw: Buffer.alloc(0),
+            stopPropagation: () => {},
+            preventDefault: () => {},
+        });
+        expect(result).toEqual({
+            username: "m",
+            password: "1",
+        });
+    });
+    it("backspace removes chars", () => {
+        const input = new BasicAuthPrompt();
+        input.handleKey({
+            key: "m",
+            ctrl: false,
+            shift: false,
+            alt: false,
+            raw: Buffer.from("m"),
+            stopPropagation: () => {},
+            preventDefault: () => {},
+        });
+        input.handleKey({
+            key: "e",
+            ctrl: false,
+            shift: false,
+            alt: false,
+            raw: Buffer.from("e"),
+            stopPropagation: () => {},
+            preventDefault: () => {},
+        });
+        input.handleKey({
+            key: "backspace",
+            ctrl: false,
+            shift: false,
+            alt: false,
+            raw: Buffer.alloc(0),
+            stopPropagation: () => {},
+            preventDefault: () => {},
+        });
+        expect(input.getCredentials()).toEqual({
+            username: "m",
+            password: "",
+        });
+    });
+    it("getCredentials returns current values", () => {
+        const input = new BasicAuthPrompt();
+        input.handleKey({
+            key: "m",
+            ctrl: false,
+            shift: false,
+            alt: false,
+            raw: Buffer.from("m"),
+            stopPropagation: () => {},
+            preventDefault: () => {},
+        });
+        input.handleKey({
+            key: "enter",
+            ctrl: false,
+            shift: false,
+            alt: false,
+            raw: Buffer.alloc(0),
+            stopPropagation: () => {},
+            preventDefault: () => {},
+        });
+        input.handleKey({
+            key: "1",
+            ctrl: false,
+            shift: false,
+            alt: false,
+            raw: Buffer.from("1"),
+            stopPropagation: () => {},
+            preventDefault: () => {},
+        });
+
+        expect(input.getCredentials()).toEqual({
+            username: "m",
+            password: "1",
+        });
+    });
+    it("password field renders masked characters", () => {
+        let input = new BasicAuthPrompt();
+        const screen = render(
+            createElement(() => {
+                const ref = useRef<BasicAuthPrompt | null>(null);
+                if (!ref.current) {
+                    ref.current = new BasicAuthPrompt();
+                }
+                input = ref.current;
+                return ref.current;
+            }, null),
+        );
+        input.handleKey({
+            key: "m",
+            ctrl: false,
+            shift: false,
+            alt: false,
+            raw: Buffer.from("m"),
+            stopPropagation: () => {},
+            preventDefault: () => {},
+        });
+        input.handleKey({
+            key: "enter",
+            ctrl: false,
+            shift: false,
+            alt: false,
+            raw: Buffer.alloc(0),
+            stopPropagation: () => {},
+            preventDefault: () => {},
+        });
+        input.handleKey({
+            key: "1",
+            ctrl: false,
+            shift: false,
+            alt: false,
+            raw: Buffer.from("1"),
+            stopPropagation: () => {},
+            preventDefault: () => {},
+        });
+        input.handleKey({
+            key: "2",
+            ctrl: false,
+            shift: false,
+            alt: false,
+            raw: Buffer.from("2"),
+            stopPropagation: () => {},
+            preventDefault: () => {},
+        });
+        input.handleKey({
+            key: "3",
+            ctrl: false,
+            shift: false,
+            alt: false,
+            raw: Buffer.from("3"),
+            stopPropagation: () => {},
+            preventDefault: () => {},
+        });
+        const mask = (input as any)._maskChar;
+        screen.rerender();
+        expect(screen.lastFrame().join("\n")).toContain(mask.repeat(3));
+        expect(screen.lastFrame().join("\n")).not.toContain("123");
+        screen.unmount();
+    });
+});

--- a/packages/ui/src/BasicAuthPrompt.ts
+++ b/packages/ui/src/BasicAuthPrompt.ts
@@ -18,7 +18,7 @@ export class BasicAuthPrompt extends Widget {
     private _activeField: "username" | "password" = "username";
     private _opts: BasicAuthPromptOptions;
     private get _maskChar(): string {
-        return caps.unicode ? '●' : '*';
+        return caps.unicode ? "●" : "*";
     }
     constructor(style?: Partial<Style>, opts?: BasicAuthPromptOptions) {
         super(style);
@@ -81,9 +81,9 @@ export class BasicAuthPrompt extends Widget {
         const username = `${this._opts.usernameLabel} ${this._username}`;
         const masked = this._maskChar.repeat(this._password.length);
         const password = `${this._opts.passwordLabel} ${masked}`;
-        screen.writeString(x,y,username);
-        if(height > 1){
-            screen.writeString(x,y+1,password);
+        screen.writeString(x, y, username);
+        if (height > 1) {
+            screen.writeString(x, y + 1, password);
         }
     }
 }

--- a/packages/ui/src/BasicAuthPrompt.ts
+++ b/packages/ui/src/BasicAuthPrompt.ts
@@ -1,0 +1,89 @@
+import { Widget } from "@termuijs/widgets";
+import { type Style, type KeyEvent, Screen, caps } from "@termuijs/core";
+
+export interface BasicAuthCredentials {
+    username: string;
+    password: string;
+}
+
+export interface BasicAuthPromptOptions {
+    usernameLabel?: string; // default: 'Username:'
+    passwordLabel?: string; // default: 'Password:'
+    onSubmit?: (credentials: BasicAuthCredentials) => void;
+}
+
+export class BasicAuthPrompt extends Widget {
+    private _username = "";
+    private _password = "";
+    private _activeField: "username" | "password" = "username";
+    private _opts: BasicAuthPromptOptions;
+    private get _maskChar(): string {
+        return caps.unicode ? '●' : '*';
+    }
+    constructor(style?: Partial<Style>, opts?: BasicAuthPromptOptions) {
+        super(style);
+
+        this._opts = {
+            usernameLabel: "Username:",
+            passwordLabel: "Password:",
+            ...opts,
+        };
+    }
+    getCredentials(): BasicAuthCredentials {
+        return {
+            username: this._username,
+            password: this._password,
+        };
+    }
+    private onSubmit(): void {
+        if (this._activeField === "username") {
+            this._activeField = "password";
+        } else if (this._activeField === "password") {
+            this._opts.onSubmit?.(this.getCredentials());
+        }
+        this.markDirty();
+    }
+    private deleteBackward(): void {
+        if (this._activeField === "username") {
+            this._username = this._username.slice(0, -1);
+        } else {
+            this._password = this._password.slice(0, -1);
+        }
+        this.markDirty();
+    }
+    private insertChar(key: string): void {
+        if (this._activeField === "username") {
+            this._username += key;
+        } else {
+            this._password += key;
+        }
+        this.markDirty();
+    }
+    handleKey(event: KeyEvent): void {
+        switch (event.key) {
+            case "enter":
+                this.onSubmit();
+                break;
+            case "backspace":
+                this.deleteBackward();
+                break;
+            default:
+                if (event.key.length === 1 && !event.ctrl && !event.alt) {
+                    this.insertChar(event.key);
+                }
+        }
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const rect = this._getContentRect();
+        const { x, y, width, height } = rect;
+        if (width <= 0 || height <= 0) return;
+        const username = `${this._opts.usernameLabel} ${this._username}`;
+        const masked = this._maskChar.repeat(this._password.length);
+        const password = `${this._opts.passwordLabel} ${masked}`;
+        screen.writeString(x,y,username);
+        if(height > 1){
+            screen.writeString(x,y+1,password);
+        }
+    }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -5,6 +5,8 @@
 // components for building beautiful CLI apps.
 // ─────────────────────────────────────────────────────
 
+import { BasicAuthPrompt } from './BasicAuthPrompt.js';
+
 // ── Re-exports from @termuijs/widgets (base components) ──
 export {
     Box,
@@ -108,4 +110,6 @@ export { Wizard } from './Wizard.js';
 export type { WizardStep, WizardOptions } from './Wizard.js';
 export { MultilineTextInput } from './MultilineTextInput.js';
 export type { MultilineTextInputOptions } from './MultilineTextInput.js';
+export {BasicAuthPrompt} from './BasicAuthPrompt.js';
+export type {BasicAuthCredentials,BasicAuthPromptOptions} from './BasicAuthPrompt.js'
 


### PR DESCRIPTION
## Description

Adds a new `BasicAuthPrompt` widget to `@termuijs/ui` that provides a sequential username and masked password input flow.

The widget supports:

* username input handling
* password masking (`*` / unicode mask support)
* enter to switch username → password
* enter to submit credentials through `onSubmit`
* backspace support for the active field
* credential retrieval through `getCredentials()`

Behavior and render tests were added to validate input flow, masking, submission, and rendering.

---

## Related Issue

Closes #262

---

## Which package(s)?

* `@termuijs/ui`

---

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [x] ✨ Feature (`type:feature`)
* [x] 🧪 Tests (`type:testing`)
* [ ] 📝 Docs (`type:docs`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

---

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] Read `CONTRIBUTING.md`
* [x] PR title follows `type: short description`
* [x] Widget state mutators call `markDirty()`
* [x] No new `any` types without explanation
* [x] No unrelated refactors bundled

---

## GSSoC 2026 Participation

* [x] I am a GSSoC 2026 contributor.

Your GSSoC profile:
`https://gssoc.girlscript.org/profile/9bfd4b06-663d-4241-98a1-455a92933a74`

---


## Screenshots / Recordings (UI changes)

### Build verification

Attached screenshot showing successful build execution:

* `bun run build`
* all packages completed successfully

<img width="515" height="175" alt="Screenshot 2026-06-03 164956" src="https://github.com/user-attachments/assets/430728de-1157-411e-8707-28d0c540f258" />

### Test verification

Attached screenshot showing `BasicAuthPrompt.test.ts` passing:

* updates username on keypress
* enter switches active field
* submits credentials on enter from password field
* backspace removes chars
* getCredentials returns current values
* password field renders masked characters

<img width="1069" height="309" alt="Screenshot 2026-06-03 165423" src="https://github.com/user-attachments/assets/33293b20-0610-4e62-9744-c0702a172fe8" />

---

## Notes for the Reviewer

Implementation is confined to `packages/ui`.

Files added:

* `packages/ui/src/BasicAuthPrompt.ts`
* `packages/ui/src/BasicAuthPrompt.test.ts`

Files modified:

* `packages/ui/src/index.ts`

Validation completed:

```bash
bun run build
bun vitest run packages/ui
bun run typecheck
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a basic authentication prompt widget for terminal interfaces with username and password input fields
  * Password field displays masked characters for security
  * Customizable labels and callback support

* **Tests**
  * Added comprehensive test suite covering input handling, field navigation, and password masking behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Karanjot786/TermUI/pull/590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->