### PR TITLE
feat:  add asciiOnly fallback for border rendering

### DIFF
--- a/packages/core/src/style/Border.test.ts
+++ b/packages/core/src/style/Border.test.ts
@@ -24,6 +24,21 @@ describe('getBorderChars', () => {
         const chars = getBorderChars('double');
         expect(chars).toMatchObject({ topLeft: '╔', topRight: '╗', bottomLeft: '╚', bottomRight: '╝' });
     });
+
+    it('returns ASCII chars when asciiOnly is enabled', () => {
+        const chars = getBorderChars('single', undefined, true);
+
+        expect(chars).toMatchObject({
+            topLeft: '+',
+            top: '-',
+            topRight: '+',
+            right: '|',
+            bottomRight: '+',
+            bottom: '-',
+            bottomLeft: '+',
+            left: '|',
+        });
+    });
 });
 
 describe('borderSize', () => {

--- a/packages/core/src/style/Border.ts
+++ b/packages/core/src/style/Border.ts
@@ -65,15 +65,35 @@ export const BORDER_CHARS: Record<Exclude<BorderStyle, 'none' | 'custom'>, Borde
     },
 };
 
+export const ASCII_BORDER_CHARS: BorderChars = {
+    topLeft: '+',
+    top: '-',
+    topRight: '+',
+    right: '|',
+    bottomRight: '+',
+    bottom: '-',
+    bottomLeft: '+',
+    left: '|',
+};
+
 /**
  * Get the border characters for a given style.
  */
-export function getBorderChars(style: BorderStyle, customChars?: Partial<BorderChars>): BorderChars | null {
+export function getBorderChars(
+    style: BorderStyle,
+    customChars?: Partial<BorderChars>,
+    asciiOnly = false,
+): BorderChars | null {
+
     if (style === 'none') return null;
+
+    if (asciiOnly) return ASCII_BORDER_CHARS;
+
     if (style === 'custom') {
         const base = BORDER_CHARS.single;
         return { ...base, ...customChars };
     }
+
     return BORDER_CHARS[style];
 }
 

--- a/packages/core/src/style/Style.ts
+++ b/packages/core/src/style/Style.ts
@@ -35,6 +35,7 @@ export interface Style {
     padding?: Partial<Edges> | number;
     margin?: Partial<Edges> | number;
     border?: BorderStyle;
+    asciiOnly?: boolean; 
     borderColor?: Color;
 
     // ── Dimensions ──────────

--- a/packages/jsx/src/reconciler.ts
+++ b/packages/jsx/src/reconciler.ts
@@ -216,6 +216,7 @@ function extractStyle(props: Record<string, any>): Partial<Style> {
     if (props.padding != null) style.padding = props.padding;
     if (props.margin != null) style.margin = props.margin;
     if (props.border != null) style.border = props.border;
+    if (props.asciiOnly != null) style.asciiOnly = props.asciiOnly;
     if (props.borderColor != null) style.borderColor = parseColorProp(props.borderColor);
     if (props.gap != null) style.gap = props.gap;
     return style;

--- a/packages/jsx/src/reconciler.ts
+++ b/packages/jsx/src/reconciler.ts
@@ -104,40 +104,40 @@ function createIntrinsicWidget(tag: string, props: Record<string, any>, children
 
         case 'progressbar': {
             return new ProgressBar(style, {
-                value:       typeof props.value === 'number' ? props.value : 0,
-                fillChar:    props.fillChar,
-                emptyChar:   props.emptyChar,
-                fillColor:   props.fillColor ? parseColorProp(props.fillColor) : undefined,
-                showLabel:   props.showLabel !== false,
+                value: typeof props.value === 'number' ? props.value : 0,
+                fillChar: props.fillChar,
+                emptyChar: props.emptyChar,
+                fillColor: props.fillColor ? parseColorProp(props.fillColor) : undefined,
+                showLabel: props.showLabel !== false,
                 labelFormat: props.labelFormat,
             });
         }
 
         case 'spinner': {
             return new Spinner(style, {
-                preset:      props.preset ?? props.spinner,
-                label:       props.label,
-                color:       props.color ? parseColorProp(props.color) : undefined,
-                active:      props.active !== false,
-                doneText:    props.doneText,
-                interval:    props.interval,
+                preset: props.preset ?? props.spinner,
+                label: props.label,
+                color: props.color ? parseColorProp(props.color) : undefined,
+                active: props.active !== false,
+                doneText: props.doneText,
+                interval: props.interval,
             });
         }
 
         case 'grid': {
             return new Grid({ ...style }, {
                 columns: props.columns ?? 12,
-                gap:     props.gap,
-                rowGap:  props.rowGap,
-                colGap:  props.colGap,
+                gap: props.gap,
+                rowGap: props.rowGap,
+                colGap: props.colGap,
             });
         }
 
         case 'skeleton': {
             return new Skeleton({ ...style }, {
-                variant:    props.variant,
+                variant: props.variant,
                 intervalMs: props.intervalMs,
-                chars:      props.chars,
+                chars: props.chars,
             });
         }
 
@@ -147,21 +147,21 @@ function createIntrinsicWidget(tag: string, props: Record<string, any>, children
                 .join('') || props.message || '';
             return new StatusMessage(content, { height: 1, ...style }, {
                 variant: props.variant,
-                icon:    props.icon,
+                icon: props.icon,
             });
         }
 
         case 'banner': {
             return new Banner({ ...style }, {
                 variant: props.variant,
-                title:   props.title,
-                body:    props.body,
+                title: props.title,
+                body: props.body,
             });
         }
 
         case 'card': {
             return new Card({ ...style }, {
-                title:       props.title,
+                title: props.title,
                 borderColor: props.borderColor ? parseColorProp(props.borderColor) : undefined,
             });
         }
@@ -169,8 +169,8 @@ function createIntrinsicWidget(tag: string, props: Record<string, any>, children
         case 'keyvalue': {
             const pairs = props.pairs ?? props.data ?? {};
             return new KeyValue(pairs, { ...style }, {
-                separator:  props.separator,
-                keyColor:   props.keyColor   ? parseColorProp(props.keyColor)   : undefined,
+                separator: props.separator,
+                keyColor: props.keyColor ? parseColorProp(props.keyColor) : undefined,
                 valueColor: props.valueColor ? parseColorProp(props.valueColor) : undefined,
             });
         }
@@ -178,7 +178,7 @@ function createIntrinsicWidget(tag: string, props: Record<string, any>, children
         case 'center': {
             return new Center({ ...style }, {
                 horizontal: props.horizontal !== false,
-                vertical:   props.vertical !== false,
+                vertical: props.vertical !== false,
             });
         }
 
@@ -192,10 +192,10 @@ function createIntrinsicWidget(tag: string, props: Record<string, any>, children
         case 'sidebar': {
             const items = props.items ?? [];
             return new Sidebar(items, { ...style }, {
-                collapsed:      props.collapsed,
+                collapsed: props.collapsed,
                 collapsedWidth: props.collapsedWidth,
-                activeColor:    props.activeColor ? parseColorProp(props.activeColor) : undefined,
-                badgeColor:     props.badgeColor  ? parseColorProp(props.badgeColor)  : undefined,
+                activeColor: props.activeColor ? parseColorProp(props.activeColor) : undefined,
+                badgeColor: props.badgeColor ? parseColorProp(props.badgeColor) : undefined,
             });
         }
 
@@ -216,7 +216,12 @@ function extractStyle(props: Record<string, any>): Partial<Style> {
     if (props.padding != null) style.padding = props.padding;
     if (props.margin != null) style.margin = props.margin;
     if (props.border != null) style.border = props.border;
-    if (props.asciiOnly != null) style.asciiOnly = props.asciiOnly;
+    const ascii =
+        typeof props.asciiOnly === 'string'
+            ? props.asciiOnly.toLowerCase() === 'true'
+            : !!props.asciiOnly;
+
+    if (props.asciiOnly != null) style.asciiOnly = ascii;
     if (props.borderColor != null) style.borderColor = parseColorProp(props.borderColor);
     if (props.gap != null) style.gap = props.gap;
     return style;

--- a/packages/widgets/src/base/Widget.ts
+++ b/packages/widgets/src/base/Widget.ts
@@ -17,6 +17,7 @@ import {
     getBorderChars,
     styleToCellAttrs,
     containsPoint,
+    caps,
 } from '@termuijs/core';
 
 /**
@@ -241,10 +242,13 @@ export abstract class Widget {
         if (width < 2 || height < 2) return;
 
         if (hasBorder) {
+            const useAscii =
+                (this._style.asciiOnly ?? false) || !caps.unicode;
+
             const chars = getBorderChars(
                 border,
                 undefined,
-                this._style.asciiOnly ?? false
+                useAscii
             );
 
             if (!chars) return;

--- a/packages/widgets/src/base/Widget.ts
+++ b/packages/widgets/src/base/Widget.ts
@@ -241,7 +241,12 @@ export abstract class Widget {
         if (width < 2 || height < 2) return;
 
         if (hasBorder) {
-            const chars = getBorderChars(border);
+            const chars = getBorderChars(
+                border,
+                undefined,
+                this._style.asciiOnly ?? false
+            );
+
             if (!chars) return;
 
             const attrs = styleToCellAttrs(this._style);


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

Adds an asciiOnly style option that allows widgets to render borders using ASCII characters (+, -, |) instead of Unicode box-drawing characters.
The change propagates the option through style extraction and widget rendering, and includes test coverage for the new behavior.

## Related Issue
Closes #614  

## Which package(s)?

<!-- Example: @termuijs/core, @termuijs/widgets, website. -->
@termuijs/core
@termuijs/widgets

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: https://gssoc.girlscript.org/profile/9cf80a43-c5ad-440b-870a-3193bfd2c79a

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->
None

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->
Added ASCII border fallback support and accompanying tests for the new behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an ASCII-only border rendering mode so widgets can use simple ASCII borders (+, -, |) instead of Unicode.
  * Exposed a style flag and matching prop to opt into ASCII borders; widgets also automatically fall back to ASCII when the environment lacks Unicode support.

* **Tests**
  * Added a unit test verifying ASCII border character rendering for the single border style.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->