### PR TITLE
feat(jsx): add useMediaQuery hook

### DIFF
--- a/packages/jsx/src/hooks/useMediaQuery.test.ts
+++ b/packages/jsx/src/hooks/useMediaQuery.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+    createFiber,
+    setCurrentFiber,
+    clearCurrentFiber,
+} from '../hooks.js';
+import { setCurrentApp } from '../runtime.js';
+import { useMediaQuery } from './useMediaQuery.js';
+
+describe('useMediaQuery', () => {
+    let fiber: ReturnType<typeof createFiber>;
+
+    beforeEach(() => {
+        fiber = createFiber();
+        setCurrentFiber(fiber);
+    });
+
+    afterEach(() => {
+        clearCurrentFiber();
+        setCurrentApp(null);
+    });
+
+    it('returns true when min-width matches', () => {
+        const mockApp = {
+            terminal: {
+                cols: 120,
+                rows: 40,
+                onResize: () => () => {},
+            },
+        };
+
+        setCurrentApp(mockApp as any);
+
+        expect(useMediaQuery('(min-width: 100)')).toBe(true);
+    });
+
+    it('returns false when min-width does not match', () => {
+        const mockApp = {
+            terminal: {
+                cols: 80,
+                rows: 40,
+                onResize: () => () => {},
+            },
+        };
+
+        setCurrentApp(mockApp as any);
+
+        expect(useMediaQuery('(min-width: 100)')).toBe(false);
+    });
+
+    it('supports max-width queries', () => {
+        const mockApp = {
+            terminal: {
+                cols: 80,
+                rows: 40,
+                onResize: () => () => {},
+            },
+        };
+
+        setCurrentApp(mockApp as any);
+
+        expect(useMediaQuery('(max-width: 100)')).toBe(true);
+    });
+
+    it('supports height queries', () => {
+        const mockApp = {
+            terminal: {
+                cols: 80,
+                rows: 50,
+                onResize: () => () => {},
+            },
+        };
+
+        setCurrentApp(mockApp as any);
+
+        expect(useMediaQuery('(min-height: 40)')).toBe(true);
+        expect(useMediaQuery('(max-height: 60)')).toBe(true);
+    });
+});

--- a/packages/jsx/src/hooks/useMediaQuery.test.ts
+++ b/packages/jsx/src/hooks/useMediaQuery.test.ts
@@ -3,6 +3,7 @@ import {
     createFiber,
     setCurrentFiber,
     clearCurrentFiber,
+    runEffects,
 } from '../hooks.js';
 import { setCurrentApp } from '../runtime.js';
 import { useMediaQuery } from './useMediaQuery.js';
@@ -76,4 +77,31 @@ describe('useMediaQuery', () => {
         expect(useMediaQuery('(min-height: 40)')).toBe(true);
         expect(useMediaQuery('(max-height: 60)')).toBe(true);
     });
+
+    it('updates when terminal is resized', () => {
+    let resizeHandler: ((cols: number, rows: number) => void) | undefined;
+
+    const mockApp = {
+        terminal: {
+            cols: 80,
+            rows: 40,
+            onResize: (handler: (cols: number, rows: number) => void) => {
+                resizeHandler = handler;
+                return () => {};
+            },
+        },
+    };
+
+    setCurrentApp(mockApp as any);
+
+    expect(useMediaQuery('(min-width: 100)')).toBe(false);
+
+    runEffects(fiber);
+
+    resizeHandler?.(120, 40);
+
+    fiber.hookIndex = 0;
+
+    expect(useMediaQuery('(min-width: 100)')).toBe(true);
+   });
 });

--- a/packages/jsx/src/hooks/useMediaQuery.test.ts
+++ b/packages/jsx/src/hooks/useMediaQuery.test.ts
@@ -30,7 +30,9 @@ describe('useMediaQuery', () => {
             },
         };
 
-        setCurrentApp(mockApp as any);
+        setCurrentApp(
+          mockApp as Parameters<typeof setCurrentApp>[0], // test-only partial app shape for useMediaQuery
+        );
 
         expect(useMediaQuery('(min-width: 100)')).toBe(true);
     });
@@ -44,7 +46,9 @@ describe('useMediaQuery', () => {
             },
         };
 
-        setCurrentApp(mockApp as any);
+        setCurrentApp(
+          mockApp as Parameters<typeof setCurrentApp>[0], // test-only partial app shape for useMediaQuery
+        );
 
         expect(useMediaQuery('(min-width: 100)')).toBe(false);
     });
@@ -58,7 +62,9 @@ describe('useMediaQuery', () => {
             },
         };
 
-        setCurrentApp(mockApp as any);
+        setCurrentApp(
+          mockApp as Parameters<typeof setCurrentApp>[0], // test-only partial app shape for useMediaQuery
+        );
 
         expect(useMediaQuery('(max-width: 100)')).toBe(true);
     });
@@ -72,7 +78,9 @@ describe('useMediaQuery', () => {
             },
         };
 
-        setCurrentApp(mockApp as any);
+        setCurrentApp(
+          mockApp as Parameters<typeof setCurrentApp>[0], // test-only partial app shape for useMediaQuery
+        );
 
         expect(useMediaQuery('(min-height: 40)')).toBe(true);
         expect(useMediaQuery('(max-height: 60)')).toBe(true);
@@ -92,7 +100,9 @@ describe('useMediaQuery', () => {
         },
     };
 
-    setCurrentApp(mockApp as any);
+    setCurrentApp(
+        mockApp as Parameters<typeof setCurrentApp>[0], // test-only partial app shape for useMediaQuery
+    );
 
     expect(useMediaQuery('(min-width: 100)')).toBe(false);
 

--- a/packages/jsx/src/hooks/useMediaQuery.ts
+++ b/packages/jsx/src/hooks/useMediaQuery.ts
@@ -1,0 +1,77 @@
+import { useState, useEffect } from '../hooks.js';
+import { getCurrentApp } from '../runtime.js';
+
+function evaluateQuery(
+    query: string,
+    cols: number,
+    rows: number,
+): boolean {
+    const normalized = query
+        .trim()
+        .replace(/^\(/, '')
+        .replace(/\)$/, '');
+    const [feature, valueString] = normalized.split(':');
+
+    if (!feature || !valueString) {
+        return false;
+    }
+
+    const value = Number(valueString.trim());
+
+    switch (feature.trim()) {
+        case 'min-width':
+            return cols >= value;
+
+        case 'max-width':
+            return cols <= value;
+
+        case 'min-height':
+            return rows >= value;
+
+        case 'max-height':
+            return rows <= value;
+
+        default:
+            return false;
+    }
+}
+
+export function useMediaQuery(query: string): boolean {
+    const app = getCurrentApp();
+
+    const getMatch = (): boolean => {
+        if (!app) {
+            return false;
+        }
+
+        return evaluateQuery(
+            query,
+            app.terminal.cols,
+            app.terminal.rows,
+        );
+    };
+
+    const [matches, setMatches] = useState(getMatch());
+
+    useEffect(() => {
+        if (!app) {
+            return;
+        }
+
+        setMatches(
+            evaluateQuery(
+                query,
+                app.terminal.cols,
+                app.terminal.rows,
+            ),
+        );
+
+        const unsubscribe = app.terminal.onResize((cols, rows) => {
+            setMatches(evaluateQuery(query, cols, rows));
+        });
+
+        return unsubscribe;
+    }, [query]);
+
+    return matches;
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -27,6 +27,7 @@ export {
     useInsertBefore,
     useReducer,
 } from './hooks.js';
+export { useMediaQuery } from './hooks/useMediaQuery.js';
 export type { AsyncState, KeyBinding, MotionPreferences } from './hooks.js';
 
 // ── Error Boundary ──


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

Adds a new `useMediaQuery` hook to `@termuijs/jsx` for responsive terminal applications.

The hook supports `min-width`, `max-width`, `min-height`, and `max-height` queries and automatically updates when the terminal is resized.

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #292

## Which package(s)?

<!-- Example: @termuijs/core, @termuijs/widgets, website. -->
@termuijs/jsx
## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: https://gssoc.girlscript.org/profile/ceb9cd2e-b1a4-421e-bece-018a5760035e

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->
Implemented:
- `useMediaQuery` hook
- terminal resize subscription
- support for width and height based media queries
- test coverage for all supported query types

Validation:
- 66 tests passing
- typecheck passing
- build passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a responsive hook that evaluates terminal-dimension media queries (min/max width and height) and updates reactively on terminal resize.
  * Hook is exported from the package public API.

* **Tests**
  * Added a test suite covering query evaluation and resize reactivity across various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->