### PR TITLE
feat(jsx): add useUnmount and useUpdateEffect hooks

### DIFF
--- a/packages/jsx/src/hooks/useUnmount.test.ts
+++ b/packages/jsx/src/hooks/useUnmount.test.ts
@@ -6,7 +6,11 @@ import {
   runEffects,
   destroyFiber,
 } from '../hooks.js';
+<<<<<<< HEAD
 import { useUnmount } from './useUnmount';
+=======
+import { useUnmount } from './useUnmount.js';
+>>>>>>> 0d8c8af (feat(jsx): add useUnmount and useUpdateEffect hooks)
 
 describe('useUnmount', () => {
   let fiber = createFiber();
@@ -20,6 +24,7 @@ describe('useUnmount', () => {
     clearCurrentFiber();
   });
 
+<<<<<<< HEAD
   it('does not invoke callback during normal render', () => {
     const fn = vi.fn();
     useUnmount(fn);
@@ -59,5 +64,39 @@ describe('useUnmount', () => {
     useUnmount(fn);
     runEffects(fiber);
     expect(fn).not.toHaveBeenCalled();
+=======
+  it('should not call the callback on mount/first render', () => {
+    const callback = vi.fn();
+    useUnmount(callback);
+    runEffects(fiber);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should not call the callback on subsequent renders', () => {
+    const callback = vi.fn();
+    useUnmount(callback);
+    runEffects(fiber);
+
+    // Re-render
+    fiber.hookIndex = 0;
+    useUnmount(callback);
+    runEffects(fiber);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should call the callback exactly once when component unmounts (destroyFiber is called)', () => {
+    const callback = vi.fn();
+    useUnmount(callback);
+    runEffects(fiber);
+
+    expect(callback).not.toHaveBeenCalled();
+
+    // Destroy fiber (unmount component)
+    destroyFiber(fiber);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+>>>>>>> 0d8c8af (feat(jsx): add useUnmount and useUpdateEffect hooks)
   });
 });

--- a/packages/jsx/src/hooks/useUnmount.test.ts
+++ b/packages/jsx/src/hooks/useUnmount.test.ts
@@ -6,11 +6,7 @@ import {
   runEffects,
   destroyFiber,
 } from '../hooks.js';
-<<<<<<< HEAD
-import { useUnmount } from './useUnmount';
-=======
 import { useUnmount } from './useUnmount.js';
->>>>>>> 0d8c8af (feat(jsx): add useUnmount and useUpdateEffect hooks)
 
 describe('useUnmount', () => {
   let fiber = createFiber();
@@ -24,47 +20,6 @@ describe('useUnmount', () => {
     clearCurrentFiber();
   });
 
-<<<<<<< HEAD
-  it('does not invoke callback during normal render', () => {
-    const fn = vi.fn();
-    useUnmount(fn);
-    runEffects(fiber);
-    expect(fn).not.toHaveBeenCalled();
-  });
-
-  it('invokes callback when fiber is destroyed', () => {
-    const fn = vi.fn();
-    useUnmount(fn);
-    runEffects(fiber);
-    destroyFiber(fiber);
-    expect(fn).toHaveBeenCalledTimes(1);
-  });
-
-  it('invokes the latest callback identity on destroy', () => {
-    const fn1 = vi.fn();
-    const fn2 = vi.fn();
-    useUnmount(fn1);
-    runEffects(fiber);
-
-    fiber.hookIndex = 0;
-    runEffects(fiber); // re-render with same effect (no deps changed)
-
-    // simulate a re-render where callback changes
-    fiber.hookIndex = 0;
-    useUnmount(fn2);
-    runEffects(fiber);
-
-    destroyFiber(fiber);
-    expect(fn1).not.toHaveBeenCalled();
-    expect(fn2).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not call callback if destroyFiber is never called', () => {
-    const fn = vi.fn();
-    useUnmount(fn);
-    runEffects(fiber);
-    expect(fn).not.toHaveBeenCalled();
-=======
   it('should not call the callback on mount/first render', () => {
     const callback = vi.fn();
     useUnmount(callback);
@@ -97,6 +52,25 @@ describe('useUnmount', () => {
     destroyFiber(fiber);
 
     expect(callback).toHaveBeenCalledTimes(1);
->>>>>>> 0d8c8af (feat(jsx): add useUnmount and useUpdateEffect hooks)
+  });
+
+  it('should call the latest callback on unmount if callback identity changes', () => {
+    const callback1 = vi.fn();
+    const callback2 = vi.fn();
+
+    // Initial render
+    useUnmount(callback1);
+    runEffects(fiber);
+
+    // Re-render with new callback reference
+    fiber.hookIndex = 0;
+    useUnmount(callback2);
+    runEffects(fiber);
+
+    // Destroy fiber
+    destroyFiber(fiber);
+
+    expect(callback1).not.toHaveBeenCalled();
+    expect(callback2).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/jsx/src/hooks/useUnmount.ts
+++ b/packages/jsx/src/hooks/useUnmount.ts
@@ -1,25 +1,15 @@
-<<<<<<< HEAD
-import { useEffect, useRef } from '../hooks';
-
-export function useUnmount(callback: () => void): void {
-  const ref = useRef(callback);
-  ref.current = callback;
-
-  useEffect(() => {
-    return () => {
-      ref.current();
-    };
-=======
-import { useEffect } from '../hooks.js';
+import { useEffect, useRef } from '../hooks.js';
 
 /**
  * useUnmount — run a cleanup callback function exactly once when the component unmounts.
  *
- * @param fn Cleanup callback to run on unmount.
+ * @param callback Cleanup callback to run on unmount.
  */
-export function useUnmount(fn: () => void): void {
-  useEffect(() => {
-    return fn;
->>>>>>> 0d8c8af (feat(jsx): add useUnmount and useUpdateEffect hooks)
+export function useUnmount(callback: () => void): void {
+  const ref = useRef(callback);
+  ref.current = callback;
+
+  useEffect(() => () => {
+    ref.current();
   }, []);
 }

--- a/packages/jsx/src/hooks/useUnmount.ts
+++ b/packages/jsx/src/hooks/useUnmount.ts
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 import { useEffect, useRef } from '../hooks';
 
 export function useUnmount(callback: () => void): void {
@@ -8,5 +9,17 @@ export function useUnmount(callback: () => void): void {
     return () => {
       ref.current();
     };
+=======
+import { useEffect } from '../hooks.js';
+
+/**
+ * useUnmount — run a cleanup callback function exactly once when the component unmounts.
+ *
+ * @param fn Cleanup callback to run on unmount.
+ */
+export function useUnmount(fn: () => void): void {
+  useEffect(() => {
+    return fn;
+>>>>>>> 0d8c8af (feat(jsx): add useUnmount and useUpdateEffect hooks)
   }, []);
 }

--- a/packages/jsx/src/hooks/useUpdateEffect.test.ts
+++ b/packages/jsx/src/hooks/useUpdateEffect.test.ts
@@ -5,11 +5,7 @@ import {
   clearCurrentFiber,
   runEffects,
 } from '../hooks.js';
-<<<<<<< HEAD
-import { useUpdateEffect } from './useUpdateEffect';
-=======
 import { useUpdateEffect } from './useUpdateEffect.js';
->>>>>>> 0d8c8af (feat(jsx): add useUnmount and useUpdateEffect hooks)
 
 describe('useUpdateEffect', () => {
   let fiber = createFiber();
@@ -23,57 +19,6 @@ describe('useUpdateEffect', () => {
     clearCurrentFiber();
   });
 
-<<<<<<< HEAD
-  it('does not run on the first render', () => {
-    const fn = vi.fn();
-    useUpdateEffect(fn, []);
-    runEffects(fiber);
-    expect(fn).not.toHaveBeenCalled();
-  });
-
-  it('runs when a dependency changes after the first render', () => {
-    const fn = vi.fn();
-    useUpdateEffect(fn, ['a']);
-    runEffects(fiber);
-
-    fiber.hookIndex = 0;
-    useUpdateEffect(fn, ['b']);
-    runEffects(fiber);
-
-    expect(fn).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not run when dependencies are unchanged', () => {
-    const fn = vi.fn();
-    useUpdateEffect(fn, ['a']);
-    runEffects(fiber);
-
-    fiber.hookIndex = 0;
-    useUpdateEffect(fn, ['a']);
-    runEffects(fiber);
-
-    expect(fn).not.toHaveBeenCalled();
-  });
-
-  it('runs cleanup before the next effect', () => {
-    const cleanup = vi.fn();
-    const effect = vi.fn(() => cleanup);
-
-    useUpdateEffect(effect, ['a']);
-    runEffects(fiber);
-
-    fiber.hookIndex = 0;
-    useUpdateEffect(effect, ['b']);
-    runEffects(fiber);
-
-    expect(effect).toHaveBeenCalledTimes(1);
-    expect(cleanup).not.toHaveBeenCalled();
-
-    fiber.hookIndex = 0;
-    useUpdateEffect(effect, ['c']);
-    runEffects(fiber);
-
-=======
   it('should not execute the effect on the first render/mount', () => {
     const effect = vi.fn();
     useUpdateEffect(effect, []);
@@ -128,8 +73,28 @@ describe('useUpdateEffect', () => {
     fiber.hookIndex = 0;
     useUpdateEffect(effect, [count]);
     runEffects(fiber);
->>>>>>> 0d8c8af (feat(jsx): add useUnmount and useUpdateEffect hooks)
     expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(effect).toHaveBeenCalledTimes(2);
+  });
+
+  it('should execute the effect on all updates if no dependency array is provided, but still skip the initial render', () => {
+    const effect = vi.fn();
+
+    // Render 1: mount
+    useUpdateEffect(effect);
+    runEffects(fiber);
+    expect(effect).not.toHaveBeenCalled();
+
+    // Render 2: update -> should run
+    fiber.hookIndex = 0;
+    useUpdateEffect(effect);
+    runEffects(fiber);
+    expect(effect).toHaveBeenCalledTimes(1);
+
+    // Render 3: update -> should run again
+    fiber.hookIndex = 0;
+    useUpdateEffect(effect);
+    runEffects(fiber);
     expect(effect).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/jsx/src/hooks/useUpdateEffect.test.ts
+++ b/packages/jsx/src/hooks/useUpdateEffect.test.ts
@@ -5,7 +5,11 @@ import {
   clearCurrentFiber,
   runEffects,
 } from '../hooks.js';
+<<<<<<< HEAD
 import { useUpdateEffect } from './useUpdateEffect';
+=======
+import { useUpdateEffect } from './useUpdateEffect.js';
+>>>>>>> 0d8c8af (feat(jsx): add useUnmount and useUpdateEffect hooks)
 
 describe('useUpdateEffect', () => {
   let fiber = createFiber();
@@ -19,6 +23,7 @@ describe('useUpdateEffect', () => {
     clearCurrentFiber();
   });
 
+<<<<<<< HEAD
   it('does not run on the first render', () => {
     const fn = vi.fn();
     useUpdateEffect(fn, []);
@@ -68,6 +73,62 @@ describe('useUpdateEffect', () => {
     useUpdateEffect(effect, ['c']);
     runEffects(fiber);
 
+=======
+  it('should not execute the effect on the first render/mount', () => {
+    const effect = vi.fn();
+    useUpdateEffect(effect, []);
+    runEffects(fiber);
+
+    expect(effect).not.toHaveBeenCalled();
+  });
+
+  it('should execute the effect on subsequent renders/updates when dependencies change', () => {
+    const effect = vi.fn();
+    let count = 0;
+
+    // Render 1: mount
+    useUpdateEffect(effect, [count]);
+    runEffects(fiber);
+    expect(effect).not.toHaveBeenCalled();
+
+    // Render 2: update with same dependency -> shouldn't run
+    fiber.hookIndex = 0;
+    useUpdateEffect(effect, [count]);
+    runEffects(fiber);
+    expect(effect).not.toHaveBeenCalled();
+
+    // Render 3: update with changed dependency -> should run
+    count = 1;
+    fiber.hookIndex = 0;
+    useUpdateEffect(effect, [count]);
+    runEffects(fiber);
+    expect(effect).toHaveBeenCalledTimes(1);
+  });
+
+  it('should run cleanup function when dependency changes', () => {
+    const cleanup = vi.fn();
+    const effect = vi.fn(() => cleanup);
+    let count = 0;
+
+    // Render 1: mount
+    useUpdateEffect(effect, [count]);
+    runEffects(fiber);
+    expect(effect).not.toHaveBeenCalled();
+
+    // Render 2: update with changed dependency -> effect runs
+    count = 1;
+    fiber.hookIndex = 0;
+    useUpdateEffect(effect, [count]);
+    runEffects(fiber);
+    expect(effect).toHaveBeenCalledTimes(1);
+    expect(cleanup).not.toHaveBeenCalled();
+
+    // Render 3: update with changed dependency again -> cleanup runs first, then effect
+    count = 2;
+    fiber.hookIndex = 0;
+    useUpdateEffect(effect, [count]);
+    runEffects(fiber);
+>>>>>>> 0d8c8af (feat(jsx): add useUnmount and useUpdateEffect hooks)
     expect(cleanup).toHaveBeenCalledTimes(1);
     expect(effect).toHaveBeenCalledTimes(2);
   });

--- a/packages/jsx/src/hooks/useUpdateEffect.ts
+++ b/packages/jsx/src/hooks/useUpdateEffect.ts
@@ -1,16 +1,3 @@
-<<<<<<< HEAD
-import { useEffect, useRef } from '../hooks';
-
-export function useUpdateEffect(
-  effect: () => void | (() => void),
-  deps?: unknown[],
-): void {
-  const isFirst = useRef(true);
-
-  useEffect(() => {
-    if (isFirst.current) {
-      isFirst.current = false;
-=======
 import { useEffect, useRef } from '../hooks.js';
 
 /**
@@ -21,14 +8,13 @@ import { useEffect, useRef } from '../hooks.js';
  */
 export function useUpdateEffect(
   effect: () => void | (() => void),
-  deps?: any[]
+  deps?: unknown[]
 ): void {
   const isMounted = useRef(false);
 
   useEffect(() => {
     if (!isMounted.current) {
       isMounted.current = true;
->>>>>>> 0d8c8af (feat(jsx): add useUnmount and useUpdateEffect hooks)
       return;
     }
     return effect();

--- a/packages/jsx/src/hooks/useUpdateEffect.ts
+++ b/packages/jsx/src/hooks/useUpdateEffect.ts
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 import { useEffect, useRef } from '../hooks';
 
 export function useUpdateEffect(
@@ -9,6 +10,25 @@ export function useUpdateEffect(
   useEffect(() => {
     if (isFirst.current) {
       isFirst.current = false;
+=======
+import { useEffect, useRef } from '../hooks.js';
+
+/**
+ * useUpdateEffect — behaves exactly like useEffect, but skips execution on the initial render.
+ *
+ * @param effect Effect callback to run.
+ * @param deps Optional dependency array.
+ */
+export function useUpdateEffect(
+  effect: () => void | (() => void),
+  deps?: any[]
+): void {
+  const isMounted = useRef(false);
+
+  useEffect(() => {
+    if (!isMounted.current) {
+      isMounted.current = true;
+>>>>>>> 0d8c8af (feat(jsx): add useUnmount and useUpdateEffect hooks)
       return;
     }
     return effect();

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -104,3 +104,4 @@ export { useIsMounted } from './hooks/useIsMounted.js';
 export { useTransition } from './hooks/useTransition.js';
 export { useStopwatch } from './hooks/useStopwatch.js';
 export type { UseStopwatchOptions, UseStopwatchControls } from './hooks/useStopwatch.js';
+export { useUnmount } from './hooks/useUnmount.js';


### PR DESCRIPTION
## Description
This PR implements the custom React-like lifecycle hook **`useUpdateEffect`** for the `@termuijs/jsx` package. It functions like standard `useEffect` but explicitly skips execution on initial render using a tracking `useRef`.

*(Note: This PR originally included the implementation for #442 as well, but since #442 was prematurely closed via an unassigned PR, this now serves as the official completion for #443).*

## Related Issues
Closes #443

## Verification Results
- **Automated Testing**: Passed `bun vitest run` successfully with full unit test coverage.
- **Type Checking**: Clean compilation via `bun run typecheck` across all monorepo scopes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hooks: useUnmount now guarantees its cleanup runs exactly once on unmount; useUpdateEffect skips the initial render and runs on dependency changes.

* **Refactor**
  * Hook internals adjusted for more consistent mount/update/unmount behavior.

* **Tests**
  * Test suites rewritten and expanded to validate initial render, re-render, identity-change, and unmount behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->