### PR TITLE
fix(core): detect style-only line changes in diff renderer

### DIFF
--- a/packages/core/src/terminal/Renderer.ts
+++ b/packages/core/src/terminal/Renderer.ts
@@ -127,7 +127,8 @@ export class Renderer {
 
         if (this._diffRenderer) {
             for (let r = 0; r < rows; r++) {
-                if (this._screen.getLine(r) === this._screen.getPreviousLine(r)) continue;
+                if (this._screen.getLine(r) === this._screen.getPreviousLine(r)
+                    && this._screen.getStyleLine(r) === this._screen.getPreviousStyleLine(r)) continue;
                 output += moveTo(0, r);
                 output += this._renderLine(r);
             }

--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -114,6 +114,7 @@ export class Screen {
     private _cols: number;
     private _rows: number;
     private _previousLines: string[] = [];
+    private _previousStyleLines: string[] = [];
     front: Cell[][];
     back: Cell[][];
 
@@ -139,16 +140,53 @@ export class Screen {
             .join('');
     }
 
+    /**
+     * Serialize the style attributes of a back-buffer row into a
+     * fingerprint string. When the characters are identical but the
+     * styles differ (color, bold, italic, etc.), this fingerprint
+     * changes, allowing the diff renderer to detect style-only updates.
+     */
+    getStyleLine(row: number): string {
+        if (row < 0 || row >= this._rows) return '';
+        let hash = 0;
+        for (const cell of this.back[row]) {
+            if (cell.width === 0) continue;
+            const fg = cell.fg.type;
+            const bg = cell.bg.type;
+            const bits =
+                (cell.bold ? 1 : 0) |
+                (cell.italic ? 2 : 0) |
+                (cell.underline ? 4 : 0) |
+                (cell.dim ? 8 : 0) |
+                (cell.strikethrough ? 16 : 0) |
+                (cell.inverse ? 32 : 0);
+            const seed = fg.charCodeAt(0) * 65536 + bg.charCodeAt(0) * 4096 + bits;
+            hash = ((hash << 7) - hash + seed) | 0;
+            if (cell.link) {
+                for (let i = 0; i < cell.link.length; i++)
+                    hash = ((hash << 5) - hash + cell.link.charCodeAt(i)) | 0;
+            }
+        }
+        return String(hash);
+    }
+
     /** Return the saved line string for the given row (empty before first saveLines call). */
     getPreviousLine(row: number): string {
         return this._previousLines[row] ?? '';
     }
 
+    /** Return the saved style fingerprint for the given row. */
+    getPreviousStyleLine(row: number): string {
+        return this._previousStyleLines[row] ?? '';
+    }
+
     /** Snapshot the current back-buffer line strings for use by diffRenderer. */
     saveLines(): void {
         this._previousLines = [];
+        this._previousStyleLines = [];
         for (let r = 0; r < this._rows; r++) {
             this._previousLines.push(this.getLine(r));
+            this._previousStyleLines.push(this.getStyleLine(r));
         }
     }
 


### PR DESCRIPTION
## Description

The differential renderer's line-level comparison only checked character text (\getLine(r) === getPreviousLine(r)\), completely ignoring style attributes. When a widget updated only colors, bold, italic, or other style attributes without changing text content, the renderer skipped the line — making style changes invisible.

### Root Cause

In \Renderer._flush()\ at line 130:
\\\	s
// Before: only text comparison
if (this._screen.getLine(r) === this._screen.getPreviousLine(r)) continue;
\\\

\getLine()\ returns only the character text (\.char\) joined together. Style attributes like \g\, \g\, \old\, \italic\, \underline\, \dim\, \strikethrough\, \inverse\, and \link\ are completely ignored.

### The Fix

1. **\Screen.ts\**: Added \getStyleLine()\ which computes a fast fingerprint hash of all style attributes for each cell in the row, and \getPreviousStyleLine()\ to retrieve the saved fingerprint. \saveLines()\ now stores both text and style fingerprints.

2. **\Renderer.ts\**: The diff check now requires BOTH text AND style to be unchanged before skipping a line:
\\\	s
// After: text AND style comparison
if (this._screen.getLine(r) === this._screen.getPreviousLine(r)
    && this._screen.getStyleLine(r) === this._screen.getPreviousStyleLine(r)) continue;
\\\

Closes #706

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal rendering accuracy by properly detecting style-only changes (colors, text formatting). Previously, visual updates were inconsistently applied when content styling changed without text modifications.

* **Performance**
  * Enhanced differential rendering efficiency to more accurately determine which screen areas require redrawing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->