### PR TITLE
feat(jsx): add useStopwatch hook with start, pause, and reset controls

### DIFF
--- a/packages/jsx/src/hooks/useStopwatch.test.ts
+++ b/packages/jsx/src/hooks/useStopwatch.test.ts
@@ -1,0 +1,119 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/jsx — Tests for useStopwatch hook
+// ─────────────────────────────────────────────────────
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+    createFiber, setCurrentFiber, clearCurrentFiber,
+    setRequestRender, runEffects, destroyFiber,
+} from '../hooks.js';
+import { useStopwatch } from './useStopwatch.js';
+
+function renderWithFiber<T>(fiber: ReturnType<typeof createFiber>, fn: () => T): T {
+    setCurrentFiber(fiber);
+    const result = fn();
+    clearCurrentFiber();
+    runEffects(fiber);
+    return result;
+}
+
+describe('useStopwatch', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        setRequestRender(() => {});
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        clearCurrentFiber();
+    });
+
+    it('elapsed starts at zero and does not advance before start()', () => {
+        const fiber = createFiber();
+
+        const [elapsed] = renderWithFiber(fiber, () => useStopwatch());
+        expect(elapsed).toBe(0);
+
+        vi.advanceTimersByTime(3000);
+
+        const [elapsed2] = renderWithFiber(fiber, () => useStopwatch());
+        expect(elapsed2).toBe(0);
+
+        destroyFiber(fiber);
+    });
+
+    it('start() begins increasing elapsed time each interval', () => {
+        const fiber = createFiber();
+
+        const [, controls] = renderWithFiber(fiber, () => useStopwatch());
+        controls.start();
+        renderWithFiber(fiber, () => useStopwatch());
+
+        vi.advanceTimersByTime(3000);
+
+        const [elapsed] = renderWithFiber(fiber, () => useStopwatch());
+        expect(elapsed).toBe(3000);
+
+        destroyFiber(fiber);
+    });
+
+    it('pause() halts ticking and keeps the elapsed value', () => {
+        const fiber = createFiber();
+
+        renderWithFiber(fiber, () => useStopwatch())[1].start();
+        renderWithFiber(fiber, () => useStopwatch());
+
+        vi.advanceTimersByTime(2000);
+
+        renderWithFiber(fiber, () => useStopwatch())[1].pause();
+        renderWithFiber(fiber, () => useStopwatch());
+
+        vi.advanceTimersByTime(2000);
+
+        const [elapsed] = renderWithFiber(fiber, () => useStopwatch());
+        expect(elapsed).toBe(2000);
+
+        destroyFiber(fiber);
+    });
+
+    it('start() after pause() resumes from the kept value', () => {
+        const fiber = createFiber();
+
+        renderWithFiber(fiber, () => useStopwatch())[1].start();
+        renderWithFiber(fiber, () => useStopwatch());
+
+        vi.advanceTimersByTime(2000);
+
+        renderWithFiber(fiber, () => useStopwatch())[1].pause();
+        renderWithFiber(fiber, () => useStopwatch());
+
+        renderWithFiber(fiber, () => useStopwatch())[1].start();
+        renderWithFiber(fiber, () => useStopwatch());
+
+        vi.advanceTimersByTime(1000);
+
+        const [elapsed] = renderWithFiber(fiber, () => useStopwatch());
+        expect(elapsed).toBe(3000);
+
+        destroyFiber(fiber);
+    });
+
+    it('reset() returns elapsed to zero and stops ticking', () => {
+        const fiber = createFiber();
+
+        renderWithFiber(fiber, () => useStopwatch())[1].start();
+        renderWithFiber(fiber, () => useStopwatch());
+
+        vi.advanceTimersByTime(3000);
+
+        renderWithFiber(fiber, () => useStopwatch())[1].reset();
+        renderWithFiber(fiber, () => useStopwatch());
+
+        vi.advanceTimersByTime(2000);
+
+        const [elapsed, controls] = renderWithFiber(fiber, () => useStopwatch());
+        expect(elapsed).toBe(0);
+        expect(controls.isRunning).toBe(false);
+
+        destroyFiber(fiber);
+    });
+});

--- a/packages/jsx/src/hooks/useStopwatch.ts
+++ b/packages/jsx/src/hooks/useStopwatch.ts
@@ -1,0 +1,69 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/jsx — useStopwatch hook
+// ─────────────────────────────────────────────────────
+import { useState, useEffect, useRef } from '../hooks.js';
+
+export interface UseStopwatchOptions {
+    intervalMs?: number;
+}
+
+export interface UseStopwatchControls {
+    start: () => void;
+    pause: () => void;
+    reset: () => void;
+    isRunning: boolean;
+}
+
+/**
+ * useStopwatch — tracks elapsed time with start, pause, and reset controls.
+ *
+ * Returns [elapsed, controls] where elapsed is in milliseconds.
+ * The stopwatch does not tick until start() is called.
+ *
+ * ```tsx
+ * const [elapsed, { start, pause, reset, isRunning }] = useStopwatch();
+ * ```
+ */
+export function useStopwatch(
+    opts?: UseStopwatchOptions,
+): [number, UseStopwatchControls] {
+    const intervalMs = opts?.intervalMs ?? 1000;
+    const [elapsed, setElapsed] = useState(0);
+    const [isRunning, setIsRunning] = useState(false);
+    const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+    useEffect(() => {
+        if (isRunning) {
+            intervalRef.current = setInterval(() => {
+                setElapsed((e) => e + intervalMs);
+            }, intervalMs);
+        } else {
+            if (intervalRef.current !== null) {
+                clearInterval(intervalRef.current);
+                intervalRef.current = null;
+            }
+        }
+
+        return () => {
+            if (intervalRef.current !== null) {
+                clearInterval(intervalRef.current);
+                intervalRef.current = null;
+            }
+        };
+    }, [isRunning, intervalMs]);
+
+    const start = (): void => {
+        setIsRunning(true);
+    };
+
+    const pause = (): void => {
+        setIsRunning(false);
+    };
+
+    const reset = (): void => {
+        setIsRunning(false);
+        setElapsed(0);
+    };
+
+    return [elapsed, { start, pause, reset, isRunning }];
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -102,3 +102,5 @@ export { useTerminalSize } from './hooks/useTerminalSize.js';
 export type { TerminalSize } from './hooks/useTerminalSize.js';
 export { useIsMounted } from './hooks/useIsMounted.js';
 export { useTransition } from './hooks/useTransition.js';
+export { useStopwatch } from './hooks/useStopwatch.js';
+export type { UseStopwatchOptions, UseStopwatchControls } from './hooks/useStopwatch.js';


### PR DESCRIPTION
 Closes #450

Adds the useStopwatch hook to packages/jsx.

What I did:

useStopwatch.ts — implemented using useState for elapsed and 
isRunning, useRef to hold the interval reference, and useEffect 
to start/clear the interval whenever isRunning or intervalMs 
changes. Cleanup runs on unmount so no timer leaks. Own 
properties follow the exact API contract from the issue.

Controls:
- start() sets isRunning to true, effect starts the interval
- pause() sets isRunning to false, effect clears the interval  
- reset() clears the interval and resets elapsed to zero
- isRunning reflects current ticking state

Interval defaults to 1000ms, configurable via opts.intervalMs.

useStopwatch.test.ts — 5 test cases using the real fiber 
harness with vi.useFakeTimers() and vi.advanceTimersByTime(). 
Covers: no tick before start, ticking after start, pause keeps 
value, resume from paused value, reset returns to zero.

index.ts — exported useStopwatch and its types.

Followed the useDebounce pattern for timer handling and the 
useCounter pattern for the hook structure.

Files changed:
- packages/jsx/src/hooks/useStopwatch.ts (new)
- packages/jsx/src/hooks/useStopwatch.test.ts (new)
- packages/jsx/src/index.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a exported useStopwatch hook providing elapsed time, start/pause/reset controls, running state, and configurable tick interval.

* **Tests**
  * Added comprehensive tests verifying start, pause, resume, reset behaviors, elapsed time progression, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->