### PR TITLE
feat(widgets): add Stat widget (#469)

### DIFF
--- a/packages/widgets/src/data/Stat.test.ts
+++ b/packages/widgets/src/data/Stat.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+afterEach(() => {
+    vi.unstubAllEnvs();
+});
+
+describe('Stat', () => {
+    it('renders label and value on consecutive rows', async () => {
+        vi.stubEnv('NO_UNICODE', '');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { Stat } = await import('./Stat.js');
+
+        const stat = new Stat('Label', 'Value');
+        stat.updateRect({ x: 0, y: 0, width: 20, height: 2 });
+        const screen = new Screen(20, 3);
+        stat.render(screen);
+
+        const row0 = screen.back[0].map((c: { char: string }) => c.char).join('').trimEnd();
+        const row1 = screen.back[1].map((c: { char: string }) => c.char).join('').trimEnd();
+        expect(row0).toBe('Label');
+        expect(row1).toBe('Value');
+    });
+
+    it('setValue updates rendered output', async () => {
+        vi.stubEnv('NO_UNICODE', '');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { Stat } = await import('./Stat.js');
+
+        const stat = new Stat('Label', 'Value');
+        stat.setValue('NewValue');
+        stat.updateRect({ x: 0, y: 0, width: 20, height: 2 });
+        const screen = new Screen(20, 3);
+        stat.render(screen);
+
+        const row1 = screen.back[1].map((c: { char: string }) => c.char).join('').trimEnd();
+        expect(row1).toBe('NewValue');
+    });
+
+    it('positive delta shows up arrow', async () => {
+        vi.stubEnv('NO_UNICODE', '');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { Stat } = await import('./Stat.js');
+
+        const stat = new Stat('Label', 'Value', {}, { delta: 5 });
+        stat.updateRect({ x: 0, y: 0, width: 20, height: 2 });
+        const screen = new Screen(20, 3);
+        stat.render(screen);
+
+        const row1 = screen.back[1].map((c: { char: string }) => c.char).join('').trimEnd();
+        expect(row1).toContain('\u2191');
+    });
+
+    it('negative delta shows down arrow', async () => {
+        vi.stubEnv('NO_UNICODE', '');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { Stat } = await import('./Stat.js');
+
+        const stat = new Stat('Label', 'Value', {}, { delta: -3 });
+        stat.updateRect({ x: 0, y: 0, width: 20, height: 2 });
+        const screen = new Screen(20, 3);
+        stat.render(screen);
+
+        const row1 = screen.back[1].map((c: { char: string }) => c.char).join('').trimEnd();
+        expect(row1).toContain('\u2193');
+    });
+
+    it('zero delta shows right arrow', async () => {
+        vi.stubEnv('NO_UNICODE', '');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { Stat } = await import('./Stat.js');
+
+        const stat = new Stat('Label', 'Value', {}, { delta: 0 });
+        stat.updateRect({ x: 0, y: 0, width: 20, height: 2 });
+        const screen = new Screen(20, 3);
+        stat.render(screen);
+
+        const row1 = screen.back[1].map((c: { char: string }) => c.char).join('').trimEnd();
+        expect(row1).toContain('\u2192');
+    });
+});

--- a/packages/widgets/src/data/Stat.ts
+++ b/packages/widgets/src/data/Stat.ts
@@ -1,0 +1,64 @@
+import { type Screen, type Style, type Color, styleToCellAttrs, stringWidth } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export interface StatOptions {
+    delta?: number;
+    valueColor?: Color;
+}
+
+export class Stat extends Widget {
+    private _label: string;
+    private _value: string;
+    private _delta: number | undefined;
+    private _valueColor: Color;
+
+    constructor(label: string, value: string, style: Partial<Style> = {}, opts: StatOptions = {}) {
+        super(style);
+        this._label = label;
+        this._value = value;
+        this._delta = opts.delta;
+        this._valueColor = opts.valueColor ?? { type: 'named', name: 'white' };
+    }
+
+    setValue(value: string): void {
+        this._value = value;
+        this.markDirty();
+    }
+
+    setDelta(delta: number | undefined): void {
+        this._delta = delta;
+        this.markDirty();
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const rect = this._getContentRect();
+        const { x, y, width, height } = rect;
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this._style);
+
+        // Row 0: label (bold)
+        screen.writeString(x, y, this._label, { ...attrs, bold: true });
+
+        if (height < 2) return;
+
+        // Row 1: value
+        screen.writeString(x, y + 1, this._value, { ...attrs, fg: this._valueColor });
+
+        // Optional delta arrow
+        if (this._delta !== undefined) {
+            const valueWidth = stringWidth(this._value);
+            const arrowX = x + valueWidth + 1;
+
+            if (arrowX >= x + width) return;
+
+            if (this._delta > 0) {
+                screen.setCell(arrowX, y + 1, { char: '\u2191', fg: { type: 'named', name: 'green' } });
+            } else if (this._delta < 0) {
+                screen.setCell(arrowX, y + 1, { char: '\u2193', fg: { type: 'named', name: 'red' } });
+            } else {
+                screen.setCell(arrowX, y + 1, { char: '\u2192', dim: true });
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Stat widget for displaying labeled statistics with customizable value colors and optional delta indicators that visually represent positive (green arrow), negative (red arrow), and zero (dim right arrow) value changes.

* **Tests**
  * Added comprehensive test coverage for the Stat widget including rendering behavior, value updates, and delta formatting validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Karanjot786/TermUI/pull/591?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->