### PR TITLE
feat: devtools inspector panel

### DIFF
--- a/packages/dev-server/src/index.ts
+++ b/packages/dev-server/src/index.ts
@@ -7,3 +7,4 @@ export { DevTools } from './devtools.js';
 export type { WidgetNode, PerfMetrics } from './devtools.js';
 export { ErrorOverlay, parseErrorStack } from './error-overlay.js';
 export type { ParsedError } from './error-overlay.js';
+export { WidgetTreeInspector } from './inspector.js';

--- a/packages/dev-server/src/inspector.test.ts
+++ b/packages/dev-server/src/inspector.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { WidgetTreeInspector } from './inspector.js';
+import type { WidgetNode } from './devtools.js';
+
+/** Helper: build a WidgetNode for testing. */
+function makeNode(
+    type: string,
+    children: WidgetNode[] = [],
+    id?: string,
+): WidgetNode {
+    return {
+        type,
+        id,
+        rect: { x: 0, y: 0, width: 40, height: 10 },
+        children,
+    };
+}
+
+describe('WidgetTreeInspector', () => {
+    let inspector: WidgetTreeInspector;
+
+    beforeEach(() => {
+        inspector = new WidgetTreeInspector();
+    });
+
+    // ── Visibility ───────────────────────────────────
+
+    describe('visibility', () => {
+        it('starts hidden', () => {
+            expect(inspector.visible).toBe(false);
+        });
+
+        it('toggle flips visibility', () => {
+            inspector.toggle();
+            expect(inspector.visible).toBe(true);
+            inspector.toggle();
+            expect(inspector.visible).toBe(false);
+        });
+
+        it('show() and hide() set visibility explicitly', () => {
+            inspector.show();
+            expect(inspector.visible).toBe(true);
+            inspector.hide();
+            expect(inspector.visible).toBe(false);
+        });
+    });
+
+    // ── Tree serialization ───────────────────────────
+
+    describe('getLines', () => {
+        it('returns "no data" when no tree is set', () => {
+            const lines = inspector.getLines(10);
+            expect(lines).toEqual(['  No widget tree data']);
+        });
+
+        it('returns "no data" after updateTree(null)', () => {
+            inspector.updateTree(makeNode('Box'));
+            inspector.updateTree(null);
+            const lines = inspector.getLines(10);
+            expect(lines).toEqual(['  No widget tree data']);
+        });
+
+        it('renders a single root node', () => {
+            inspector.updateTree(makeNode('Box', [], 'root'));
+            const lines = inspector.getLines(10);
+            expect(lines.length).toBe(1);
+            expect(lines[0]).toContain('Box#root');
+            expect(lines[0]).toContain('(0,0 40x10)');
+        });
+
+        it('renders a nested tree with indentation', () => {
+            const tree = makeNode('Box', [
+                makeNode('Text', [], 'title'),
+                makeNode('Text', [], 'body'),
+            ], 'root');
+            inspector.updateTree(tree);
+            const lines = inspector.getLines(10);
+
+            expect(lines.length).toBe(3);
+            expect(lines[0]).toContain('Box#root');
+            expect(lines[1]).toContain('Text#title');
+            expect(lines[2]).toContain('Text#body');
+        });
+
+        it('respects maxLines limit', () => {
+            const tree = makeNode('Box', [
+                makeNode('A'),
+                makeNode('B'),
+                makeNode('C'),
+            ]);
+            inspector.updateTree(tree);
+            const lines = inspector.getLines(2);
+            expect(lines.length).toBe(2);
+        });
+    });
+
+    // ── Selection ────────────────────────────────────
+
+    describe('selection', () => {
+        it('starts at index 0', () => {
+            expect(inspector.selectedIndex).toBe(0);
+        });
+
+        it('selectNext moves selection down', () => {
+            inspector.updateTree(makeNode('Box', [makeNode('Text')]));
+            inspector.selectNext();
+            expect(inspector.selectedIndex).toBe(1);
+        });
+
+        it('selectNext clamps at the last node', () => {
+            inspector.updateTree(makeNode('Box'));
+            inspector.selectNext();
+            inspector.selectNext();
+            expect(inspector.selectedIndex).toBe(0);
+        });
+
+        it('selectPrev moves selection up', () => {
+            inspector.updateTree(makeNode('Box', [makeNode('Text')]));
+            inspector.selectNext();
+            inspector.selectPrev();
+            expect(inspector.selectedIndex).toBe(0);
+        });
+
+        it('selectPrev clamps at 0', () => {
+            inspector.updateTree(makeNode('Box', [makeNode('Text')]));
+            inspector.selectPrev();
+            expect(inspector.selectedIndex).toBe(0);
+        });
+
+        it('getSelectedNode returns the correct node', () => {
+            const child = makeNode('Text', [], 'child');
+            const tree = makeNode('Box', [child], 'root');
+            inspector.updateTree(tree);
+            expect(inspector.getSelectedNode()?.id).toBe('root');
+            inspector.selectNext();
+            expect(inspector.getSelectedNode()?.id).toBe('child');
+        });
+
+        it('getSelectedNode returns null when no tree', () => {
+            expect(inspector.getSelectedNode()).toBeNull();
+        });
+
+        it('marks the selected line with > prefix', () => {
+            inspector.updateTree(makeNode('Box', [makeNode('Text')]));
+            const lines = inspector.getLines(10);
+            expect(lines[0].startsWith('>')).toBe(true);
+            expect(lines[1].startsWith(' ')).toBe(true);
+        });
+    });
+
+    // ── Expand / Collapse ────────────────────────────
+
+    describe('expand/collapse', () => {
+        it('toggleExpand collapses a node with children', () => {
+            inspector.updateTree(makeNode('Box', [
+                makeNode('Text', [], 'a'),
+                makeNode('Text', [], 'b'),
+            ], 'root'));
+
+            expect(inspector.getLines(10).length).toBe(3);
+
+            inspector.toggleExpand();
+            const lines = inspector.getLines(10);
+            expect(lines.length).toBe(1);
+            expect(lines[0]).toContain('\u25b8'); // ▸
+        });
+
+        it('toggleExpand re-expands a collapsed node', () => {
+            inspector.updateTree(makeNode('Box', [makeNode('Text')], 'root'));
+
+            inspector.toggleExpand();
+            expect(inspector.getLines(10).length).toBe(1);
+            inspector.toggleExpand();
+            expect(inspector.getLines(10).length).toBe(2);
+        });
+
+        it('toggleExpand does nothing on a leaf node', () => {
+            inspector.updateTree(makeNode('Text', [], 'leaf'));
+            inspector.toggleExpand();
+            expect(inspector.getLines(10).length).toBe(1);
+        });
+
+        it('expandAll expands all nodes', () => {
+            inspector.updateTree(makeNode('Box', [
+                makeNode('Inner', [makeNode('Text')]),
+            ]));
+            inspector.collapseAll();
+            expect(inspector.getLines(10).length).toBe(1);
+
+            inspector.expandAll();
+            expect(inspector.getLines(10).length).toBe(3);
+        });
+
+        it('collapseAll collapses all nodes with children', () => {
+            inspector.updateTree(makeNode('Box', [
+                makeNode('Inner', [makeNode('Text')]),
+            ]));
+            inspector.collapseAll();
+
+            const lines = inspector.getLines(10);
+            expect(lines.length).toBe(1);
+            expect(lines[0]).toContain('\u25b8'); // ▸
+        });
+
+        it('selection clamps when tree shrinks after collapse', () => {
+            inspector.updateTree(makeNode('Box', [
+                makeNode('A'),
+                makeNode('B'),
+            ]));
+            inspector.selectNext();
+            inspector.selectNext();
+            expect(inspector.selectedIndex).toBe(2);
+
+            inspector.selectPrev();
+            inspector.selectPrev();
+            inspector.toggleExpand();
+            expect(inspector.selectedIndex).toBe(0);
+        });
+    });
+
+    // ── Node count ───────────────────────────────────
+
+    describe('nodeCount', () => {
+        it('returns 0 for no tree', () => {
+            expect(inspector.nodeCount).toBe(0);
+        });
+
+        it('returns 0 after updateTree(null)', () => {
+            inspector.updateTree(makeNode('Box'));
+            inspector.updateTree(null);
+            expect(inspector.nodeCount).toBe(0);
+        });
+
+        it('counts all nodes including collapsed subtrees', () => {
+            inspector.updateTree(makeNode('Box', [
+                makeNode('A', [makeNode('B')]),
+                makeNode('C'),
+            ]));
+            inspector.collapseAll();
+            expect(inspector.nodeCount).toBe(4);
+        });
+    });
+});

--- a/packages/dev-server/src/inspector.ts
+++ b/packages/dev-server/src/inspector.ts
@@ -1,0 +1,202 @@
+// ─────────────────────────────────────────────────────
+// Widget Tree Inspector — toggleable interactive view
+// of the live component hierarchy.
+//
+// Pure data/logic module. Produces string lines for
+// display; does not render to Screen directly.
+// ─────────────────────────────────────────────────────
+
+import type { WidgetNode } from './devtools.js';
+
+/** A flattened entry in the visible tree list. */
+interface FlatEntry {
+    node: WidgetNode;
+    depth: number;
+    hasChildren: boolean;
+    expanded: boolean;
+    /** Stable key used for the collapsed set. */
+    key: string;
+}
+
+/**
+ * Toggleable widget tree inspector.
+ *
+ * Walks a `WidgetNode` snapshot and provides interactive,
+ * navigable, expand/collapse tree output as plain-text lines.
+ *
+ * Usage:
+ * ```ts
+ * const inspector = new WidgetTreeInspector();
+ * inspector.updateTree(widgetTreeSnapshot);
+ * inspector.toggle(); // show
+ * const lines = inspector.getLines(20);
+ * ```
+ */
+export class WidgetTreeInspector {
+    private _visible = false;
+    private _tree: WidgetNode | null = null;
+    private _flatList: FlatEntry[] = [];
+    private _selectedIndex = 0;
+    private _collapsedKeys: Set<string> = new Set();
+
+    // ── Visibility ───────────────────────────────────
+
+    get visible(): boolean { return this._visible; }
+    toggle(): void { this._visible = !this._visible; }
+    show(): void { this._visible = true; }
+    hide(): void { this._visible = false; }
+
+    // ── Tree data ────────────────────────────────────
+
+    /**
+     * Replace the current widget tree snapshot and rebuild
+     * the flat list. Pass `null` to clear.
+     */
+    updateTree(root: WidgetNode | null): void {
+        this._tree = root;
+        this._rebuildFlatList();
+    }
+
+    /** Total node count in the full tree (including collapsed subtrees). */
+    get nodeCount(): number {
+        if (!this._tree) return 0;
+        return this._countNodes(this._tree);
+    }
+
+    // ── Selection ────────────────────────────────────
+
+    get selectedIndex(): number { return this._selectedIndex; }
+
+    selectNext(): void {
+        if (this._flatList.length === 0) return;
+        this._selectedIndex = Math.min(
+            this._selectedIndex + 1,
+            this._flatList.length - 1,
+        );
+    }
+
+    selectPrev(): void {
+        if (this._flatList.length === 0) return;
+        this._selectedIndex = Math.max(this._selectedIndex - 1, 0);
+    }
+
+    /** Return the WidgetNode at the current selection, or null. */
+    getSelectedNode(): WidgetNode | null {
+        if (this._flatList.length === 0) return null;
+        return this._flatList[this._selectedIndex]?.node ?? null;
+    }
+
+    // ── Expand / Collapse ────────────────────────────
+
+    /** Toggle expand/collapse for the currently selected node. */
+    toggleExpand(): void {
+        const entry = this._flatList[this._selectedIndex];
+        if (!entry || !entry.hasChildren) return;
+        if (this._collapsedKeys.has(entry.key)) {
+            this._collapsedKeys.delete(entry.key);
+        } else {
+            this._collapsedKeys.add(entry.key);
+        }
+        this._rebuildFlatList();
+    }
+
+    /** Expand all nodes. */
+    expandAll(): void {
+        this._collapsedKeys.clear();
+        this._rebuildFlatList();
+    }
+
+    /** Collapse all nodes that have children. */
+    collapseAll(): void {
+        if (!this._tree) return;
+        this._walkForCollapse(this._tree, []);
+        this._rebuildFlatList();
+    }
+
+    // ── Rendering ────────────────────────────────────
+
+    /**
+     * Return indented tree lines for display.
+     * @param maxLines Maximum number of lines to return.
+     */
+    getLines(maxLines: number): string[] {
+        if (!this._tree || this._flatList.length === 0) {
+            return ['  No widget tree data'];
+        }
+
+        const lines: string[] = [];
+        for (let i = 0; i < this._flatList.length && lines.length < maxLines; i++) {
+            const entry = this._flatList[i];
+            const indent = '  '.repeat(entry.depth + 1);
+            const marker = this._getMarker(entry);
+            const selected = i === this._selectedIndex ? '>' : ' ';
+            const rect = `(${entry.node.rect.x},${entry.node.rect.y} ${entry.node.rect.width}x${entry.node.rect.height})`;
+            const id = entry.node.id ? '#' + entry.node.id : '';
+            lines.push(
+                `${selected}${indent}${marker}${entry.node.type}${id} ${rect}`,
+            );
+        }
+
+        return lines;
+    }
+
+    // ── Private helpers ──────────────────────────────
+
+    /** Build a stable key for a node for collapse tracking. */
+    private _nodeKey(node: WidgetNode, path: number[]): string {
+        if (node.id) return `${node.type}#${node.id}`;
+        return `${node.type}@${path.join('.')}`;
+    }
+
+    /** Get the expand/collapse marker character. */
+    private _getMarker(entry: FlatEntry): string {
+        if (!entry.hasChildren) return '  ';
+        return entry.expanded ? '\u25be ' : '\u25b8 ';
+    }
+
+    /** Recursively count all nodes in a tree. */
+    private _countNodes(node: WidgetNode): number {
+        let count = 1;
+        for (const child of node.children) {
+            count += this._countNodes(child);
+        }
+        return count;
+    }
+
+    /** Rebuild the flat visible list from the current tree and collapse state. */
+    private _rebuildFlatList(): void {
+        this._flatList = [];
+        if (this._tree) {
+            this._flatten(this._tree, 0, []);
+        }
+        // Clamp selection to new bounds
+        if (this._selectedIndex >= this._flatList.length) {
+            this._selectedIndex = Math.max(0, this._flatList.length - 1);
+        }
+    }
+
+    /** Recursively flatten the tree, skipping children of collapsed nodes. */
+    private _flatten(node: WidgetNode, depth: number, path: number[]): void {
+        const key = this._nodeKey(node, path);
+        const hasChildren = node.children.length > 0;
+        const expanded = !this._collapsedKeys.has(key);
+
+        this._flatList.push({ node, depth, hasChildren, expanded, key });
+
+        if (hasChildren && expanded) {
+            for (let i = 0; i < node.children.length; i++) {
+                this._flatten(node.children[i], depth + 1, [...path, i]);
+            }
+        }
+    }
+
+    /** Walk the full tree and mark every node with children as collapsed. */
+    private _walkForCollapse(node: WidgetNode, path: number[]): void {
+        if (node.children.length > 0) {
+            this._collapsedKeys.add(this._nodeKey(node, path));
+        }
+        for (let i = 0; i < node.children.length; i++) {
+            this._walkForCollapse(node.children[i], [...path, i]);
+        }
+    }
+}

--- a/packages/dev-server/src/inspector.ts
+++ b/packages/dev-server/src/inspector.ts
@@ -7,6 +7,7 @@
 // ─────────────────────────────────────────────────────
 
 import type { WidgetNode } from './devtools.js';
+import { caps } from '@termuijs/core';
 
 /** A flattened entry in the visible tree list. */
 interface FlatEntry {
@@ -151,7 +152,9 @@ export class WidgetTreeInspector {
     /** Get the expand/collapse marker character. */
     private _getMarker(entry: FlatEntry): string {
         if (!entry.hasChildren) return '  ';
-        return entry.expanded ? '\u25be ' : '\u25b8 ';
+        return entry.expanded
+            ? (caps.unicode ? '\u25be ' : 'v ')
+            : (caps.unicode ? '\u25b8 ' : '> ');
     }
 
     /** Recursively count all nodes in a tree. */


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

Adds a new WidgetTreeInspector utility to @termuijs/dev-server.

The inspector provides a standalone widget tree model with support for tree snapshots, selection navigation, expand/collapse behavior, node counting, and serialization into display-ready text lines. Comprehensive test coverage has been added to validate core inspector functionality and ensure existing dev-server behavior remains unchanged.

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #328 

## Which package(s)?

@termuijs/dev-server

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/0ea29967-7ada-4e3b-83ec-9da126f5d72a`

## Screenshots / Recordings (UI changes)

N/A — no UI changes.

## Notes for the Reviewer

Files Changed

- packages/dev-server/src/inspector.ts (new)
- packages/dev-server/src/inspector.test.ts (new)
- packages/dev-server/src/index.ts (export added)

Implementation

The new WidgetTreeInspector supports:

- Visibility toggling (toggle, show, hide)
- Tree snapshot updates (updateTree)
- Selection navigation (selectNext, selectPrev)
- Expand/collapse operations (toggleExpand, expandAll, collapseAll)
- Node lookup (getSelectedNode)
- Tree serialization (getLines)
- Full node counting (nodeCount)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a toggleable widget tree inspector: show/hide the inspector, navigate and select nodes, expand/collapse branches (single or all), view node counts, and get compact indented text representations with truncation.
* **Tests**
  * Added comprehensive tests covering visibility, selection/navigation, expand/collapse behavior, node counting, rendering/output formatting, and truncation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->