### PR TITLE
feat(jsx): add useBoolean hook

### DIFF
--- a/packages/jsx/src/hooks/useBoolean.test.ts
+++ b/packages/jsx/src/hooks/useBoolean.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createFiber, setCurrentFiber, clearCurrentFiber, setRequestRender } from '../hooks.js';
+import { useBoolean } from './useBoolean';
+
+describe('useBoolean', () => {
+  let fiber = createFiber();
+
+  beforeEach(() => {
+    fiber = createFiber();
+    setRequestRender(() => { });
+    setCurrentFiber(fiber);
+  });
+
+  afterEach(() => {
+    clearCurrentFiber();
+  });
+
+  it('defaults initial value to false', () => {
+    const [value] = useBoolean();
+    expect(value).toBe(false);
+  });
+
+  it('useBoolean(true) starts with true', () => {
+    const [value] = useBoolean(true);
+    expect(value).toBe(true);
+  });
+
+  it('setTrue() sets the value to true', () => {
+    const [, controls] = useBoolean(false);
+    controls.setTrue();
+
+    fiber.hookIndex = 0;
+    const [nextValue] = useBoolean(false);
+    expect(nextValue).toBe(true);
+  });
+
+  it('setFalse() sets the value to false', () => {
+    const [, controls] = useBoolean(true);
+    controls.setFalse();
+
+    fiber.hookIndex = 0;
+    const [nextValue] = useBoolean(true);
+    expect(nextValue).toBe(false);
+  });
+
+  it('toggle() flips the current value', () => {
+    const [, controls] = useBoolean(false);
+    controls.toggle();
+
+    fiber.hookIndex = 0;
+    const [nextValue] = useBoolean(false);
+    expect(nextValue).toBe(true);
+
+    controls.toggle();
+    fiber.hookIndex = 0;
+    const [finalValue] = useBoolean(false);
+    expect(finalValue).toBe(false);
+  });
+
+  it('set(value) sets the value directly', () => {
+    const [, controls] = useBoolean(false);
+    controls.set(true);
+
+    fiber.hookIndex = 0;
+    const [nextValue] = useBoolean(false);
+    expect(nextValue).toBe(true);
+  });
+});

--- a/packages/jsx/src/hooks/useBoolean.ts
+++ b/packages/jsx/src/hooks/useBoolean.ts
@@ -1,0 +1,19 @@
+import { useState } from '../hooks.js';
+
+export interface UseBooleanActions {
+  setTrue: () => void;
+  setFalse: () => void;
+  toggle: () => void;
+  set: (value: boolean) => void;
+}
+
+export function useBoolean(initialValue = false): [boolean, UseBooleanActions] {
+  const [value, setValue] = useState(initialValue);
+
+  return [value, {
+    setTrue: () => setValue(true),
+    setFalse: () => setValue(false),
+    toggle: () => setValue((prev) => !prev),
+    set: (value: boolean) => setValue(value),
+  }];
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -31,6 +31,8 @@ export { useToggle } from './hooks/useToggle.js';
 export type { AsyncState, KeyBinding, MotionPreferences } from './hooks.js';
 export { useCounter } from './hooks/useCounter.js';
 export type { UseCounterActions, UseCounterOptions } from './hooks/useCounter.js';
+export { useBoolean } from './hooks/useBoolean.js';
+export type { UseBooleanActions } from './hooks/useBoolean.js';
 export { useClipboard } from './hooks/useClipboard.js';
 export type { UseClipboardOptions, UseClipboardResult } from './hooks/useClipboard.js';
 


### PR DESCRIPTION
Implements useBoolean hook with setTrue, setFalse, toggle, and set actions.

Closes #436

## Changes
- \packages/jsx/src/hooks/useBoolean.ts\ - new hook
- \packages/jsx/src/hooks/useBoolean.test.ts\ - tests (6 cases)
- \packages/jsx/src/index.ts\ - added export

## Verification
- \un vitest run packages/jsx\ - all 108 tests pass
- \un run build\ - all packages build
- Pre-existing typecheck errors in useClipboard.test.ts (unrelated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a custom hook that provides boolean state management with convenient control methods including set true, set false, toggle, and direct value assignment.

* **Tests**
  * Added comprehensive test suite to ensure the boolean state hook works reliably across initialization, state updates, and multiple transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->