### PR TITLE
fix(widgets): mark LogView dirty on scroll

### DIFF
--- a/packages/widgets/src/display/LogView.test.ts
+++ b/packages/widgets/src/display/LogView.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Screen } from '@termuijs/core';
 import { LogView } from './LogView.js';
 
@@ -59,5 +59,81 @@ describe('LogView', () => {
     const log = new LogView({ width: 20, height: 3 });
     log.updateRect({ x: 0, y: 0, width: 20, height: 3 });
     expect(() => log.render(screen)).not.toThrow();
+  });
+
+  it('renders lines and highlights ERROR, WARN, INFO keywords', () => {
+    const logView = new LogView({ width: 20, height: 4 });
+    logView.updateRect({ x: 0, y: 0, width: 20, height: 4 });
+    logView.setLines([
+      'INFO: Starting',
+      'WARN: Warning text',
+      'ERROR: Fatal failure',
+      'Just normal text',
+    ]);
+    const screen = new Screen(20, 4);
+    logView.render(screen);
+
+    const rows = screen.back.map(row => row.map(cell => cell.char).join(''));
+    expect(rows[0]).toContain('INFO: Starting');
+    expect(rows[1]).toContain('WARN: Warning text');
+    expect(rows[2]).toContain('ERROR: Fatal failure');
+    expect(rows[3]).toContain('Just normal text');
+
+    // Verify colors are applied based on keywords
+    expect(screen.back[0][0].fg).toEqual({ type: 'named', name: 'green' });
+    expect(screen.back[1][0].fg).toEqual({ type: 'named', name: 'yellow' });
+    expect(screen.back[2][0].fg).toEqual({ type: 'named', name: 'red' });
+    expect(screen.back[3][0].fg.type).toBe('none');
+  });
+
+  it('respects autoScroll: false', () => {
+    const logView = new LogView({ width: 20, height: 2 }, { autoScroll: false });
+    logView.updateRect({ x: 0, y: 0, width: 20, height: 2 });
+    logView.setLines(['Line 1', 'Line 2']);
+
+    const screen = new Screen(20, 2);
+    logView.render(screen);
+    let rows = screen.back.map(row => row.map(cell => cell.char).join(''));
+    expect(rows[0]).toContain('Line 1');
+    expect(rows[1]).toContain('Line 2');
+
+    // Append line 3, with autoScroll: false it should still show Line 1 and Line 2
+    logView.appendLine('Line 3');
+    const screen2 = new Screen(20, 2);
+    logView.render(screen2);
+    rows = screen2.back.map(row => row.map(cell => cell.char).join(''));
+    expect(rows[0]).toContain('Line 1');
+    expect(rows[1]).toContain('Line 2');
+  });
+
+  it('scrolls manually and triggers markDirty()', () => {
+    const logView = new LogView({ width: 20, height: 2 }, { autoScroll: false });
+    logView.updateRect({ x: 0, y: 0, width: 20, height: 2 });
+    logView.setLines(['Line 1', 'Line 2', 'Line 3', 'Line 4']);
+
+    const spy = vi.spyOn(logView, 'markDirty');
+
+    // Scroll down
+    logView.scrollDown(2);
+    expect(spy).toHaveBeenCalled();
+    spy.mockClear();
+
+    const screen = new Screen(20, 2);
+    logView.render(screen);
+    let rows = screen.back.map(row => row.map(cell => cell.char).join(''));
+    // With offset = 2, we expect Line 3 and Line 4 to render
+    expect(rows[0]).toContain('Line 3');
+    expect(rows[1]).toContain('Line 4');
+
+    // Scroll up
+    logView.scrollUp(1);
+    expect(spy).toHaveBeenCalled();
+
+    const screen2 = new Screen(20, 2);
+    logView.render(screen2);
+    rows = screen2.back.map(row => row.map(cell => cell.char).join(''));
+    // With offset = 1, we expect Line 2 and Line 3 to render
+    expect(rows[0]).toContain('Line 2');
+    expect(rows[1]).toContain('Line 3');
   });
 });

--- a/packages/widgets/src/display/LogView.test.ts
+++ b/packages/widgets/src/display/LogView.test.ts
@@ -136,4 +136,20 @@ describe('LogView', () => {
     expect(rows[0]).toContain('Line 2');
     expect(rows[1]).toContain('Line 3');
   });
+
+  it('scrollDown clamps to the last full page to prevent blank lines', () => {
+    const logView = new LogView({ width: 20, height: 2 }, { autoScroll: false });
+    logView.updateRect({ x: 0, y: 0, width: 20, height: 2 });
+    logView.setLines(['Line 1', 'Line 2', 'Line 3', 'Line 4']);
+
+    // Scroll down past maximum possible offset (4 lines, height 2 -> max offset is 2)
+    logView.scrollDown(10);
+
+    const screen = new Screen(20, 2);
+    logView.render(screen);
+    const rows = screen.back.map(row => row.map(cell => cell.char).join(''));
+    // With offset clamped to 2, it must still render Line 3 and Line 4 (not trailing blank lines)
+    expect(rows[0]).toContain('Line 3');
+    expect(rows[1]).toContain('Line 4');
+  });
 });

--- a/packages/widgets/src/display/LogView.ts
+++ b/packages/widgets/src/display/LogView.ts
@@ -56,8 +56,11 @@ export class LogView extends Widget {
     }
 
     scrollDown(n = 1): void {
+        const rect = this._getContentRect();
+        const visibleLines = Math.max(1, rect.height);
+        const maxScroll = Math.max(0, this._lines.length - visibleLines);
         this._scrollOffset = Math.min(
-            Math.max(0, this._lines.length - 1),
+            maxScroll,
             this._scrollOffset + n,
         );
         this.markDirty();

--- a/packages/widgets/src/display/LogView.ts
+++ b/packages/widgets/src/display/LogView.ts
@@ -52,6 +52,7 @@ export class LogView extends Widget {
 
     scrollUp(n = 1): void {
         this._scrollOffset = Math.max(0, this._scrollOffset - n);
+        this.markDirty();
     }
 
     scrollDown(n = 1): void {
@@ -59,6 +60,7 @@ export class LogView extends Widget {
             Math.max(0, this._lines.length - 1),
             this._scrollOffset + n,
         );
+        this.markDirty();
     }
 
     private _scrollToBottom(): void {


### PR DESCRIPTION
## Description

This PR resolves a bug in `@termuijs/widgets` where the `LogView` widget scroll methods (`scrollUp` and `scrollDown`) were not calling `this.markDirty()`.

This bug prevented the rendering engine from identifying that the widget's internal scroll position changed, thus programmatic scrolling did not visually update the log viewport until another event marked the widget dirty.

## Related Issue

Closes #658

## Which package(s)?

`@termuijs/widgets`

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: https://gssoc.girlscript.org/profile/Harshithk951

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for LogView widget covering empty rendering, log level styling (INFO/WARN/ERROR), auto-scroll functionality, and manual scroll behavior.

* **Bug Fixes**
  * LogView now properly re-renders when users scroll up or down to display the correct content in the visible area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->