### PR TITLE
feat(core): add terminal bell and OSC notification API

### DIFF
--- a/packages/core/src/terminal/Terminal.test.ts
+++ b/packages/core/src/terminal/Terminal.test.ts
@@ -1,0 +1,56 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/core — Tests for Terminal adapter
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi } from 'vitest';
+import { Terminal } from './Terminal.js';
+import { bell, notify } from '../utils/ansi.js';
+
+function createFakeStdout() {
+    return {
+        write: vi.fn(() => true),
+        columns: 80,
+        rows: 24,
+        on: vi.fn(),
+        off: vi.fn()
+    } as unknown as NodeJS.WriteStream;
+}
+
+describe('Terminal', () => {
+    it('bell() writes BEL', () => {
+        const stdout = createFakeStdout();
+        const terminal = new Terminal({ stdout });
+
+        terminal.bell();
+
+        expect(stdout.write).toHaveBeenCalledWith('\x07');
+    });
+
+    it('notify("Done") writes an OSC 9 notification containing Done', () => {
+        const stdout = createFakeStdout();
+        const terminal = new Terminal({ stdout });
+
+        terminal.notify('Done');
+
+        expect(stdout.write).toHaveBeenCalledWith('\x1b]9;Done\x07');
+    });
+
+    it('notify("Build", "ok") writes an OSC 9 notification containing both title and body', () => {
+        const stdout = createFakeStdout();
+        const terminal = new Terminal({ stdout });
+
+        terminal.notify('Build', 'ok');
+
+        expect(stdout.write).toHaveBeenCalledWith('\x1b]9;Build: ok\x07');
+    });
+});
+
+describe('ansi helpers', () => {
+    it('bell constant equals BEL control byte', () => {
+        expect(bell).toBe('\x07');
+    });
+
+    it('notify("hi") returns OSC 9 notification sequence', () => {
+        expect(notify('hi')).toBe('\x1b]9;hi\x07');
+    });
+});

--- a/packages/core/src/terminal/Terminal.ts
+++ b/packages/core/src/terminal/Terminal.ts
@@ -132,6 +132,15 @@ export class Terminal {
     hideCursor(): void { this.write(ansi.hideCursor); }
     showCursor(): void { this.write(ansi.showCursor); }
 
+    /** Ring the terminal bell (BEL). */
+    bell(): void { this.write(ansi.bell); }
+
+    /** Send an OSC 9 desktop notification. Body is appended after a separator. */
+    notify(title: string, body?: string): void {
+        const payload = body === undefined ? title : `${title}: ${body}`;
+        this.write(ansi.notify(payload));
+    }
+
     // ── Output ──────────────────────────────────────────
 
     write(data: string): void {

--- a/packages/core/src/utils/ansi.ts
+++ b/packages/core/src/utils/ansi.ts
@@ -116,7 +116,9 @@ export const bell = '\x07';
 
 /** OSC 9 desktop notification: ESC ] 9 ; <text> BEL. */
 export function notify(text: string): string {
-    return `${OSC}9;${text}${bell}`;
+    // Strip C0/C1 controls and ESC to prevent terminal escape injection.
+    const safeText = text.replace(/[\u0000-\u001F\u007F-\u009F\u001B]/g, '');
+    return `${OSC}9;${safeText}${bell}`;
 }
 
 // ── Clipboard ───────────────────────────────────────

--- a/packages/core/src/utils/ansi.ts
+++ b/packages/core/src/utils/ansi.ts
@@ -111,6 +111,14 @@ export function hyperlinkOpen(url: string): string {
 /** OSC 8 close: ESC ] 8 ; ; ST. */
 export const hyperlinkClose: string = '\x1b]8;;\x1b\\';
 
+/** The BEL control byte. */
+export const bell = '\x07';
+
+/** OSC 9 desktop notification: ESC ] 9 ; <text> BEL. */
+export function notify(text: string): string {
+    return `${OSC}9;${text}${bell}`;
+}
+
 // ── Clipboard ───────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Description

Adds terminal bell and OSC 9 desktop notification support to `@termuijs/core`.

This PR introduces `ansi.bell`, `ansi.notify(text)`, `Terminal.bell()`, and `Terminal.notify(title, body?)`. It also adds tests covering BEL output and OSC 9 notification behavior.

## Related Issue

Closes #458

## Which package(s)?

@termuijs/core

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [x] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

Implemented the additive terminal bell and OSC 9 notification API as specified in #458.

Changes are limited to `packages/core`:

* Added `ansi.bell`
* Added `ansi.notify(text)`
* Added `Terminal.bell()`
* Added `Terminal.notify(title, body?)`
* Added tests covering BEL and OSC 9 notification behavior

Validation performed:

* ✅ `bun vitest run packages/core` passes
* ✅ `bun run build --filter @termuijs/core` passes

Repository-wide commands currently fail due to an unrelated issue in `@termuijs/adapters`:

```text
Cannot find module 'zod' or its corresponding type declarations.
```

This issue is outside the scope of #458 and no files outside `packages/core` were modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added terminal bell and desktop notification support, including title/body messaging and sanitization of control characters for reliable notifications.

* **Tests**
  * Added tests covering bell emission and notification formatting for single-message and title/body cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->