### PR TITLE
feat(ui): add EmailInput widget

### DIFF
--- a/packages/ui/src/EmailInput.test.ts
+++ b/packages/ui/src/EmailInput.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Screen, caps } from '@termuijs/core';
+import { EmailInput } from './EmailInput.js';
+
+describe('EmailInput', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('initial render shows placeholder', () => {
+        const input = new EmailInput({}, { placeholder: 'Enter email...' });
+        const screen = new Screen(20, 3);
+        
+        input.updateRect({ x: 0, y: 0, width: 20, height: 3 });
+        input.render(screen);
+        
+        const row1 = screen.back[1].map(c => c.char).join('');
+        expect(row1).toContain('Enter email...');
+    });
+
+    it('typing a valid email makes isValid() return true', () => {
+        const input = new EmailInput();
+        
+        const chars = 'a@b.com'.split('');
+        for (const char of chars) {
+            input.handleKey({ key: char, ctrl: false, shift: false, alt: false, raw: Buffer.from(char), stopPropagation: () => {}, preventDefault: () => {} });
+        }
+
+        expect(input.getValue()).toBe('a@b.com');
+        expect(input.isValid()).toBe(true);
+    });
+
+    it('typing an invalid email makes isValid() return false', () => {
+        const input = new EmailInput();
+        
+        const chars = 'notvalid'.split('');
+        for (const char of chars) {
+            input.handleKey({ key: char, ctrl: false, shift: false, alt: false, raw: Buffer.from(char), stopPropagation: () => {}, preventDefault: () => {} });
+        }
+
+        expect(input.getValue()).toBe('notvalid');
+        expect(input.isValid()).toBe(false);
+    });
+
+    it('enter fires onSubmit when valid', () => {
+        let submittedValue = '';
+        const input = new EmailInput({}, {
+            onSubmit: (val) => { submittedValue = val; }
+        });
+        
+        const chars = 'test@example.com'.split('');
+        for (const char of chars) {
+            input.handleKey({ key: char, ctrl: false, shift: false, alt: false, raw: Buffer.from(char), stopPropagation: () => {}, preventDefault: () => {} });
+        }
+
+        expect(input.isValid()).toBe(true);
+        
+        // Press enter
+        input.handleKey({ key: 'enter', ctrl: false, shift: false, alt: false, raw: Buffer.from('enter'), stopPropagation: () => {}, preventDefault: () => {} });
+        
+        expect(submittedValue).toBe('test@example.com');
+    });
+
+    it('enter does not fire onSubmit when invalid', () => {
+        let submittedValue = '';
+        const input = new EmailInput({}, {
+            onSubmit: (val) => { submittedValue = val; }
+        });
+        
+        const chars = 'test@'.split('');
+        for (const char of chars) {
+            input.handleKey({ key: char, ctrl: false, shift: false, alt: false, raw: Buffer.from(char), stopPropagation: () => {}, preventDefault: () => {} });
+        }
+
+        expect(input.isValid()).toBe(false);
+        
+        // Press enter
+        input.handleKey({ key: 'enter', ctrl: false, shift: false, alt: false, raw: Buffer.from('enter'), stopPropagation: () => {}, preventDefault: () => {} });
+        
+        expect(submittedValue).toBe('');
+    });
+
+    it('tab completes domain suggestion', () => {
+        const input = new EmailInput({}, {
+            domains: ['gmail.com', 'outlook.com', 'yahoo.com']
+        });
+        
+        const chars = 'user@g'.split('');
+        for (const char of chars) {
+            input.handleKey({ key: char, ctrl: false, shift: false, alt: false, raw: Buffer.from(char), stopPropagation: () => {}, preventDefault: () => {} });
+        }
+
+        expect(input.getValue()).toBe('user@g');
+        
+        // Press tab
+        input.handleKey({ key: 'tab', ctrl: false, shift: false, alt: false, raw: Buffer.from('tab'), stopPropagation: () => {}, preventDefault: () => {} });
+        
+        expect(input.getValue()).toBe('user@gmail.com');
+    });
+});

--- a/packages/ui/src/EmailInput.ts
+++ b/packages/ui/src/EmailInput.ts
@@ -34,7 +34,7 @@ export class EmailInput extends Widget {
         style: Partial<Style> = {},
         opts: EmailInputOptions = {},
     ) {
-        super(mergeStyles(defaultStyle(), { border: 'single', height: 3 }, style));
+        super(mergeStyles(defaultStyle(), { border: 'single', height: 3, ...style }));
         this._placeholder = opts.placeholder ?? '';
         this._domains = opts.domains ?? ['gmail.com', 'outlook.com', 'yahoo.com'];
         this._onSubmit = opts.onSubmit;

--- a/packages/ui/src/EmailInput.ts
+++ b/packages/ui/src/EmailInput.ts
@@ -1,0 +1,189 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/ui — EmailInput widget
+//
+// A TextInput restricted to email addresses.
+// - Validates email format
+// - Shows inline error for invalid emails
+// - Supports tab autocomplete for domains
+// ─────────────────────────────────────────────────────
+
+import { Widget } from '@termuijs/widgets';
+import { type Style, type Color, type Screen, type KeyEvent, styleToCellAttrs, truncate } from '@termuijs/core';
+
+export interface EmailInputOptions {
+    placeholder?: string;
+    /** Common domains to suggest after '@'. Default: ['gmail.com','outlook.com','yahoo.com'] */
+    domains?: string[];
+    onSubmit?: (value: string) => void;
+    onChange?: (value: string, valid: boolean) => void;
+    errorColor?: Color;
+}
+
+export class EmailInput extends Widget {
+    private _raw = '';
+    private _cursorPos = 0;
+    private _placeholder: string;
+    private _domains: string[];
+    private _onSubmit?: (value: string) => void;
+    private _onChange?: (value: string, valid: boolean) => void;
+    private _errorColor: Color;
+    
+    focusable = true;
+
+    constructor(
+        style: Partial<Style> = {},
+        opts: EmailInputOptions = {},
+    ) {
+        super({ border: 'single', height: 3, ...style });
+        this._placeholder = opts.placeholder ?? '';
+        this._domains = opts.domains ?? ['gmail.com', 'outlook.com', 'yahoo.com'];
+        this._onSubmit = opts.onSubmit;
+        this._onChange = opts.onChange;
+        this._errorColor = opts.errorColor ?? { type: 'named', name: 'red' };
+    }
+
+    getValue(): string {
+        return this._raw;
+    }
+
+    isValid(): boolean {
+        return /^[^@]+@[^@]+\.[^@]+$/.test(this._raw);
+    }
+
+    private _notify(): void {
+        this._onChange?.(this._raw, this.isValid());
+        this.markDirty();
+    }
+
+    insertChar(char: string): void {
+        this._raw =
+            this._raw.slice(0, this._cursorPos) +
+            char +
+            this._raw.slice(this._cursorPos);
+        this._cursorPos++;
+        this._notify();
+    }
+
+    deleteBack(): void {
+        if (this._cursorPos > 0) {
+            this._raw =
+                this._raw.slice(0, this._cursorPos - 1) +
+                this._raw.slice(this._cursorPos);
+            this._cursorPos--;
+            this._notify();
+        }
+    }
+
+    deleteForward(): void {
+        if (this._cursorPos < this._raw.length) {
+            this._raw =
+                this._raw.slice(0, this._cursorPos) +
+                this._raw.slice(this._cursorPos + 1);
+            this._notify();
+        }
+    }
+
+    moveCursorLeft(): void { 
+        this._cursorPos = Math.max(0, this._cursorPos - 1); 
+        this.markDirty(); 
+    }
+    
+    moveCursorRight(): void { 
+        this._cursorPos = Math.min(this._raw.length, this._cursorPos + 1); 
+        this.markDirty(); 
+    }
+    
+    moveCursorHome(): void { 
+        this._cursorPos = 0; 
+        this.markDirty(); 
+    }
+    
+    moveCursorEnd(): void { 
+        this._cursorPos = this._raw.length; 
+        this.markDirty(); 
+    }
+
+    autocompleteDomain(): void {
+        const atIndex = this._raw.lastIndexOf('@');
+        if (atIndex === -1) return;
+
+        const typedDomain = this._raw.slice(atIndex + 1);
+        const match = this._domains.find(d => d.startsWith(typedDomain));
+        
+        if (match) {
+            this._raw = this._raw.slice(0, atIndex + 1) + match;
+            this._cursorPos = this._raw.length;
+            this._notify();
+        }
+    }
+
+    handleKey(event: KeyEvent): void {
+        switch (event.key) {
+            case 'backspace': this.deleteBack(); break;
+            case 'delete': this.deleteForward(); break;
+            case 'left': this.moveCursorLeft(); break;
+            case 'right': this.moveCursorRight(); break;
+            case 'home': this.moveCursorHome(); break;
+            case 'end': this.moveCursorEnd(); break;
+            case 'tab': this.autocompleteDomain(); break;
+            case 'return':
+            case 'enter':
+                if (this.isValid()) {
+                    this._onSubmit?.(this._raw);
+                }
+                break;
+            default:
+                if (event.key && event.key.length === 1 && !event.ctrl && !event.alt) {
+                    this.insertChar(event.key);
+                }
+        }
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const rect = this._getContentRect();
+        const { x, y, width, height } = rect;
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this._style);
+
+        if (this._raw.length === 0 && !this.isFocused) {
+            screen.writeString(x, y, truncate(this._placeholder, width), { ...attrs, dim: true });
+            return;
+        }
+
+        const display = this._raw;
+        const visibleWidth = width - 1;
+        let scrollX = 0;
+        if (this._cursorPos > visibleWidth) {
+            scrollX = this._cursorPos - visibleWidth;
+        }
+
+        const visibleText = display.slice(scrollX, scrollX + visibleWidth);
+        
+        // Show error indicator if invalid and not empty
+        const isError = this._raw.length > 0 && !this.isValid();
+        const renderAttrs = isError ? { ...attrs, fg: this._errorColor } : attrs;
+
+        screen.writeString(x, y, visibleText, renderAttrs);
+
+        if (this.isFocused) {
+            const cursorScreenPos = x + this._cursorPos - scrollX;
+            if (cursorScreenPos >= x && cursorScreenPos < x + width) {
+                const cursorChar = this._cursorPos < display.length
+                    ? display[this._cursorPos]
+                    : ' ';
+                screen.setCell(cursorScreenPos, y, {
+                    char: cursorChar,
+                    ...renderAttrs,
+                    inverse: true,
+                });
+            }
+        }
+        
+        // Inline error indicator if error
+        if (isError && width > 4) {
+            const hint = `[!]`;
+            screen.writeString(x + width - hint.length, y, hint, { ...renderAttrs, fg: this._errorColor });
+        }
+    }
+}

--- a/packages/ui/src/EmailInput.ts
+++ b/packages/ui/src/EmailInput.ts
@@ -8,7 +8,7 @@
 // ─────────────────────────────────────────────────────
 
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Color, type Screen, type KeyEvent, styleToCellAttrs, truncate } from '@termuijs/core';
+import { type Style, type Color, type Screen, type KeyEvent, styleToCellAttrs, truncate, mergeStyles, defaultStyle } from '@termuijs/core';
 
 export interface EmailInputOptions {
     placeholder?: string;
@@ -34,7 +34,7 @@ export class EmailInput extends Widget {
         style: Partial<Style> = {},
         opts: EmailInputOptions = {},
     ) {
-        super({ border: 'single', height: 3, ...style });
+        super(mergeStyles(defaultStyle(), { border: 'single', height: 3 }, style));
         this._placeholder = opts.placeholder ?? '';
         this._domains = opts.domains ?? ['gmail.com', 'outlook.com', 'yahoo.com'];
         this._onSubmit = opts.onSubmit;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -161,3 +161,5 @@ export type { ThemeSwitcherOptions } from './ThemeSwitcher.js';
 
 export { TreeSelect } from './TreeSelect.js';
 export type { TreeSelectNode, TreeSelectOptions } from './TreeSelect.js';
+export { EmailInput } from './EmailInput.js';
+export type { EmailInputOptions } from './EmailInput.js';


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

This PR adds the `EmailInput` widget to `@termuijs/ui`. It behaves like a standard text input but validates for basic email structures and highlights in red with a `[!]` indicator when invalid. It also includes domain autocomplete via the `<Tab>` key, allowing quick completion of domains like `@gmail.com`.

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #257 

## Which package(s)?

`@termuijs/ui`

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/00bcdf9e-cd87-4516-8572-5dfd618ac784`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Email input widget with placeholder, inline validation highlighting, domain autocomplete via Tab, cursor navigation, editing controls, and Enter-to-submit when the address is valid. Shows an inline invalid indicator when appropriate.

* **Tests**
  * Added tests covering rendering, typing behavior, validation (valid/invalid), submit logic, domain autocomplete, and cleanup between tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->