### PR TITLE
fix(create-termui-app): validate project name to prevent path traversal

### DIFF
--- a/packages/create-termui-app/src/index.ts
+++ b/packages/create-termui-app/src/index.ts
@@ -13,6 +13,21 @@ import {
 import { generateProject, type ProjectConfig } from "./templates.js";
 import { parseArgs, isNonInteractive } from "./args.js";
 
+const VALID_PROJECT_NAME_RE = /^[a-zA-Z0-9@][a-zA-Z0-9_.-]*$/;
+
+function validateProjectName(name: string, source: string): void {
+    if (!VALID_PROJECT_NAME_RE.test(name)) {
+        throw new Error(
+            `Invalid project name "${name}" (from ${source}). Use only letters, digits, hyphens, underscores, dots, or start with @ for scoped packages.`
+        );
+    }
+    if (name === "." || name === "..") {
+        throw new Error(
+            `Invalid project name "${name}". "." and ".." are not allowed as project names.`
+        );
+    }
+}
+
 const TEMPLATES = [
     "Empty (start from scratch)",
     "Dashboard (real-time data)",
@@ -56,6 +71,7 @@ async function main() {
     // ───────── CI MODE ─────────
     if (isNonInteractive(args)) {
         projectName ??= "my-termui-app";
+        validateProjectName(projectName, "command-line argument");
 
         if (args.template && !TEMPLATE_KEYS.includes(args.template as any)) {
             throw new Error(
@@ -116,6 +132,7 @@ async function main() {
     if (!projectName) {
         projectName = await textPrompt("Project name", "my-termui-app");
     }
+    validateProjectName(projectName, "interactive prompt");
 
     const templateIdx = await selectPrompt("What kind of app?", TEMPLATES);
     template = TEMPLATE_KEYS[templateIdx];


### PR DESCRIPTION
## Description

The \create-termui-app\ scaffolding tool accepts arbitrary project names from user input (CLI args or interactive prompt) and passes them directly to \esolve()\ and \join()\ for file system operations without any validation. This allows path traversal via names like \../../../etc/evil\ or \../../malicious\, enabling arbitrary file writes outside the intended project directory.

### Root Cause

At \index.ts:92\ and \index.ts:147\:
\\\	s
const projectDir = resolve(process.cwd(), projectName);
\\\

\projectName\ comes from \rgs.name\ (CLI argument) or \	extPrompt()\ (interactive) — both unsanitized.

### The Fix

Added \alidateProjectName()\ that checks the name against \/^[a-zA-Z0-9@][a-zA-Z0-9_.-]*$/\ and rejects \.\/\..\. Called after name resolution from both CLI args and the interactive prompt.

Closes #705