### PR TITLE
fix(core): reset _previousLines on Screen.resize() to prevent stale diff renderer state after terminal resize

### DIFF
--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -303,6 +303,7 @@ export class Screen {
         this._rows = rows;
         this.front = this._createGrid(cols, rows);
         this.back = this._createGrid(cols, rows);
+        this._previousLines = [];
     }
 
     /**


### PR DESCRIPTION
## Description

When the terminal is resized, `Screen.resize()` creates fresh front/back grids but leaves `_previousLines` (the diff renderer's line cache) untouched. After a resize making the terminal smaller, stale content from the pre-resize grid remains in `_previousLines`, causing the diff renderer to skip rows whose current content happens to match the stale cached strings.

## Root Cause

The `resize()` method recreated the front/back buffers but did not clear `_previousLines`.

## Fix

Added `this._previousLines = [];` at the end of `resize()` to force a full re-render after terminal resize.

## Changes

- `packages/core/src/terminal/Screen.ts:306` — reset `_previousLines` on resize

Closes #681

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where terminal display content would not refresh correctly following a screen resize operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->