### PR TITLE
feat: add AI assistant example using AI widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ bun run dev
 | Showcase | Widget gallery | Various display widgets | [`examples/showcase`](./examples/showcase) |
 | Widget Gallery | All widgets in one place | Comprehensive widget showcase | [`examples/widget-gallery`](./examples/widget-gallery) |
 | CLI Wrapper | Live log streaming | Subprocesses, streaming output | [`examples/cli-wrapper-live`](./examples/cli-wrapper-live) |
+| AI Assistant | Interactive AI chat with streaming | ChatMessage, StreamingText, ToolCall, ToolApproval, useAI, dual-mode operation | [`examples/ai-assistant`](./examples/ai-assistant) |
 
 ## Project structure
 

--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,18 @@
         "vitest": "^2.1.0",
       },
     },
+    "examples/ai-assistant": {
+      "name": "@termuijs/example-ai-assistant",
+      "version": "0.1.0",
+      "dependencies": {
+        "@termuijs/adapters": "workspace:*",
+        "@termuijs/core": "workspace:*",
+        "@termuijs/jsx": "workspace:*",
+        "@termuijs/tss": "workspace:*",
+        "@termuijs/ui": "workspace:*",
+        "@termuijs/widgets": "workspace:*",
+      },
+    },
     "examples/ai-streaming": {
       "name": "@termuijs/example-ai-streaming",
       "version": "0.1.0",
@@ -298,16 +310,18 @@
         "zod": "^3.0.0",
       },
       "peerDependencies": {
-        "@octokit/rest": "^21.0.0",
         "@anthropic-ai/sdk": "^0.39.0",
+        "@octokit/rest": "^21.0.0",
+        "chalk": "^5.0.0",
         "commander": "^15.0.0",
         "conf": "^10.2.0",
         "openai": "^4.0.0",
         "zod": "^3.0.0",
       },
       "optionalPeers": [
-        "@octokit/rest",
         "@anthropic-ai/sdk",
+        "@octokit/rest",
+        "chalk",
         "commander",
         "conf",
         "openai",
@@ -605,6 +619,8 @@
     "@termuijs/data": ["@termuijs/data@workspace:packages/data"],
 
     "@termuijs/dev-server": ["@termuijs/dev-server@workspace:packages/dev-server"],
+
+    "@termuijs/example-ai-assistant": ["@termuijs/example-ai-assistant@workspace:examples/ai-assistant"],
 
     "@termuijs/example-ai-streaming": ["@termuijs/example-ai-streaming@workspace:examples/ai-streaming"],
 

--- a/examples/ai-assistant/README.md
+++ b/examples/ai-assistant/README.md
@@ -1,0 +1,94 @@
+# AI Assistant Example
+
+An interactive AI assistant demonstrating TermUI's AI-focused widgets and streaming capabilities.
+
+## Features
+
+- **Dual-mode operation:**
+  - **Mock Mode:** Works without any API key, streams predefined responses
+  - **Real Mode:** Connects to Claude (Anthropic) when `ANTHROPIC_API_KEY` is set
+- **ChatMessage** - Displays conversation history with role badges and timestamps
+- **StreamingText** - Streams AI responses character-by-character
+- **ToolCall** - Shows AI tool invocations with status indicators
+- **ToolApproval** - Interactive tool approval flow with [y/n] prompts
+- **Token Usage Display** - Shows input and output token counts
+- **Interactive Input** - Type messages and press Enter to chat
+
+## Project Structure
+
+```text
+ai-assistant/
+├── package.json
+├── README.md
+└── src/
+    └── index.tsx
+```
+
+## Installation & Usage
+
+### Mock Mode (no API key required)
+
+```bash
+cd examples/ai-assistant
+bun install
+bun run dev
+```
+
+The app will run in mock mode, responding with pre-defined messages.
+
+### Real Mode (with Anthropic API)
+
+Set the `ANTHROPIC_API_KEY` environment variable, then run:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+cd examples/ai-assistant
+bun install
+bun run dev
+```
+
+The app will stream real responses from Claude.
+
+## Controls
+
+- **Enter** - Send message
+- **Backspace** - Delete character
+- **[y]** - Approve tool call (when shown)
+- **[n]** - Deny tool call (when shown)
+- **Ctrl+C** - Quit application
+
+## What's Demonstrated
+
+1. **useAI Hook** - Initializes the AI adapter (mock or real)
+2. **ChatMessage Widget** - Renders conversation history with timestamps
+3. **StreamingText** - Streams tokens as they arrive
+4. **ToolCall & ToolApproval** - Demonstrates tool invocation and approval flow
+5. **Token Tracking** - Displays token usage statistics
+6. **Dual-mode Architecture** - Gracefully handles both mock and real operations
+
+## Implementation Notes
+
+- When `ANTHROPIC_API_KEY` is missing, the app automatically falls back to mock mode
+- Tool calls are demonstrated randomly after assistant responses (real mode only)
+- Token counts are tracked and displayed in the header
+- The tool approval system shows a prompt allowing users to approve or deny tool execution
+
+## Running the Build
+
+```bash
+bun run build
+```
+
+## Dependencies
+
+- `@termuijs/core` - Core framework
+- `@termuijs/widgets` - Widget library (ChatMessage, StreamingText, ToolCall, ToolApproval)
+- `@termuijs/adapters` - useAI hook for AI provider integration
+- `@termuijs/jsx` - JSX runtime and hooks
+- `@termuijs/tss` - Theming system
+
+## Learn More
+
+- [TermUI Documentation](https://termui.io)
+- [Anthropic Claude API](https://docs.anthropic.com)
+- [Other Examples](../README.md)

--- a/examples/ai-assistant/README.md
+++ b/examples/ai-assistant/README.md
@@ -69,7 +69,7 @@ The app will stream real responses from Claude.
 ## Implementation Notes
 
 - When `ANTHROPIC_API_KEY` is missing, the app automatically falls back to mock mode
-- Tool calls are demonstrated randomly after assistant responses (real mode only)
+- Tool calls are demonstrated randomly after assistant responses
 - Token counts are tracked and displayed in the header
 - The tool approval system shows a prompt allowing users to approve or deny tool execution
 

--- a/examples/ai-assistant/package.json
+++ b/examples/ai-assistant/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@termuijs/example-ai-assistant",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "AI Assistant example with mock and real modes, demonstrating ChatMessage, StreamingText, ToolCall, and ToolApproval",
+  "scripts": {
+    "start": "bun src/index.tsx",
+    "dev": "bun --watch src/index.tsx",
+    "build": "echo 'no build needed'"
+  },
+  "dependencies": {
+    "@termuijs/core": "workspace:*",
+    "@termuijs/widgets": "workspace:*",
+    "@termuijs/ui": "workspace:*",
+    "@termuijs/adapters": "workspace:*",
+    "@termuijs/jsx": "workspace:*",
+    "@termuijs/tss": "workspace:*"
+  },
+  "engines": {
+    "bun": ">=1.3.0"
+  }
+}

--- a/examples/ai-assistant/src/index.tsx
+++ b/examples/ai-assistant/src/index.tsx
@@ -51,6 +51,7 @@ class AIAssistantApp extends Widget {
   private modeLabel: Text;
   private tokenLabel: Text;
   private isStreaming = false;
+  private isMockMode = IS_MOCK;
   private inputTokens = 0;
   private outputTokens = 0;
   private aiAdapter: ReturnType<typeof useAI> | null = null;
@@ -71,6 +72,8 @@ class AIAssistantApp extends Widget {
         });
       } catch (e) {
         console.error('Failed to initialize AI adapter:', e);
+        this.isMockMode = true;
+        this.aiAdapter = null;
       }
     }
 
@@ -80,7 +83,7 @@ class AIAssistantApp extends Widget {
       flexDirection: 'row',
       height: 1,
       gap: 1,
-      padding: [0, 1],
+      padding: { top: 0, bottom: 0, left: 1, right: 1 },
       border: 'single',
       borderColor: { type: 'named' as const, name: 'brightBlack' as const },
     });
@@ -90,7 +93,7 @@ class AIAssistantApp extends Widget {
       fg: { type: 'named' as const, name: 'cyan' as const },
     });
 
-    this.modeLabel = new Text(IS_MOCK ? '[mock mode]' : '[claude-haiku]', {
+    this.modeLabel = new Text(this.isMockMode ? '[mock mode]' : '[claude-haiku]', {
       dim: true,
     });
 
@@ -125,7 +128,7 @@ class AIAssistantApp extends Widget {
     const initialMessage = new ChatMessage(
       {
         role: 'assistant',
-        content: IS_MOCK
+        content: this.isMockMode
           ? 'Hi! Running in mock mode (no ANTHROPIC_API_KEY). Type and press Enter!'
           : 'Hi! I am Claude. How can I help you?',
         timestamp: new Date(),
@@ -140,7 +143,7 @@ class AIAssistantApp extends Widget {
       flexDirection: 'row',
       height: 3,
       gap: 1,
-      padding: [0, 1],
+      padding: { top: 0, bottom: 0, left: 1, right: 1 },
       border: 'single',
       borderColor: { type: 'named' as const, name: 'brightBlack' as const },
     });
@@ -185,6 +188,12 @@ class AIAssistantApp extends Widget {
     this.tokenLabel.setContent(`in:${this.inputTokens} out:${this.outputTokens}`);
   }
 
+  private removeStreamingTextWidget(): void {
+    if (!this.streamingTextWidget) return;
+    this.chatContainer.removeChild(this.streamingTextWidget);
+    this.streamingTextWidget = null;
+  }
+
   private async handleSendMessage(userText: string): Promise<void> {
     if (!userText.trim() || this.isStreaming) return;
 
@@ -210,25 +219,28 @@ class AIAssistantApp extends Widget {
 
       // Stream response
       let fullResponse = '';
+      this.inputTokens += Math.ceil(userText.length / 4);
+      this.updateTokenLabel();
 
       // Create streaming text widget
-      this.streamingTextWidget = new StreamingText(
+      const streamingTextWidget = new StreamingText(
         {
           text: '',
           speed: 1,
         },
         { border: 'single', height: 5 }
       );
-      this.chatContainer.addChild(this.streamingTextWidget);
+      this.streamingTextWidget = streamingTextWidget;
+      this.chatContainer.addChild(streamingTextWidget);
 
-      if (IS_MOCK || !this.aiAdapter) {
+      if (this.isMockMode || !this.aiAdapter) {
         const stream = mockStream();
         for await (const token of stream) {
           fullResponse += token;
-          this.streamingTextWidget.setText(fullResponse);
+          streamingTextWidget.setText(fullResponse);
           this.outputTokens++;
           this.updateTokenLabel();
-          this.streamingTextWidget.tick();
+          streamingTextWidget.tick();
           this.markDirty();
         }
       } else {
@@ -239,19 +251,16 @@ class AIAssistantApp extends Widget {
 
         for await (const token of this.aiAdapter.chat(aiMessages)) {
           fullResponse += token;
-          this.streamingTextWidget.setText(fullResponse);
+          streamingTextWidget.setText(fullResponse);
           this.outputTokens++;
           this.updateTokenLabel();
-          this.streamingTextWidget.tick();
+          streamingTextWidget.tick();
           this.markDirty();
         }
-
-        this.inputTokens += Math.ceil(userText.length / 4);
-        this.updateTokenLabel();
       }
 
       // Replace streaming widget with final ChatMessage
-      this.chatContainer.removeChild(this.streamingTextWidget);
+      this.removeStreamingTextWidget();
       const assistantMessage = new ChatMessage(
         {
           role: 'assistant',
@@ -267,6 +276,7 @@ class AIAssistantApp extends Widget {
         await this.demonstrateToolApproval();
       }
     } catch (e) {
+      this.removeStreamingTextWidget();
       const errorMsg = e instanceof Error ? e.message : String(e);
       const errorMessage = new ChatMessage(
         {
@@ -278,6 +288,7 @@ class AIAssistantApp extends Widget {
       );
       this.chatContainer.addChild(errorMessage);
     } finally {
+      this.removeStreamingTextWidget();
       this.isStreaming = false;
       this.textInput.isFocused = true;
       this.markDirty();

--- a/examples/ai-assistant/src/index.tsx
+++ b/examples/ai-assistant/src/index.tsx
@@ -1,0 +1,395 @@
+import { App } from '@termuijs/core';
+import { Widget, Box, Text, ChatMessage, ToolCall, ToolApproval, StreamingText, ScrollView, TextInput } from '@termuijs/widgets';
+import type { Screen, KeyEvent } from '@termuijs/core';
+import { useAI, type AIMessage } from '@termuijs/adapters';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// AI Assistant Example
+// ──────────────────────────────────────────────────────────────────────────────
+//
+// Demonstrates TermUI's AI-focused widgets:
+//   - ChatMessage: displays conversation history
+//   - StreamingText: streams AI responses token-by-token
+//   - ToolCall & ToolApproval: shows tool invocations with approval workflow
+//   - useAI: hooks into Anthropic Claude API
+//
+// Dual-mode operation:
+//   - Mock Mode: works without ANTHROPIC_API_KEY, uses predefined responses
+//   - Real Mode: uses Claude API when ANTHROPIC_API_KEY is set
+//
+// Note: ChatMessage widgets are used for conversation history instead of
+// a ChatThread widget (which does not exist in the repository). Simple
+// token counting is displayed in the header instead of a TokenUsage widget
+// (which also does not exist).
+
+const IS_MOCK = !process.env.ANTHROPIC_API_KEY;
+
+const MOCK_REPLIES = [
+  'Hello! Running in mock mode. Set ANTHROPIC_API_KEY to use real Claude.',
+  'Mock mode is active. This is a pre-defined response without any API calls.',
+  'No API key detected. I am running in demonstration mode with predefined responses.',
+];
+
+const EXAMPLE_TOOLS = [
+  { name: 'search_web', args: { query: 'TermUI terminal framework' } },
+  { name: 'calculate', args: { expression: '42 * 2' } },
+];
+
+async function* mockStream(): AsyncGenerator<string> {
+  const reply = MOCK_REPLIES[Math.floor(Math.random() * MOCK_REPLIES.length)];
+  for (const ch of reply) {
+    yield ch;
+    await new Promise(r => setTimeout(r, 20));
+  }
+}
+
+class AIAssistantApp extends Widget {
+  private chatContainer: Box;
+  private streamingTextWidget: StreamingText | null = null;
+  private toolApprovalWidget: ToolApproval | null = null;
+  private textInput: TextInput;
+  private modeLabel: Text;
+  private tokenLabel: Text;
+  private isStreaming = false;
+  private inputTokens = 0;
+  private outputTokens = 0;
+  private aiAdapter: ReturnType<typeof useAI> | null = null;
+
+  constructor() {
+    super({
+      flexDirection: 'column',
+      flexGrow: 1,
+      padding: 1,
+      gap: 1,
+    });
+
+    // Initialize AI adapter if API key exists
+    if (!IS_MOCK) {
+      try {
+        this.aiAdapter = useAI('anthropic', {
+          apiKey: process.env.ANTHROPIC_API_KEY!,
+        });
+      } catch (e) {
+        console.error('Failed to initialize AI adapter:', e);
+      }
+    }
+
+    // ── Header ───────────────────────────────────────────────────────────────
+
+    const headerBox = new Box({
+      flexDirection: 'row',
+      height: 1,
+      gap: 1,
+      padding: [0, 1],
+      border: 'single',
+      borderColor: { type: 'named' as const, name: 'brightBlack' as const },
+    });
+
+    const titleText = new Text('AI Assistant', {
+      bold: true,
+      fg: { type: 'named' as const, name: 'cyan' as const },
+    });
+
+    this.modeLabel = new Text(IS_MOCK ? '[mock mode]' : '[claude-haiku]', {
+      dim: true,
+    });
+
+    this.tokenLabel = new Text('in:0 out:0', {
+      dim: true,
+      fg: { type: 'named' as const, name: 'yellow' as const },
+    });
+
+    headerBox.addChild(titleText);
+    headerBox.addChild(this.modeLabel);
+    headerBox.addChild(this.tokenLabel);
+
+    // ── Messages scroll view ──────────────────────────────────────────────────
+
+    const messagesScroll = new ScrollView(
+      {
+        flexGrow: 1,
+        border: 'single',
+        borderColor: { type: 'named' as const, name: 'brightBlack' as const },
+      },
+      { showScrollbar: true }
+    );
+
+    this.chatContainer = new Box({
+      flexDirection: 'column',
+      gap: 1,
+    });
+
+    messagesScroll.addChild(this.chatContainer);
+
+    // Add initial assistant message
+    const initialMessage = new ChatMessage(
+      {
+        role: 'assistant',
+        content: IS_MOCK
+          ? 'Hi! Running in mock mode (no ANTHROPIC_API_KEY). Type and press Enter!'
+          : 'Hi! I am Claude. How can I help you?',
+        timestamp: new Date(),
+      },
+      { height: 3 }
+    );
+    this.chatContainer.addChild(initialMessage);
+
+    // ── Input area ────────────────────────────────────────────────────────────
+
+    const inputBox = new Box({
+      flexDirection: 'row',
+      height: 3,
+      gap: 1,
+      padding: [0, 1],
+      border: 'single',
+      borderColor: { type: 'named' as const, name: 'brightBlack' as const },
+    });
+
+    const inputLabel = new Text('> ', {
+      fg: { type: 'named' as const, name: 'green' as const },
+      bold: true,
+    });
+
+    this.textInput = new TextInput(
+      { flexGrow: 1 },
+      {
+        placeholder: 'Type message and press Enter...',
+        onSubmit: (val) => this.handleSendMessage(val),
+      }
+    );
+
+    inputBox.addChild(inputLabel);
+    inputBox.addChild(this.textInput);
+
+    // ── Help bar ──────────────────────────────────────────────────────────────
+
+    const helpText = new Text(
+      ' [Enter] Send | [y/n] Approve tool | [Ctrl+C] Quit ',
+      {
+        dim: true,
+        height: 1,
+      }
+    );
+
+    // ── Build widget tree ─────────────────────────────────────────────────────
+
+    this.addChild(headerBox);
+    this.addChild(messagesScroll);
+    this.addChild(inputBox);
+    this.addChild(helpText);
+
+    this.textInput.isFocused = true;
+  }
+
+  private updateTokenLabel(): void {
+    this.tokenLabel.setContent(`in:${this.inputTokens} out:${this.outputTokens}`);
+  }
+
+  private async handleSendMessage(userText: string): Promise<void> {
+    if (!userText.trim() || this.isStreaming) return;
+
+    this.isStreaming = true;
+    this.textInput.isFocused = false;
+
+    // Add user message
+    const userMessage = new ChatMessage(
+      {
+        role: 'user',
+        content: userText,
+        timestamp: new Date(),
+      },
+      { height: 3 }
+    );
+    this.chatContainer.addChild(userMessage);
+
+    try {
+      // Collect all messages for API call
+      const allMessages: AIMessage[] = [
+        { role: 'assistant', content: 'Hi! I am Claude. How can I help you?' },
+      ];
+
+      // Stream response
+      let fullResponse = '';
+
+      // Create streaming text widget
+      this.streamingTextWidget = new StreamingText(
+        {
+          text: '',
+          speed: 1,
+        },
+        { border: 'single', height: 5 }
+      );
+      this.chatContainer.addChild(this.streamingTextWidget);
+
+      if (IS_MOCK || !this.aiAdapter) {
+        const stream = mockStream();
+        for await (const token of stream) {
+          fullResponse += token;
+          this.streamingTextWidget.setText(fullResponse);
+          this.outputTokens++;
+          this.updateTokenLabel();
+          this.streamingTextWidget.tick();
+          this.markDirty();
+        }
+      } else {
+        const aiMessages: AIMessage[] = [
+          ...allMessages,
+          { role: 'user', content: userText },
+        ];
+
+        for await (const token of this.aiAdapter.chat(aiMessages)) {
+          fullResponse += token;
+          this.streamingTextWidget.setText(fullResponse);
+          this.outputTokens++;
+          this.updateTokenLabel();
+          this.streamingTextWidget.tick();
+          this.markDirty();
+        }
+
+        this.inputTokens += Math.ceil(userText.length / 4);
+        this.updateTokenLabel();
+      }
+
+      // Replace streaming widget with final ChatMessage
+      this.chatContainer.removeChild(this.streamingTextWidget);
+      const assistantMessage = new ChatMessage(
+        {
+          role: 'assistant',
+          content: fullResponse,
+          timestamp: new Date(),
+        },
+        { height: 5 }
+      );
+      this.chatContainer.addChild(assistantMessage);
+
+      // Occasionally demonstrate tool approval workflow
+      if (Math.random() > 0.6) {
+        await this.demonstrateToolApproval();
+      }
+    } catch (e) {
+      const errorMsg = e instanceof Error ? e.message : String(e);
+      const errorMessage = new ChatMessage(
+        {
+          role: 'assistant',
+          content: `Error: ${errorMsg}`,
+          timestamp: new Date(),
+        },
+        { height: 3 }
+      );
+      this.chatContainer.addChild(errorMessage);
+    } finally {
+      this.isStreaming = false;
+      this.textInput.isFocused = true;
+      this.markDirty();
+    }
+  }
+
+  private async demonstrateToolApproval(): Promise<void> {
+    const toolCallWidget = new ToolCall(
+      {
+        name: 'search_web',
+        args: { query: 'TermUI framework' },
+        status: 'running',
+        collapsed: false,
+      },
+      { border: 'single', height: 6 }
+    );
+
+    this.chatContainer.addChild(toolCallWidget);
+    this.markDirty();
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    toolCallWidget.setStatus('done');
+    toolCallWidget.setResult('Search completed successfully');
+    this.markDirty();
+
+    const tool = EXAMPLE_TOOLS[Math.floor(Math.random() * EXAMPLE_TOOLS.length)];
+    let toolDone = false;
+
+    const toolWidget = new ToolApproval(
+      {
+        name: tool.name,
+        args: tool.args,
+        status: 'pending',
+        collapsed: false,
+        onApprove: () => {
+          toolWidget.setStatus('running');
+          setTimeout(() => {
+            toolWidget.setStatus('done');
+            toolWidget.setResult(`${tool.name} executed successfully`);
+            toolDone = true;
+          }, 500);
+        },
+        onDeny: () => {
+          toolWidget.setStatus('error');
+          toolWidget.setResult('Tool execution denied');
+          toolDone = true;
+        },
+      },
+      { border: 'single', height: 6 }
+    );
+
+    this.toolApprovalWidget = toolWidget;
+    this.chatContainer.addChild(toolWidget);
+    this.markDirty();
+
+    // Wait for approval/denial
+    while (!toolDone) {
+      await new Promise(r => setTimeout(r, 100));
+    }
+  }
+
+  handleKey(event: KeyEvent): boolean {
+    if (event.key === 'q' || (event.ctrl && event.key === 'c')) {
+      return false;
+    }
+
+    if (event.key === 'y' && this.toolApprovalWidget) {
+      this.toolApprovalWidget.handleKey('y');
+      return true;
+    }
+
+    if (event.key === 'n' && this.toolApprovalWidget) {
+      this.toolApprovalWidget.handleKey('n');
+      return true;
+    }
+
+    // Route other keys to TextInput
+    if (event.key === 'enter' || event.key === 'return') {
+      this.textInput.submit();
+      return true;
+    }
+
+    if (event.key === 'backspace') {
+      this.textInput.deleteBack();
+      return true;
+    }
+
+    if (event.key && event.key.length === 1 && !event.ctrl && !event.alt) {
+      this.textInput.insertChar(event.key);
+      return true;
+    }
+
+    return true;
+  }
+
+  protected _renderSelf(_screen: Screen): void {}
+}
+
+async function main() {
+  const root = new AIAssistantApp();
+
+  const app = new App(root, {
+    fullscreen: true,
+    title: 'AI Assistant',
+    fps: 30,
+  });
+
+  const exitCode = await app.mount();
+  process.exit(exitCode);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/create-termui-app/templates/ai-assistant/package.json
+++ b/packages/create-termui-app/templates/ai-assistant/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@termuijs/core": "latest",
     "@termuijs/widgets": "latest",
+    "@termuijs/adapters": "latest",
     "@termuijs/ui": "latest",
     "@termuijs/jsx": "latest",
     "@termuijs/tss": "latest"

--- a/packages/create-termui-app/templates/ai-assistant/src/index.tsx
+++ b/packages/create-termui-app/templates/ai-assistant/src/index.tsx
@@ -29,6 +29,7 @@ class AIAssistantApp extends Widget {
   private streamingTextWidget: StreamingText | null = null;
   private textInput: TextInput;
   private isStreaming = false;
+  private isMockMode = IS_MOCK;
   private aiAdapter: ReturnType<typeof useAI> | null = null;
 
   constructor() {
@@ -46,6 +47,8 @@ class AIAssistantApp extends Widget {
         });
       } catch (e) {
         console.error('Failed to initialize AI adapter:', e);
+        this.isMockMode = true;
+        this.aiAdapter = null;
       }
     }
 
@@ -54,7 +57,7 @@ class AIAssistantApp extends Widget {
       flexDirection: 'row',
       height: 1,
       gap: 1,
-      padding: [0, 1],
+      padding: { top: 0, bottom: 0, left: 1, right: 1 },
       border: 'single',
       borderColor: { type: 'named' as const, name: 'brightBlack' as const },
     });
@@ -64,7 +67,7 @@ class AIAssistantApp extends Widget {
       fg: { type: 'named' as const, name: 'cyan' as const },
     });
 
-    const modeLabel = new Text(IS_MOCK ? '[mock mode]' : '[claude]', {
+    const modeLabel = new Text(this.isMockMode ? '[mock mode]' : '[claude]', {
       dim: true,
     });
 
@@ -91,7 +94,7 @@ class AIAssistantApp extends Widget {
     const initialMessage = new ChatMessage(
       {
         role: 'assistant',
-        content: IS_MOCK
+        content: this.isMockMode
           ? 'Hi! Running in mock mode. Set ANTHROPIC_API_KEY to use real Claude.'
           : 'Hi! I am Claude. How can I help you?',
         timestamp: new Date(),
@@ -105,7 +108,7 @@ class AIAssistantApp extends Widget {
       flexDirection: 'row',
       height: 3,
       gap: 1,
-      padding: [0, 1],
+      padding: { top: 0, bottom: 0, left: 1, right: 1 },
       border: 'single',
       borderColor: { type: 'named' as const, name: 'brightBlack' as const },
     });
@@ -139,6 +142,12 @@ class AIAssistantApp extends Widget {
     this.textInput.isFocused = true;
   }
 
+  private removeStreamingTextWidget(): void {
+    if (!this.streamingTextWidget) return;
+    this.chatContainer.removeChild(this.streamingTextWidget);
+    this.streamingTextWidget = null;
+  }
+
   private async handleSendMessage(userText: string): Promise<void> {
     if (!userText.trim() || this.isStreaming) return;
 
@@ -154,37 +163,39 @@ class AIAssistantApp extends Widget {
     try {
       let fullResponse = '';
 
-      this.streamingTextWidget = new StreamingText(
+      const streamingTextWidget = new StreamingText(
         { text: '', speed: 1 },
         { border: 'single', height: 5 }
       );
-      this.chatContainer.addChild(this.streamingTextWidget);
+      this.streamingTextWidget = streamingTextWidget;
+      this.chatContainer.addChild(streamingTextWidget);
 
-      if (IS_MOCK || !this.aiAdapter) {
+      if (this.isMockMode || !this.aiAdapter) {
         const stream = mockStream();
         for await (const token of stream) {
           fullResponse += token;
-          this.streamingTextWidget.setText(fullResponse);
-          this.streamingTextWidget.tick();
+          streamingTextWidget.setText(fullResponse);
+          streamingTextWidget.tick();
           this.markDirty();
         }
       } else {
         const aiMessages: AIMessage[] = [{ role: 'user', content: userText }];
         for await (const token of this.aiAdapter.chat(aiMessages)) {
           fullResponse += token;
-          this.streamingTextWidget.setText(fullResponse);
-          this.streamingTextWidget.tick();
+          streamingTextWidget.setText(fullResponse);
+          streamingTextWidget.tick();
           this.markDirty();
         }
       }
 
-      this.chatContainer.removeChild(this.streamingTextWidget);
+      this.removeStreamingTextWidget();
       const assistantMessage = new ChatMessage(
         { role: 'assistant', content: fullResponse, timestamp: new Date() },
         { height: 5 }
       );
       this.chatContainer.addChild(assistantMessage);
     } catch (e) {
+      this.removeStreamingTextWidget();
       const errorMsg = e instanceof Error ? e.message : String(e);
       const errorMessage = new ChatMessage(
         { role: 'assistant', content: `Error: ${errorMsg}`, timestamp: new Date() },
@@ -192,6 +203,7 @@ class AIAssistantApp extends Widget {
       );
       this.chatContainer.addChild(errorMessage);
     } finally {
+      this.removeStreamingTextWidget();
       this.isStreaming = false;
       this.textInput.isFocused = true;
       this.markDirty();
@@ -239,327 +251,4 @@ main().catch((err) => {
   console.error(err);
   process.exit(1);
 });
-
-// ── Mock adapter (works without ANTHROPIC_API_KEY) ────────────────────────────
-
-const MOCK_REPLIES = [
-  'Hello! Running in mock mode. Set ANTHROPIC_API_KEY to use real Claude.',
-  'Mock mode is active. This is a pre-defined response without any API calls.',
-  'No API key detected. I am running in demonstration mode with predefined responses.',
-];
-
-async function* mockStream(_messages: Message[]): AsyncGenerator<string> {
-  const reply = MOCK_REPLIES[Math.floor(Math.random() * MOCK_REPLIES.length)];
-  for (const ch of reply) {
-    yield ch;
-    await new Promise(r => setTimeout(r, 20));
-  }
-}
-
-// ── Components ────────────────────────────────────────────────────────────────
-
-const IS_MOCK = !process.env.ANTHROPIC_API_KEY;
-
-interface ExampleToolCall {
-  name: string;
-  args: Record<string, unknown>;
-}
-
-const EXAMPLE_TOOLS: ExampleToolCall[] = [
-  { name: 'search_web', args: { query: 'TermUI terminal framework' } },
-  { name: 'calculate', args: { expression: '42 * 2' } },
-];
-
-function AiAssistant() {
-  const theme = useTheme();
-  const [messages, setMessages] = useState<Message[]>([
-    {
-      role: 'assistant',
-      content: IS_MOCK
-        ? 'Hi! Running in mock mode (no ANTHROPIC_API_KEY). Type and press Enter!'
-        : 'Hi! I am Claude. How can I help you?',
-      timestamp: new Date(),
-    },
-  ]);
-  const [input, setInput] = useState('');
-  const [streaming, setStreaming] = useState('');
-  const [busy, setBusy] = useState(false);
-  const [usage, setUsage] = useState<TokenUsageData>({
-    inputTokens: 0,
-    outputTokens: 0,
-  });
-  const [toolCall, setToolCall] = useState<ToolCallState | null>(null);
-  const [toolApprovalActive, setToolApprovalActive] = useState(false);
-
-  // Initialize AI adapter
-  let ai: ReturnType<typeof useAI> | null = null;
-  try {
-    if (!IS_MOCK) {
-      ai = useAI('anthropic', {
-        apiKey: process.env.ANTHROPIC_API_KEY!,
-      });
-    }
-  } catch (e) {
-    console.error('Failed to load AI adapter:', e);
-  }
-
-  const send = async () => {
-    const text = input.trim();
-    if (!text || busy) return;
-
-    const userMsg: Message = {
-      role: 'user',
-      content: text,
-      timestamp: new Date(),
-    };
-
-    const nextMessages: Message[] = [...messages, userMsg];
-    setMessages(nextMessages);
-    setInput('');
-    setBusy(true);
-    setStreaming('');
-
-    try {
-      let full = '';
-
-      const aiMessages: AIMessage[] = nextMessages.map(m => ({
-        role: m.role,
-        content: m.content,
-      }));
-
-      if (IS_MOCK || !ai) {
-        const src = mockStream(nextMessages);
-        for await (const chunk of src) {
-          full += chunk;
-          setStreaming(full);
-        }
-      } else {
-        for await (const token of ai.chat(aiMessages)) {
-          full += token;
-          setStreaming(full);
-        }
-        setUsage(prev => ({
-          inputTokens: prev.inputTokens + Math.ceil(text.length / 4),
-          outputTokens: prev.outputTokens + Math.ceil(full.length / 4),
-        }));
-      }
-
-      const assistantMsg: Message = {
-        role: 'assistant',
-        content: full,
-        timestamp: new Date(),
-      };
-      setMessages(m => [...m, assistantMsg]);
-
-      // Demo: Show tool call occasionally
-      if (Math.random() > 0.7) {
-        const tool = EXAMPLE_TOOLS[Math.floor(Math.random() * EXAMPLE_TOOLS.length)];
-        setToolCall({
-          name: tool.name,
-          args: tool.args,
-          status: 'pending',
-        });
-        setToolApprovalActive(true);
-      }
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      setMessages(m => [
-        ...m,
-        {
-          role: 'assistant',
-          content: 'Error: ' + msg,
-          timestamp: new Date(),
-        },
-      ]);
-    } finally {
-      setStreaming('');
-      setBusy(false);
-    }
-  };
-
-  const handleToolApproval = (approved: boolean) => {
-    if (toolCall) {
-      setToolCall(prev =>
-        prev
-          ? {
-              ...prev,
-              status: 'running',
-              result: approved ? `${prev.name} executed` : 'Tool call denied',
-            }
-          : null
-      );
-      setToolApprovalActive(false);
-
-      setTimeout(() => {
-        setToolCall(prev => (prev ? { ...prev, status: 'done' } : null));
-      }, 500);
-    }
-  };
-
-  useKeymap([
-    { key: 'enter', action: () => { void send(); }, description: 'Send' },
-    {
-      key: 'backspace',
-      action: () => setInput(v => v.slice(0, -1)),
-      description: 'Delete',
-    },
-    { key: 'c', ctrl: true, action: () => process.exit(0), description: 'Quit' },
-    {
-      key: 'y',
-      action: () => {
-        if (toolApprovalActive) handleToolApproval(true);
-      },
-      description: 'Approve tool',
-    },
-    {
-      key: 'n',
-      action: () => {
-        if (toolApprovalActive) handleToolApproval(false);
-      },
-      description: 'Deny tool',
-    },
-    ...(' abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.,!?-_()').split(
-      ''
-    ).map(ch => ({
-      key: ch,
-      action: () => {
-        if (!busy) setInput(v => v + ch);
-      },
-      description: '',
-    })),
-  ]);
-
-  return (
-    <box flexDirection="column" flexGrow={1} padding={1}>
-      {/* Header */}
-      <box border="single" padding={1} flexDirection="row" marginBottom={1}>
-        <text bold>AI Assistant</text>
-        <text color={theme.colors.muted}>
-          {' '}
-          {IS_MOCK ? '[mock mode]' : '[anthropic:claude-haiku]'}
-        </text>
-        <text color={theme.colors.muted}>
-          {' '}
-          in:{usage.inputTokens} out:{usage.outputTokens}
-        </text>
-      </box>
-
-      {/* Messages area */}
-      <box flexDirection="column" flexGrow={1} padding={1} marginBottom={1}>
-        {messages.map((m, i) => (
-          <box key={i} flexDirection="column" marginBottom={1}>
-            <box flexDirection="row" marginBottom={1}>
-              <text
-                bold
-                color={m.role === 'user' ? theme.colors.primary : theme.colors.success}
-              >
-                {m.role === 'user' ? 'You' : 'Claude'}
-              </text>
-              <text dim color={theme.colors.muted}>
-                {' '}
-                {m.timestamp.toLocaleTimeString()}
-              </text>
-            </box>
-            <text>{m.content}</text>
-          </box>
-        ))}
-
-        {/* Streaming indicator */}
-        {streaming.length > 0 && (
-          <box flexDirection="column" marginBottom={1}>
-            <text bold color={theme.colors.success}>
-              Claude
-            </text>
-            <text>{streaming}█</text>
-          </box>
-        )}
-
-        {/* Tool call display */}
-        {toolCall && (
-          <box
-            flexDirection="column"
-            border="single"
-            padding={1}
-            marginTop={1}
-            borderColor={theme.colors.muted}
-          >
-            <box flexDirection="row" marginBottom={1}>
-              <text bold>Tool: </text>
-              <text>{toolCall.name}</text>
-            </box>
-            <box flexDirection="row" marginBottom={1}>
-              <text dim>Status: </text>
-              <text
-                color={
-                  toolCall.status === 'done'
-                    ? theme.colors.success
-                    : toolCall.status === 'error'
-                      ? theme.colors.error
-                      : theme.colors.muted
-                }
-              >
-                {toolCall.status}
-              </text>
-            </box>
-
-            {/* Approval prompt */}
-            {toolApprovalActive && (
-              <box flexDirection="row" marginTop={1}>
-                <text color={theme.colors.success} bold>
-                  [y]
-                </text>
-                <text> Approve </text>
-                <text color={theme.colors.error} bold>
-                  [n]
-                </text>
-                <text> Deny</text>
-              </box>
-            )}
-
-            {toolCall.result && (
-              <box flexDirection="column" marginTop={1}>
-                <text dim>Result:</text>
-                <text>{String(toolCall.result)}</text>
-              </box>
-            )}
-          </box>
-        )}
-      </box>
-
-      {/* Input area */}
-      <box border="single" padding={1} marginBottom={1}>
-        <text color={theme.colors.muted}>&gt; </text>
-        <text>{input}{busy ? '' : '█'}</text>
-        {busy && <text color={theme.colors.muted}> thinking...</text>}
-      </box>
-
-      {/* Help text */}
-      <box padding={0} flexDirection="column">
-        <text dim>
-          Ctrl+C to quit{IS_MOCK ? ' | Set ANTHROPIC_API_KEY for real Claude' : ''}
-        </text>
-        {toolApprovalActive && (
-          <text dim>| [y] to approve tool | [n] to deny</text>
-        )}
-      </box>
-    </box>
-  );
-}
-
-function App() {
-  return (
-    <ErrorBoundary fallback={(err) => (
-      <box border="single" borderColor="red" padding={1}>
-        <text color="red" bold>Error</text>
-        <text>{err.message}</text>
-      </box>
-    )}>
-      <AutoThemeProvider>
-        <AiAssistant />
-      </AutoThemeProvider>
-    </ErrorBoundary>
-  );
-}
-
-render(<App />, { title: 'AI Assistant' });
 

--- a/packages/create-termui-app/templates/ai-assistant/src/index.tsx
+++ b/packages/create-termui-app/templates/ai-assistant/src/index.tsx
@@ -1,165 +1,565 @@
-/** @jsxImportSource @termuijs/jsx */
-import { render, useState, useKeymap, useEffect, ErrorBoundary } from '@termuijs/jsx';
-import { AutoThemeProvider, useTheme } from '@termuijs/tss';
+import { App } from '@termuijs/core';
+import { Widget, Box, Text, ChatMessage, StreamingText, ScrollView, TextInput } from '@termuijs/widgets';
+import type { Screen, KeyEvent } from '@termuijs/core';
+import { useAI, type AIMessage } from '@termuijs/adapters';
 
-// ── Types ────────────────────────────────────────────────────────────────────
+// ──────────────────────────────────────────────────────────────────────────────
+// AI Assistant Template - Minimal Version
+// ──────────────────────────────────────────────────────────────────────────────
+//
+// A simple starter template demonstrating:
+//   - ChatMessage widget for conversation display
+//   - StreamingText widget for streamed responses
+//   - useAI for Claude API integration
+//   - Dual-mode: mock (no API key) and real (with API key)
 
-interface Message { role: 'user' | 'assistant'; content: string; }
-interface TokenUsageData { inputTokens: number; outputTokens: number; }
+const IS_MOCK = !process.env.ANTHROPIC_API_KEY;
+
+const MOCK_REPLY = 'Hello! This is a mock response. Set ANTHROPIC_API_KEY to use real Claude.';
+
+async function* mockStream(): AsyncGenerator<string> {
+  for (const ch of MOCK_REPLY) {
+    yield ch;
+    await new Promise(r => setTimeout(r, 20));
+  }
+}
+
+class AIAssistantApp extends Widget {
+  private chatContainer: Box;
+  private streamingTextWidget: StreamingText | null = null;
+  private textInput: TextInput;
+  private isStreaming = false;
+  private aiAdapter: ReturnType<typeof useAI> | null = null;
+
+  constructor() {
+    super({
+      flexDirection: 'column',
+      flexGrow: 1,
+      padding: 1,
+      gap: 1,
+    });
+
+    if (!IS_MOCK) {
+      try {
+        this.aiAdapter = useAI('anthropic', {
+          apiKey: process.env.ANTHROPIC_API_KEY!,
+        });
+      } catch (e) {
+        console.error('Failed to initialize AI adapter:', e);
+      }
+    }
+
+    // Header
+    const headerBox = new Box({
+      flexDirection: 'row',
+      height: 1,
+      gap: 1,
+      padding: [0, 1],
+      border: 'single',
+      borderColor: { type: 'named' as const, name: 'brightBlack' as const },
+    });
+
+    const titleText = new Text('AI Assistant', {
+      bold: true,
+      fg: { type: 'named' as const, name: 'cyan' as const },
+    });
+
+    const modeLabel = new Text(IS_MOCK ? '[mock mode]' : '[claude]', {
+      dim: true,
+    });
+
+    headerBox.addChild(titleText);
+    headerBox.addChild(modeLabel);
+
+    // Messages scroll view
+    const messagesScroll = new ScrollView(
+      {
+        flexGrow: 1,
+        border: 'single',
+        borderColor: { type: 'named' as const, name: 'brightBlack' as const },
+      },
+      { showScrollbar: true }
+    );
+
+    this.chatContainer = new Box({
+      flexDirection: 'column',
+      gap: 1,
+    });
+
+    messagesScroll.addChild(this.chatContainer);
+
+    const initialMessage = new ChatMessage(
+      {
+        role: 'assistant',
+        content: IS_MOCK
+          ? 'Hi! Running in mock mode. Set ANTHROPIC_API_KEY to use real Claude.'
+          : 'Hi! I am Claude. How can I help you?',
+        timestamp: new Date(),
+      },
+      { height: 3 }
+    );
+    this.chatContainer.addChild(initialMessage);
+
+    // Input area
+    const inputBox = new Box({
+      flexDirection: 'row',
+      height: 3,
+      gap: 1,
+      padding: [0, 1],
+      border: 'single',
+      borderColor: { type: 'named' as const, name: 'brightBlack' as const },
+    });
+
+    const inputLabel = new Text('> ', {
+      fg: { type: 'named' as const, name: 'green' as const },
+      bold: true,
+    });
+
+    this.textInput = new TextInput(
+      { flexGrow: 1 },
+      {
+        placeholder: 'Type a message...',
+        onSubmit: (val) => this.handleSendMessage(val),
+      }
+    );
+
+    inputBox.addChild(inputLabel);
+    inputBox.addChild(this.textInput);
+
+    const helpText = new Text(' [Enter] Send | [Ctrl+C] Quit ', {
+      dim: true,
+      height: 1,
+    });
+
+    this.addChild(headerBox);
+    this.addChild(messagesScroll);
+    this.addChild(inputBox);
+    this.addChild(helpText);
+
+    this.textInput.isFocused = true;
+  }
+
+  private async handleSendMessage(userText: string): Promise<void> {
+    if (!userText.trim() || this.isStreaming) return;
+
+    this.isStreaming = true;
+    this.textInput.isFocused = false;
+
+    const userMessage = new ChatMessage(
+      { role: 'user', content: userText, timestamp: new Date() },
+      { height: 3 }
+    );
+    this.chatContainer.addChild(userMessage);
+
+    try {
+      let fullResponse = '';
+
+      this.streamingTextWidget = new StreamingText(
+        { text: '', speed: 1 },
+        { border: 'single', height: 5 }
+      );
+      this.chatContainer.addChild(this.streamingTextWidget);
+
+      if (IS_MOCK || !this.aiAdapter) {
+        const stream = mockStream();
+        for await (const token of stream) {
+          fullResponse += token;
+          this.streamingTextWidget.setText(fullResponse);
+          this.streamingTextWidget.tick();
+          this.markDirty();
+        }
+      } else {
+        const aiMessages: AIMessage[] = [{ role: 'user', content: userText }];
+        for await (const token of this.aiAdapter.chat(aiMessages)) {
+          fullResponse += token;
+          this.streamingTextWidget.setText(fullResponse);
+          this.streamingTextWidget.tick();
+          this.markDirty();
+        }
+      }
+
+      this.chatContainer.removeChild(this.streamingTextWidget);
+      const assistantMessage = new ChatMessage(
+        { role: 'assistant', content: fullResponse, timestamp: new Date() },
+        { height: 5 }
+      );
+      this.chatContainer.addChild(assistantMessage);
+    } catch (e) {
+      const errorMsg = e instanceof Error ? e.message : String(e);
+      const errorMessage = new ChatMessage(
+        { role: 'assistant', content: `Error: ${errorMsg}`, timestamp: new Date() },
+        { height: 3 }
+      );
+      this.chatContainer.addChild(errorMessage);
+    } finally {
+      this.isStreaming = false;
+      this.textInput.isFocused = true;
+      this.markDirty();
+    }
+  }
+
+  handleKey(event: KeyEvent): boolean {
+    if (event.key === 'q' || (event.ctrl && event.key === 'c')) {
+      return false;
+    }
+
+    if (event.key === 'enter' || event.key === 'return') {
+      this.textInput.submit();
+      return true;
+    }
+
+    if (event.key === 'backspace') {
+      this.textInput.deleteBack();
+      return true;
+    }
+
+    if (event.key && event.key.length === 1 && !event.ctrl && !event.alt) {
+      this.textInput.insertChar(event.key);
+      return true;
+    }
+
+    return true;
+  }
+
+  protected _renderSelf(_screen: Screen): void {}
+}
+
+async function main() {
+  const root = new AIAssistantApp();
+  const app = new App(root, {
+    fullscreen: true,
+    title: 'AI Assistant',
+    fps: 30,
+  });
+  const exitCode = await app.mount();
+  process.exit(exitCode);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
 
 // ── Mock adapter (works without ANTHROPIC_API_KEY) ────────────────────────────
 
 const MOCK_REPLIES = [
-    'Hello! Running in mock mode. Set ANTHROPIC_API_KEY for real Claude.',
-    'Mock mode active — your message was received!',
-    'No API key needed in mock mode. Real Claude would answer here.',
+  'Hello! Running in mock mode. Set ANTHROPIC_API_KEY to use real Claude.',
+  'Mock mode is active. This is a pre-defined response without any API calls.',
+  'No API key detected. I am running in demonstration mode with predefined responses.',
 ];
 
-async function* mockStream(_prompt: string): AsyncGenerator<string> {
-    const reply = MOCK_REPLIES[Math.floor(Math.random() * MOCK_REPLIES.length)];
-    for (const ch of reply) {
-        yield ch;
-        await new Promise(r => setTimeout(r, 20));
-    }
-}
-
-async function* claudeStream(
-    messages: Message[],
-    onUsage: (u: TokenUsageData) => void,
-): AsyncGenerator<string> {
-    const res = await fetch('https://api.anthropic.com/v1/messages', {
-        method: 'POST',
-        headers: {
-            'content-type': 'application/json',
-            'x-api-key': process.env.ANTHROPIC_API_KEY ?? '',
-            'anthropic-version': '2023-06-01',
-        },
-        body: JSON.stringify({
-            model: 'claude-3-5-haiku-20241022',
-            max_tokens: 1024,
-            stream: true,
-            messages: messages.map(m => ({ role: m.role, content: m.content })),
-        }),
-    });
-    if (!res.ok) throw new Error('Claude API ' + res.status + ': ' + res.statusText);
-    const reader = res.body!.getReader();
-    const dec = new TextDecoder();
-    let buf = '';
-    while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buf += dec.decode(value, { stream: true });
-        const lines = buf.split('\n');
-        buf = lines.pop() ?? '';
-        for (const line of lines) {
-            if (!line.startsWith('data: ')) continue;
-            const raw = line.slice(6).trim();
-            if (raw === '[DONE]') return;
-            try {
-                const ev = JSON.parse(raw);
-                if (ev.type === 'content_block_delta' && ev.delta?.type === 'text_delta') yield ev.delta.text as string;
-                if (ev.type === 'message_delta' && ev.usage) onUsage({ inputTokens: ev.usage.input_tokens ?? 0, outputTokens: ev.usage.output_tokens ?? 0 });
-            } catch { /* skip */ }
-        }
-    }
+async function* mockStream(_messages: Message[]): AsyncGenerator<string> {
+  const reply = MOCK_REPLIES[Math.floor(Math.random() * MOCK_REPLIES.length)];
+  for (const ch of reply) {
+    yield ch;
+    await new Promise(r => setTimeout(r, 20));
+  }
 }
 
 // ── Components ────────────────────────────────────────────────────────────────
 
 const IS_MOCK = !process.env.ANTHROPIC_API_KEY;
 
-function AiAssistant() {
-    const theme = useTheme();
-    const [messages, setMessages] = useState<Message[]>([{
-        role: 'assistant',
-        content: IS_MOCK
-            ? 'Hi! Running in mock mode (no ANTHROPIC_API_KEY). Type and press Enter!'
-            : 'Hi! I am Claude. How can I help you?',
-    }]);
-    const [input, setInput]           = useState('');
-    const [streaming, setStreaming]   = useState('');
-    const [busy, setBusy]             = useState(false);
-    const [usage, setUsage]           = useState<TokenUsageData>({ inputTokens: 0, outputTokens: 0 });
+interface ExampleToolCall {
+  name: string;
+  args: Record<string, unknown>;
+}
 
-    const send = async () => {
-        const text = input.trim();
-        if (!text || busy) return;
-        const next: Message[] = [...messages, { role: 'user', content: text }];
-        setMessages(next);
-        setInput('');
-        setBusy(true);
-        setStreaming('');
-        try {
-            let full = '';
-            const src = IS_MOCK ? mockStream(text) : claudeStream(next, setUsage);
-            for await (const chunk of src) { full += chunk; setStreaming(full); }
-            setMessages(m => [...m, { role: 'assistant', content: full }]);
-        } catch (e) {
-            const msg = e instanceof Error ? e.message : String(e);
-            setMessages(m => [...m, { role: 'assistant', content: 'Error: ' + msg }]);
-        } finally { setStreaming(''); setBusy(false); }
+const EXAMPLE_TOOLS: ExampleToolCall[] = [
+  { name: 'search_web', args: { query: 'TermUI terminal framework' } },
+  { name: 'calculate', args: { expression: '42 * 2' } },
+];
+
+function AiAssistant() {
+  const theme = useTheme();
+  const [messages, setMessages] = useState<Message[]>([
+    {
+      role: 'assistant',
+      content: IS_MOCK
+        ? 'Hi! Running in mock mode (no ANTHROPIC_API_KEY). Type and press Enter!'
+        : 'Hi! I am Claude. How can I help you?',
+      timestamp: new Date(),
+    },
+  ]);
+  const [input, setInput] = useState('');
+  const [streaming, setStreaming] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [usage, setUsage] = useState<TokenUsageData>({
+    inputTokens: 0,
+    outputTokens: 0,
+  });
+  const [toolCall, setToolCall] = useState<ToolCallState | null>(null);
+  const [toolApprovalActive, setToolApprovalActive] = useState(false);
+
+  // Initialize AI adapter
+  let ai: ReturnType<typeof useAI> | null = null;
+  try {
+    if (!IS_MOCK) {
+      ai = useAI('anthropic', {
+        apiKey: process.env.ANTHROPIC_API_KEY!,
+      });
+    }
+  } catch (e) {
+    console.error('Failed to load AI adapter:', e);
+  }
+
+  const send = async () => {
+    const text = input.trim();
+    if (!text || busy) return;
+
+    const userMsg: Message = {
+      role: 'user',
+      content: text,
+      timestamp: new Date(),
     };
 
-    useKeymap([
-        { key: 'enter',     action: () => { void send(); },                   description: 'Send' },
-        { key: 'backspace', action: () => setInput(v => v.slice(0, -1)),       description: 'Delete' },
-        { key: 'c', ctrl: true, action: () => process.exit(0),                description: 'Quit' },
-        ...(' abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.,!?-_()').split('').map(ch => ({
-            key: ch, action: () => { if (!busy) setInput(v => v + ch); }, description: '',
-        })),
-    ]);
+    const nextMessages: Message[] = [...messages, userMsg];
+    setMessages(nextMessages);
+    setInput('');
+    setBusy(true);
+    setStreaming('');
 
-    return (
-        <box flexDirection="column" flexGrow={1} padding={1}>
-            <box border="single" padding={1} flexDirection="row">
-                <text bold>AI Assistant</text>
-                <text> {IS_MOCK ? '[mock mode]' : '[claude-3-5-haiku]'}</text>
-                <text color={theme.colors.muted}> in:{usage.inputTokens} out:{usage.outputTokens}</text>
+    try {
+      let full = '';
+
+      const aiMessages: AIMessage[] = nextMessages.map(m => ({
+        role: m.role,
+        content: m.content,
+      }));
+
+      if (IS_MOCK || !ai) {
+        const src = mockStream(nextMessages);
+        for await (const chunk of src) {
+          full += chunk;
+          setStreaming(full);
+        }
+      } else {
+        for await (const token of ai.chat(aiMessages)) {
+          full += token;
+          setStreaming(full);
+        }
+        setUsage(prev => ({
+          inputTokens: prev.inputTokens + Math.ceil(text.length / 4),
+          outputTokens: prev.outputTokens + Math.ceil(full.length / 4),
+        }));
+      }
+
+      const assistantMsg: Message = {
+        role: 'assistant',
+        content: full,
+        timestamp: new Date(),
+      };
+      setMessages(m => [...m, assistantMsg]);
+
+      // Demo: Show tool call occasionally
+      if (Math.random() > 0.7) {
+        const tool = EXAMPLE_TOOLS[Math.floor(Math.random() * EXAMPLE_TOOLS.length)];
+        setToolCall({
+          name: tool.name,
+          args: tool.args,
+          status: 'pending',
+        });
+        setToolApprovalActive(true);
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setMessages(m => [
+        ...m,
+        {
+          role: 'assistant',
+          content: 'Error: ' + msg,
+          timestamp: new Date(),
+        },
+      ]);
+    } finally {
+      setStreaming('');
+      setBusy(false);
+    }
+  };
+
+  const handleToolApproval = (approved: boolean) => {
+    if (toolCall) {
+      setToolCall(prev =>
+        prev
+          ? {
+              ...prev,
+              status: 'running',
+              result: approved ? `${prev.name} executed` : 'Tool call denied',
+            }
+          : null
+      );
+      setToolApprovalActive(false);
+
+      setTimeout(() => {
+        setToolCall(prev => (prev ? { ...prev, status: 'done' } : null));
+      }, 500);
+    }
+  };
+
+  useKeymap([
+    { key: 'enter', action: () => { void send(); }, description: 'Send' },
+    {
+      key: 'backspace',
+      action: () => setInput(v => v.slice(0, -1)),
+      description: 'Delete',
+    },
+    { key: 'c', ctrl: true, action: () => process.exit(0), description: 'Quit' },
+    {
+      key: 'y',
+      action: () => {
+        if (toolApprovalActive) handleToolApproval(true);
+      },
+      description: 'Approve tool',
+    },
+    {
+      key: 'n',
+      action: () => {
+        if (toolApprovalActive) handleToolApproval(false);
+      },
+      description: 'Deny tool',
+    },
+    ...(' abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.,!?-_()').split(
+      ''
+    ).map(ch => ({
+      key: ch,
+      action: () => {
+        if (!busy) setInput(v => v + ch);
+      },
+      description: '',
+    })),
+  ]);
+
+  return (
+    <box flexDirection="column" flexGrow={1} padding={1}>
+      {/* Header */}
+      <box border="single" padding={1} flexDirection="row" marginBottom={1}>
+        <text bold>AI Assistant</text>
+        <text color={theme.colors.muted}>
+          {' '}
+          {IS_MOCK ? '[mock mode]' : '[anthropic:claude-haiku]'}
+        </text>
+        <text color={theme.colors.muted}>
+          {' '}
+          in:{usage.inputTokens} out:{usage.outputTokens}
+        </text>
+      </box>
+
+      {/* Messages area */}
+      <box flexDirection="column" flexGrow={1} padding={1} marginBottom={1}>
+        {messages.map((m, i) => (
+          <box key={i} flexDirection="column" marginBottom={1}>
+            <box flexDirection="row" marginBottom={1}>
+              <text
+                bold
+                color={m.role === 'user' ? theme.colors.primary : theme.colors.success}
+              >
+                {m.role === 'user' ? 'You' : 'Claude'}
+              </text>
+              <text dim color={theme.colors.muted}>
+                {' '}
+                {m.timestamp.toLocaleTimeString()}
+              </text>
+            </box>
+            <text>{m.content}</text>
+          </box>
+        ))}
+
+        {/* Streaming indicator */}
+        {streaming.length > 0 && (
+          <box flexDirection="column" marginBottom={1}>
+            <text bold color={theme.colors.success}>
+              Claude
+            </text>
+            <text>{streaming}█</text>
+          </box>
+        )}
+
+        {/* Tool call display */}
+        {toolCall && (
+          <box
+            flexDirection="column"
+            border="single"
+            padding={1}
+            marginTop={1}
+            borderColor={theme.colors.muted}
+          >
+            <box flexDirection="row" marginBottom={1}>
+              <text bold>Tool: </text>
+              <text>{toolCall.name}</text>
+            </box>
+            <box flexDirection="row" marginBottom={1}>
+              <text dim>Status: </text>
+              <text
+                color={
+                  toolCall.status === 'done'
+                    ? theme.colors.success
+                    : toolCall.status === 'error'
+                      ? theme.colors.error
+                      : theme.colors.muted
+                }
+              >
+                {toolCall.status}
+              </text>
             </box>
 
-            <box flexDirection="column" flexGrow={1} padding={1}>
-                {messages.map((m, i) => (
-                    <box key={i} flexDirection="column" marginBottom={1}>
-                        <text bold color={m.role === 'user' ? theme.colors.primary : theme.colors.success}>
-                            {m.role === 'user' ? 'You' : 'Claude'}
-                        </text>
-                        <text>{m.content}</text>
-                    </box>
-                ))}
-                {streaming.length > 0 && (
-                    <box flexDirection="column">
-                        <text bold color={theme.colors.success}>Claude</text>
-                        <text>{streaming}█</text>
-                    </box>
-                )}
-            </box>
+            {/* Approval prompt */}
+            {toolApprovalActive && (
+              <box flexDirection="row" marginTop={1}>
+                <text color={theme.colors.success} bold>
+                  [y]
+                </text>
+                <text> Approve </text>
+                <text color={theme.colors.error} bold>
+                  [n]
+                </text>
+                <text> Deny</text>
+              </box>
+            )}
 
-            <box border="single" padding={1}>
-                <text color={theme.colors.muted}>&gt; </text>
-                <text>{input}{busy ? '' : '█'}</text>
-                {busy && <text color={theme.colors.muted}> thinking...</text>}
-            </box>
+            {toolCall.result && (
+              <box flexDirection="column" marginTop={1}>
+                <text dim>Result:</text>
+                <text>{String(toolCall.result)}</text>
+              </box>
+            )}
+          </box>
+        )}
+      </box>
 
-            <box padding={1}>
-                <text dim>Ctrl+C to quit{IS_MOCK ? ' | Set ANTHROPIC_API_KEY for real Claude' : ''}</text>
-            </box>
-        </box>
-    );
+      {/* Input area */}
+      <box border="single" padding={1} marginBottom={1}>
+        <text color={theme.colors.muted}>&gt; </text>
+        <text>{input}{busy ? '' : '█'}</text>
+        {busy && <text color={theme.colors.muted}> thinking...</text>}
+      </box>
+
+      {/* Help text */}
+      <box padding={0} flexDirection="column">
+        <text dim>
+          Ctrl+C to quit{IS_MOCK ? ' | Set ANTHROPIC_API_KEY for real Claude' : ''}
+        </text>
+        {toolApprovalActive && (
+          <text dim>| [y] to approve tool | [n] to deny</text>
+        )}
+      </box>
+    </box>
+  );
 }
 
 function App() {
-    return (
-        <AutoThemeProvider>
-            <ErrorBoundary fallback={(err) => (
-                <box border="single" borderColor="red" padding={1}>
-                    <text color="red" bold>Error</text>
-                    <text>{err.message}</text>
-                </box>
-            )}>
-                <AiAssistant />
-            </ErrorBoundary>
-        </AutoThemeProvider>
-    );
+  return (
+    <ErrorBoundary fallback={(err) => (
+      <box border="single" borderColor="red" padding={1}>
+        <text color="red" bold>Error</text>
+        <text>{err.message}</text>
+      </box>
+    )}>
+      <AutoThemeProvider>
+        <AiAssistant />
+      </AutoThemeProvider>
+    </ErrorBoundary>
+  );
 }
 
-render(<App />, { title: 'my-ai-app' });
+render(<App />, { title: 'AI Assistant' });
+


### PR DESCRIPTION
## Description

Adds a new AI Assistant example under `examples/ai-assistant` demonstrating the existing AI-related widgets available in the repository. The example supports both mock mode and real Anthropic integration through `useAI`. This PR also updates the `create-termui-app` AI assistant template and the root README.

## Related Issue

Closes #102

## Which package(s)?

* examples/ai-assistant
* create-termui-app
* documentation

## Type of Change

* [x] ✨ Feature (`type:feature`)
* [x] 📝 Docs (`type:docs`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* GSSoC profile: `https://gssoc.girlscript.org/profile/84adde4d-7c32-44f4-8f86-5a5f723d95cf`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

* Uses existing AI widgets available in the repository:

  * `ChatMessage`
  * `StreamingText`
  * `ToolCall`
  * `ToolApproval`
  * `useAI`

* Mock mode is available when `ANTHROPIC_API_KEY` is not configured.

* The example follows patterns already used in:

  * `examples/ai-streaming`
  * `examples/chat-app`

* The repository currently does not contain `ChatThread` or `TokenUsage` widgets, so the example demonstrates the AI widgets that are currently available in the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive AI Assistant example: dual-mode chat (mock & real), streaming responses, chat history, tool calls/approval, and token usage display
  * Keyboard controls for input, submission, approval, and quitting

* **Documentation**
  * Added example README and updated main README to list the AI Assistant with usage and run instructions

* **Templates**
  * Included AI Assistant example in project templates and package metadata for local demos
<!-- end of auto-generated comment: release notes by coderabbit.ai -->