### PR TITLE
feat(core): add directional 2D spatial focus navigation

### DIFF
--- a/packages/core/src/events/FocusManager.test.ts
+++ b/packages/core/src/events/FocusManager.test.ts
@@ -87,3 +87,62 @@ describe('FocusManager', () => {
         expect(fm.isFocused('b')).toBe(true);
     });
 });
+
+describe('FocusManager Spatial Navigation', () => {
+    it('right move picks the nearest right neighbor', () => {
+        const fm = new FocusManager();
+        fm.register(makeWidget('a', 0, true));
+        fm.register(makeWidget('b', 1, true));
+        
+        fm.setRect('a', { x: 0, y: 0, width: 4, height: 1 });
+        fm.setRect('b', { x: 10, y: 0, width: 4, height: 1 });
+        
+        fm.focusWidget('a');
+        expect(fm.focusRight()).toBe(true);
+        expect(fm.currentId).toBe('b');
+    });
+
+    it('down move picks the nearest below neighbor', () => {
+        const fm = new FocusManager();
+        fm.register(makeWidget('top', 0, true));
+        fm.register(makeWidget('bottom', 1, true));
+        
+        fm.setRect('top', { x: 0, y: 0, width: 10, height: 2 });
+        fm.setRect('bottom', { x: 0, y: 5, width: 10, height: 2 });
+        
+        fm.focusWidget('top');
+        expect(fm.focusDown()).toBe(true);
+        expect(fm.currentId).toBe('bottom');
+    });
+
+    it('no candidate in a direction returns false', () => {
+        const fm = new FocusManager();
+        fm.register(makeWidget('lonely', 0, true));
+        fm.setRect('lonely', { x: 5, y: 5, width: 5, height: 5 });
+        
+        fm.focusWidget('lonely');
+        
+        expect(fm.focusUp()).toBe(false);
+        expect(fm.focusDown()).toBe(false);
+        expect(fm.focusLeft()).toBe(false);
+        expect(fm.focusRight()).toBe(false);
+        expect(fm.currentId).toBe('lonely');
+    });
+
+    it('a closer widget wins over a farther one on the same axis', () => {
+        const fm = new FocusManager();
+        fm.register(makeWidget('start', 0, true));
+        fm.register(makeWidget('close', 1, true));
+        fm.register(makeWidget('far', 2, true));
+        
+        fm.setRect('start', { x: 0, y: 0, width: 2, height: 2 });
+        fm.setRect('close', { x: 5, y: 0, width: 2, height: 2 }); // dx=5
+        fm.setRect('far', { x: 15, y: 0, width: 2, height: 2 });  // dx=15
+        
+        fm.focusWidget('start');
+        
+        expect(fm.focusRight()).toBe(true);
+        // It should pick the closer one
+        expect(fm.currentId).toBe('close');
+    });
+});

--- a/packages/core/src/events/FocusManager.test.ts
+++ b/packages/core/src/events/FocusManager.test.ts
@@ -115,6 +115,32 @@ describe('FocusManager Spatial Navigation', () => {
         expect(fm.currentId).toBe('bottom');
     });
 
+    it('up move picks the nearest above neighbor', () => {
+        const fm = new FocusManager();
+        fm.register(makeWidget('bottom', 0, true));
+        fm.register(makeWidget('top', 1, true));
+        
+        fm.setRect('bottom', { x: 0, y: 5, width: 10, height: 2 });
+        fm.setRect('top', { x: 0, y: 0, width: 10, height: 2 });
+        
+        fm.focusWidget('bottom');
+        expect(fm.focusUp()).toBe(true);
+        expect(fm.currentId).toBe('top');
+    });
+
+    it('left move picks the nearest left neighbor', () => {
+        const fm = new FocusManager();
+        fm.register(makeWidget('right', 0, true));
+        fm.register(makeWidget('left', 1, true));
+        
+        fm.setRect('right', { x: 10, y: 0, width: 4, height: 1 });
+        fm.setRect('left', { x: 0, y: 0, width: 4, height: 1 });
+        
+        fm.focusWidget('right');
+        expect(fm.focusLeft()).toBe(true);
+        expect(fm.currentId).toBe('left');
+    });
+
     it('no candidate in a direction returns false', () => {
         const fm = new FocusManager();
         fm.register(makeWidget('lonely', 0, true));

--- a/packages/core/src/events/FocusManager.ts
+++ b/packages/core/src/events/FocusManager.ts
@@ -85,6 +85,9 @@ export class FocusManager {
         const idx = this._focusables.findIndex(f => f.id === id);
         if (idx < 0) return;
 
+        // Clean up spatial rect to prevent memory leaks
+        this._rects.delete(id);
+
         const wasFocused = idx === this._currentIndex;
         this._focusables.splice(idx, 1);
 

--- a/packages/core/src/events/FocusManager.ts
+++ b/packages/core/src/events/FocusManager.ts
@@ -4,6 +4,7 @@
 
 import { EventEmitter } from './EventEmitter.js';
 import type { FocusEvent } from './types.js';
+import type { Rect } from '../layout/Rect.js';
 
 export interface Focusable {
     id: string;
@@ -19,6 +20,7 @@ export interface Focusable {
  * - Tab-order cycling (focusNext/focusPrev)
  * - Focus trapping (for modals — limits Tab to a container)
  * - Focus groups (for arrow-key navigation within a group)
+ * - 2D Spatial navigation (focusUp/Down/Left/Right)
  */
 export class FocusManager {
     private _focusables: Focusable[] = [];
@@ -42,6 +44,11 @@ export class FocusManager {
      * Maps groupId → ordered list of widget IDs.
      */
     private _groups: Map<string, string[]> = new Map();
+
+    /**
+     * Record of on-screen rects for widgets, used for spatial navigation.
+     */
+    private _rects: Map<string, Rect> = new Map();
 
     /** Currently focused widget ID, or null if none */
     get currentId(): string | null {
@@ -273,6 +280,89 @@ export class FocusManager {
             }
         }
         return false;
+    }
+
+    // ── Spatial Navigation ──────────────────────────────
+
+    /** Record the on-screen rect for a widget, used for spatial navigation. */
+    setRect(id: string, rect: Rect): void {
+        this._rects.set(id, rect);
+    }
+
+    private _spatialFocus(
+        isValid: (cx: number, cy: number, tx: number, ty: number) => boolean,
+        calcDistance: (cx: number, cy: number, tx: number, ty: number) => number
+    ): boolean {
+        const currentId = this.currentId;
+        if (!currentId) return false;
+
+        const currentRect = this._rects.get(currentId);
+        if (!currentRect) return false;
+
+        const cx = currentRect.x + currentRect.width / 2;
+        const cy = currentRect.y + currentRect.height / 2;
+
+        let bestId: string | null = null;
+        let minDistance = Infinity;
+
+        // Iterate over active focusables to respect traps
+        const candidates = this._getActiveFocusables();
+
+        for (const node of candidates) {
+            if (!node.focusable || node.id === currentId) continue;
+            
+            const targetRect = this._rects.get(node.id);
+            if (!targetRect) continue;
+
+            const tx = targetRect.x + targetRect.width / 2;
+            const ty = targetRect.y + targetRect.height / 2;
+
+            if (isValid(cx, cy, tx, ty)) {
+                const dist = calcDistance(cx, cy, tx, ty);
+                if (dist < minDistance) {
+                    minDistance = dist;
+                    bestId = node.id;
+                }
+            }
+        }
+
+        if (bestId) {
+            this.focusWidget(bestId);
+            return true;
+        }
+        return false;
+    }
+
+    /** Move focus to the nearest focusable widget above the current one. */
+    focusUp(): boolean {
+        return this._spatialFocus(
+            (cx, cy, tx, ty) => ty < cy,
+            (cx, cy, tx, ty) => (cy - ty) + Math.abs(tx - cx)
+        );
+    }
+
+    /** Move focus to the nearest focusable widget below the current one. */
+    focusDown(): boolean {
+        return this._spatialFocus(
+            (cx, cy, tx, ty) => ty > cy,
+            (cx, cy, tx, ty) => (ty - cy) + Math.abs(tx - cx)
+        );
+    }
+
+    /** Move focus to the nearest focusable widget to the left of the current one. */
+    focusLeft(): boolean {
+        return this._spatialFocus(
+            (cx, cy, tx, ty) => tx < cx,
+            (cx, cy, tx, ty) => (cx - tx) + Math.abs(ty - cy)
+        );
+    }
+
+    /** Move focus to the nearest focusable widget to the right of the current one. */
+    focusRight(): boolean {
+        return this._spatialFocus(
+            (cx, cy, tx, ty) => tx > cx,
+            (cx, cy, tx, ty) => (tx - cx) + Math.abs(ty - cy)
+        );
     }
 
     // ── Private ──────────────────────────────────────────


### PR DESCRIPTION
Closes #465

### What was built
This PR introduces directional 2D spatial focus navigation (`focusUp`, `focusDown`, `focusLeft`, `focusRight`) to the `FocusManager` in `@termuijs/core`.

### Implementation Details
* Added a `setRect(id, rect)` method to register on-screen bounding boxes for widgets.
* Implemented a mathematical engine that calculates center-based shortest distances along targeted half-planes to find the nearest valid widget in a given direction.
* Leveraged existing `_getActiveFocusables()` and `_changeFocus()` logic to respect focus traps and avoid mutating existing tab-order behaviors.
* Added a comprehensive spatial navigation test suite to `FocusManager.test.ts`.

### Acceptance Criteria Met
- [x] `setRect` records a rect for a widget id.
- [x] `focusRight` moves to the nearest widget to the right.
- [x] `focusDown` moves to the nearest widget below.
- [x] `focusUp`/`focusLeft` mirror the behavior.
- [x] A direction with no candidate leaves focus unchanged and returns `false`.
- [x] Existing tab-order `focusNext`/`focusPrev` behavior is perfectly preserved.
- [x] Passes `bun vitest run packages/core`.
- [x] Passes `bun run typecheck`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Directional focus navigation: move focus Up, Down, Left, or Right based on widget layout.
  * Widgets can supply spatial geometry so the system chooses the nearest valid neighbor when navigating.

* **Tests**
  * Added tests covering directional navigation, no-candidate behavior, and tie-breaking to ensure correct focus selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Karanjot786/TermUI/pull/598?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->