### PR TITLE
feat(widgets): add Rule widget

### DIFF
--- a/packages/widgets/src/display/Rule.test.ts
+++ b/packages/widgets/src/display/Rule.test.ts
@@ -24,7 +24,7 @@ function renderRule(
 
 /** Read a single row from the back buffer as a plain string. */
 function rowText(screen: Screen, row: number): string {
-    return screen.back[row].map(c => c.char).join('');
+    return screen.getLine(row);
 }
 
 describe('Rule', () => {

--- a/packages/widgets/src/display/Rule.test.ts
+++ b/packages/widgets/src/display/Rule.test.ts
@@ -1,0 +1,124 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for Rule widget
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Rule } from './Rule.js';
+import { Screen, caps } from '@termuijs/core';
+
+afterEach(() => vi.restoreAllMocks());
+
+/** Helper: create a Rule, set rect, render to a screen, return both. */
+function renderRule(
+    style: ConstructorParameters<typeof Rule>[0] = {},
+    opts: ConstructorParameters<typeof Rule>[1] = {},
+    width = 20,
+    height = 1,
+) {
+    const rule = new Rule(style, opts);
+    const screen = new Screen(width, height);
+    rule.updateRect({ x: 0, y: 0, width, height });
+    rule.render(screen);
+    return { rule, screen };
+}
+
+/** Read a single row from the back buffer as a plain string. */
+function rowText(screen: Screen, row: number): string {
+    return screen.back[row].map(c => c.char).join('');
+}
+
+describe('Rule', () => {
+    // ── 1. Horizontal rule fills the row with the line glyph ─────────────
+    it('horizontal rule fills the row with the line glyph', () => {
+        const { screen } = renderRule({}, {}, 20, 1);
+        const row = rowText(screen, 0);
+        const hz = caps.unicode ? '─' : '-';
+        // Every cell should be the line glyph
+        expect(row).toBe(hz.repeat(20));
+    });
+
+    // ── 2. Title renders centered in the horizontal rule ─────────────────
+    it('title renders centered in the horizontal rule', () => {
+        const { screen } = renderRule({}, { title: 'Logs' }, 20, 1);
+        const row = rowText(screen, 0);
+        expect(row).toContain('Logs');
+        // Line glyphs should appear on both sides of the title
+        const hz = caps.unicode ? '─' : '-';
+        expect(row).toContain(hz);
+        // Title should be roughly centered: " Logs " is 6 chars, so
+        // leftLen = floor((20 - 6) / 2) = 7, title starts at col 7
+        const titleIndex = row.indexOf(' Logs ');
+        expect(titleIndex).toBeGreaterThan(0);
+        // There should be line glyphs after the title too
+        const afterTitle = row.slice(titleIndex + 6);
+        expect(afterTitle).toContain(hz);
+    });
+
+    // ── 3. Vertical rule fills the column height ─────────────────────────
+    it('vertical rule fills the column height', () => {
+        const { screen } = renderRule({}, { orientation: 'vertical' }, 1, 5);
+        const vt = caps.unicode ? '│' : '|';
+        for (let r = 0; r < 5; r++) {
+            expect(screen.back[r][0].char).toBe(vt);
+        }
+    });
+
+    // ── 4. setTitle updates the rendered output ──────────────────────────
+    it('setTitle updates the rendered output and marks dirty', () => {
+        const rule = new Rule({}, { title: 'Old' });
+        rule.clearDirty();
+        rule.setTitle('New');
+        expect(rule.isDirty).toBe(true);
+
+        // Re-render and verify new title appears
+        const screen = new Screen(20, 1);
+        rule.updateRect({ x: 0, y: 0, width: 20, height: 1 });
+        rule.render(screen);
+        const row = rowText(screen, 0);
+        expect(row).toContain('New');
+        expect(row).not.toContain('Old');
+    });
+
+    // ── 5. ASCII fallback when caps.unicode is false ─────────────────────
+    it('ASCII fallback line renders when caps.unicode is false', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+
+        const { screen } = renderRule({}, { title: 'Logs' }, 20, 1);
+        const row = rowText(screen, 0);
+        expect(row).toContain('Logs');
+        expect(row).toContain('-');
+        // Should NOT contain Unicode line glyphs
+        expect(row).not.toContain('─');
+    });
+
+    // ── 6. Vertical rule uses ASCII fallback ─────────────────────────────
+    it('vertical rule uses ASCII fallback when caps.unicode is false', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+
+        const { screen } = renderRule({}, { orientation: 'vertical' }, 1, 3);
+        for (let r = 0; r < 3; r++) {
+            expect(screen.back[r][0].char).toBe('|');
+        }
+    });
+
+    // ── 7. Line uses opts.color, default brightBlack ─────────────────────
+    it('uses default brightBlack color', () => {
+        const { screen } = renderRule({}, {}, 10, 1);
+        expect(screen.back[0][0].fg).toEqual({ type: 'named', name: 'brightBlack' });
+    });
+
+    it('uses custom color from opts', () => {
+        const color = { type: 'named' as const, name: 'cyan' as const };
+        const { screen } = renderRule({}, { color }, 10, 1);
+        expect(screen.back[0][0].fg).toEqual(color);
+    });
+
+    // ── 8. Edge cases ────────────────────────────────────────────────────
+    it('handles zero-size rect without error', () => {
+        expect(() => renderRule({}, {}, 0, 0)).not.toThrow();
+    });
+
+    it('handles title wider than available width', () => {
+        expect(() => renderRule({}, { title: 'Very Long Title' }, 5, 1)).not.toThrow();
+    });
+});

--- a/packages/widgets/src/display/Rule.ts
+++ b/packages/widgets/src/display/Rule.ts
@@ -54,9 +54,11 @@ export class Rule extends Widget {
     }
 
     protected _renderSelf(screen: Screen): void {
-        const { x, y, width, height } = this._rect;
-        if (width <= 0 || height <= 0) return;
+        const { x, y, width, height } = this._getContentRect();
 
+        if (width <= 0 || height <= 0) {
+            return;
+        }
         const fg = this._color;
         const lineAttrs = { fg };
 

--- a/packages/widgets/src/display/Rule.ts
+++ b/packages/widgets/src/display/Rule.ts
@@ -1,0 +1,109 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Rule widget (horizontal / vertical divider)
+// ─────────────────────────────────────────────────────
+
+import { type Screen, type Style, type Color, caps, stringWidth } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export type RuleOrientation = 'horizontal' | 'vertical';
+
+export interface RuleOptions {
+    /** Line direction. Default: 'horizontal'. */
+    orientation?: RuleOrientation;
+    /** Title centered in the line (horizontal only). */
+    title?: string;
+    /** Line color. Default: brightBlack */
+    color?: Color;
+}
+
+/** Default line color used when no color option is provided. */
+const DEFAULT_COLOR: Color = { type: 'named', name: 'brightBlack' };
+
+/**
+ * Rule — a horizontal or vertical divider line with an optional centered title.
+ *
+ * Horizontal example (no title):
+ *   ────────────────────
+ *
+ * Horizontal example (with title):
+ *   ────── Logs ──────
+ *
+ * Vertical example:
+ *   │
+ *   │
+ *   │
+ *
+ * Uses `caps.unicode` to choose between Unicode box-drawing and ASCII fallback.
+ */
+export class Rule extends Widget {
+    private _orientation: RuleOrientation;
+    private _title: string | undefined;
+    private _color: Color;
+
+    constructor(style: Partial<Style> = {}, opts: RuleOptions = {}) {
+        super(style);
+        this._orientation = opts.orientation ?? 'horizontal';
+        this._title = opts.title;
+        this._color = opts.color ?? DEFAULT_COLOR;
+    }
+
+    /** Update the title text. Calls markDirty(). */
+    setTitle(title: string): void {
+        this._title = title;
+        this.markDirty();
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width, height } = this._rect;
+        if (width <= 0 || height <= 0) return;
+
+        const fg = this._color;
+        const lineAttrs = { fg };
+
+        if (this._orientation === 'vertical') {
+            const vt = caps.unicode ? '│' : '|';
+            for (let r = 0; r < height; r++) {
+                screen.setCell(x, y + r, { char: vt, ...lineAttrs });
+            }
+            return;
+        }
+
+        // ── Horizontal ──
+        const hz = caps.unicode ? '─' : '-';
+
+        if (!this._title) {
+            // No title — fill entire width with the line glyph
+            for (let c = 0; c < width; c++) {
+                screen.setCell(x + c, y, { char: hz, ...lineAttrs });
+            }
+            return;
+        }
+
+        // Title present — center it with a space on each side: " Title "
+        const padded = ` ${this._title} `;
+        const titleWidth = stringWidth(padded);
+
+        if (titleWidth >= width) {
+            // Title is too wide to leave room for line glyphs — just render it
+            screen.writeString(x, y, padded.slice(0, width), lineAttrs);
+            return;
+        }
+
+        const leftLen = Math.floor((width - titleWidth) / 2);
+        const rightLen = width - leftLen - titleWidth;
+
+        // Left line segment
+        for (let c = 0; c < leftLen; c++) {
+            screen.setCell(x + c, y, { char: hz, ...lineAttrs });
+        }
+
+        // Centered title
+        screen.writeString(x + leftLen, y, padded, lineAttrs);
+
+        // Right line segment
+        const rightStart = leftLen + titleWidth;
+        for (let c = 0; c < rightLen; c++) {
+            screen.setCell(x + rightStart + c, y, { char: hz, ...lineAttrs });
+        }
+    }
+}

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -158,11 +158,12 @@ export { Stopwatch } from './display/Stopwatch.js';
 export type { StopwatchOptions } from './display/Stopwatch.js';
 export { OrderedList } from './display/OrderedList.js';
 export type { OrderedListItem, OrderedListOptions } from './display/OrderedList.js';
-
 export { Typewriter } from './display/Typewriter.js';
 export type { TypewriterOptions } from './display/Typewriter.js';
+
 export { Timeline } from './display/Timeline.js';
 export type { TimelineItem, TimelineStatus } from './display/Timeline.js';
+
 export { Marquee } from './display/Marquee.js';
 export type { MarqueeDirection, MarqueeOptions } from './display/Marquee.js';export { DataGrid } from './data/DataGrid.js';
 export { DataGrid as DataGridView } from './data/DataGrid.js';


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

Adds a Rule widget to @termuijs/widgets that renders a horizontal or vertical divider line with an optional centered title. Uses caps.unicode for box-drawing glyphs (─ / | ) with ASCII fallbacks (- / | ).

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #473 

## Which package(s)?

@termuijs/widgets

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

-  ✨ Feature (`type:feature`)

## Checklist

-  ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
-  Tests pass locally: `bun vitest run`
-  Build passes: `bun run build`
-  Typecheck passes: `bun run typecheck`
-  You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
-  Your PR title follows `type: short description`.
-  Widget state mutators call `markDirty()` (if your change affects rendering).
-  No new `any` types without an inline comment explaining why.
-  No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

-  You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/901726b7-d593-41ba-b695-a4b8000cb3ff`

## Screenshots / Recordings (UI changes)

N/A — no visual UI; terminal widget tested via screen buffer assertions.

## Notes for the Reviewer

- Followed Tag.ts structure as the reference pattern for small display widgets with caps.unicode glyph selection.
- Title is padded as " Title " and centered with equal line segments on both sides. When the title is wider than the available width, it is truncated gracefully.
- Vertical mode ignores the title option (as specified in the API contract: "horizontal only").
- setTitle() calls markDirty() per project convention.
- Tests use vi.spyOn(caps, 'unicode', 'get') instead of mutating caps directly, with afterEach(() => vi.restoreAllMocks()) for cleanup.
- No dependencies added. bun.lock unchanged. No files touched outside packages/widgets.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a Rule widget for horizontal or vertical dividers with optional centered titles, color override, and automatic Unicode/ASCII glyph fallback. Orientation and options are available in the public widgets API.

* **Tests**
  * Added tests for both orientations, title centering and updates, color selection, glyph fallback, and edge cases (zero-size and oversized titles).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->