### PR TITLE
fix(widgets): align Tree handleKey with core KeyMap canonical key names (closes #680)

### DIFF
--- a/packages/widgets/src/display/Tree.test.ts
+++ b/packages/widgets/src/display/Tree.test.ts
@@ -142,13 +142,13 @@ describe('Tree', () => {
         });
     });
 
-    describe('4. Cursor moves with ArrowDown / ArrowUp', () => {
-        it('ArrowDown moves cursor down', () => {
+    describe('4. Cursor moves with down / up', () => {
+        it('down moves cursor down', () => {
             const nodes = makeNodes();
             const tree = makeTree(nodes);
             expect(tree.selectedIndex).toBe(0);
 
-            tree.handleKey('ArrowDown');
+            tree.handleKey('down');
             expect(tree.selectedIndex).toBe(1);
         });
 
@@ -160,12 +160,12 @@ describe('Tree', () => {
             expect(tree.selectedIndex).toBe(1);
         });
 
-        it('ArrowUp moves cursor up', () => {
+        it('up moves cursor up', () => {
             const nodes = makeNodes();
             const tree = makeTree(nodes);
 
-            tree.handleKey('ArrowDown'); // → 1
-            tree.handleKey('ArrowUp');   // → 0
+            tree.handleKey('down'); // → 1
+            tree.handleKey('up');   // → 0
             expect(tree.selectedIndex).toBe(0);
         });
 
@@ -178,29 +178,29 @@ describe('Tree', () => {
             expect(tree.selectedIndex).toBe(0);
         });
 
-        it('ArrowUp at first item is a no-op', () => {
+        it('up at first item is a no-op', () => {
             const nodes = makeNodes();
             const tree = makeTree(nodes);
-            tree.handleKey('ArrowUp');
+            tree.handleKey('up');
             expect(tree.selectedIndex).toBe(0);
         });
 
-        it('ArrowDown at last item is a no-op', () => {
+        it('down at last item is a no-op', () => {
             const nodes = makeNodes();
             const tree = makeTree(nodes);
-            tree.handleKey('ArrowDown'); // → 1 (last)
-            tree.handleKey('ArrowDown'); // no-op
+            tree.handleKey('down'); // → 1 (last)
+            tree.handleKey('down'); // no-op
             expect(tree.selectedIndex).toBe(1);
         });
     });
 
-    describe('5. ArrowRight expands a collapsed parent', () => {
-        it('ArrowRight expands collapsed parent', () => {
+    describe('5. right expands a collapsed parent', () => {
+        it('right expands collapsed parent', () => {
             const nodes = makeNodes();
             const tree = makeTree(nodes);
             // "src" is at index 0, collapsed
 
-            tree.handleKey('ArrowRight');
+            tree.handleKey('right');
 
             expect(nodes[0].expanded).toBe(true);
         });
@@ -214,13 +214,13 @@ describe('Tree', () => {
             expect(nodes[0].expanded).toBe(true);
         });
 
-        it('ArrowRight on already-expanded parent is a no-op', () => {
+        it('right on already-expanded parent is a no-op', () => {
             const nodes = makeNodes();
             nodes[0].expanded = true;
             const tree = makeTree(nodes);
 
             const before = (tree as any)._visibleNodes.length;
-            tree.handleKey('ArrowRight'); // already expanded
+            tree.handleKey('right'); // already expanded
             const after = (tree as any)._visibleNodes.length;
 
             // No change
@@ -228,14 +228,14 @@ describe('Tree', () => {
         });
     });
 
-    describe('6. ArrowLeft collapses an expanded parent', () => {
-        it('ArrowLeft collapses an expanded parent', () => {
+    describe('6. left collapses an expanded parent', () => {
+        it('left collapses an expanded parent', () => {
             const nodes = makeNodes();
             nodes[0].expanded = true;
             const tree = makeTree(nodes);
             // src is expanded and selected
 
-            tree.handleKey('ArrowLeft');
+            tree.handleKey('left');
 
             expect(nodes[0].expanded).toBe(false);
         });
@@ -250,25 +250,25 @@ describe('Tree', () => {
             expect(nodes[0].expanded).toBe(false);
         });
 
-        it('ArrowLeft on collapsed node moves to parent', () => {
+        it('left on collapsed node moves to parent', () => {
             const nodes = makeNodes();
             nodes[0].expanded = true;
             const tree = makeTree(nodes);
             // visible: [src(0), components(1), utils(2), package.json(3)]
-            tree.handleKey('ArrowDown'); // → components (index 1)
-            tree.handleKey('ArrowLeft'); // components is collapsed → move to parent (src, index 0)
+            tree.handleKey('down'); // → components (index 1)
+            tree.handleKey('left'); // components is collapsed → move to parent (src, index 0)
 
             expect(tree.selectedIndex).toBe(0);
         });
     });
 
-    describe('7. onSelect called when Enter pressed on leaf node', () => {
-        it('calls onSelect for a leaf node on Enter', () => {
+    describe('7. onSelect called when enter pressed on leaf node', () => {
+        it('calls onSelect for a leaf node on enter', () => {
             const handler = vi.fn();
             const nodes: TreeNode[] = [{ label: 'README.md', data: 'readme' }];
             const tree = makeTree(nodes, handler);
 
-            tree.handleKey('Enter');
+            tree.handleKey('enter');
 
             expect(handler).toHaveBeenCalledOnce();
             expect(handler).toHaveBeenCalledWith(nodes[0], [0]);
@@ -285,12 +285,12 @@ describe('Tree', () => {
             expect(handler).toHaveBeenCalledWith(nodes[0], [0]);
         });
 
-        it('does not call onSelect when Enter pressed on parent node', () => {
+        it('does not call onSelect when enter pressed on parent node', () => {
             const handler = vi.fn();
             const nodes = makeNodes(); // src is a parent
             const tree = makeTree(nodes, handler);
 
-            tree.handleKey('Enter'); // should toggle, not select
+            tree.handleKey('enter'); // should toggle, not select
 
             expect(handler).not.toHaveBeenCalled();
         });
@@ -304,9 +304,9 @@ describe('Tree', () => {
             // visible: src(0), components(1), Button.ts(2), utils(3), package.json(4)
 
             // Navigate to Button.ts (index 2)
-            tree.handleKey('ArrowDown'); // → 1 (components)
-            tree.handleKey('ArrowDown'); // → 2 (Button.ts)
-            tree.handleKey('Enter');
+            tree.handleKey('down'); // → 1 (components)
+            tree.handleKey('down'); // → 2 (Button.ts)
+            tree.handleKey('enter');
 
             expect(handler).toHaveBeenCalledOnce();
             const [calledNode, calledPath] = handler.mock.calls[0];
@@ -315,19 +315,19 @@ describe('Tree', () => {
         });
     });
 
-    describe('Home / End navigation', () => {
-        it('Home moves to first node', () => {
+    describe('home / end navigation', () => {
+        it('home moves to first node', () => {
             const nodes = makeNodes();
             const tree = makeTree(nodes);
-            tree.handleKey('ArrowDown');
-            tree.handleKey('Home');
+            tree.handleKey('down');
+            tree.handleKey('home');
             expect(tree.selectedIndex).toBe(0);
         });
 
-        it('End moves to last visible node', () => {
+        it('end moves to last visible node', () => {
             const nodes = makeNodes();
             const tree = makeTree(nodes);
-            tree.handleKey('End');
+            tree.handleKey('end');
             expect(tree.selectedIndex).toBe(1); // "package.json"
         });
     });
@@ -335,7 +335,7 @@ describe('Tree', () => {
     describe('setNodes()', () => {
         it('resets selection and rebuilds visible nodes', () => {
             const tree = makeTree(makeNodes());
-            tree.handleKey('ArrowDown');
+            tree.handleKey('down');
             expect(tree.selectedIndex).toBe(1);
 
             const newNodes: TreeNode[] = [{ label: 'only' }];

--- a/packages/widgets/src/display/Tree.ts
+++ b/packages/widgets/src/display/Tree.ts
@@ -36,7 +36,7 @@ interface VisibleEntry {
  *
  * Supports:
  * - Expand/collapse of parent nodes
- * - Keyboard navigation (ArrowUp/Down/Left/Right, j/k/h/l, Home/End)
+ * - Keyboard navigation (up/down/left/right, j/k/h/l, home/end)
  * - Enter/Space to toggle or select
  * - onSelect callback for leaf nodes
  * - Unicode and ASCII fallback symbols
@@ -169,31 +169,36 @@ export class Tree extends Widget {
      * when this widget is focused.
      */
     handleKey(key: string): void {
-        switch (key) {
-            case 'ArrowUp':
+        const normalized = key.toLowerCase();
+        switch (normalized) {
+            case 'arrowup':
+            case 'up':
             case 'k':
                 this.movePrev();
                 break;
-            case 'ArrowDown':
+            case 'arrowdown':
+            case 'down':
             case 'j':
                 this.moveNext();
                 break;
-            case 'Enter':
+            case 'enter':
             case ' ':
                 this.toggle();
                 break;
-            case 'ArrowLeft':
+            case 'arrowleft':
+            case 'left':
             case 'h':
                 this.collapse();
                 break;
-            case 'ArrowRight':
+            case 'arrowright':
+            case 'right':
             case 'l':
                 this.expand();
                 break;
-            case 'Home':
+            case 'home':
                 this.moveFirst();
                 break;
-            case 'End':
+            case 'end':
                 this.moveLast();
                 break;
         }

--- a/packages/widgets/src/display/Tree.ts
+++ b/packages/widgets/src/display/Tree.ts
@@ -183,6 +183,7 @@ export class Tree extends Widget {
                 break;
             case 'enter':
             case ' ':
+            case 'space':
                 this.toggle();
                 break;
             case 'arrowleft':


### PR DESCRIPTION
## Problem
`Tree.handleKey()` switched on `'ArrowUp'`, `'ArrowDown'`, `'ArrowLeft'`, `'ArrowRight'`, `'Enter'`, `'Home'`, `'End'`. Core input normalization emits lowercase names so these cases never matched, breaking keyboard navigation completely for real terminals.

## Fix
- Normalize via `key.toLowerCase()` before switching — same pattern as `KeyValue.handleKey()`
- Primary cases now match KeyMap: `up`, `down`, `left`, `right`, `enter`, `home`, `end`
- Vim aliases `j`, `k`, `h`, `l` preserved
- Legacy `arrowup`/`arrowdown` etc. still work for subclass callers (e.g. JSONView tests)
- Updated test descriptions and key calls to use canonical names

## Changes
- `packages/widgets/src/display/Tree.ts` — key normalization in `handleKey()`
- `packages/widgets/src/display/Tree.test.ts` — tests updated to canonical key names

## Verification
- `bun vitest run packages/widgets` — 522 passed
- `bun run typecheck` — passed

Closes #680

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Tree widget keyboard navigation consistency by normalizing key handling so common key names (up/down/left/right/home/end/enter) behave reliably across inputs.
* **Tests**
  * Updated Tree keyboard-navigation tests to reflect the normalized key names and ensure correct focus, expand/collapse, and selection behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->