### PR TITLE
feat(core): add OSC 8 hyperlink cell support

### DIFF
--- a/packages/core/src/terminal/Screen.test.ts
+++ b/packages/core/src/terminal/Screen.test.ts
@@ -3,8 +3,9 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi } from 'vitest';
-import { Screen, emptyCell, cellsEqual } from '../terminal/Screen.js';
-import { caps } from '../terminal/env-caps.js';
+import { Screen, emptyCell, resetCell, cellsEqual } from './Screen.js';
+import { caps } from './env-caps.js';
+import { hyperlinkOpen, hyperlinkClose } from '../utils/ansi.js';
 
 describe('Screen', () => {
     it('initializes with correct dimensions', () => {
@@ -147,5 +148,46 @@ describe('cellsEqual', () => {
         const a = emptyCell();
         const b = { ...emptyCell(), fg: { type: 'named' as const, name: 'red' as const } };
         expect(cellsEqual(a, b)).toBe(false);
+    });
+});
+
+describe('Screen and Cell Hyperlink Support', () => {
+    it('a cell written with link retains it', () => {
+        const s = new Screen(20, 1);
+        s.setCell(0, 0, { char: 'x', link: 'https://termui.dev' });
+        expect(s.back[0][0].link).toBe('https://termui.dev');
+    });
+
+    it('emptyCell().link is undefined', () => {
+        expect(emptyCell().link).toBeUndefined();
+    });
+
+    it('resetCell clears a previously set link', () => {
+        const cell = emptyCell();
+        cell.link = 'https://termui.dev';
+        resetCell(cell);
+        expect(cell.link).toBeUndefined();
+    });
+
+    it('cellsEqual distinguishes differing links', () => {
+        const c1 = emptyCell();
+        const c2 = emptyCell();
+        
+        expect(cellsEqual(c1, c2)).toBe(true);
+        
+        c1.link = 'https://termui.dev';
+        expect(cellsEqual(c1, c2)).toBe(false);
+        
+        c2.link = 'https://termui.dev';
+        expect(cellsEqual(c1, c2)).toBe(true);
+    });
+
+    it('hyperlinkOpen produces a valid OSC 8 prefix', () => {
+        const url = 'https://termui.dev';
+        expect(hyperlinkOpen(url)).toBe(`\x1b]8;;${url}\x1b\\`);
+    });
+
+    it('hyperlinkClose produces a valid OSC 8 suffix', () => {
+        expect(hyperlinkClose).toBe(`\x1b]8;;\x1b\\`);
     });
 });

--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -37,6 +37,8 @@ export interface Cell {
      * - 0 for continuation cells (second half of a wide char)
      */
     width: number;
+    /** Optional OSC 8 hyperlink target for this cell. */
+    link?: string;
 }
 
 /** Create a blank cell with default attributes */
@@ -52,6 +54,7 @@ export function emptyCell(): Cell {
         strikethrough: false,
         inverse: false,
         width: 1,
+        link: undefined,
     };
 }
 
@@ -67,6 +70,7 @@ export function resetCell(cell: Cell): void {
     cell.strikethrough = false;
     cell.inverse = false;
     cell.width = 1;
+    cell.link = undefined;
 }
 
 /** Check if two cells are visually identical */
@@ -80,6 +84,7 @@ export function cellsEqual(a: Cell, b: Cell): boolean {
         a.strikethrough === b.strikethrough &&
         a.inverse === b.inverse &&
         a.width === b.width &&
+        a.link === b.link &&
         colorsEqual(a.fg, b.fg) &&
         colorsEqual(a.bg, b.bg)
     );

--- a/packages/core/src/utils/ansi.ts
+++ b/packages/core/src/utils/ansi.ts
@@ -99,6 +99,8 @@ export function setTitle(title: string): string {
 
 /** OSC 8 open: ESC ] 8 ; ; <url> ST. */
 export function hyperlinkOpen(url: string): string {
+    // Block non-http/https/file schemes (e.g. javascript:, data:).
+    if (!/^(https?|file):\/\//i.test(url)) return '';
     // Strip C0/C1 controls and ESC to prevent terminal escape injection.
     const safeUrl = url.replace(/[\u0000-\u001F\u007F-\u009F\u001B]/g, '');
     return `\x1b]8;;${safeUrl}\x1b\\`;

--- a/packages/core/src/utils/ansi.ts
+++ b/packages/core/src/utils/ansi.ts
@@ -95,6 +95,16 @@ export function setTitle(title: string): string {
     return `${OSC}0;${title}\x07`;
 }
 
+// ── Hyperlinks (OSC 8) ──────────────────────────────
+
+/** OSC 8 open: ESC ] 8 ; ; <url> ST. */
+export function hyperlinkOpen(url: string): string {
+    return `\x1b]8;;${url}\x1b\\`;
+}
+
+/** OSC 8 close: ESC ] 8 ; ; ST. */
+export const hyperlinkClose: string = '\x1b]8;;\x1b\\';
+
 // ── Clipboard ───────────────────────────────────────
 
 /**

--- a/packages/core/src/utils/ansi.ts
+++ b/packages/core/src/utils/ansi.ts
@@ -99,7 +99,9 @@ export function setTitle(title: string): string {
 
 /** OSC 8 open: ESC ] 8 ; ; <url> ST. */
 export function hyperlinkOpen(url: string): string {
-    return `\x1b]8;;${url}\x1b\\`;
+    // Strip C0/C1 controls and ESC to prevent terminal escape injection.
+    const safeUrl = url.replace(/[\u0000-\u001F\u007F-\u009F\u001B]/g, '');
+    return `\x1b]8;;${safeUrl}\x1b\\`;
 }
 
 /** OSC 8 close: ESC ] 8 ; ; ST. */


### PR DESCRIPTION
Closes #464

### What was built
This PR introduces minimal, additive OSC 8 hyperlink support to the `@termuijs/core` package, specifically extending the `Cell` interface and providing ANSI escape helpers.

### Implementation Details
* Added optional `link?: string` field to the `Cell` interface.
* Updated `emptyCell()`, `resetCell()`, and `cellsEqual()` to properly handle the new `link` property without mutating existing behavior for non-linked cells.
* Exported `hyperlinkOpen(url)` and `hyperlinkClose` from `ansi.ts` using standard OSC 8 sequences and string terminators (`\x1b\\`).
* Added comprehensive coverage in `Screen.test.ts` for lifecycle behavior, equality checks, and ANSI serialization.

### Acceptance Criteria Met
- [x] `Cell` gains an optional `link?: string`.
- [x] `emptyCell()` returns link as undefined.
- [x] `resetCell()` clears link.
- [x] `cellsEqual()` distinguishes differing links.
- [x] `ansi.hyperlinkOpen` wraps url in OSC 8.
- [x] Passes `bun vitest run packages/core`.
- [x] Passes `bun run typecheck`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hyperlink support to terminal cells, enabling clickable links in terminal output.
* **Tests**
  * Added coverage verifying link preservation, clearing, equality handling, and correct open/close escape behavior for terminal hyperlinks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->