### PR TITLE
feat(jsx): add useUpdateEffect hook

### DIFF
--- a/packages/jsx/src/hooks/useUpdateEffect.test.ts
+++ b/packages/jsx/src/hooks/useUpdateEffect.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  createFiber,
+  setCurrentFiber,
+  clearCurrentFiber,
+  runEffects,
+} from '../hooks.js';
+import { useUpdateEffect } from './useUpdateEffect';
+
+describe('useUpdateEffect', () => {
+  let fiber = createFiber();
+
+  beforeEach(() => {
+    fiber = createFiber();
+    setCurrentFiber(fiber);
+  });
+
+  afterEach(() => {
+    clearCurrentFiber();
+  });
+
+  it('does not run on the first render', () => {
+    const fn = vi.fn();
+    useUpdateEffect(fn, []);
+    runEffects(fiber);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('runs when a dependency changes after the first render', () => {
+    const fn = vi.fn();
+    useUpdateEffect(fn, ['a']);
+    runEffects(fiber);
+
+    fiber.hookIndex = 0;
+    useUpdateEffect(fn, ['b']);
+    runEffects(fiber);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not run when dependencies are unchanged', () => {
+    const fn = vi.fn();
+    useUpdateEffect(fn, ['a']);
+    runEffects(fiber);
+
+    fiber.hookIndex = 0;
+    useUpdateEffect(fn, ['a']);
+    runEffects(fiber);
+
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('runs cleanup before the next effect', () => {
+    const cleanup = vi.fn();
+    const effect = vi.fn(() => cleanup);
+
+    useUpdateEffect(effect, ['a']);
+    runEffects(fiber);
+
+    fiber.hookIndex = 0;
+    useUpdateEffect(effect, ['b']);
+    runEffects(fiber);
+
+    expect(effect).toHaveBeenCalledTimes(1);
+    expect(cleanup).not.toHaveBeenCalled();
+
+    fiber.hookIndex = 0;
+    useUpdateEffect(effect, ['c']);
+    runEffects(fiber);
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(effect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/jsx/src/hooks/useUpdateEffect.ts
+++ b/packages/jsx/src/hooks/useUpdateEffect.ts
@@ -1,0 +1,16 @@
+import { useEffect, useRef } from '../hooks';
+
+export function useUpdateEffect(
+  effect: () => void | (() => void),
+  deps?: unknown[],
+): void {
+  const isFirst = useRef(true);
+
+  useEffect(() => {
+    if (isFirst.current) {
+      isFirst.current = false;
+      return;
+    }
+    return effect();
+  }, deps);
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -37,6 +37,7 @@ export { useList } from './hooks/useList.js';
 export type { UseListActions } from './hooks/useList.js';
 export { useMap } from './hooks/useMap.js';
 export type { UseMapActions } from './hooks/useMap.js';
+export { useUpdateEffect } from './hooks/useUpdateEffect.js';
 
 // ── Error Boundary ──
 export { ErrorBoundary } from './error-boundary.js';


### PR DESCRIPTION
Implements useUpdateEffect hook that works like useEffect but skips the first render.

Closes #443

## Changes
- \packages/jsx/src/hooks/useUpdateEffect.ts\ - new hook
- \packages/jsx/src/hooks/useUpdateEffect.test.ts\ - tests (4 cases)
- \packages/jsx/src/index.ts\ - added export

## Verification
- \un vitest run packages/jsx\ - all 106 tests pass
- \un run build\ - all packages build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the useUpdateEffect hook to run effects on dependency changes while skipping the initial render, with support for optional cleanup functions. It is now available from the package entrypoint.

* **Tests**
  * Added a comprehensive test suite validating initial-skip behavior, execution on dependency changes, no run when deps unchanged, and proper cleanup invocation between updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->