### PR TITLE
feat(jsx): add useList hook

### DIFF
--- a/packages/jsx/src/hooks/useList.test.ts
+++ b/packages/jsx/src/hooks/useList.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { clearCurrentFiber, createFiber, setCurrentFiber } from '../hooks.js';
+import { useList } from './useList.js';
+
+function renderList<T>(fiber = createFiber(), initialList?: T[]) {
+  fiber.hookIndex = 0;
+  setCurrentFiber(fiber);
+  const result = useList(initialList);
+  clearCurrentFiber();
+  return { fiber, result };
+}
+
+describe('useList', () => {
+  afterEach(() => {
+    clearCurrentFiber();
+  });
+
+  it('defaults to an empty array', () => {
+    const { result } = renderList();
+    const [list] = result;
+    expect(list).toEqual([]);
+  });
+
+  it('push(item) appends an item to the end', () => {
+    const { fiber, result } = renderList<number>(undefined, [1, 2]);
+    const [, actions] = result;
+
+    actions.push(3);
+
+    const [nextList] = renderList(fiber, [1, 2]).result;
+    expect(nextList).toEqual([1, 2, 3]);
+  });
+
+  it('removeAt(index) removes the item at that index', () => {
+    const { fiber, result } = renderList<string>(undefined, ['a', 'b', 'c']);
+    const [, actions] = result;
+
+    actions.removeAt(1);
+
+    const [nextList] = renderList(fiber, ['a', 'b', 'c']).result;
+    expect(nextList).toEqual(['a', 'c']);
+  });
+
+  it('insertAt(index, item) inserts an item at that index', () => {
+    const { fiber, result } = renderList<string>(undefined, ['a', 'c']);
+    const [, actions] = result;
+
+    actions.insertAt(1, 'b');
+
+    const [nextList] = renderList(fiber, ['a', 'c']).result;
+    expect(nextList).toEqual(['a', 'b', 'c']);
+  });
+
+  it('update(index, item) replaces the item at that index', () => {
+    const { fiber, result } = renderList<number>(undefined, [1, 2, 3]);
+    const [, actions] = result;
+
+    actions.update(1, 99);
+
+    const [nextList] = renderList(fiber, [1, 2, 3]).result;
+    expect(nextList).toEqual([1, 99, 3]);
+  });
+
+  it('clear() empties the list and set(items) replaces it', () => {
+    const { fiber, result } = renderList<number>(undefined, [1, 2, 3]);
+    const [, actions] = result;
+
+    actions.clear();
+
+    const [cleared] = renderList(fiber, [1, 2, 3]).result;
+    expect(cleared).toEqual([]);
+
+    actions.set([4, 5]);
+
+    const [replaced] = renderList(fiber, [1, 2, 3]).result;
+    expect(replaced).toEqual([4, 5]);
+  });
+
+  it('actions never mutate the previous array in place', () => {
+    const { fiber, result } = renderList<number>(undefined, [1, 2, 3]);
+    const [, actions] = result;
+    const [original] = result;
+
+    actions.push(4);
+
+    const [nextList] = renderList(fiber, [1, 2, 3]).result;
+    expect(original).toEqual([1, 2, 3]);
+    expect(nextList).toEqual([1, 2, 3, 4]);
+    expect(original).not.toBe(nextList);
+  });
+});

--- a/packages/jsx/src/hooks/useList.ts
+++ b/packages/jsx/src/hooks/useList.ts
@@ -1,0 +1,23 @@
+import { useState } from '../hooks.js';
+
+export interface UseListActions<T> {
+  push: (item: T) => void;
+  removeAt: (index: number) => void;
+  insertAt: (index: number, item: T) => void;
+  update: (index: number, item: T) => void;
+  clear: () => void;
+  set: (items: T[]) => void;
+}
+
+export function useList<T>(initialList?: T[]): [T[], UseListActions<T>] {
+  const [list, setList] = useState<T[]>(initialList ?? []);
+
+  return [list, {
+    push: (item: T) => setList((prev) => [...prev, item]),
+    removeAt: (index: number) => setList((prev) => prev.filter((_, i) => i !== index)),
+    insertAt: (index: number, item: T) => setList((prev) => [...prev.slice(0, index), item, ...prev.slice(index)]),
+    update: (index: number, item: T) => setList((prev) => prev.map((v, i) => i === index ? item : v)),
+    clear: () => setList([]),
+    set: (items: T[]) => setList(items),
+  }];
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -33,6 +33,8 @@ export { useCounter } from './hooks/useCounter.js';
 export type { UseCounterActions, UseCounterOptions } from './hooks/useCounter.js';
 export { useClipboard } from './hooks/useClipboard.js';
 export type { UseClipboardOptions, UseClipboardResult } from './hooks/useClipboard.js';
+export { useList } from './hooks/useList.js';
+export type { UseListActions } from './hooks/useList.js';
 
 // ── Error Boundary ──
 export { ErrorBoundary } from './error-boundary.js';


### PR DESCRIPTION
Implements useList hook with push, removeAt, insertAt, update, clear, and set actions.

Closes #437

## Changes
- \packages/jsx/src/hooks/useList.ts\ - new hook
- \packages/jsx/src/hooks/useList.test.ts\ - tests (7 cases)
- \packages/jsx/src/index.ts\ - added export

## Verification
- \un vitest run packages/jsx\ - all 109 tests pass
- \un run build\ - all packages build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new hook for managing list state with built-in actions: add items, remove by index, insert at positions, update specific items, clear all contents, and replace the entire list.

* **Tests**
  * Added comprehensive test coverage for the new list management hook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->