### PR TITLE
feat(ui): add Transfer widget

### DIFF
--- a/packages/ui/src/Transfer.test.ts
+++ b/packages/ui/src/Transfer.test.ts
@@ -1,0 +1,203 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/ui — Tests for Transfer component
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Transfer } from './Transfer.js';
+import { Screen, caps } from '@termuijs/core';
+
+const ITEMS = [
+    { label: 'Apple', value: 'apple' },
+    { label: 'Banana', value: 'banana' },
+    { label: 'Cherry', value: 'cherry' },
+];
+
+describe('Transfer', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('initializes with all items in the source pane', () => {
+        const transfer = new Transfer(ITEMS);
+        expect(transfer.sourceItems).toEqual(ITEMS);
+        expect(transfer.targetItems).toEqual([]);
+        expect(transfer.targetValues).toEqual([]);
+        expect(transfer.activePane).toBe('source');
+        expect(transfer.sourceCursorIndex).toBe(0);
+        expect(transfer.targetCursorIndex).toBe(0);
+    });
+
+    it('navigates cursors via selectNext and selectPrev', () => {
+        const transfer = new Transfer(ITEMS);
+        
+        // Down in source
+        transfer.selectNext();
+        expect(transfer.sourceCursorIndex).toBe(1);
+        
+        // Up in source
+        transfer.selectPrev();
+        expect(transfer.sourceCursorIndex).toBe(0);
+
+        // Switch to target (empty)
+        transfer.toggleActivePane();
+        expect(transfer.activePane).toBe('target');
+        expect(transfer.targetCursorIndex).toBe(0);
+
+        // Up/down in empty target should stay at 0
+        transfer.selectNext();
+        expect(transfer.targetCursorIndex).toBe(0);
+        transfer.selectPrev();
+        expect(transfer.targetCursorIndex).toBe(0);
+    });
+
+    it('toggles active pane with tab key', () => {
+        const transfer = new Transfer(ITEMS);
+        expect(transfer.activePane).toBe('source');
+        
+        transfer.handleKey({ key: 'tab' } as any);
+        expect(transfer.activePane).toBe('target');
+
+        transfer.handleKey({ key: 'tab' } as any);
+        expect(transfer.activePane).toBe('source');
+    });
+
+    it('navigates via arrow keys', () => {
+        const transfer = new Transfer(ITEMS);
+        expect(transfer.sourceCursorIndex).toBe(0);
+
+        transfer.handleKey({ key: 'down' } as any);
+        expect(transfer.sourceCursorIndex).toBe(1);
+
+        transfer.handleKey({ key: 'up' } as any);
+        expect(transfer.sourceCursorIndex).toBe(0);
+    });
+
+    it('transfers item to target with right arrow and back with left arrow', () => {
+        const onChange = vi.fn();
+        const transfer = new Transfer(ITEMS, { onChange });
+
+        // Left pane (source) is active, right arrow should transfer item
+        transfer.handleKey({ key: 'right' } as any);
+        expect(transfer.sourceItems).toEqual([ITEMS[1], ITEMS[2]]);
+        expect(transfer.targetItems).toEqual([ITEMS[0]]);
+        expect(transfer.targetValues).toEqual(['apple']);
+        expect(onChange).toHaveBeenCalledWith(['apple']);
+        expect(transfer.sourceCursorIndex).toBe(0);
+
+        // If target is empty, pressing left on target pane should do nothing
+        // Let's toggle to target pane and transfer it back
+        transfer.handleKey({ key: 'tab' } as any);
+        expect(transfer.activePane).toBe('target');
+        expect(transfer.targetCursorIndex).toBe(0);
+
+        transfer.handleKey({ key: 'left' } as any);
+        expect(transfer.sourceItems).toEqual([ITEMS[1], ITEMS[2], ITEMS[0]]);
+        expect(transfer.targetItems).toEqual([]);
+        expect(transfer.targetValues).toEqual([]);
+        expect(onChange).toHaveBeenLastCalledWith([]);
+        expect(transfer.targetCursorIndex).toBe(0);
+    });
+
+    it('respects disabled items during navigation and transfer', () => {
+        const itemsWithDisabled = [
+            { label: 'A', value: 'a' },
+            { label: 'B', value: 'b', disabled: true },
+            { label: 'C', value: 'c' },
+        ];
+        const onChange = vi.fn();
+        const transfer = new Transfer(itemsWithDisabled, { onChange });
+
+        // Cursor should start at 0
+        expect(transfer.sourceCursorIndex).toBe(0);
+
+        // Moving down should skip 1 (B is disabled) and land on 2 (C)
+        transfer.selectNext();
+        expect(transfer.sourceCursorIndex).toBe(2);
+
+        // Moving up should skip 1 and land on 0
+        transfer.selectPrev();
+        expect(transfer.sourceCursorIndex).toBe(0);
+
+        // Cannot transfer disabled items directly
+        // (Just to test if we can somehow try to transfer disabled,
+        // we'll temporarily force the index and try to transfer it)
+        (transfer as any)._sourceCursorIndex = 1;
+        transfer.transferToTarget();
+        expect(transfer.targetItems).toEqual([]);
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('clamps cursor indices after transferring items', () => {
+        const transfer = new Transfer(ITEMS);
+        
+        // Move to the last item
+        transfer.selectNext();
+        transfer.selectNext();
+        expect(transfer.sourceCursorIndex).toBe(2);
+
+        // Transfer last item (Cherry)
+        transfer.transferToTarget();
+        // Since Cherry was index 2, and now there are only 2 items left (Apple, Banana),
+        // the source cursor should be clamped to 1 (Banana)
+        expect(transfer.sourceCursorIndex).toBe(1);
+        expect(transfer.sourceItems).toEqual([ITEMS[0], ITEMS[1]]);
+        expect(transfer.targetItems).toEqual([ITEMS[2]]);
+    });
+
+    it('renders with unicode formatting (default)', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+
+        const screen = new Screen(21, 3);
+        const transfer = new Transfer(ITEMS);
+        transfer.updateRect({ x: 0, y: 0, width: 21, height: 3 });
+        transfer.render(screen);
+
+        // leftPaneWidth = Math.floor((21-1)/2) = 10
+        // rightPaneWidth = 10
+        // dividerIndex = 10
+        // Row 0: source active index 0 (Apple), target empty
+        // Source active: '❯ Apple   ' (length 10)
+        // Divider: '│'
+        // Target empty: '          ' (length 10)
+        const row0 = screen.back[0].map(c => c.char).join('');
+        expect(row0).toBe('❯ Apple  │          ');
+
+        const row1 = screen.back[1].map(c => c.char).join('');
+        expect(row1).toBe('  Banana  │          ');
+
+        const row2 = screen.back[2].map(c => c.char).join('');
+        expect(row2).toBe('  Cherry  │          ');
+    });
+
+    it('renders with ASCII formatting when unicode is false', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+
+        const screen = new Screen(21, 3);
+        const transfer = new Transfer(ITEMS);
+        transfer.updateRect({ x: 0, y: 0, width: 21, height: 3 });
+        transfer.render(screen);
+
+        // Row 0: source active index 0 (Apple), target empty
+        // Source active: '> Apple   ' (length 10)
+        // Divider: '|'
+        // Target empty: '          ' (length 10)
+        const row0 = screen.back[0].map(c => c.char).join('');
+        expect(row0).toBe('> Apple   |          ');
+
+        const row1 = screen.back[1].map(c => c.char).join('');
+        expect(row1).toBe('  Banana  |          ');
+    });
+
+    it('overwrites unused lines with blank spaces', () => {
+        const screen = new Screen(21, 5);
+        const transfer = new Transfer(ITEMS); // 3 items
+        transfer.updateRect({ x: 0, y: 0, width: 21, height: 5 }); // 5 height viewport
+        transfer.render(screen);
+
+        const row3 = screen.back[3].map(c => c.char).join('');
+        expect(row3).toBe('          │          ');
+
+        const row4 = screen.back[4].map(c => c.char).join('');
+        expect(row4).toBe('          │          ');
+    });
+});

--- a/packages/ui/src/Transfer.ts
+++ b/packages/ui/src/Transfer.ts
@@ -1,0 +1,230 @@
+// Transfer — dual-list shuttle selector widget
+import { Widget } from '@termuijs/widgets';
+import {
+    type Style,
+    type Screen,
+    type KeyEvent,
+    mergeStyles,
+    defaultStyle,
+    styleToCellAttrs,
+    caps,
+} from '@termuijs/core';
+
+export interface TransferItem {
+    label: string;
+    value: string;
+    disabled?: boolean;
+}
+
+export interface TransferOptions {
+    activeColor?: Style['fg'];
+    onChange?: (targetValues: string[]) => void;
+}
+
+export class Transfer extends Widget {
+    private _sourceItems: TransferItem[];
+    private _targetItems: TransferItem[] = [];
+    private _sourceCursorIndex = 0;
+    private _targetCursorIndex = 0;
+    private _activePane: 'source' | 'target' = 'source';
+    private _activeColor: Style['fg'];
+    private _onChange?: (targetValues: string[]) => void;
+    focusable = true;
+
+    constructor(items: TransferItem[], config: TransferOptions = {}) {
+        super(mergeStyles(defaultStyle(), { height: Math.max(items.length, 1) }));
+        this._sourceItems = [...items];
+        this._activeColor = config.activeColor ?? { type: 'named', name: 'cyan' };
+        this._onChange = config.onChange;
+        this._clampCursors();
+    }
+
+    get targetValues(): string[] {
+        return this._targetItems.map(item => item.value);
+    }
+
+    get sourceValues(): string[] {
+        return this._sourceItems.map(item => item.value);
+    }
+
+    get targetItems(): TransferItem[] {
+        return [...this._targetItems];
+    }
+
+    get sourceItems(): TransferItem[] {
+        return [...this._sourceItems];
+    }
+
+    get activePane(): 'source' | 'target' {
+        return this._activePane;
+    }
+
+    get sourceCursorIndex(): number {
+        return this._sourceCursorIndex;
+    }
+
+    get targetCursorIndex(): number {
+        return this._targetCursorIndex;
+    }
+
+    toggleActivePane(): void {
+        this._activePane = this._activePane === 'source' ? 'target' : 'source';
+        this.markDirty();
+    }
+
+    private _clampCursors(): void {
+        if (this._sourceItems.length === 0) {
+            this._sourceCursorIndex = 0;
+        } else {
+            this._sourceCursorIndex = Math.max(0, Math.min(this._sourceCursorIndex, this._sourceItems.length - 1));
+        }
+
+        if (this._targetItems.length === 0) {
+            this._targetCursorIndex = 0;
+        } else {
+            this._targetCursorIndex = Math.max(0, Math.min(this._targetCursorIndex, this._targetItems.length - 1));
+        }
+    }
+
+    selectNext(): void {
+        if (this._activePane === 'source') {
+            let n = this._sourceCursorIndex + 1;
+            while (n < this._sourceItems.length && this._sourceItems[n].disabled) n++;
+            if (n < this._sourceItems.length) {
+                this._sourceCursorIndex = n;
+                this.markDirty();
+            }
+        } else {
+            let n = this._targetCursorIndex + 1;
+            while (n < this._targetItems.length && this._targetItems[n].disabled) n++;
+            if (n < this._targetItems.length) {
+                this._targetCursorIndex = n;
+                this.markDirty();
+            }
+        }
+    }
+
+    selectPrev(): void {
+        if (this._activePane === 'source') {
+            let n = this._sourceCursorIndex - 1;
+            while (n >= 0 && this._sourceItems[n].disabled) n--;
+            if (n >= 0) {
+                this._sourceCursorIndex = n;
+                this.markDirty();
+            }
+        } else {
+            let n = this._targetCursorIndex - 1;
+            while (n >= 0 && this._targetItems[n].disabled) n--;
+            if (n >= 0) {
+                this._targetCursorIndex = n;
+                this.markDirty();
+            }
+        }
+    }
+
+    transferToTarget(): void {
+        if (this._sourceItems.length === 0) return;
+        const item = this._sourceItems[this._sourceCursorIndex];
+        if (item.disabled) return;
+
+        this._sourceItems.splice(this._sourceCursorIndex, 1);
+        this._targetItems.push(item);
+
+        this._clampCursors();
+        this.markDirty();
+        this._onChange?.(this.targetValues);
+    }
+
+    transferToSource(): void {
+        if (this._targetItems.length === 0) return;
+        const item = this._targetItems[this._targetCursorIndex];
+        if (item.disabled) return;
+
+        this._targetItems.splice(this._targetCursorIndex, 1);
+        this._sourceItems.push(item);
+
+        this._clampCursors();
+        this.markDirty();
+        this._onChange?.(this.targetValues);
+    }
+
+    handleKey(event: KeyEvent): void {
+        switch (event.key) {
+            case 'up':
+                this.selectPrev();
+                break;
+            case 'down':
+                this.selectNext();
+                break;
+            case 'tab':
+                this.toggleActivePane();
+                break;
+            case 'right':
+                if (this._activePane === 'source') {
+                    this.transferToTarget();
+                }
+                break;
+            case 'left':
+                if (this._activePane === 'target') {
+                    this.transferToSource();
+                }
+                break;
+        }
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width, height } = this._rect;
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this.style);
+
+        const leftPaneWidth = Math.floor((width - 1) / 2);
+        const rightPaneWidth = width - 1 - leftPaneWidth;
+        if (leftPaneWidth < 0 || rightPaneWidth < 0) return;
+
+        const dividerX = x + leftPaneWidth;
+        const dividerChar = caps.unicode ? '│' : '|';
+        const indicator = caps.unicode ? '❯ ' : '> ';
+        const noIndicator = ' '.repeat(indicator.length);
+
+        for (let i = 0; i < height; i++) {
+            // 1. Left pane (source)
+            if (i < this._sourceItems.length) {
+                const o = this._sourceItems[i];
+                const active = this._activePane === 'source' && i === this._sourceCursorIndex;
+                const text = (active ? indicator : noIndicator) + o.label;
+                const truncatedText = text.slice(0, leftPaneWidth).padEnd(leftPaneWidth, ' ');
+                screen.writeString(x, y + i, truncatedText, {
+                    ...attrs,
+                    fg: o.disabled ? { type: 'named' as const, name: 'brightBlack' as const } : active ? this._activeColor : attrs.fg,
+                    bold: active,
+                    dim: o.disabled,
+                });
+            } else {
+                screen.writeString(x, y + i, ' '.repeat(leftPaneWidth), attrs);
+            }
+
+            // 2. Divider
+            screen.setCell(dividerX, y + i, {
+                char: dividerChar,
+                ...attrs,
+            });
+
+            // 3. Right pane (target)
+            if (i < this._targetItems.length) {
+                const o = this._targetItems[i];
+                const active = this._activePane === 'target' && i === this._targetCursorIndex;
+                const text = (active ? indicator : noIndicator) + o.label;
+                const truncatedText = text.slice(0, rightPaneWidth).padEnd(rightPaneWidth, ' ');
+                screen.writeString(dividerX + 1, y + i, truncatedText, {
+                    ...attrs,
+                    fg: o.disabled ? { type: 'named' as const, name: 'brightBlack' as const } : active ? this._activeColor : attrs.fg,
+                    bold: active,
+                    dim: o.disabled,
+                });
+            } else {
+                screen.writeString(dividerX + 1, y + i, ' '.repeat(rightPaneWidth), attrs);
+            }
+        }
+    }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -63,6 +63,9 @@ export type { SnippetPromptOptions } from './SnippetPrompt.js';
 export { MultiSelect } from './MultiSelect.js';
 export type { MultiSelectOption, MultiSelectOptions } from './MultiSelect.js';
 
+export { Transfer } from './Transfer.js';
+export type { TransferItem, TransferOptions } from './Transfer.js';
+
 export { Tree } from './Tree.js';
 export type { TreeNode, TreeOptions } from './Tree.js';
 


### PR DESCRIPTION
### Summary
This PR implements the interactive `Transfer` (dual-list shuttle selector) widget for `@termuijs/ui`, resolving #484.

### Proposed Changes
- **`Transfer` Widget (`Transfer.ts`)**:
  - Extends `Widget` from `@termuijs/widgets`.
  - Manages a source (left) pane and a target (right) pane.
  - Implements keyboard event handling inside `handleKey`:
    - `up` / `down`: Navigate within the active pane (skipping disabled items).
    - `tab`: Switch active focus between the source and target panes.
    - `right`: Transfer the selected source item to the target pane.
    - `left`: Transfer the selected target item back to the source pane.
  - Supports dynamic unicode checks using `caps.unicode` for item selection indicators (`❯ ` / `> `) and divider characters (`│` / `|`).
  - Automatically clears unused rows up to the widget's viewport height to prevent ghost cells on item transfer.
  - Clamps cursor indices correctly after transferring items.
  - Calls `onChange(targetValues)` on changes.
- **Widget Export (`index.ts`)**:
  - Exports the widget class alongside `TransferItem` and `TransferOptions` interfaces.
- **Tests (`Transfer.test.ts`)**:
  - Verifies state, keyboard routing, index bounds clamping, disabled items skipping, and grid rendering (with both unicode and ASCII configurations).

### Verification Plan
- Verified code compilation with `bun run typecheck`.
- Ran the build output cleanly using `bun run build`.
- Ran the test runner suite: `bun vitest run packages/ui` (all tests passed).

Closes #484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Transfer widget: a dual-list selector for moving items between source and target lists with keyboard navigation and item transfer operations.

* **Tests**
  * Added comprehensive test suite covering navigation, item transfers, disabled item behavior, rendering, and character mode support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->