### PR TITLE
fix(widgets): support custom Banner padding

### DIFF
--- a/packages/widgets/src/feedback/Banner.test.ts
+++ b/packages/widgets/src/feedback/Banner.test.ts
@@ -1,5 +1,5 @@
 import { Screen } from '@termuijs/core';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { Banner } from './Banner.js';
 import type { StatusVariant } from './StatusMessage.js';
 
@@ -119,5 +119,77 @@ describe('Banner', () => {
 
         expect(cell(screen, 0, 0).char).toBe(' ');
         expect(rowText(screen, 0)).not.toContain('Hidden');
+    });
+
+    it('renders with default padding (padding = 1)', () => {
+        const banner = new Banner(
+            { width: 30, height: 6 },
+            { title: 'TITLE', body: 'BODY' }
+        );
+        banner.updateRect({ x: 0, y: 0, width: 30, height: 6 });
+        const screen = new Screen(30, 6);
+        banner.render(screen);
+
+        const rows = screen.back.map(row => row.map(cell => cell.char).join(''));
+        
+        // Default padding: 1. Border width: 1.
+        // cx = x + borderWidth (1) + padding.left (1) = 2.
+        // cy = y + borderWidth (1) + padding.top (1) = 2.
+        // Row 2 should contain the title
+        expect(rows[2].slice(2, 7)).toBe('TITLE');
+        // Row 3 should contain the body
+        expect(rows[3].slice(2, 6)).toBe('BODY');
+    });
+
+    it('respects custom padding: 0', () => {
+        const banner = new Banner(
+            { width: 30, height: 6, padding: 0 },
+            { title: 'TITLE', body: 'BODY' }
+        );
+        banner.updateRect({ x: 0, y: 0, width: 30, height: 6 });
+        const screen = new Screen(30, 6);
+        banner.render(screen);
+
+        const rows = screen.back.map(row => row.map(cell => cell.char).join(''));
+        
+        // padding: 0. Border width: 1.
+        // cx = x + 1 + 0 = 1.
+        // cy = y + 1 + 0 = 1.
+        // Row 1 should contain the title
+        expect(rows[1].slice(1, 6)).toBe('TITLE');
+        // Row 2 should contain the body
+        expect(rows[2].slice(1, 5)).toBe('BODY');
+    });
+
+    it('respects custom edge padding: { top: 0, left: 3 }', () => {
+        const banner = new Banner(
+            { width: 30, height: 6, padding: { top: 0, left: 3 } },
+            { title: 'TITLE', body: 'BODY' }
+        );
+        banner.updateRect({ x: 0, y: 0, width: 30, height: 6 });
+        const screen = new Screen(30, 6);
+        banner.render(screen);
+
+        const rows = screen.back.map(row => row.map(cell => cell.char).join(''));
+
+        // padding left: 3, top: 0. Border: 1.
+        // cx = 1 + 3 = 4.
+        // cy = 1 + 0 = 1.
+        expect(rows[1].slice(4, 9)).toBe('TITLE');
+        expect(rows[2].slice(4, 8)).toBe('BODY');
+    });
+
+    it('mutations trigger markDirty()', () => {
+        const banner = new Banner();
+        const spy = vi.spyOn(banner, 'markDirty');
+
+        banner.setTitle('New Title');
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        banner.setBody('New Body');
+        expect(spy).toHaveBeenCalledTimes(2);
+
+        banner.setVariant('success');
+        expect(spy).toHaveBeenCalledTimes(3);
     });
 });

--- a/packages/widgets/src/feedback/Banner.test.ts
+++ b/packages/widgets/src/feedback/Banner.test.ts
@@ -179,6 +179,59 @@ describe('Banner', () => {
         expect(rows[2].slice(4, 8)).toBe('BODY');
     });
 
+    it('respects custom edge padding: { right: 5, bottom: 2 } for content truncation and clipping', () => {
+        const banner = new Banner(
+            { width: 20, height: 6, padding: { right: 5, bottom: 2 } },
+            { title: 'LONGTITLE', body: 'LONGBODY' }
+        );
+        banner.updateRect({ x: 0, y: 0, width: 20, height: 6 });
+        const screen = new Screen(20, 6);
+        banner.render(screen);
+
+        const rows = screen.back.map(row => row.map(cell => cell.char).join(''));
+
+        // Width = 20. Border = 1. Padding: left = 0, right = 5.
+        // cx = 1 (border) + 0 (padding.left) = 1.
+        // contentWidth = 20 - 2 (border) - 0 (padding.left) - 5 (padding.right) = 13.
+        // cy = 1 (border) + 0 (padding.top) = 1.
+        // Title is rendered at row 1.
+        expect(rows[1].slice(1, 10)).toBe('LONGTITLE');
+        // Body is rendered at row 2.
+        expect(rows[2].slice(1, 9)).toBe('LONGBODY');
+
+        // Let's test truncation by adding a very long body (contentHeight = 2).
+        const banner2 = new Banner(
+            { width: 20, height: 6, padding: { right: 10, bottom: 2 } },
+            { title: 'TITLE', body: 'VERYLONGBODYTEXT' }
+        );
+        banner2.updateRect({ x: 0, y: 0, width: 20, height: 6 });
+        const screen2 = new Screen(20, 6);
+        banner2.render(screen2);
+
+        const rows2 = screen2.back.map(row => row.map(cell => cell.char).join(''));
+        
+        // Width = 20. Border = 1. Padding: left = 0, right = 10.
+        // contentWidth = 20 - 2 - 0 - 10 = 8.
+        // Body 'VERYLONGBODYTEXT' should be truncated to 8 characters ('VERYLONG').
+        // Row 2 should contain 'VERYLONG'
+        expect(rows2[2]).toContain('VERYLONG');
+        expect(rows2[2]).not.toContain('VERYLONGB');
+
+        // Let's test clipping by adding bottom padding = 3 (contentHeight = 1).
+        const banner3 = new Banner(
+            { width: 20, height: 6, padding: { right: 10, bottom: 3 } },
+            { title: 'TITLE', body: 'BODY' }
+        );
+        banner3.updateRect({ x: 0, y: 0, width: 20, height: 6 });
+        const screen3 = new Screen(20, 6);
+        banner3.render(screen3);
+
+        const rows3 = screen3.back.map(row => row.map(cell => cell.char).join(''));
+        // With contentHeight = 1, only the Title can be rendered. The body should be clipped and not render at all.
+        // Row 2 (where body would be) should be empty/spaces except for the border.
+        expect(rows3[2].slice(2, 18).trim()).toBe('');
+    });
+
     it('mutations trigger markDirty()', () => {
         const banner = new Banner();
         const spy = vi.spyOn(banner, 'markDirty');

--- a/packages/widgets/src/feedback/Banner.ts
+++ b/packages/widgets/src/feedback/Banner.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets — Banner widget
 // ─────────────────────────────────────────────────────
 
-import { type Screen, type Style, type Color, styleToCellAttrs, getBorderChars } from '@termuijs/core';
+import { type Screen, type Style, type Color, styleToCellAttrs, getBorderChars, normalizeEdges } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 import { type StatusVariant } from './StatusMessage.js';
 
@@ -93,11 +93,13 @@ export class Banner extends Widget {
             }
         }
 
-        // Content area (inside border + padding=1)
-        const cx = x + 2; // border(1) + padding(1)
-        const cy = y + 2;
-        const contentWidth = Math.max(0, width - 4);  // left/right border+padding
-        const contentHeight = Math.max(0, height - 4); // top/bottom border+padding
+        // Content area (inside border + padding)
+        const padding = normalizeEdges(this._style.padding);
+        const borderWidth = borderChars ? 1 : 0;
+        const cx = x + borderWidth + padding.left;
+        const cy = y + borderWidth + padding.top;
+        const contentWidth = Math.max(0, width - borderWidth * 2 - padding.left - padding.right);
+        const contentHeight = Math.max(0, height - borderWidth * 2 - padding.top - padding.bottom);
 
         let row = 0;
 


### PR DESCRIPTION
## Description

This PR resolves a bug in `@termuijs/widgets` where the `Banner` widget ignored custom padding values passed in the widget style constructor (falling back to hardcoded padding offset margins of 1).

Refactored `_renderSelf()` in `Banner.ts` to calculate coordinates dynamically using `normalizeEdges` and `borderWidth` bounds.

## Related Issue

Closes #659

## Which package(s)?

`@termuijs/widgets`

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: https://gssoc.girlscript.org/profile/Harshithk951

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved padding calculation in the Banner widget to respect custom padding configurations
  * Enhanced border width handling for accurate content area rendering

* **Tests**
  * Added comprehensive test suite for the Banner widget covering multiple padding scenarios
  * Added behavioral tests to verify Banner update operations are properly tracked

<!-- end of auto-generated comment: release notes by coderabbit.ai -->