### PR TITLE
fix(widgets): status indicator updates and scrollbar tests

### DIFF
--- a/packages/widgets/src/data/StatusIndicator.test.ts
+++ b/packages/widgets/src/data/StatusIndicator.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Screen } from '@termuijs/core';
 import { StatusIndicator } from './StatusIndicator.js';
 
@@ -57,5 +57,22 @@ describe('StatusIndicator', () => {
     b.updateRect({ x: 0, y: 0, width: 30, height: 1 });
     b.render(screenB);
     expect(screenA.back[0][0].char).not.toBe(screenB.back[0][0].char);
+  });
+
+  it('setStatus updates status and marks dirty', () => {
+    const si = new StatusIndicator('API Server', true);
+    const markDirtySpy = vi.spyOn(si, 'markDirty');
+    
+    si.setStatus(false);
+    expect(si.getStatus()).toBe(false);
+    expect(markDirtySpy).toHaveBeenCalled();
+  });
+
+  it('setLabel updates label and marks dirty', () => {
+    const si = new StatusIndicator('API Server', true);
+    const markDirtySpy = vi.spyOn(si, 'markDirty');
+    
+    si.setLabel('Database Server');
+    expect(markDirtySpy).toHaveBeenCalled();
   });
 });

--- a/packages/widgets/src/data/StatusIndicator.ts
+++ b/packages/widgets/src/data/StatusIndicator.ts
@@ -35,6 +35,7 @@ export class StatusIndicator extends Widget {
 
     setStatus(isUp: boolean): void {
         this._isUp = isUp;
+        this.markDirty();
     }
 
     getStatus(): boolean {
@@ -43,6 +44,7 @@ export class StatusIndicator extends Widget {
 
     setLabel(label: string): void {
         this._label = label;
+        this.markDirty();
     }
 
     protected _renderSelf(screen: Screen): void {

--- a/packages/widgets/src/feedback/Scrollbar.test.ts
+++ b/packages/widgets/src/feedback/Scrollbar.test.ts
@@ -1,0 +1,125 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for Scrollbar widget
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi } from 'vitest';
+import { Screen, ScrollbarSets } from '@termuijs/core';
+import { Scrollbar } from './Scrollbar.js';
+
+describe('Scrollbar', () => {
+    it('does not render if contentLength <= viewportLength', () => {
+        const screen = new Screen(10, 10);
+        const sb = new Scrollbar({}, {
+            contentLength: 10,
+            viewportLength: 10,
+            orientation: 'verticalRight',
+        });
+        sb.updateRect({ x: 0, y: 0, width: 10, height: 10 });
+        sb.render(screen);
+
+        // Grid should remain empty (all empty characters)
+        const allChars = screen.back.flat().map(c => c.char).join('').trim();
+        expect(allChars).toBe('');
+    });
+
+    it('renders verticalRight scrollbar with arrows', () => {
+        const screen = new Screen(5, 5);
+        const sb = new Scrollbar({}, {
+            contentLength: 100,
+            viewportLength: 20,
+            orientation: 'verticalRight',
+            showArrows: true,
+        });
+        sb.updateRect({ x: 0, y: 0, width: 5, height: 5 });
+        sb.render(screen);
+
+        // Rightmost column (index 4) should have the scrollbar cells
+        const column4 = screen.back.map(row => row[4].char).join('');
+        const vertical = ScrollbarSets.VERTICAL;
+
+        expect(column4[0]).toBe(vertical.begin);
+        expect(column4[4]).toBe(vertical.end);
+        expect(column4).toContain(vertical.thumb);
+        expect(column4).toContain(vertical.track);
+    });
+
+    it('renders horizontalBottom scrollbar with arrows', () => {
+        const screen = new Screen(5, 5);
+        const sb = new Scrollbar({}, {
+            contentLength: 100,
+            viewportLength: 20,
+            orientation: 'horizontalBottom',
+            showArrows: true,
+        });
+        sb.updateRect({ x: 0, y: 0, width: 5, height: 5 });
+        sb.render(screen);
+
+        // Bottom row (index 4) should have the scrollbar cells
+        const row4 = screen.back[4].map(cell => cell.char).join('');
+        const horizontal = ScrollbarSets.HORIZONTAL;
+
+        expect(row4[0]).toBe(horizontal.begin);
+        expect(row4[4]).toBe(horizontal.end);
+        expect(row4).toContain(horizontal.thumb);
+        expect(row4).toContain(horizontal.track);
+    });
+
+    it('renders without arrows when showArrows is false', () => {
+        const screen = new Screen(5, 5);
+        const sb = new Scrollbar({}, {
+            contentLength: 100,
+            viewportLength: 20,
+            orientation: 'verticalRight',
+            showArrows: false,
+        });
+        sb.updateRect({ x: 0, y: 0, width: 5, height: 5 });
+        sb.render(screen);
+
+        const column4 = screen.back.map(row => row[4].char).join('');
+        const vertical = ScrollbarSets.VERTICAL;
+
+        expect(column4[0]).not.toBe(vertical.begin);
+        expect(column4[4]).not.toBe(vertical.end);
+        expect(column4).toContain(vertical.thumb);
+        expect(column4).toContain(vertical.track);
+    });
+
+    it('updates position and triggers re-render', () => {
+        const screen = new Screen(5, 5);
+        const sb = new Scrollbar({}, {
+            contentLength: 100,
+            viewportLength: 20,
+            position: 0,
+            orientation: 'verticalRight',
+            showArrows: false,
+        });
+        sb.updateRect({ x: 0, y: 0, width: 5, height: 5 });
+        sb.render(screen);
+
+        const firstRender = screen.back.map(row => row[4].char).join('');
+
+        // Move to the bottom scroll position
+        sb.setPosition(80);
+        
+        // Clear screen and render again
+        const freshScreen = new Screen(5, 5);
+        sb.render(freshScreen);
+        const secondRender = freshScreen.back.map(row => row[4].char).join('');
+
+        expect(firstRender).not.toBe(secondRender);
+    });
+
+    it('updates contentLength and viewportLength', () => {
+        const sb = new Scrollbar({}, {
+            contentLength: 100,
+            viewportLength: 20,
+        });
+        const markDirtySpy = vi.spyOn(sb, 'markDirty');
+
+        sb.setContentLength(150);
+        expect(markDirtySpy).toHaveBeenCalledTimes(1);
+
+        sb.setViewportLength(30);
+        expect(markDirtySpy).toHaveBeenCalledTimes(2);
+    });
+});


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

<!-- What does this PR do? 1 to 3 sentences. -->

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #

## Which package(s)?

<!-- Example: @termuijs/core, @termuijs/widgets, website. -->

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [ ] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [ ] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for the Scrollbar widget, covering rendering conditions, arrow character display, and position updates.
  * Expanded StatusIndicator tests to verify state updates and re-rendering behavior.

* **Bug Fixes**
  * StatusIndicator now properly re-renders when status or label is changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->