### PR TITLE
fix(widgets): align ScrollView key names with core KeyMap canonical names (closes #676)

### DIFF
--- a/packages/widgets/src/layout/ScrollView.test.ts
+++ b/packages/widgets/src/layout/ScrollView.test.ts
@@ -118,33 +118,33 @@ describe('ScrollView', () => {
         expect(screen.back[0][9].char).toBe(' ');
     });
 
-    it('ArrowDown scrolls down by 1', () => {
+    it('down scrolls down by 1', () => {
         const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
         sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
-        sv.onKey(key('ArrowDown'));
+        sv.onKey(key('down'));
         expect(sv.scrollOffset).toBe(1);
     });
 
-    it('ArrowUp scrolls up by 1', () => {
+    it('up scrolls up by 1', () => {
         const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
         sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
         sv.scrollBy(5);
-        sv.onKey(key('ArrowUp'));
+        sv.onKey(key('up'));
         expect(sv.scrollOffset).toBe(4);
     });
 
-    it('PageDown scrolls down by viewport height - 1', () => {
+    it('pagedown scrolls down by viewport height - 1', () => {
         const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
         sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
-        sv.onKey(key('PageDown'));
+        sv.onKey(key('pagedown'));
         expect(sv.scrollOffset).toBe(4);
     });
 
-    it('PageUp scrolls up by viewport height - 1', () => {
+    it('pageup scrolls up by viewport height - 1', () => {
         const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
         sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
         sv.scrollBy(10);
-        sv.onKey(key('PageUp'));
+        sv.onKey(key('pageup'));
         expect(sv.scrollOffset).toBe(6);
     });
 });

--- a/packages/widgets/src/layout/ScrollView.ts
+++ b/packages/widgets/src/layout/ScrollView.ts
@@ -63,10 +63,10 @@ export class ScrollView extends Widget {
     /** Handle keyboard navigation */
     onKey(event: KeyEvent): void {
         switch (event.key) {
-            case 'ArrowUp':   this.scrollBy(-1); break;
-            case 'ArrowDown': this.scrollBy(1); break;
-            case 'PageUp':    this.scrollBy(-Math.max(1, this._rect.height - 1)); break;
-            case 'PageDown':  this.scrollBy(Math.max(1, this._rect.height - 1)); break;
+            case 'up':       this.scrollBy(-1); break;
+            case 'down':     this.scrollBy(1); break;
+            case 'pageup':   this.scrollBy(-Math.max(1, this._rect.height - 1)); break;
+            case 'pagedown': this.scrollBy(Math.max(1, this._rect.height - 1)); break;
         }
     }
 


### PR DESCRIPTION
## Problem
`ScrollView.onKey()` switched on `'ArrowUp'`, `'ArrowDown'`, `'PageUp'`, `'PageDown'` but `@termuijs/core` KeyMap emits lowercase normalized names (`'up'`, `'down'`, `'pageup'`, `'pagedown'`). The cases never matched so scrolling never worked when focus bubbled key events from App.

## Fix
Replaced all non-canonical key names in `onKey()` with their lowercase equivalents matching core KeyMap output. Updated test descriptions and key calls to match.

## Changes
- `packages/widgets/src/layout/ScrollView.ts` — key names aligned with KeyMap
- `packages/widgets/src/layout/ScrollView.test.ts` — tests updated to use canonical key names

## Verification
- `bun vitest run packages/widgets` — 522 passed
- `bun run typecheck` — passed

Closes #676

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated ScrollView keyboard navigation test cases with simplified key identifiers.

* **Refactor**
  * Streamlined internal keyboard event handling in ScrollView while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->