### PR TITLE
Feat chalk adapter

### DIFF
--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -45,7 +45,8 @@
     "commander": "^15.0.0",
     "zod": "^3.0.0",
     "openai": "^4.0.0",
-    "@anthropic-ai/sdk": "^0.39.0"
+    "@anthropic-ai/sdk": "^0.39.0",
+    "chalk": "^5.0.0"
   },
   "peerDependenciesMeta": {
     "conf": {
@@ -62,7 +63,10 @@
     },
     "@anthropic-ai/sdk": {
       "optional": true
-    }
+    },
+     "chalk": {
+    "optional": true
+  }
   },
   "keywords": [
     "terminal",

--- a/packages/adapters/src/chalk/index.test.ts
+++ b/packages/adapters/src/chalk/index.test.ts
@@ -2,23 +2,29 @@ import { describe, expect, it } from 'vitest'
 import { chalkToTermUI, ensureChalkInstalled } from './index.js'
 
 describe('chalk adapter', () => {
-  it('passes ANSI strings through when NO_COLOR is not set', () => {
-    delete process.env.NO_COLOR
+ it('passes ANSI strings through when NO_COLOR is not set', () => {
+  const originalNoColor = process.env.NO_COLOR
 
-    const input = '\u001B[31merror\u001B[39m'
+  delete process.env.NO_COLOR
 
-    expect(chalkToTermUI(input)).toBe(input)
-  })
+  const input = '\u001B[31merror\u001B[39m'
 
-  it('strips ANSI sequences when NO_COLOR is set', () => {
-    process.env.NO_COLOR = '1'
+  expect(chalkToTermUI(input)).toBe(input)
 
-    const input = '\u001B[31merror\u001B[39m'
+  process.env.NO_COLOR = originalNoColor
+})
 
-    expect(chalkToTermUI(input)).toBe('error')
+it('strips ANSI sequences when NO_COLOR is set', () => {
+  const originalNoColor = process.env.NO_COLOR
 
-    delete process.env.NO_COLOR
-  })
+  process.env.NO_COLOR = '1'
+
+  const input = '\u001B[31merror\u001B[39m'
+
+  expect(chalkToTermUI(input)).toBe('error')
+
+  process.env.NO_COLOR = originalNoColor
+})
 
   it('exports chalk dependency guard', () => {
     expect(typeof ensureChalkInstalled).toBe('function')

--- a/packages/adapters/src/chalk/index.test.ts
+++ b/packages/adapters/src/chalk/index.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { chalkToTermUI, ensureChalkInstalled } from './index.js'
+
+describe('chalk adapter', () => {
+  it('passes ANSI strings through when NO_COLOR is not set', () => {
+    delete process.env.NO_COLOR
+
+    const input = '\u001B[31merror\u001B[39m'
+
+    expect(chalkToTermUI(input)).toBe(input)
+  })
+
+  it('strips ANSI sequences when NO_COLOR is set', () => {
+    process.env.NO_COLOR = '1'
+
+    const input = '\u001B[31merror\u001B[39m'
+
+    expect(chalkToTermUI(input)).toBe('error')
+
+    delete process.env.NO_COLOR
+  })
+
+  it('exports chalk dependency guard', () => {
+    expect(typeof ensureChalkInstalled).toBe('function')
+  })
+})

--- a/packages/adapters/src/chalk/index.ts
+++ b/packages/adapters/src/chalk/index.ts
@@ -1,0 +1,26 @@
+import { createRequire } from 'node:module'
+
+
+const ANSI_REGEX = /\x1B\[[0-?]*[ -/]*[@-~]/g;
+
+
+
+export function ensureChalkInstalled(): void {
+  try {
+    const require = createRequire(import.meta.url)
+    require('chalk')
+  } catch (error) {
+    throw new Error(
+      'chalkToTermUI() requires the optional peer dependency `chalk`. Install `chalk` before using this adapter.',
+      { cause: error }
+    )
+  }
+}
+
+export function chalkToTermUI(input: string): string {
+  if (process.env.NO_COLOR) {
+    return input.replace(ANSI_REGEX, '')
+  }
+
+  return input
+}

--- a/packages/adapters/src/chalk/index.ts
+++ b/packages/adapters/src/chalk/index.ts
@@ -18,7 +18,7 @@ export function ensureChalkInstalled(): void {
 }
 
 export function chalkToTermUI(input: string): string {
-  if (process.env.NO_COLOR) {
+  if ('NO_COLOR' in process.env) {
     return input.replace(ANSI_REGEX, '')
   }
 

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -5,6 +5,7 @@ export type { SetConfValue, UseConfResult } from './conf/index.js'
 
 export { zodValidator } from './zod/index.js'
 export type { PromptValidator } from './zod/index.js'
+export { chalkToTermUI } from './chalk/index.js'
 
 export { useAI } from './ai/index.js'
 export type {


### PR DESCRIPTION
## Description

Adds a Chalk adapter to `@termuijs/adapters` for handling Chalk-styled strings inside TermUI widgets.

### Changes

* Added `chalkToTermUI` adapter in `packages/adapters/src/chalk/index.ts`
* Added ANSI passthrough behavior
* Added ANSI stripping when `NO_COLOR` is set
* Added optional peer dependency support for `chalk`
* Exported the adapter from `packages/adapters/src/index.ts`
* Added tests covering ANSI passthrough and ANSI stripping modes

## Related Issue

Closes #72

## Which package(s)?

@termuijs/adapters

## Type of Change

* [x] ✨ Feature (`type:feature`)
* [x] 🧪 Tests (`type:testing`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md](https://chatgpt.com/c/CONTRIBUTING.md)`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [ ] Widget state mutators call `markDirty()` (not applicable)
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/2af89ea2-51ba-40f3-a887-93e5300bea0e`

## Screenshots 


<img width="1591" height="784" alt="image" src="https://github.com/user-attachments/assets/f85ddb6a-ce8f-48ab-9483-77c3037b3fb9" />

<img width="1561" height="617" alt="image" src="https://github.com/user-attachments/assets/602b50f8-7b27-4eb1-8cff-0938919f03d7" />


## Notes for the Reviewer

Implemented a Chalk compatibility adapter following existing adapter patterns. The adapter preserves ANSI-styled strings by default and strips ANSI escape sequences when `NO_COLOR` is set. Added tests covering both behaviors and exported the adapter through the package entrypoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional color output integration via Chalk; works when installed and remains optional otherwise
  * Color handling respects NO_COLOR to strip ANSI styling; otherwise preserves colors
  * Color adapter exposed from the adapters entry point with clearer messaging when color support isn’t available

* **Tests**
  * Added tests for pass-through vs. stripping behavior based on NO_COLOR
  * Verified the new color adapter’s public API and messaging behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->