### PR TITLE
test(widgets): add TextInput dirty state tests

### DIFF
--- a/packages/widgets/src/input/TextInput.test.ts
+++ b/packages/widgets/src/input/TextInput.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { TextInput } from './TextInput.js';
+
+describe('TextInput', () => {
+    it('marks dirty when value setter is used', () => {
+        const input = new TextInput();
+
+        input.clearDirty();
+        input.value = 'hello';
+
+        expect(input.isDirty).toBe(true);
+    });
+
+    it('marks dirty after insertChar()', () => {
+        const input = new TextInput();
+
+        input.clearDirty();
+        input.insertChar('A');
+
+        expect(input.isDirty).toBe(true);
+    });
+
+    it('marks dirty after deleteBack()', () => {
+        const input = new TextInput();
+
+        input.value = 'abc';
+        input.moveCursorEnd();
+        input.clearDirty();
+
+        input.deleteBack();
+
+        expect(input.isDirty).toBe(true);
+    });
+
+    it('marks dirty after deleteForward()', () => {
+        const input = new TextInput();
+
+        input.value = 'abc';
+        input.moveCursorHome();
+        input.clearDirty();
+
+        input.deleteForward();
+
+        expect(input.isDirty).toBe(true);
+    });
+
+    it('marks dirty after clear()', () => {
+        const input = new TextInput();
+
+        input.value = 'abc';
+        input.clearDirty();
+
+        input.clear();
+
+        expect(input.isDirty).toBe(true);
+    });
+
+    it('marks dirty after cursor movement', () => {
+        const input = new TextInput();
+
+        input.value = 'abc';
+
+        input.clearDirty();
+        input.moveCursorLeft();
+        expect(input.isDirty).toBe(true);
+
+        input.clearDirty();
+        input.moveCursorRight();
+        expect(input.isDirty).toBe(true);
+
+        input.clearDirty();
+        input.moveCursorHome();
+        expect(input.isDirty).toBe(true);
+
+        input.clearDirty();
+        input.moveCursorEnd();
+        expect(input.isDirty).toBe(true);
+    });
+});


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description
Adds regression tests for TextInput dirty-state propagation.
<br>
The new test suite verifies that all state-mutating methods correctly mark the widget as dirty after updating internal state. This helps prevent future regressions of the TextInput rendering bug fixed in #675.
<!-- What does this PR do? 1 to 3 sentences. -->

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #686 

## Which package(s)?
@termuijs/widgets
<!-- Example: @termuijs/core, @termuijs/widgets, website. -->

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)
N/A
<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

This PR adds regression tests for TextInput dirty-state propagation.

The test suite covers:

* value setter
* insertChar()
* deleteBack()
* deleteForward()
* clear()
* cursor movement methods

These tests provide regression coverage for the TextInput dirty-state behavior introduced in the fix for issue #675 and help prevent similar rendering issues from being reintroduced in future changes.

**Validation completed:**

* `bun vitest run packages/widgets/src/input/TextInput.test.ts` ✅
* `bun run build` ✅

Note: repository-wide `bun run typecheck` currently reports failures in the recently added `examples/markdown-editor` package that are unrelated to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the TextInput component to verify state management behavior across various user interactions and operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->