### PR TITLE
feat(widgets): add EmptyState widget (#474)

### DIFF
--- a/packages/widgets/src/feedback/EmptyState.test.ts
+++ b/packages/widgets/src/feedback/EmptyState.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Screen, caps } from '@termuijs/core';
+import { EmptyState } from './EmptyState.js';
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+function row(screen: Screen, y: number): string {
+    return screen.back[y].map((c: { char: string }) => c.char).join('');
+}
+
+describe('EmptyState', () => {
+    it('renders icon + title centered', () => {
+        const es = new EmptyState('No items');
+        es.updateRect({ x: 0, y: 0, width: 30, height: 5 });
+        const screen = new Screen(30, 5);
+        es.render(screen);
+
+        const iconRow = 1;
+        const titleRow = 2;
+        expect(row(screen, iconRow).trim()).toBe('📭');
+        expect(row(screen, titleRow).trim()).toBe('No items');
+    });
+
+    it('renders description when provided', () => {
+        const es = new EmptyState('No results', {}, { description: 'Try a different search' });
+        es.updateRect({ x: 0, y: 0, width: 40, height: 6 });
+        const screen = new Screen(40, 6);
+        es.render(screen);
+
+        const descRow = 3;
+        expect(row(screen, descRow).trim()).toContain('Try a different search');
+    });
+
+    it('setTitle updates text', () => {
+        const es = new EmptyState('Old title');
+        es.setTitle('New title');
+        es.updateRect({ x: 0, y: 0, width: 30, height: 5 });
+        const screen = new Screen(30, 5);
+        es.render(screen);
+
+        const titleRow = 2;
+        expect(row(screen, titleRow).trim()).toContain('New title');
+        expect(row(screen, titleRow).trim()).not.toContain('Old title');
+    });
+
+    it('handles very narrow width gracefully', () => {
+        const es = new EmptyState('Wide title', {}, { description: 'desc' });
+        es.updateRect({ x: 0, y: 0, width: 3, height: 5 });
+        const screen = new Screen(3, 5);
+        expect(() => es.render(screen)).not.toThrow();
+    });
+
+    it('renders hint when provided', () => {
+        const es = new EmptyState('No data', {}, { hint: 'Press F5 to refresh' });
+        es.updateRect({ x: 0, y: 0, width: 40, height: 7 });
+        const screen = new Screen(40, 7);
+        es.render(screen);
+
+        const hintRow = 6;
+        expect(row(screen, hintRow).trim()).toContain('Press F5 to refresh');
+    });
+});

--- a/packages/widgets/src/feedback/EmptyState.ts
+++ b/packages/widgets/src/feedback/EmptyState.ts
@@ -1,0 +1,68 @@
+import { type Screen, type Style, styleToCellAttrs, stringWidth, caps } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export interface EmptyStateOptions {
+    icon?: string;
+    description?: string;
+    hint?: string;
+}
+
+export class EmptyState extends Widget {
+    private _title: string;
+    private _icon: string;
+    private _description: string = '';
+    private _hint: string = '';
+
+    constructor(title: string, style: Partial<Style> = {}, opts: EmptyStateOptions = {}) {
+        super(style);
+        this._title = title;
+        this._icon = opts.icon ?? (caps.unicode ? '📭' : '[]');
+        if (opts.description !== undefined) this._description = opts.description;
+        if (opts.hint !== undefined) this._hint = opts.hint;
+    }
+
+    setTitle(title: string): void {
+        this._title = title;
+        this.markDirty();
+    }
+
+    setDescription(description: string): void {
+        this._description = description;
+        this.markDirty();
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const rect = this._getContentRect();
+        const { x, y, width, height } = rect;
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this._style);
+        const hasHint = this._hint.length > 0;
+        const hasDesc = this._description.length > 0;
+
+        const hintRow = hasHint ? y + height - 1 : -1;
+        const mainHeight = hasHint ? height - 1 : height;
+
+        const contentLines = 1 + 1 + (hasDesc ? 1 : 0);
+        const startRow = y + Math.max(0, Math.floor((mainHeight - contentLines) / 2));
+
+        const iconX = x + Math.max(0, Math.floor((width - stringWidth(this._icon)) / 2));
+        screen.writeString(iconX, startRow, this._icon, attrs);
+
+        const titleStr = this._title;
+        const titleX = x + Math.max(0, Math.floor((width - stringWidth(titleStr)) / 2));
+        screen.writeString(titleX, startRow + 1, titleStr, { ...attrs, bold: true });
+
+        if (hasDesc) {
+            const descStr = this._description;
+            const descX = x + Math.max(0, Math.floor((width - stringWidth(descStr)) / 2));
+            screen.writeString(descX, startRow + 2, descStr, { ...attrs, dim: true });
+        }
+
+        if (hasHint) {
+            const hintStr = this._hint;
+            const hintX = x + Math.max(0, Math.floor((width - stringWidth(hintStr)) / 2));
+            screen.writeString(hintX, hintRow, hintStr, { ...attrs, dim: true });
+        }
+    }
+}

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -83,6 +83,10 @@ export { StatusMessage } from './feedback/StatusMessage.js';
 export type { StatusMessageOptions, StatusVariant } from './feedback/StatusMessage.js';
 export { Banner } from './feedback/Banner.js';
 export type { BannerOptions } from './feedback/Banner.js';
+export { EmptyState } from './feedback/EmptyState.js';
+export type { EmptyStateOptions } from './feedback/EmptyState.js';
+export { Callout } from './feedback/Callout.js';
+export type { CalloutVariant, CalloutOptions } from './feedback/Callout.js';
 
 // ── New Data Widgets ──────────────────────────────────
 export { KeyValue } from './data/KeyValue.js';
@@ -106,6 +110,8 @@ export type { GradientOptions } from './display/Gradient.js';
 
 export { Markdown } from './display/Markdown.js';
 export type { MarkdownOptions } from './display/Markdown.js';
+export { Code } from './display/Code.js';
+export type { CodeOptions } from './display/Code.js';
 export { Badge } from './display/Badge.js';
 export type { BadgeOptions, BadgeVariant } from './display/Badge.js';
 export { Tag } from './display/Tag.js';
@@ -128,6 +134,8 @@ export { ScatterPlot } from './data/ScatterPlot.js';
 export type { ScatterPlotOptions, ScatterPoint } from './data/ScatterPlot.js';
 export { RadarChart } from './data/RadarChart.js';
 export type { RadarChartOptions, RadarSeries } from './data/RadarChart.js';
+export { Stat } from './data/Stat.js';
+export type { StatOptions } from './data/Stat.js';
 
 export { CandlestickChart } from './data/CandlestickChart.js';
 export type { CandlestickChartOptions, Candle } from './data/CandlestickChart.js';
@@ -138,6 +146,9 @@ export type { StopwatchOptions } from './display/Stopwatch.js';
 export { OrderedList } from './display/OrderedList.js';
 export type { OrderedListItem, OrderedListOptions } from './display/OrderedList.js';
 
-
 export { Typewriter } from './display/Typewriter.js';
 export type { TypewriterOptions } from './display/Typewriter.js';
+export { Timeline } from './display/Timeline.js';
+export type { TimelineItem, TimelineStatus } from './display/Timeline.js';
+export { Marquee } from './display/Marquee.js';
+export type { MarqueeDirection, MarqueeOptions } from './display/Marquee.js';


### PR DESCRIPTION
Closes #474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added EmptyState widget for displaying empty states with customizable icon, title, optional description, and hint
  * Expanded public widget library with additional exports: Callout, Code, Stat, Timeline, and Marquee components

* **Tests**
  * Added unit tests validating EmptyState rendering, optional description/hint, title updates, and behavior in narrow layouts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->