### PR TITLE
feat: Add handleKey and useCommandPalette hook to CommandPalette

### DIFF
--- a/packages/ui/src/CommandPalette.ts
+++ b/packages/ui/src/CommandPalette.ts
@@ -1,6 +1,6 @@
 // CommandPalette — fuzzy-search command launcher
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Screen, mergeStyles, defaultStyle, styleToCellAttrs, getBorderChars, caps } from '@termuijs/core';
+import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, getBorderChars, caps } from '@termuijs/core';
 
 export interface Command { id: string; label: string; shortcut?: string; action: () => void; category?: string; }
 export interface CommandPaletteOptions { placeholder?: string; borderColor?: Style['fg']; activeColor?: Style['fg']; maxVisible?: number; }
@@ -37,6 +37,76 @@ export class CommandPalette extends Widget {
     selectNext(): void { if (this._selectedIndex < this._filtered.length - 1) { this._selectedIndex++; this.markDirty(); } }
     selectPrev(): void { if (this._selectedIndex > 0) { this._selectedIndex--; this.markDirty(); } }
     confirm(): void { const c = this._filtered[this._selectedIndex]; if (c) { this.hide(); c.action(); } }
+
+    /**
+     * Handle a KeyEvent from @termuijs/core.
+     *
+     * Wires all palette interactions to a single entry point so callers
+     * only need:
+     *   app.on('key', e => palette.handleKey(e))
+     *
+     * Built-in bindings (only active while the palette is visible):
+     *   Ctrl+P          — open / close (toggle)
+     *   ArrowUp / k     — move selection up
+     *   ArrowDown / j   — move selection down
+     *   Enter           — confirm selected command
+     *   Escape          — close
+     *   Backspace       — delete last character
+     *   any printable   — append character to query
+     *
+     * Ctrl+P is also handled while hidden so the palette can be opened.
+     * All handled events have stopPropagation() called automatically.
+     */
+    handleKey(event: KeyEvent): void {
+        // Ctrl+P toggles the palette regardless of current visibility
+        if (event.ctrl && event.key === 'p') {
+            event.stopPropagation();
+            this.toggle();
+            return;
+        }
+
+        // Remaining bindings only apply while the palette is open
+        if (!this._visible) return;
+
+        const { key, ctrl } = event;
+
+        if (key === 'escape' || (ctrl && key === 'c')) {
+            event.stopPropagation();
+            this.hide();
+            return;
+        }
+
+        if (key === 'up' || key === 'k') {
+            event.stopPropagation();
+            this.selectPrev();
+            return;
+        }
+
+        if (key === 'down' || key === 'j') {
+            event.stopPropagation();
+            this.selectNext();
+            return;
+        }
+
+        if (key === 'return' || key === 'enter') {
+            event.stopPropagation();
+            this.confirm();
+            return;
+        }
+
+        if (key === 'backspace' || key === 'delete') {
+            event.stopPropagation();
+            this.deleteBack();
+            return;
+        }
+
+        // Printable character — append to query
+        // Ignore control sequences (key.length > 1 means special key name)
+        if (!ctrl && !event.alt && key.length === 1) {
+            event.stopPropagation();
+            this.insertChar(key);
+        }
+    }
 
     private _filter(): void {
         const q = this._query.toLowerCase();

--- a/packages/ui/src/CommandPalette.ts
+++ b/packages/ui/src/CommandPalette.ts
@@ -76,13 +76,13 @@ export class CommandPalette extends Widget {
             return;
         }
 
-        if (key === 'up' || key === 'k') {
+        if (key === 'up') {
             event.stopPropagation();
             this.selectPrev();
             return;
         }
 
-        if (key === 'down' || key === 'j') {
+        if (key === 'down') {
             event.stopPropagation();
             this.selectNext();
             return;

--- a/packages/ui/src/hooks/useCommandPalette.ts
+++ b/packages/ui/src/hooks/useCommandPalette.ts
@@ -1,0 +1,52 @@
+// useCommandPalette — convenience hook for wiring CommandPalette to an App
+import type { KeyEvent } from '@termuijs/core';
+import { CommandPalette, type Command, type CommandPaletteOptions } from '../CommandPalette.js';
+
+export interface UseCommandPaletteOptions extends CommandPaletteOptions {
+    /** Initial command list */
+    commands: Command[];
+}
+
+export interface UseCommandPaletteReturn {
+    /** The CommandPalette widget instance — add it to your layout */
+    palette: CommandPalette;
+    /**
+     * Pass this directly to your app's key event listener.
+     *
+     * @example
+     * ```ts
+     * const { palette, handleKey } = useCommandPalette({ commands })
+     * app.on('key', handleKey)
+     * layout.add(palette)
+     * ```
+     */
+    handleKey: (event: KeyEvent) => void;
+}
+
+/**
+ * Create a CommandPalette and return the widget plus a bound key handler.
+ *
+ * The handler automatically wires Ctrl+P (open/close), arrow navigation,
+ * Enter, Escape, Backspace, and character input — no manual binding needed.
+ *
+ * @example
+ * ```ts
+ * import { useCommandPalette } from '@termuijs/ui'
+ *
+ * const { palette, handleKey } = useCommandPalette({
+ *   commands: [
+ *     { id: 'save', label: 'Save File', shortcut: 'Ctrl+S', action: () => save() },
+ *     { id: 'quit', label: 'Quit', category: 'App', action: () => process.exit(0) },
+ *   ],
+ * })
+ *
+ * app.on('key', handleKey)
+ * rootLayout.add(palette)
+ * ```
+ */
+export function useCommandPalette(options: UseCommandPaletteOptions): UseCommandPaletteReturn {
+    const { commands, ...paletteOptions } = options;
+    const palette = new CommandPalette(commands, paletteOptions);
+    const handleKey = (event: KeyEvent) => palette.handleKey(event);
+    return { palette, handleKey };
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -65,6 +65,9 @@ export type { FormField, FormOptions } from './Form.js';
 export { CommandPalette } from './CommandPalette.js';
 export type { Command, CommandPaletteOptions } from './CommandPalette.js';
 
+export { useCommandPalette } from './hooks/useCommandPalette.js';
+export type { UseCommandPaletteOptions, UseCommandPaletteReturn } from './hooks/useCommandPalette.js';
+
 export { prompt, NonInteractiveError } from './prompts.js';
 export type { TextPromptOptions, ConfirmPromptOptions, SelectPromptOptions } from './prompts.js';
 


### PR DESCRIPTION
## Description
Adds `handleKey(event: KeyEvent)` to the existing `CommandPalette` class and a `useCommandPalette` hook, addressing the specific gaps noted by the maintainer in #238. No existing code was rewritten.

## Related Issue
Closes #238

## Which package(s)?
`@termuijs/ui`

## Type of Change
- [x] ✨ Feature (`type:feature`)

## Checklist
- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation
- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/50e83960-7a96-44e0-bcd7-2e0c089225e9`

## Screenshots / Recordings (UI changes)
Manual verification via `bunx tsx test-palette.ts`:
- Ctrl+P → opens palette (visible: true)
- Typing 'q' → filters internally, palette stays open
- Enter → fires matched command (`Quit!`), closes palette (visible: false)
- Escape → closes palette (visible: false)

<img width="1490" height="792" alt="image" src="https://github.com/user-attachments/assets/fdf0a046-ec14-41c2-b43e-d2e59b3d6124" />

## Notes for the Reviewer
Three targeted changes only, as requested:

1. `handleKey(event: KeyEvent)` added to `CommandPalette` - single entry point wiring Ctrl+P (open/close), ↑↓ navigation, Enter, Escape, Backspace, and printable character input. Calls `stopPropagation()` on all handled events.

2. `packages/ui/src/hooks/useCommandPalette.ts` - new hook returning `{ palette, handleKey }`. Caller usage: `app.on('key', handleKey); layout.add(palette)`.

3. `useCommandPalette` and its types exported from `packages/ui/src/index.ts`.

Existing `show`, `hide`, `toggle`, `insertChar`, `deleteBack`, `selectNext`, `selectPrev`, `confirm`, `_filter`, and `_renderSelf` are completely untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command palette now supports comprehensive keyboard interactions for toggling, navigating, typing queries, and confirming selections.
  * A new convenience hook makes it simple to add the command palette to your app with automatic keyboard handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->