### PR TITLE
feat(jsx): add useMap hook

### DIFF
--- a/packages/jsx/src/hooks/useMap.test.ts
+++ b/packages/jsx/src/hooks/useMap.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createFiber, setCurrentFiber, clearCurrentFiber, setRequestRender } from '../hooks.js';
+import { useMap } from './useMap';
+
+describe('useMap', () => {
+  let fiber = createFiber();
+
+  beforeEach(() => {
+    fiber = createFiber();
+    setRequestRender(() => { });
+    setCurrentFiber(fiber);
+  });
+
+  afterEach(() => {
+    clearCurrentFiber();
+  });
+
+  it('useMap() defaults to an empty Map', () => {
+    const [map] = useMap();
+    expect(map.size).toBe(0);
+  });
+
+  it('useMap(entries) seeds the map from the entries', () => {
+    const [map] = useMap([['a', 1], ['b', 2]]);
+    expect(map.get('a')).toBe(1);
+    expect(map.get('b')).toBe(2);
+    expect(map.size).toBe(2);
+  });
+
+  it('set(key, value) adds or overwrites an entry', () => {
+    const [, actions] = useMap<string, number>([['a', 1]]);
+    actions.set('b', 2);
+
+    fiber.hookIndex = 0;
+    const [nextMap] = useMap([['a', 1]]);
+    expect(nextMap.get('b')).toBe(2);
+    expect(nextMap.size).toBe(2);
+
+    actions.set('a', 99);
+    fiber.hookIndex = 0;
+    const [updatedMap] = useMap([['a', 1]]);
+    expect(updatedMap.get('a')).toBe(99);
+  });
+
+  it('remove(key) deletes an entry', () => {
+    const [, actions] = useMap<string, number>([['a', 1], ['b', 2]]);
+    actions.remove('a');
+
+    fiber.hookIndex = 0;
+    const [nextMap] = useMap([['a', 1], ['b', 2]]);
+    expect(nextMap.has('a')).toBe(false);
+    expect(nextMap.size).toBe(1);
+  });
+
+  it('reset() restores the initial entries', () => {
+    const [, actions] = useMap<string, number>([['a', 1]]);
+    actions.set('b', 2);
+    actions.remove('a');
+
+    fiber.hookIndex = 0;
+    actions.reset();
+
+    fiber.hookIndex = 0;
+    const [resetMap] = useMap([['a', 1]]);
+    expect(resetMap.size).toBe(1);
+    expect(resetMap.get('a')).toBe(1);
+  });
+
+  it('get(key) returns the current value or undefined', () => {
+    const [map, actions] = useMap<string, number>([['a', 1]]);
+    expect(actions.get('a')).toBe(1);
+    expect(actions.get('missing')).toBeUndefined();
+    expect(map.get('a')).toBe(1);
+  });
+
+  it('actions create a new Map and never mutate the previous one', () => {
+    const [original, actions] = useMap<string, number>([['a', 1]]);
+    actions.set('b', 2);
+
+    fiber.hookIndex = 0;
+    const [nextMap] = useMap([['a', 1]]);
+    expect(original.size).toBe(1);
+    expect(nextMap.size).toBe(2);
+    expect(original).not.toBe(nextMap);
+  });
+});

--- a/packages/jsx/src/hooks/useMap.ts
+++ b/packages/jsx/src/hooks/useMap.ts
@@ -1,0 +1,30 @@
+import { useRef, useState } from '../hooks.js';
+
+export interface UseMapActions<K, V> {
+  set: (key: K, value: V) => void;
+  remove: (key: K) => void;
+  reset: () => void;
+  get: (key: K) => V | undefined;
+}
+
+export function useMap<K, V>(
+  initialEntries?: ReadonlyArray<readonly [K, V]>,
+): [Map<K, V>, UseMapActions<K, V>] {
+  const initialRef = useRef(initialEntries);
+  const [map, setMap] = useState(new Map(initialEntries));
+
+  return [map, {
+    set: (key: K, value: V) => setMap((prev) => {
+      const next = new Map(prev);
+      next.set(key, value);
+      return next;
+    }),
+    remove: (key: K) => setMap((prev) => {
+      const next = new Map(prev);
+      next.delete(key);
+      return next;
+    }),
+    reset: () => setMap(new Map(initialRef.current)),
+    get: (key: K) => map.get(key),
+  }];
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -35,6 +35,8 @@ export { useClipboard } from './hooks/useClipboard.js';
 export type { UseClipboardOptions, UseClipboardResult } from './hooks/useClipboard.js';
 export { useList } from './hooks/useList.js';
 export type { UseListActions } from './hooks/useList.js';
+export { useMap } from './hooks/useMap.js';
+export type { UseMapActions } from './hooks/useMap.js';
 
 // ── Error Boundary ──
 export { ErrorBoundary } from './error-boundary.js';


### PR DESCRIPTION
Implements useMap hook with set, remove, reset, and get actions.

Closes #438

## Changes
- \packages/jsx/src/hooks/useMap.ts\ - new hook
- \packages/jsx/src/hooks/useMap.test.ts\ - tests (7 cases)
- \packages/jsx/src/index.ts\ - added export

## Verification
- \un vitest run packages/jsx\ - all 109 tests pass
- \un run build\ - all packages build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hook to manage Map state in components with immutable actions to set, remove, reset, and get values.
  * Hook and its action types are now exported for public use.

* **Tests**
  * Added a test suite verifying default behavior, initialization from seed entries, and correctness of all action methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->