### PR TITLE
docs: add Bun installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ bun install
 bun run dev
 ```
 
-Requires [Bun](https://bun.sh) 1.3.0 or newer.
+Requires [Bun](https://bun.sh) 1.3.0 or newer. Install it with `curl -fsSL https://bun.sh/install | bash` (macOS/Linux) or `powershell -c "irm bun.sh/install.ps1 | iex"` (Windows).
 
 ## Manual Setup
 
@@ -417,6 +417,7 @@ examples/
 ```
 
 ## Development
+> **Note:** This project uses [Bun](https://bun.sh) as its package manager. Install Bun first: https://bun.sh/docs/installation
 
 ```bash
 bun install


### PR DESCRIPTION
## Description
Added Bun installation instructions in README to help contributors 
in standard Node.js environments set up Bun correctly.

## Related Issue
Closes #423

## Which package(s)?
README.md (root documentation)

## Type of Change
## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📝 Docs

## Checklist
- [ ] ⭐ You starred the repo
- [ ] Tests pass locally
- [ ] Build passes
...
- [ ] You read CONTRIBUTING.md 
- [ ] Your PR title follows...  

## GSSoC 2026 Participation
- [ ] You are a GSSoC 2026 contributor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with expanded Bun prerequisites, including installation commands for macOS, Linux, and Windows.
  * Added Development section clarifying Bun as the package manager with installation documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->