### PR TITLE
feat(jsx): add useUnmount hook

### DIFF
--- a/packages/jsx/src/hooks/useUnmount.test.ts
+++ b/packages/jsx/src/hooks/useUnmount.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  createFiber,
+  setCurrentFiber,
+  clearCurrentFiber,
+  runEffects,
+  destroyFiber,
+} from '../hooks.js';
+import { useUnmount } from './useUnmount';
+
+describe('useUnmount', () => {
+  let fiber = createFiber();
+
+  beforeEach(() => {
+    fiber = createFiber();
+    setCurrentFiber(fiber);
+  });
+
+  afterEach(() => {
+    clearCurrentFiber();
+  });
+
+  it('does not invoke callback during normal render', () => {
+    const fn = vi.fn();
+    useUnmount(fn);
+    runEffects(fiber);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('invokes callback when fiber is destroyed', () => {
+    const fn = vi.fn();
+    useUnmount(fn);
+    runEffects(fiber);
+    destroyFiber(fiber);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes the latest callback identity on destroy', () => {
+    const fn1 = vi.fn();
+    const fn2 = vi.fn();
+    useUnmount(fn1);
+    runEffects(fiber);
+
+    fiber.hookIndex = 0;
+    runEffects(fiber); // re-render with same effect (no deps changed)
+
+    // simulate a re-render where callback changes
+    fiber.hookIndex = 0;
+    useUnmount(fn2);
+    runEffects(fiber);
+
+    destroyFiber(fiber);
+    expect(fn1).not.toHaveBeenCalled();
+    expect(fn2).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call callback if destroyFiber is never called', () => {
+    const fn = vi.fn();
+    useUnmount(fn);
+    runEffects(fiber);
+    expect(fn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/jsx/src/hooks/useUnmount.ts
+++ b/packages/jsx/src/hooks/useUnmount.ts
@@ -1,0 +1,12 @@
+import { useEffect, useRef } from '../hooks';
+
+export function useUnmount(callback: () => void): void {
+  const ref = useRef(callback);
+  ref.current = callback;
+
+  useEffect(() => {
+    return () => {
+      ref.current();
+    };
+  }, []);
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -33,10 +33,14 @@ export { useCounter } from './hooks/useCounter.js';
 export type { UseCounterActions, UseCounterOptions } from './hooks/useCounter.js';
 export { useClipboard } from './hooks/useClipboard.js';
 export type { UseClipboardOptions, UseClipboardResult } from './hooks/useClipboard.js';
+<<<<<<< HEAD
 export { useList } from './hooks/useList.js';
 export type { UseListActions } from './hooks/useList.js';
 export { useMap } from './hooks/useMap.js';
 export type { UseMapActions } from './hooks/useMap.js';
+=======
+export { useUnmount } from './hooks/useUnmount.js';
+>>>>>>> d67f96e (feat(jsx): add useUnmount hook)
 
 // ── Error Boundary ──
 export { ErrorBoundary } from './error-boundary.js';

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -33,14 +33,10 @@ export { useCounter } from './hooks/useCounter.js';
 export type { UseCounterActions, UseCounterOptions } from './hooks/useCounter.js';
 export { useClipboard } from './hooks/useClipboard.js';
 export type { UseClipboardOptions, UseClipboardResult } from './hooks/useClipboard.js';
-<<<<<<< HEAD
 export { useList } from './hooks/useList.js';
 export type { UseListActions } from './hooks/useList.js';
 export { useMap } from './hooks/useMap.js';
 export type { UseMapActions } from './hooks/useMap.js';
-=======
-export { useUnmount } from './hooks/useUnmount.js';
->>>>>>> d67f96e (feat(jsx): add useUnmount hook)
 
 // ── Error Boundary ──
 export { ErrorBoundary } from './error-boundary.js';

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -38,6 +38,7 @@ export type { UseListActions } from './hooks/useList.js';
 export { useMap } from './hooks/useMap.js';
 export type { UseMapActions } from './hooks/useMap.js';
 
+export { useUnmount } from './hooks/useUnmount.js';
 // ── Error Boundary ──
 export { ErrorBoundary } from './error-boundary.js';
 export type { ErrorBoundaryProps } from './error-boundary.js';


### PR DESCRIPTION
Implements useUnmount hook that runs a callback when the component unmounts.

Closes #442

## Changes
- \packages/jsx/src/hooks/useUnmount.ts\ - new hook
- \packages/jsx/src/hooks/useUnmount.test.ts\ - tests (4 cases)
- \packages/jsx/src/index.ts\ - added export

## Verification
- \un vitest run packages/jsx\ - all 106 tests pass
- \un run build\ - all packages build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a useUnmount hook that runs provided cleanup logic when a component unmounts and always uses the latest callback identity.

* **Tests**
  * Added tests validating unmount behavior: cleanup callbacks fire exactly once on teardown, are not invoked during normal effect processing, and the most recent callback is used after rerenders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->