### PR TITLE
test(widgets): add unit tests for Skeleton widget

### DIFF
--- a/packages/widgets/src/feedback/Skeleton.test.ts
+++ b/packages/widgets/src/feedback/Skeleton.test.ts
@@ -1,0 +1,135 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for Skeleton widget
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { Screen, caps } from '@termuijs/core';
+import { Skeleton } from './Skeleton.js';
+import * as motion from '@termuijs/motion';
+
+describe('Skeleton', () => {
+    let timerCallback: (() => void) | undefined;
+
+    beforeEach(() => {
+        timerCallback = undefined;
+        vi.spyOn(caps, 'motion', 'get').mockReturnValue(true);
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+        vi.spyOn(motion, 'timerPoolSubscribe').mockImplementation((_interval, cb) => {
+            timerCallback = cb;
+            return () => {};
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('initializes with default options and subscribes to timers', () => {
+        const skeleton = new Skeleton();
+        expect(skeleton).toBeDefined();
+        expect(motion.timerPoolSubscribe).toHaveBeenCalledWith(600, expect.any(Function));
+        expect(timerCallback).toBeDefined();
+    });
+
+    it('does not subscribe to timer pool if motion is disabled', () => {
+        vi.spyOn(caps, 'motion', 'get').mockReturnValue(false);
+        const skeleton = new Skeleton();
+        expect(skeleton).toBeDefined();
+        expect(motion.timerPoolSubscribe).not.toHaveBeenCalled();
+    });
+
+    it('renders pulse variant with unicode defaults', () => {
+        const skeleton = new Skeleton({}, { variant: 'pulse' });
+        skeleton.updateRect({ x: 0, y: 0, width: 5, height: 2 });
+        const screen = new Screen(5, 2);
+        skeleton.render(screen);
+
+        // Frame 0 uses first char ('░')
+        for (let row = 0; row < 2; row++) {
+            const rendered = screen.back[row].map(c => c.char).join('');
+            expect(rendered).toBe('░░░░░');
+            for (let col = 0; col < 5; col++) {
+                expect(screen.back[row][col].dim).toBe(true);
+            }
+        }
+    });
+
+    it('advances pulse frame and updates rendering on timer tick', () => {
+        const skeleton = new Skeleton({}, { variant: 'pulse' });
+        skeleton.updateRect({ x: 0, y: 0, width: 5, height: 2 });
+        const screen1 = new Screen(5, 2);
+        skeleton.render(screen1);
+        expect(screen1.back[0].map(c => c.char).join('')).toBe('░░░░░');
+
+        // Trigger timer tick to advance frame to 1 (uses '▒')
+        if (timerCallback) timerCallback();
+
+        const screen2 = new Screen(5, 2);
+        skeleton.render(screen2);
+        expect(screen2.back[0].map(c => c.char).join('')).toBe('▒▒▒▒▒');
+        expect(screen2.back[0][0].dim).toBe(false);
+    });
+
+    it('renders pulse variant with ASCII fallback when unicode is disabled', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+        const skeleton = new Skeleton({}, { variant: 'pulse' });
+        skeleton.updateRect({ x: 0, y: 0, width: 5, height: 1 });
+
+        const screen = new Screen(5, 1);
+        skeleton.render(screen);
+
+        // ASCII default chars are ['-', '#']
+        expect(screen.back[0].map(c => c.char).join('')).toBe('-----');
+    });
+
+    it('renders pulse variant with custom characters', () => {
+        const skeleton = new Skeleton({}, { variant: 'pulse', chars: ['A', 'B'] });
+        skeleton.updateRect({ x: 0, y: 0, width: 5, height: 1 });
+
+        const screen1 = new Screen(5, 1);
+        skeleton.render(screen1);
+        expect(screen1.back[0].map(c => c.char).join('')).toBe('AAAAA');
+
+        if (timerCallback) timerCallback();
+
+        const screen2 = new Screen(5, 1);
+        skeleton.render(screen2);
+        expect(screen2.back[0].map(c => c.char).join('')).toBe('BBBBB');
+    });
+
+    it('renders shimmer variant and shifts band on timer tick', () => {
+        const skeleton = new Skeleton({}, { variant: 'shimmer', chars: ['-', '#'] });
+        // Width 10: shimmer band is max(1, 10 * 0.2) = 2.
+        skeleton.updateRect({ x: 0, y: 0, width: 10, height: 1 });
+
+        const screen1 = new Screen(10, 1);
+        skeleton.render(screen1);
+        // Initially, shimmerPos = 0, bandStart = 0, bandWidth = 2 -> indices 0 and 1 are '#'
+        expect(screen1.back[0].map(c => c.char).join('')).toBe('##--------');
+
+        // Advance shimmerPos by 1 -> bandStart = 1
+        if (timerCallback) timerCallback();
+
+        const screen2 = new Screen(10, 1);
+        skeleton.render(screen2);
+        expect(screen2.back[0].map(c => c.char).join('')).toBe('-##-------');
+    });
+
+    it('calls unsubscribe and clears timer on unmount', () => {
+        const unsubscribeMock = vi.fn();
+        vi.spyOn(motion, 'timerPoolSubscribe').mockReturnValue(unsubscribeMock);
+
+        const skeleton = new Skeleton();
+        skeleton.unmount();
+
+        expect(unsubscribeMock).toHaveBeenCalled();
+    });
+
+    it('does not render if dimensions are zero or negative', () => {
+        const skeleton = new Skeleton();
+        skeleton.updateRect({ x: 0, y: 0, width: 0, height: 0 });
+
+        const screen = new Screen(5, 5);
+        expect(() => skeleton.render(screen)).not.toThrow();
+    });
+});


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

<!-- What does this PR do? 1 to 3 sentences. -->

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #

## Which package(s)?

<!-- Example: @termuijs/core, @termuijs/widgets, website. -->

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [ ] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/3b805a2f-cf2a-43bb-8dd8-3fd9ee78b606`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Added comprehensive test suite for the Skeleton widget
* Verifies initialization, configuration options, and timer-based animations
* Validates pulse and shimmer animation variants with proper character rendering
* Tests frame advancement, animation state management, and cleanup behavior
* Confirms widget stability with edge cases including zero or negative dimensions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->