### PR TITLE
feat(ui): add Switch widget

### DIFF
--- a/packages/ui/src/Switch.test.ts
+++ b/packages/ui/src/Switch.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Screen, caps } from '@termuijs/core';
+import { Switch } from './Switch.js';
+
+describe('Switch', () => {
+    it('initial state uses defaultValue', () => {
+        const sw = new Switch({ defaultValue: true });
+
+        expect(sw.value).toBe(true);
+    });
+
+    it('space toggles value', () => {
+        const sw = new Switch({ defaultValue: false });
+
+        sw.handleKey({
+            key: 'space',
+            ctrl: false,
+            alt: false,
+        } as any);
+
+        expect(sw.value).toBe(true);
+    });
+
+    it('left and right set value', () => {
+        const sw = new Switch({ defaultValue: false });
+
+        sw.handleKey({ key: 'right' } as any);
+        expect(sw.value).toBe(true);
+
+        sw.handleKey({ key: 'left' } as any);
+        expect(sw.value).toBe(false);
+    });
+
+    it('onChange fires only when value changes', () => {
+        const onChange = vi.fn();
+
+        const sw = new Switch({
+            defaultValue: false,
+            onChange,
+        });
+
+        sw.setValue(false);
+        expect(onChange).not.toHaveBeenCalled();
+
+        sw.setValue(true);
+        expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders label', () => {
+        const sw = new Switch({
+            label: 'Wifi',
+            defaultValue: true,
+        });
+
+        sw.updateRect({
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 1,
+        });
+
+        const screen = new Screen(20, 1);
+
+        sw.render(screen);
+
+        const row = screen.back[0]
+            .map((c: { char: string }) => c.char)
+            .join('');
+
+        expect(row).toContain('Wifi');
+    });
+
+    it('supports ascii fallback', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+
+        const sw = new Switch({
+            label: 'Wifi',
+        });
+
+        sw.updateRect({
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 1,
+        });
+
+        const screen = new Screen(20, 1);
+
+        sw.render(screen);
+
+        const row = screen.back[0]
+            .map((c: { char: string }) => c.char)
+            .join('');
+
+        expect(row).toContain('O');
+    });
+});

--- a/packages/ui/src/Switch.test.ts
+++ b/packages/ui/src/Switch.test.ts
@@ -1,8 +1,11 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { Screen, caps } from '@termuijs/core';
 import { Switch } from './Switch.js';
 
 describe('Switch', () => {
+         afterEach(() => {
+          vi.restoreAllMocks();
+         });
     it('initial state uses defaultValue', () => {
         const sw = new Switch({ defaultValue: true });
 
@@ -13,10 +16,10 @@ describe('Switch', () => {
         const sw = new Switch({ defaultValue: false });
 
         sw.handleKey({
-            key: 'space',
-            ctrl: false,
-            alt: false,
-        } as any);
+         key: 'space',
+         ctrl: false,
+         alt: false,
+       } as any); // test: partial KeyEvent is sufficient for unit testing handleKey
 
         expect(sw.value).toBe(true);
     });
@@ -24,12 +27,12 @@ describe('Switch', () => {
     it('left and right set value', () => {
         const sw = new Switch({ defaultValue: false });
 
-        sw.handleKey({ key: 'right' } as any);
+        sw.handleKey({ key: 'right' } as any); // test: partial KeyEvent is sufficient for handleKey unit testing
         expect(sw.value).toBe(true);
 
-        sw.handleKey({ key: 'left' } as any);
-        expect(sw.value).toBe(false);
-    });
+        sw.handleKey({ key: 'left' } as any); // test: partial KeyEvent is sufficient for handleKey unit testing
+        expect(sw.value).toBe(false);  
+      });
 
     it('onChange fires only when value changes', () => {
         const onChange = vi.fn();

--- a/packages/ui/src/Switch.ts
+++ b/packages/ui/src/Switch.ts
@@ -1,0 +1,86 @@
+import { Widget } from '@termuijs/widgets';
+import {
+    type Screen,
+    type KeyEvent,
+    mergeStyles,
+    defaultStyle,
+    styleToCellAttrs,
+    caps,
+} from '@termuijs/core';
+
+export interface SwitchOptions {
+    defaultValue?: boolean;
+    label?: string;
+    onChange?: (value: boolean) => void;
+}
+
+export class Switch extends Widget {
+    private _value: boolean;
+    private _label?: string;
+    onChange?: (value: boolean) => void;
+
+    focusable = true;
+
+    constructor(options: SwitchOptions = {}) {
+        super(mergeStyles(defaultStyle(), { height: 1 }));
+
+        this._value = options.defaultValue ?? false;
+        this._label = options.label;
+        this.onChange = options.onChange;
+    }
+
+    get value(): boolean {
+        return this._value;
+    }
+
+    setValue(value: boolean): void {
+        if (this._value === value) return;
+
+        this._value = value;
+        this.onChange?.(value);
+        this.markDirty();
+    }
+
+    toggle(): void {
+        this.setValue(!this._value);
+    }
+
+    handleKey(event: KeyEvent): void {
+        switch (event.key) {
+            case 'space':
+                this.toggle();
+                break;
+
+            case 'right':
+                this.setValue(true);
+                break;
+
+            case 'left':
+                this.setValue(false);
+                break;
+        }
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width } = this._rect;
+
+        if (width <= 0) return;
+
+        const attrs = styleToCellAttrs(this.style);
+
+        const track = caps.unicode
+            ? (this._value ? '──●' : '●──')
+            : (this._value ? '--O' : 'O--');
+
+        const text = this._label
+            ? `${this._label} ${track}`
+            : track;
+
+        screen.writeString(
+            x,
+            y,
+            text.slice(0, width),
+            attrs
+        );
+    }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -131,6 +131,8 @@ export type { SegmentedControlOptions } from './SegmentedControl.js';
 export { SearchableSelect } from './SearchableSelect.js';
 export { Toggle } from './Toggle.js';
 export type { ToggleOptions } from './Toggle.js';
+export { Switch } from './Switch.js';
+export type { SwitchOptions } from './Switch.js';
 export { Checkbox } from './Checkbox.js';
 export type { CheckboxOptions } from './Checkbox.js';
 


### PR DESCRIPTION
## Description

Added a new `Switch` widget to `@termuijs/ui` that renders a labelled on/off switch with keyboard interaction. The widget supports toggling via space, setting values via left/right arrow keys, and includes tests for rendering and behavior.

## Related Issue

Closes #480

## Which package(s)?

@termuijs/ui

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [x] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [ ] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md](https://chatgpt.com/c/CONTRIBUTING.md)`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: https://gssoc.girlscript.org/profile/2ac2ddb2-72eb-438c-9502-7f64481c93fb

## Screenshots / Recordings (UI changes)

N/A (terminal UI widget)

## Notes for the Reviewer

Implemented the Switch widget following the API contract and package-specific AGENT instructions. Added rendering and interaction tests and exported the widget from `packages/ui/src/index.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a Switch terminal UI component with boolean toggling, optional label, and onChange callbacks.
  * Full keyboard support: space to toggle, left/right to set state.
  * Renders using unicode or ASCII based on terminal capabilities.

* **Tests**
  * Added tests for initialization, key handling, onChange behavior, label rendering, and ASCII fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->