### PR TITLE
feat(examples): add pomodoro-timer example

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -221,6 +221,20 @@
         "typescript": "^5.4.0",
       },
     },
+    "examples/pomodoro-timer": {
+      "name": "@termuijs/example-pomodoro-timer",
+      "version": "0.1.0",
+      "dependencies": {
+        "@termuijs/core": "workspace:*",
+        "@termuijs/jsx": "workspace:*",
+        "@termuijs/motion": "workspace:*",
+        "@termuijs/ui": "workspace:*",
+        "@termuijs/widgets": "workspace:*",
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3",
+      },
+    },
     "examples/process-monitor": {
       "name": "@termuijs/example-process-monitor",
       "version": "0.1.0",
@@ -683,6 +697,8 @@
     "@termuijs/example-markdown-editor": ["@termuijs/example-markdown-editor@workspace:examples/markdown-editor"],
 
     "@termuijs/example-multi-screen-router": ["@termuijs/example-multi-screen-router@workspace:examples/multi-screen-router"],
+
+    "@termuijs/example-pomodoro-timer": ["@termuijs/example-pomodoro-timer@workspace:examples/pomodoro-timer"],
 
     "@termuijs/example-process-monitor": ["@termuijs/example-process-monitor@workspace:examples/process-monitor"],
 

--- a/examples/pomodoro-timer/package.json
+++ b/examples/pomodoro-timer/package.json
@@ -1,0 +1,26 @@
+{
+    "name" : "@termuijs/example-pomodoro-timer",
+    "version":"0.1.0",
+    "private" : true,
+    "description": "Pomodoro timer example app" ,
+    "type": "module",
+    "scripts": {
+        "start":"bun src/index.tsx",
+        "dev": "bun --watch src/index.tsx",
+        "build": "echo 'no build needed'",
+        "typecheck": "tsc --noEmit"
+    },
+    "dependencies": {
+        "@termuijs/core":"workspace:*",
+        "@termuijs/widgets":"workspace:*",
+        "@termuijs/ui":"workspace:*",
+        "@termuijs/jsx":"workspace:*",
+        "@termuijs/motion":"workspace:*"
+    },
+    "devDependencies": {
+        "typescript":"^5.9.3"
+    },
+    "engines": {
+        "bun":">=1.3.0"
+    }
+}

--- a/examples/pomodoro-timer/src/index.tsx
+++ b/examples/pomodoro-timer/src/index.tsx
@@ -1,0 +1,243 @@
+import { App, type KeyEvent, type Screen } from '@termuijs/core';
+import { Widget, Box, Text, Center, ProgressBar } from '@termuijs/widgets';
+import { transition } from '@termuijs/motion';
+
+// ── Constants ──
+
+const WORK_SECONDS = 25 * 60;
+const BREAK_SECONDS = 5 * 60;
+
+
+// ── Types ──
+
+type Phase = 'work' | 'break';
+
+// ── PomodoroApp Widget ──
+
+class PomodoroApp extends Widget {
+    private _phase: Phase = 'work';
+    private _remaining: number = WORK_SECONDS;
+    private _running: boolean = true;
+    private _toastTimer: ReturnType<typeof setTimeout> | null = null;
+
+    private _phaseLabel: Text;
+    private _timerDisplay: Text;
+    private _progressBar: ProgressBar;
+    private _statusText: Text;
+    private _toastText: Text;
+
+    constructor() {
+        super({
+            flexDirection: 'column',
+            width: 50,
+            height: 16,
+            border: 'double',
+            borderColor: { type: 'named', name: 'cyan' },
+            padding: 1,
+        });
+
+        const title = new Text(' TermUI Pomodoro Timer ', {
+            bold: true,
+            height: 1,
+            fg: { type: 'named', name: 'cyan' },
+        }, { align: 'center' });
+
+        this._phaseLabel = new Text('-- Work Phase --', {
+            bold: true,
+            height: 1,
+            fg: { type: 'named', name: 'red' },
+        }, { align: 'center' });
+
+        this._timerDisplay = new Text('25:00', {
+            bold: true,
+            height: 1,
+            fg: { type: 'named', name: 'white' },
+        }, { align: 'center' });
+
+        this._progressBar = new ProgressBar({}, { value: 0 });
+
+        this._statusText = new Text('Status: Running', {
+            height: 1,
+            fg: { type: 'named', name: 'brightBlack' },
+        }, { align: 'center' });
+
+        this._toastText = new Text('', {
+            height: 1,
+            fg: { type: 'named', name: 'yellow' },
+        }, { align: 'center' });
+
+        const hintsText = new Text(
+            '[space] pause/resume  [r] reset  [q] quit',
+            { height: 1, fg: { type: 'named', name: 'brightBlack' } },
+            { align: 'center' }
+        );
+
+        this.addChild(title);
+        this.addChild(new Box({ height: 1 }));
+        this.addChild(this._phaseLabel);
+        this.addChild(new Box({ height: 1 }));
+        this.addChild(this._timerDisplay);
+        this.addChild(new Box({ height: 1 }));
+        this.addChild(this._progressBar);
+        this.addChild(new Box({ height: 1 }));
+        this.addChild(this._statusText);
+        this.addChild(this._toastText);
+        this.addChild(new Box({ height: 1 }));
+        this.addChild(hintsText);
+
+        this._updateDisplay();
+    }
+
+    // ── Helpers ──
+
+    private _phaseDuration(): number {
+        return this._phase === 'work' ? WORK_SECONDS : BREAK_SECONDS;
+    }
+
+    private _formatTime(seconds: number): string {
+        const m = Math.floor(seconds / 60);
+        const s = seconds % 60;
+        return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+    }
+
+    private _elapsedFraction(): number {
+        const total = this._phaseDuration();
+        return (total - this._remaining) / total;
+    }
+
+    // ── Tick ──
+
+    tick(): void {
+        if (!this._running) return;
+        if (this._remaining <= 1) {
+            this._advancePhase();
+            return;
+        }
+        this._remaining -= 1;
+        this._updateDisplay();
+    }
+
+    private _advancePhase(): void {
+        this._phase = this._phase === 'work' ? 'break' : 'work';
+        this._remaining = this._phaseDuration();
+        this._triggerPulse();
+        this._showToast();
+        this._updateDisplay();
+    }
+
+    private _triggerPulse(): void {
+        transition({
+            durationMs: 400,
+            onFrame: (progress: number) => {
+                // Flash the timer white then fade back to phase color
+                if (progress < 0.5) {
+                    this._timerDisplay.style.fg = { type: 'named', name: 'white' };
+                } else {
+                    this._timerDisplay.style.fg = this._phase === 'work'
+                     ? { type: 'named' as const, name: 'red' as const }
+                     : { type: 'named' as const, name: 'green' as const };
+                }
+                this.markDirty();
+            },
+        });
+    }
+
+    private _showToast(): void {
+        const label = this._phase === 'work' ? 'Work' : 'Break';
+        const msg = `>> ${label} phase started! <<`;
+
+        this._toastText.setContent(msg);
+        this.markDirty();
+
+        if (this._toastTimer !== null) {
+            clearTimeout(this._toastTimer);
+        }
+
+        this._toastTimer = setTimeout(() => {
+            this._toastText.setContent('');
+            this._toastTimer = null;
+            this.markDirty();
+        }, 3000);
+    }
+
+    private _updateDisplay(): void {
+        const phaseLabel = this._phase === 'work' ? 'Work' : 'Break';
+        const phaseColor = this._phase === 'work'
+            ? { type: 'named' as const, name: 'red' as const }
+            : { type: 'named' as const, name: 'green' as const };
+
+        this._phaseLabel.setContent(`-- ${phaseLabel} Phase --`);
+        this._phaseLabel.style.fg = phaseColor;
+
+        this._timerDisplay.setContent(this._formatTime(this._remaining));
+        this._timerDisplay.style.fg = phaseColor;
+
+        this._progressBar.setValue(this._elapsedFraction());
+        this._progressBar.style.fg = phaseColor;
+
+        const status = this._running ? 'Running' : 'Paused';
+        this._statusText.setContent(`Status: ${status}`);
+
+        this.markDirty();
+    }
+
+    // ── Key Handling ──
+
+    handleKey(event: KeyEvent): boolean {
+        if (event.key === 'q' || (event.ctrl && event.key === 'c')) {
+            return false;
+        }
+        if (event.key === 'space') {
+            this._running = !this._running;
+            this._updateDisplay();
+            return true;
+        }
+        if (event.key === 'r') {
+            this._remaining = this._phaseDuration();
+            this._updateDisplay();
+            return true;
+        }
+        return true;
+    }
+
+    protected _renderSelf(_screen: Screen): void {
+        // Child widgets handle rendering
+    }
+}
+
+// ── Application Mounting ──
+
+async function main() {
+    const pomodoroApp = new PomodoroApp();
+    const centerLayout = new Center({}, { horizontal: true, vertical: true });
+    centerLayout.addChild(pomodoroApp);
+
+    const app = new App(centerLayout, {
+        fullscreen: true,
+        title: 'Pomodoro Timer',
+        fps: 30,
+    });
+
+    const tickInterval = setInterval(() => {
+        pomodoroApp.tick();
+        app.requestRender();
+    }, 1000);
+
+    app.events.on('key', (event) => {
+        const shouldContinue = pomodoroApp.handleKey(event);
+        if (!shouldContinue) {
+            clearInterval(tickInterval);
+            app.exit(0);
+        }
+        app.requestRender();
+    });
+
+    const exitCode = await app.mount();
+    clearInterval(tickInterval);
+    process.exit(exitCode);
+}
+
+main().catch((err) => {
+    console.error('Pomodoro timer error:', err);
+    process.exit(1);
+});

--- a/examples/pomodoro-timer/tsconfig.json
+++ b/examples/pomodoro-timer/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions":{
+        "outDir":"dist",
+        "rootDir":"src",
+        "jsx":"react-jsx",
+        "jsxImportSource": "@termuijs/jsx",
+        "lib": ["ES2022"],
+        "types": ["node"]
+    },
+    "include":["src/**/*"],
+    "exclude": ["node_modules","dist"]
+}


### PR DESCRIPTION
## Description

Adds a terminal-based Pomodoro timer example app with 25min work / 5min break countdown loop, progress bar, toast notifications, and motion pulse on phase transition.

## Related Issue

Closes #520 

## Which package(s)?

- examples/pomodoro-timer

## Type of Change

Feature (type:feature)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] I'm a GSSoC 2026 contributor.
- GSSoC profile: `https://gssoc.girlscript.org/profile/6e1bbb53-448c-4f69-962a-dfe4a0e6a325`

## Screenshots / Recordings (UI changes)

<img width="1364" height="718" alt="WhatsApp Image 2026-06-04 at 23 48 08" src="https://github.com/user-attachments/assets/4848d604-544a-405f-9d2b-3afc1cf16e0a" />


## Notes for the Reviewer
Followed examples/calculator/ pattern exactly. 
All three checks pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Pomodoro timer example app with configurable work/break phases.
  * Controls: pause/resume (Space), reset phase (r), and exit (q / Ctrl+C).
  * UI: timer display, progress bar, status text, and brief animated toast on phase transitions.

* **Chores**
  * Example project scaffolded with TypeScript config, dev/start scripts, and typecheck setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->