### PR TITLE
test: add LayerManager unit tests

### DIFF
--- a/packages/core/src/terminal/LayerManager.test.ts
+++ b/packages/core/src/terminal/LayerManager.test.ts
@@ -101,3 +101,190 @@ describe('LayerManager — Hit Testing', () => {
         expect(lm.hitTest(26, 13)).toBe('btn-new');
     });
 });
+
+
+import { Screen } from './Screen.js';
+
+describe('LayerManager - Layer Operations', () => {
+    it('creates a layer', () => {
+        const lm = new LayerManager(10, 10);
+
+        const layer = lm.createLayer('modal', 100);
+
+        expect(layer.id).toBe('modal');
+        expect(layer.zIndex).toBe(100);
+        expect(lm.hasLayer('modal')).toBe(true);
+    });
+
+    it('removes a layer', () => {
+        const lm = new LayerManager(10, 10);
+
+        lm.createLayer('modal', 100);
+
+        expect(lm.hasLayer('modal')).toBe(true);
+
+        lm.removeLayer('modal');
+
+        expect(lm.hasLayer('modal')).toBe(false);
+    });
+
+    it('sorts layers by zIndex', () => {
+        const lm = new LayerManager(10, 10);
+
+        lm.createLayer('top', 100);
+        lm.createLayer('base', 0);
+        lm.createLayer('middle', 50);
+
+        const sorted = lm.getSortedLayers();
+
+        expect(sorted[0].id).toBe('base');
+        expect(sorted[1].id).toBe('middle');
+        expect(sorted[2].id).toBe('top');
+    });
+
+    it('does not return invisible layers', () => {
+        const lm = new LayerManager(10, 10);
+
+        const layer = lm.createLayer('hidden', 100);
+        layer.visible = false;
+
+        expect(lm.getSortedLayers()).toHaveLength(0);
+    });
+});
+
+describe('LayerManager - Cell Writing', () => {
+    it('writes a cell to a layer', () => {
+        const lm = new LayerManager(10, 10);
+
+        const layer = lm.createLayer('base', 0);
+
+        lm.setCell('base', 2, 3, {
+            char: 'A',
+        });
+
+        expect(layer.cells[3][2].char).toBe('A');
+    });
+
+    it('writes strings to a layer', () => {
+        const lm = new LayerManager(20, 10);
+
+        const layer = lm.createLayer('base', 0);
+
+        lm.writeString('base', 0, 0, 'ABC');
+
+        expect(layer.cells[0][0].char).toBe('A');
+        expect(layer.cells[0][1].char).toBe('B');
+        expect(layer.cells[0][2].char).toBe('C');
+    });
+});
+
+describe('LayerManager - Dirty Region', () => {
+    it('creates dirty region after first write', () => {
+        const lm = new LayerManager(10, 10);
+
+        const layer = lm.createLayer('base', 0);
+
+        lm.setCell('base', 2, 3, {
+            char: 'A',
+        });
+
+        expect(layer.dirtyRegion).toEqual({
+            x: 2,
+            y: 3,
+            width: 1,
+            height: 1,
+        });
+    });
+
+    it('expands dirty region correctly', () => {
+        const lm = new LayerManager(10, 10);
+
+        const layer = lm.createLayer('base', 0);
+
+        lm.setCell('base', 2, 2, {
+            char: 'A',
+        });
+
+        lm.setCell('base', 5, 5, {
+            char: 'B',
+        });
+
+        expect(layer.dirtyRegion).toEqual({
+            x: 2,
+            y: 2,
+            width: 4,
+            height: 4,
+        });
+    });
+});
+
+describe('LayerManager - Compositing', () => {
+    it('composites layer cells onto the screen', () => {
+        const lm = new LayerManager(10, 10);
+
+        lm.createLayer('base', 0);
+
+        lm.setCell('base', 1, 1, {
+            char: 'X',
+        });
+
+        const screen = new Screen(10, 10);
+
+        lm.composite(screen);
+
+        expect(screen.back[1][1].char).toBe('X');
+    });
+
+    it('higher z-index layer wins during composite', () => {
+        const lm = new LayerManager(10, 10);
+
+        lm.createLayer('bottom', 0);
+        lm.createLayer('top', 100);
+
+        lm.setCell('bottom', 1, 1, {
+            char: 'A',
+        });
+
+        lm.setCell('top', 1, 1, {
+            char: 'B',
+        });
+
+        const screen = new Screen(10, 10);
+
+        lm.composite(screen);
+
+        expect(screen.back[1][1].char).toBe('B');
+    });
+});
+
+describe('LayerManager - Resize', () => {
+    it('resizes layer grids', () => {
+        const lm = new LayerManager(10, 10);
+
+        const layer = lm.createLayer('base', 0);
+
+        lm.resize(20, 15);
+
+        expect(lm.cols).toBe(20);
+        expect(lm.rows).toBe(15);
+
+        expect(layer.cells.length).toBe(15);
+        expect(layer.cells[0].length).toBe(20);
+    });
+
+    it('clears dirty regions on resize', () => {
+        const lm = new LayerManager(10, 10);
+
+        const layer = lm.createLayer('base', 0);
+
+        lm.setCell('base', 1, 1, {
+            char: 'A',
+        });
+
+        expect(layer.dirtyRegion).not.toBeNull();
+
+        lm.resize(20, 15);
+
+        expect(layer.dirtyRegion).toBeNull();
+    });
+});


### PR DESCRIPTION
## Description

Added comprehensive unit tests for the LayerManager component in `@termuijs/core`.

The test suite covers:

* Layer creation and removal
* Layer sorting by zIndex
* Visibility handling
* Writing cells and strings to layers
* Dirty region creation and expansion
* Layer compositing behavior
* Resize handling
* Hit testing functionality
* Overlapping region priority based on z-index
* Hit grid clearing and reallocation

This improves coverage for the core layering subsystem and helps prevent regressions in future refactors.

## Related Issue

Closes #661

## Which package(s)?

@termuijs/core

## Type of Change

* [x] 🧪 Tests (`type:testing`)

## Checklist

* [x] ⭐ You starred the repo.
* [x] Tests pass locally: `bun vitest run`
* [x] You read `CONTRIBUTING.md`.
* [x] Your PR title follows `type: short description`.
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.

Your GSSoC profile:
https://gssoc.girlscript.org/profile/14763dcf-f59d-42dd-be2a-85a14812f687

## Screenshots / Recordings (UI changes)

N/A (Test-only change)

## Notes for the Reviewer

Added LayerManager unit tests covering layer operations, hit testing, dirty-region tracking, compositing behavior, and resize handling.

All tests pass successfully:

```bash
bun vitest run packages/core/src/terminal/LayerManager.test.ts
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for layer management functionality, including layer creation, removal, sorting by visual depth, visibility filtering, cell grid operations, dirty region tracking, compositing with correct visual layering, and grid resizing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->