### PR TITLE
fix(core): use full border width for inner content offset in LayoutEngine to prevent child widgets overlapping border

### DIFF
--- a/packages/core/src/layout/LayoutEngine.ts
+++ b/packages/core/src/layout/LayoutEngine.ts
@@ -85,8 +85,8 @@ function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, p
     const nodeHeight = node.computed.height;
 
     // Inner content area (after padding + border)
-    const innerX = padding.left + (border.horizontal / 2);
-    const innerY = padding.top + (border.vertical / 2);
+    const innerX = padding.left + border.horizontal;
+    const innerY = padding.top + border.vertical;
     const innerWidth = Math.max(0, nodeWidth - padding.left - padding.right - border.horizontal);
     const innerHeight = Math.max(0, nodeHeight - padding.top - padding.bottom - border.vertical);
 


### PR DESCRIPTION
## Description

The layout engine computes the inner content area's x/y offset as `padding + border / 2`. For a 1-cell border, `border.horizontal / 2 = 0.5`, which becomes `0` after `Math.floor()`. Child widgets are placed at the parent's top-left corner, directly overlapping the border characters.

## Root Cause

`LayoutEngine.ts:88-89` used `border.horizontal / 2` and `border.vertical / 2` for the inner content offset, which after `Math.floor()` rounded to 0 for standard 1-cell borders.

## Fix

Changed `border.horizontal / 2` → `border.horizontal` and `border.vertical / 2` → `border.vertical` so the inner content starts at the correct position after the border.

## Changes

- `packages/core/src/layout/LayoutEngine.ts:88-89` — use full border width for inner content offset

Closes #682

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layout positioning calculations to correctly account for border thickness when determining child element placement within containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->