### PR TITLE
test(jsx): add useFocusManager test

### DIFF
--- a/packages/jsx/src/hooks/useFocusManager.test.ts
+++ b/packages/jsx/src/hooks/useFocusManager.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createFiber, setCurrentFiber, clearCurrentFiber, setRequestRender } from '../hooks.js';
+import { useFocusManager } from './useFocusManager';
+
+describe('useFocusManager', () => {
+  let fiber = createFiber();
+
+  beforeEach(() => {
+    fiber = createFiber();
+    setRequestRender(() => { });
+    setCurrentFiber(fiber);
+  });
+
+  afterEach(() => {
+    clearCurrentFiber();
+  });
+
+  it('initializes focused state to null', () => {
+    const { focused } = useFocusManager();
+    expect(focused).toBeNull();
+  });
+
+  it('focus(id) updates the focused state', () => {
+    const result = useFocusManager();
+    expect(result.focused).toBeNull();
+
+    // Trigger focus
+    result.focus('input-field');
+
+    // Re-render
+    fiber.hookIndex = 0;
+    const nextResult = useFocusManager();
+    expect(nextResult.focused).toBe('input-field');
+  });
+
+  it('blur() resets focused state back to null', () => {
+    const result = useFocusManager();
+    
+    // Focus an element
+    result.focus('input-field');
+
+    // Re-render and blur
+    fiber.hookIndex = 0;
+    const nextResult = useFocusManager();
+    nextResult.blur();
+
+    // Re-render to verify it reset to null
+    fiber.hookIndex = 0;
+    const finalResult = useFocusManager();
+    expect(finalResult.focused).toBeNull();
+  });
+});

--- a/packages/jsx/src/hooks/useFocusManager.test.ts
+++ b/packages/jsx/src/hooks/useFocusManager.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createFiber, setCurrentFiber, clearCurrentFiber, setRequestRender } from '../hooks.js';
-import { useFocusManager } from './useFocusManager';
+import { useFocusManager } from './useFocusManager.js';
 
 describe('useFocusManager', () => {
   let fiber = createFiber();


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

Adds a unit test suite for the `useFocusManager` hook in `@termuijs/jsx`. The tests verify:
- Initial focus state is set to `null`
- Calling `focus(id)` correctly sets the focused element ID
- Calling `blur()` resets the focus state to `null`
The tests are driven using the framework's native Fiber test harness.

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #698 

## Which package(s)?

`@termuijs/jsx`

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/9440c0f2-4d37-4e76-b1d3-cc1f490858ca`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test suite for focus management that verifies initial focused state is null, that invoking focus updates the focused id, and that invoking blur resets the focused state. Tests exercise lifecycle-related re-render behavior to ensure focus changes are observed correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->