### PR TITLE
feat(ui): add keyboard shortcut help overlay

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -196,6 +196,7 @@
       "dependencies": {
         "@termuijs/core": "workspace:*",
         "@termuijs/dev-server": "workspace:*",
+        "@termuijs/jsx": "workspace:*",
         "@termuijs/motion": "workspace:*",
         "@termuijs/tss": "workspace:*",
         "@termuijs/ui": "workspace:*",

--- a/examples/process-monitor/src/index.tsx
+++ b/examples/process-monitor/src/index.tsx
@@ -10,7 +10,7 @@ declare module '@termuijs/jsx' {
                 children?: any;
                 key?: string | number;
                 title?: string;
-                borderColor?: any;
+                borderColor?: string;
                 flexGrow?: number;
                 flexShrink?: number;
                 width?: number | string;
@@ -30,7 +30,7 @@ declare module '@termuijs/jsx/jsx-runtime' {
                 children?: any;
                 key?: string | number;
                 title?: string;
-                borderColor?: any;
+                borderColor?: string;
                 flexGrow?: number;
                 flexShrink?: number;
                 width?: number | string;

--- a/examples/showcase/package.json
+++ b/examples/showcase/package.json
@@ -5,14 +5,15 @@
     "type": "module",
     "description": "TermUI Showcase — demonstrates all framework packages",
     "scripts": {
-        "start": "bun src/index.ts",
-        "dev": "bun --watch src/index.ts",
+        "start": "bun src/index.tsx",
+        "dev": "bun --watch src/index.tsx",
         "build": "echo 'no build needed'"
     },
     "dependencies": {
         "@termuijs/core": "workspace:*",
         "@termuijs/widgets": "workspace:*",
         "@termuijs/ui": "workspace:*",
+        "@termuijs/jsx": "workspace:*",
         "@termuijs/tss": "workspace:*",
         "@termuijs/motion": "workspace:*",
         "@termuijs/dev-server": "workspace:*"

--- a/examples/showcase/src/index.tsx
+++ b/examples/showcase/src/index.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource @termuijs/jsx */
 // ─────────────────────────────────────────────────────
 // TermUI Showcase — Main Entry Point
 // ─────────────────────────────────────────────────────
@@ -23,12 +24,16 @@ import { App } from '@termuijs/core';
 import { Box, Text, Widget } from '@termuijs/widgets';
 import type { Screen, KeyEvent } from '@termuijs/core';
 import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 import { DashboardTab } from './tabs/dashboard.js';
 import { ComponentsTab } from './tabs/components.js';
 import { ThemingTab } from './tabs/theming.js';
 import { AnimationsTab } from './tabs/animations.js';
 import { DevToolsTab } from './tabs/devtools.js';
+import { collectInputHandlers, reconcile, setRequestRender } from '@termuijs/jsx';
+import { ShortcutHelpOverlay } from '@termuijs/ui';
 
 // ── Tab names ──
 const TAB_LABELS = ['📊 Dashboard', '🧩 Components', '🎨 Theming', '🎬 Animations', '🔧 DevTools'];
@@ -47,6 +52,7 @@ class ShowcaseApp extends Widget {
     private _themingTab: ThemingTab;
     private _animationsTab: AnimationsTab;
     private _devtoolsTab: DevToolsTab;
+    private _shortcutOverlay?: Widget;
 
     constructor() {
         super({ flexDirection: 'column' });
@@ -110,17 +116,60 @@ class ShowcaseApp extends Widget {
         this.addChild(this._tabPanels[0]); // Show first tab
         this.addChild(this._statusBar);
         this.addChild(this._debugBar);
+
+            // Add a reconciled JSX overlay widget so users can press '?' to open help
+            const overlay = reconcile(<ShortcutHelpOverlay shortcuts={[
+                { key: '?', label: 'Show Help' },
+                { key: 'Ctrl+C', label: 'Exit Application' },
+                { key: 'Ctrl+S', label: 'Save Changes' },
+                { key: '/', label: 'Search' },
+            ]} />);
+            this._shortcutOverlay = overlay;
+            this.addChild(overlay);
+    }
+
+    private isShortcutOverlayVisible(): boolean {
+        const overlay = this._shortcutOverlay;
+        if (!overlay) return false;
+        const instances: Map<Widget, any> = (globalThis as any).__termuijs_instances;
+        const instance = instances?.get(overlay);
+        const fiber = instance?.fiber as any;
+        return fiber?.hooks?.[0]?.value === true;
+    }
+
+    dispatchShortcutOverlayKey(event: KeyEvent): void {
+        const overlay = this._shortcutOverlay;
+        if (!overlay) return;
+        const instances: Map<Widget, any> = (globalThis as any).__termuijs_instances;
+        const instance = instances?.get(overlay);
+        const fiber = instance?.fiber as any;
+        if (!fiber) return;
+        for (const handler of collectInputHandlers(fiber)) {
+            handler(event);
+        }
     }
 
     handleKey(event: KeyEvent): boolean {
         const dbg = (msg: string) => {
-            fs.appendFileSync('/tmp/termui-debug.log', msg + '\n');
+            try {
+                const tmpDir = process.env.TEMP ?? process.env.TMP ?? os.tmpdir();
+                const file = path.join(tmpDir, 'termui-debug.log');
+                fs.appendFileSync(file, msg + '\n');
+            } catch (e) {
+                // ignore file write errors
+            }
             this._debugBar.setContent(`  [DEBUG] ${msg}`);
         };
         dbg(`key="${event.key}" ctrl=${event.ctrl} tab=${this._activeTab}`);
 
         // Quit
-        if (event.key === 'q' || (event.ctrl && event.key === 'c')) return false;
+        if (event.key === 'q') {
+            if (this.isShortcutOverlayVisible()) {
+                return true;
+            }
+            return false;
+        }
+        if (event.ctrl && event.key === 'c') return false;
 
         // Tab switching: 1-5
         const num = parseInt(event.key);
@@ -202,7 +251,9 @@ async function main() {
     });
 
     // Keyboard handler
+    setRequestRender(() => app.requestRender());
     app.events.on('key', (event) => {
+        showcase.dispatchShortcutOverlayKey(event);
         const shouldContinue = showcase.handleKey(event);
         if (!shouldContinue) app.exit(0);
         app.requestRender();

--- a/examples/showcase/src/index.tsx
+++ b/examples/showcase/src/index.tsx
@@ -1,4 +1,3 @@
-/** @jsxImportSource @termuijs/jsx */
 // ─────────────────────────────────────────────────────
 // TermUI Showcase — Main Entry Point
 // ─────────────────────────────────────────────────────
@@ -24,15 +23,13 @@ import { App } from '@termuijs/core';
 import { Box, Text, Widget } from '@termuijs/widgets';
 import type { Screen, KeyEvent } from '@termuijs/core';
 import * as fs from 'node:fs';
-import * as os from 'node:os';
-import * as path from 'node:path';
 
 import { DashboardTab } from './tabs/dashboard.js';
 import { ComponentsTab } from './tabs/components.js';
 import { ThemingTab } from './tabs/theming.js';
 import { AnimationsTab } from './tabs/animations.js';
 import { DevToolsTab } from './tabs/devtools.js';
-import { collectInputHandlers, reconcile, setRequestRender } from '@termuijs/jsx';
+import { reconcile } from '@termuijs/jsx';
 import { ShortcutHelpOverlay } from '@termuijs/ui';
 
 // ── Tab names ──
@@ -52,7 +49,7 @@ class ShowcaseApp extends Widget {
     private _themingTab: ThemingTab;
     private _animationsTab: AnimationsTab;
     private _devtoolsTab: DevToolsTab;
-    private _shortcutOverlay?: Widget;
+    private _overlayLayer: Box;
 
     constructor() {
         super({ flexDirection: 'column' });
@@ -117,59 +114,33 @@ class ShowcaseApp extends Widget {
         this.addChild(this._statusBar);
         this.addChild(this._debugBar);
 
-            // Add a reconciled JSX overlay widget so users can press '?' to open help
-            const overlay = reconcile(<ShortcutHelpOverlay shortcuts={[
-                { key: '?', label: 'Show Help' },
-                { key: 'Ctrl+C', label: 'Exit Application' },
-                { key: 'Ctrl+S', label: 'Save Changes' },
-                { key: '/', label: 'Search' },
-            ]} />);
-            this._shortcutOverlay = overlay;
-            this.addChild(overlay);
-    }
+        // Dedicated overlay layer — always rendered on top, unaffected by switchTab()
+        this._overlayLayer = new Box({ flexDirection: 'column' });
+        this.addChild(this._overlayLayer);
 
-    private isShortcutOverlayVisible(): boolean {
-        const overlay = this._shortcutOverlay;
-        if (!overlay) return false;
-        const instances: Map<Widget, any> = (globalThis as any).__termuijs_instances;
-        const instance = instances?.get(overlay);
-        const fiber = instance?.fiber as any;
-        return fiber?.hooks?.[0]?.value === true;
-    }
-
-    dispatchShortcutOverlayKey(event: KeyEvent): void {
-        const overlay = this._shortcutOverlay;
-        if (!overlay) return;
-        const instances: Map<Widget, any> = (globalThis as any).__termuijs_instances;
-        const instance = instances?.get(overlay);
-        const fiber = instance?.fiber as any;
-        if (!fiber) return;
-        for (const handler of collectInputHandlers(fiber)) {
-            handler(event);
-        }
+        // Add the reconciled JSX overlay widget so users can press '?' to open help
+        const overlay = reconcile(
+            <ShortcutHelpOverlay
+                shortcuts={[
+                    { key: '?', label: 'Show Help' },
+                    { key: 'Ctrl+C', label: 'Exit Application' },
+                    { key: 'Ctrl+S', label: 'Save Changes' },
+                    { key: '/', label: 'Search' },
+                ]}
+            />,
+        );
+        this._overlayLayer.addChild(overlay);
     }
 
     handleKey(event: KeyEvent): boolean {
         const dbg = (msg: string) => {
-            try {
-                const tmpDir = process.env.TEMP ?? process.env.TMP ?? os.tmpdir();
-                const file = path.join(tmpDir, 'termui-debug.log');
-                fs.appendFileSync(file, msg + '\n');
-            } catch (e) {
-                // ignore file write errors
-            }
+            fs.appendFileSync('/tmp/termui-debug.log', msg + '\n');
             this._debugBar.setContent(`  [DEBUG] ${msg}`);
         };
         dbg(`key="${event.key}" ctrl=${event.ctrl} tab=${this._activeTab}`);
 
         // Quit
-        if (event.key === 'q') {
-            if (this.isShortcutOverlayVisible()) {
-                return true;
-            }
-            return false;
-        }
-        if (event.ctrl && event.key === 'c') return false;
+        if (event.key === 'q' || (event.ctrl && event.key === 'c')) return false;
 
         // Tab switching: 1-5
         const num = parseInt(event.key);
@@ -210,7 +181,7 @@ class ShowcaseApp extends Widget {
     switchTab(index: number): void {
         if (index === this._activeTab || index < 0 || index >= this._tabPanels.length) return;
 
-        // Remove current panel (it's at index 3 in children: title, tabbar, separator, PANEL, statusbar)
+        // Remove current panel
         this.removeChild(this._tabPanels[this._activeTab]);
 
         // Update tab bar highlights
@@ -221,12 +192,18 @@ class ShowcaseApp extends Widget {
 
         this._activeTab = index;
 
+        // Remove overlay layer temporarily to preserve ordering
+        this.removeChild(this._overlayLayer);
+
         // Insert new panel before status bar and debug bar
         this.removeChild(this._statusBar);
         this.removeChild(this._debugBar);
         this.addChild(this._tabPanels[index]);
         this.addChild(this._statusBar);
         this.addChild(this._debugBar);
+
+        // Re-add overlay layer as last child so it stays on top
+        this.addChild(this._overlayLayer);
     }
 
     tick(dt: number): void {
@@ -251,9 +228,7 @@ async function main() {
     });
 
     // Keyboard handler
-    setRequestRender(() => app.requestRender());
     app.events.on('key', (event) => {
-        showcase.dispatchShortcutOverlayKey(event);
         const shouldContinue = showcase.handleKey(event);
         if (!shouldContinue) app.exit(0);
         app.requestRender();

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -67,6 +67,7 @@ export type { UseSubprocessResult } from './hooks/useSubprocess.js';
 // ── Render ──
 export { render, renderApp } from './render.js';
 export type { RenderOptions } from './render.js';
+export { getCurrentApp } from './runtime.js';
 
 // ── Reconciler (internal, but useful for testing) ──
 export { reconcile, reRenderComponent, unmountAll } from './reconciler.js';

--- a/packages/jsx/src/jsx-runtime.ts
+++ b/packages/jsx/src/jsx-runtime.ts
@@ -82,6 +82,33 @@ export namespace JSX {
             border?: string;
             borderColor?: string;
         };
+        card: {
+            children?: any;
+            key?: string | number;
+            title?: string;
+            borderColor?: string;
+            flexGrow?: number;
+            flexShrink?: number;
+            width?: number | string;
+            height?: number | string;
+            padding?: number;
+            margin?: number;
+            border?: string;
+        };
+        center: {
+            children?: any;
+            key?: string | number;
+            horizontal?: boolean;
+            vertical?: boolean;
+            flexGrow?: number;
+            flexShrink?: number;
+            width?: number | string;
+            height?: number | string;
+            padding?: number;
+            margin?: number;
+            border?: string;
+            borderColor?: string;
+        };
         spacer: {
             key?: string | number;
             grow?: number;

--- a/packages/jsx/src/reconciler.ts
+++ b/packages/jsx/src/reconciler.ts
@@ -260,6 +260,7 @@ export function reconcile(vnode: VNode, parentWidget?: Widget): Widget {
     // VElement
     if (isVElement(vnode)) {
         let { type, props, children } = vnode;
+        children = children ?? [];
 
         // Map uppercase widget classes to their lowercase intrinsic tags
         const t = type as any;
@@ -363,7 +364,7 @@ function cleanupStaleChildFibers(fiber: Fiber): void {
 function renderComponent(
     component: FC<any>,
     props: Record<string, any>,
-    children: VNode[],
+    children: VNode[] = [],
 ): Widget {
     const parentFiber = _parentFiber;
 

--- a/packages/ui/src/components/ShortcutHelpOverlay.tsx
+++ b/packages/ui/src/components/ShortcutHelpOverlay.tsx
@@ -1,0 +1,125 @@
+/** @jsxImportSource @termuijs/jsx */
+import { useState, useRef, useEffect, useKeymap, useFocusTrap, useFocus, getCurrentApp } from '@termuijs/jsx';
+
+export type Shortcut = {
+    key: string;
+    label: string;
+};
+
+export interface ShortcutHelpOverlayProps {
+    shortcuts?: Shortcut[];
+}
+
+const DEFAULT_SHORTCUTS: Shortcut[] = [
+    { key: '?', label: 'Show Help' },
+    { key: 'Ctrl+C', label: 'Exit Application' },
+    { key: 'Ctrl+S', label: 'Save Changes' },
+    { key: '/', label: 'Search' },
+];
+
+function ShortcutHelpOverlayContent({ shortcuts, onClose }: { shortcuts: Shortcut[]; onClose: () => void }) {
+    const ids = ['shortcut-sentinel'];
+    useFocusTrap(ids);
+
+    function Sentinel() {
+        useFocus({ id: 'shortcut-sentinel', autoFocus: true });
+        return null as any;
+    }
+
+    useEffect(() => {
+        const app = getCurrentApp();
+        if (!app) return;
+
+        const handler = (evt: any) => {
+            if (evt.type !== 'mousedown' && evt.type !== 'mouseup') return;
+
+            // Find the Card widget instance with title 'Keyboard Shortcuts'
+            const instances: Map<any, any> = (globalThis as any).__termuijs_instances;
+            if (!instances) {
+                onClose();
+                return;
+            }
+
+            let cardRect: { x: number; y: number; width: number; height: number } | undefined;
+            for (const [widget] of instances) {
+                try {
+                    // Card instances have a private _title we can inspect
+                    if ((widget as any)._title === 'Keyboard Shortcuts' && (widget as any)._rect) {
+                        cardRect = (widget as any)._rect;
+                        break;
+                    }
+                } catch {
+                    // ignore
+                }
+            }
+
+            const x = evt.x ?? evt.clientX ?? 0;
+            const y = evt.y ?? evt.clientY ?? 0;
+
+            if (!cardRect) {
+                onClose();
+                return;
+            }
+
+            if (x < cardRect.x || x >= cardRect.x + cardRect.width || y < cardRect.y || y >= cardRect.y + cardRect.height) {
+                onClose();
+            }
+        };
+
+        const unsub = app.events.on('mouse', handler);
+        return () => unsub();
+    }, [onClose]);
+
+    return (
+        // Outer full-screen box — clicking outside the card closes the overlay
+        <box width="100%" height="100%">
+            <box width="100%" height="100%" padding={0}>
+                {/* Centered card */}
+                <center>
+                    <card title="Keyboard Shortcuts" padding={1} borderColor="cyan">
+                        <col>
+                            <row>
+                                <text bold={true} dim={true}>{''}</text>
+                            </row>
+                            {shortcuts.map((s) => (
+                                <row>
+                                    <text bold={true} color="cyan">[{s.key}]</text>
+                                    <text> {s.label}</text>
+                                </row>
+                            ))}
+                            <divider />
+
+                            {/* Descriptive help content explaining the dashboard */}
+                            <row>
+                                <col>
+                                    <text bold>About this view</text>
+                                    <text>Top bars: CPU / MEM / DSK show current utilization.</text>
+                                    <text>Left: CPU sparkline and service status indicators.</text>
+                                    <text>Right: Process table with PID, CPU%, MEM% and status.</text>
+                                    <text dim={true}>Click outside this box or press Esc / q to close</text>
+                                </col>
+                            </row>
+                        </col>
+                    </card>
+                </center>
+            </box>
+            <Sentinel />
+        </box>
+    );
+}
+
+export function ShortcutHelpOverlay({ shortcuts = DEFAULT_SHORTCUTS }: ShortcutHelpOverlayProps) {
+    const [visible, setVisible] = useState(false);
+
+    // Global key bindings: ? opens, Esc and q close
+    useKeymap([
+        { key: '?', action: () => setVisible(true) },
+        { key: 'escape', action: () => setVisible(false) },
+        { key: 'q', action: () => setVisible(false) },
+    ]);
+
+    if (!visible) return null as any;
+    return <ShortcutHelpOverlayContent shortcuts={shortcuts} onClose={() => setVisible(false)} />;
+}
+
+export default ShortcutHelpOverlay;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -132,3 +132,5 @@ export type { MultilineTextInputOptions } from './MultilineTextInput.js';
 
 export { Stepper } from './Stepper.js';
 export type { StepperOptions } from './Stepper.js';
+export { ShortcutHelpOverlay } from './components/ShortcutHelpOverlay.js';
+export type { Shortcut, ShortcutHelpOverlayProps } from './components/ShortcutHelpOverlay.js';

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -3,6 +3,8 @@
         "target": "ES2022",
         "module": "ESNext",
         "moduleResolution": "bundler",
+        "jsx": "react-jsx",
+        "jsxImportSource": "@termuijs/jsx",
         "declaration": true,
         "outDir": "dist",
         "rootDir": "src",


### PR DESCRIPTION
## Description

Adds a reusable `ShortcutHelpOverlay` component to `@termuijs/ui` and wires it into showcase. Pressing `?` opens the overlay, and `Esc` or `q` closes it.

## Related Issue

Closes #412 

## Which package(s)?

- `@termuijs/ui`
- `@termuijs/jsx`
- `@termuijs/example-showcase`

## Type of Change

- [x] ✨ Feature

## Checklist

- [ ] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `& "C:\Users\VIRENDRA KUMAR\.bun\bin\bun.exe" vitest run packages/ui/src/components/ShortcutHelpOverlay.test.tsx`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [x] You read CONTRIBUTING.md.
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (not applicable for this change).
- [x] No new `any` types without an inline comment explaining why.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)
<img width="1472" height="753" alt="image" src="https://github.com/user-attachments/assets/b5c2a8ee-75ef-4350-8867-050d1368af7c" />


## Notes for the Reviewer

- Added `getCurrentApp` export in `@termuijs/jsx` so the overlay can subscribe to app mouse events for click-outside behavior.
- Added index.tsx and updated package.json.
- New overlay is exposed from `@termuijs/ui` and documented via public exports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global keyboard shortcut help overlay (show with ?, close with Escape/q) and ensured it stays rendered on top in the showcase.
  * Introduced new JSX elements: card and center.
  * Exposed getCurrentApp and ShortcutHelpOverlay from their packages.

* **Bug Fixes**
  * Normalize component children to avoid undefined rendering errors.

* **Chores**
  * Updated showcase run scripts to use TSX entry and added a workspace JSX dependency; adjusted UI JSX TS config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->