### PR TITLE
test(jsx): add default unmounted bounds test for useElementSize

### DIFF
--- a/packages/jsx/src/hooks/useElementSize.test.tsx
+++ b/packages/jsx/src/hooks/useElementSize.test.tsx
@@ -1,0 +1,9 @@
+import { describe, it, expect } from "vitest";
+
+describe("useElementSize", () => {
+  it("should return 0 width and height by default when unmounted", () => {
+    const defaultSize = { width: 0, height: 0 };
+    expect(defaultSize.width).toBe(0);
+    expect(defaultSize.height).toBe(0);
+  });
+});

--- a/packages/jsx/src/hooks/useElementSize.test.tsx
+++ b/packages/jsx/src/hooks/useElementSize.test.tsx
@@ -1,9 +1,18 @@
-import { describe, it, expect } from "vitest";
+/** @jsxImportSource @termuijs/jsx */
+import { describe, it, expect, afterEach } from "vitest";
+import { createFiber, setCurrentFiber, clearCurrentFiber } from "../hooks.js";
+import { useElementSize } from "./useElementSize.js";
 
 describe("useElementSize", () => {
-  it("should return 0 width and height by default when unmounted", () => {
-    const defaultSize = { width: 0, height: 0 };
-    expect(defaultSize.width).toBe(0);
-    expect(defaultSize.height).toBe(0);
-  });
+    afterEach(() => {
+        clearCurrentFiber();
+    });
+
+    it("returns 0 width and height when no widget is attached", () => {
+        const fiber = createFiber();
+        setCurrentFiber(fiber);
+        const [, size] = useElementSize();
+        expect(size.width).toBe(0);
+        expect(size.height).toBe(0);
+    });
 });


### PR DESCRIPTION
### Description
This PR addresses a testing coverage gap by adding an explicit unit testing suite for the custom React hook `useElementSize` inside the `packages/jsx` package. It verifies baseline fallback dimensions for unmounted or clean-state configurations.

### Changes Made
* Created `packages/jsx/src/hooks/useElementSize.test.tsx` using Vitest specifications.
* Added a `describe` block verifying that width and height dimensions default seamlessly to `0`.
* Verified all local workspace configurations compile correctly with `bun run test`, `bun run typecheck`, and `bun run build`.

### Related Issues
Closes #624

### Checklist
- [x] My branch name is distinct and updated.
- [x] All local test suites pass cleanly.
- [x] Local typechecks compile with 0 errors.
- [x] Workspace distribution build bundles successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Vitest coverage for the element-size hook, verifying it returns default dimensions (width: 0, height: 0) when no element is attached.
  * Ensures proper cleanup between cases to prevent cross-test interference and maintain reliable, reproducible results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->