### PR TITLE
fix(widgets): mark TextInput dirty after state mutations

### DIFF
--- a/packages/widgets/src/input/TextInput.ts
+++ b/packages/widgets/src/input/TextInput.ts
@@ -47,6 +47,7 @@ export class TextInput extends Widget {
     set value(v: string) {
         this._value = v.slice(0, this._maxLength);
         this._cursorPos = Math.min(this._cursorPos, this._value.length);
+        this.markDirty();
     }
 
     /**
@@ -60,6 +61,7 @@ export class TextInput extends Widget {
             this._value.slice(this._cursorPos);
         this._cursorPos++;
         this._onChange?.(this._value);
+        this.markDirty();
     }
 
     /**
@@ -72,6 +74,7 @@ export class TextInput extends Widget {
                 this._value.slice(this._cursorPos);
             this._cursorPos--;
             this._onChange?.(this._value);
+            this.markDirty();
         }
     }
 
@@ -84,15 +87,26 @@ export class TextInput extends Widget {
                 this._value.slice(0, this._cursorPos) +
                 this._value.slice(this._cursorPos + 1);
             this._onChange?.(this._value);
+            this.markDirty();
         }
     }
 
-    moveCursorLeft(): void { this._cursorPos = Math.max(0, this._cursorPos - 1); }
-    moveCursorRight(): void { this._cursorPos = Math.min(this._value.length, this._cursorPos + 1); }
-    moveCursorHome(): void { this._cursorPos = 0; }
-    moveCursorEnd(): void { this._cursorPos = this._value.length; }
+    moveCursorLeft(): void { this._cursorPos = Math.max(0, this._cursorPos - 1); 
+        this.markDirty();
+    }
+    moveCursorRight(): void { this._cursorPos = Math.min(this._value.length, this._cursorPos + 1); 
+        this.markDirty();
+    }
+    moveCursorHome(): void { this._cursorPos = 0; 
+        this.markDirty();
+    }
+    moveCursorEnd(): void { this._cursorPos = this._value.length;
+        this.markDirty();
+     }
     submit(): void { this._onSubmit?.(this._value); }
-    clear(): void { this._value = ''; this._cursorPos = 0; this._onChange?.(''); }
+    clear(): void { this._value = ''; this._cursorPos = 0; this._onChange?.(''); 
+        this.markDirty();
+    }
 
     protected _renderSelf(screen: Screen): void {
         const rect = this._getContentRect();


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description
This PR fixes a rendering issue in the TextInput widget where several state-mutating methods updated internal state without calling markDirty().

Added markDirty() calls to all methods that modify rendered state (value setter, text insertion/deletion, cursor movement, and clear operation) so programmatic updates trigger immediate re-rendering.

<!-- What does this PR do? 1 to 3 sentences. -->

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #675 

## Which package(s)?
@termuijs/widgets
<!-- Example: @termuijs/core, @termuijs/widgets, website. -->

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)
N/A
<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer
This change is intentionally limited to TextInput state-mutating methods and does not modify rendering logic or widget behavior beyond ensuring proper dirty-state propagation after updates.

**Validation completed:**

- bun vitest run packages/widgets ✅
- bun run typecheck ✅
- bun run build✅

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced TextInput widget to reliably update the display during all user interactions. The component now consistently refreshes when entering text, navigating the cursor, deleting characters, and clearing the field, providing a more responsive and stable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->