### PR TITLE
feat(widgets): add Breadcrumbs widget

### DIFF
--- a/packages/widgets/src/display/Breadcrumbs.test.ts
+++ b/packages/widgets/src/display/Breadcrumbs.test.ts
@@ -1,0 +1,95 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for Breadcrumbs widget
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Breadcrumbs } from './Breadcrumbs.js';
+import { Screen, caps } from '@termuijs/core';
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+function rowText(screen: Screen, row: number): string {
+    return screen.back[row].map(c => c.char).join('').trimEnd();
+}
+
+describe('Breadcrumbs', () => {
+    it('renders all segments with separators', () => {
+        const bc = new Breadcrumbs(['Home', 'Docs', 'API']);
+        const screen = new Screen(40, 1);
+        bc.updateRect({ x: 0, y: 0, width: 40, height: 1 });
+        bc.render(screen);
+
+        const row = rowText(screen, 0);
+        expect(row).toContain('Home');
+        expect(row).toContain('Docs');
+        expect(row).toContain('API');
+        const sep = caps.unicode ? '❯' : '>';
+        expect(row).toContain(` ${sep} `);
+    });
+
+    it('last segment renders in the active color', () => {
+        const bc = new Breadcrumbs(['Home', 'API'], {}, { activeColor: { type: 'named', name: 'yellow' } });
+        const screen = new Screen(40, 1);
+        bc.updateRect({ x: 0, y: 0, width: 40, height: 1 });
+        bc.render(screen);
+
+        // "Home ❯ API"
+        // Let's find 'A'
+        const aCell = screen.back[0].find(c => c.char === 'A');
+        expect(aCell).toBeDefined();
+        expect(aCell!.fg).toEqual({ type: 'named', name: 'yellow' });
+    });
+
+    it('narrow width truncates leading segments to an ellipsis', () => {
+        const bc = new Breadcrumbs(['Home', 'Docs', 'API']);
+        const screen = new Screen(15, 1);
+        bc.updateRect({ x: 0, y: 0, width: 15, height: 1 });
+        bc.render(screen);
+
+        const row = rowText(screen, 0);
+        expect(row).not.toContain('Home');
+        const ellipsis = caps.unicode ? '…' : '...';
+        expect(row).toContain(ellipsis);
+        expect(row).toContain('API');
+    });
+
+    it('setSegments replaces the rendered output', () => {
+        const bc = new Breadcrumbs(['A', 'B']);
+        const screen = new Screen(40, 1);
+        bc.updateRect({ x: 0, y: 0, width: 40, height: 1 });
+        
+        bc.setSegments(['X', 'Y']);
+        bc.render(screen);
+
+        const row = rowText(screen, 0);
+        expect(row).toContain('X');
+        expect(row).toContain('Y');
+        expect(row).not.toContain('A');
+    });
+
+    it('ASCII fallback separator renders when caps.unicode is false', async () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+        const { Breadcrumbs } = await import('./Breadcrumbs.js');
+        
+        const bc = new Breadcrumbs(['A', 'B']);
+        const screen = new Screen(40, 1);
+        bc.updateRect({ x: 0, y: 0, width: 40, height: 1 });
+        bc.render(screen);
+
+        const row = rowText(screen, 0);
+        expect(row).toContain('A > B');
+        expect(row).not.toContain('❯');
+    });
+
+    it('uses custom separator when provided', () => {
+        const bc = new Breadcrumbs(['A', 'B'], {}, { separator: '/' });
+        const screen = new Screen(40, 1);
+        bc.updateRect({ x: 0, y: 0, width: 40, height: 1 });
+        bc.render(screen);
+
+        const row = rowText(screen, 0);
+        expect(row).toContain('A / B');
+    });
+});

--- a/packages/widgets/src/display/Breadcrumbs.ts
+++ b/packages/widgets/src/display/Breadcrumbs.ts
@@ -1,0 +1,97 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Breadcrumbs widget
+// ─────────────────────────────────────────────────────
+
+import { type Screen, type Style, type Color, stringWidth, caps, styleToCellAttrs } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export interface BreadcrumbsOptions {
+    /** Separator drawn between segments. Default: caps.unicode ? '❯' : '>' */
+    separator?: string;
+    /** Color of the last (current) segment. Default: cyan */
+    activeColor?: Color;
+}
+
+/**
+ * Breadcrumbs — renders a non-interactive path trail of segments with separators and truncation.
+ *
+ * Example output:
+ *   Home ❯ Docs ❯ API
+ */
+export class Breadcrumbs extends Widget {
+    private _segments: string[];
+    private _separator?: string;
+    private _activeColor?: Color;
+
+    constructor(segments: string[], style: Partial<Style> = {}, opts: BreadcrumbsOptions = {}) {
+        super(style);
+        this._segments = segments;
+        this._separator = opts.separator;
+        this._activeColor = opts.activeColor;
+    }
+
+    /** Update the trail of segments. */
+    setSegments(segments: string[]): void {
+        this._segments = segments;
+        this.markDirty();
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width } = this._rect;
+        if (width <= 0 || this._segments.length === 0) return;
+
+        const attrs = styleToCellAttrs(this._style);
+        const activeColor: Color = this._activeColor ?? { type: 'named', name: 'cyan' };
+        const separatorChar = this._separator ?? (caps.unicode ? '❯' : '>');
+        const ellipsis = caps.unicode ? '…' : '...';
+        const sep = ` ${separatorChar} `;
+
+        let visibleSegments = [...this._segments];
+        let text = visibleSegments.join(sep);
+        let tw = stringWidth(text);
+
+        // Truncate from the left if it exceeds width
+        while (tw > width && visibleSegments.length > 1) {
+            visibleSegments.shift();
+            text = ellipsis + sep + visibleSegments.join(sep);
+            tw = stringWidth(text);
+        }
+
+        const hasTruncated = visibleSegments.length < this._segments.length;
+        
+        let currentX = x;
+        const renderList: Array<{ type: 'normal' | 'separator' | 'active', text: string }> = [];
+
+        if (hasTruncated) {
+            renderList.push({ type: 'normal', text: ellipsis });
+        }
+
+        for (let i = 0; i < visibleSegments.length; i++) {
+            if (i > 0 || hasTruncated) {
+                renderList.push({ type: 'separator', text: sep });
+            }
+            const isLast = i === visibleSegments.length - 1;
+            renderList.push({ 
+                type: isLast ? 'active' : 'normal', 
+                text: visibleSegments[i] 
+            });
+        }
+
+        // Render each part
+        for (const item of renderList) {
+            const itemWidth = stringWidth(item.text);
+            if (currentX - x >= width) break;
+            
+            const remainingWidth = width - (currentX - x);
+            const str = item.text;
+            
+            const itemAttrs = { ...attrs };
+            if (item.type === 'active') {
+                itemAttrs.fg = activeColor;
+            }
+            
+            screen.writeString(currentX, y, str.slice(0, remainingWidth), itemAttrs);
+            currentX += stringWidth(str.slice(0, remainingWidth));
+        }
+    }
+}

--- a/packages/widgets/src/display/Breadcrumbs.ts
+++ b/packages/widgets/src/display/Breadcrumbs.ts
@@ -37,8 +37,8 @@ export class Breadcrumbs extends Widget {
     }
 
     protected _renderSelf(screen: Screen): void {
-        const { x, y, width } = this._rect;
-        if (width <= 0 || this._segments.length === 0) return;
+        const { x, y, width, height } = this._getContentRect();
+        if (width <= 0 || height <= 0 || this._segments.length === 0) return;
 
         const attrs = styleToCellAttrs(this._style);
         const activeColor: Color = this._activeColor ?? { type: 'named', name: 'cyan' };
@@ -58,16 +58,25 @@ export class Breadcrumbs extends Widget {
         }
 
         const hasTruncated = visibleSegments.length < this._segments.length;
+        let showEllipsis = hasTruncated;
+        
+        // If width is so narrow that ellipsis + separator consumes all space,
+        // hide them so at least part of the final segment stays visible.
+        if (showEllipsis && visibleSegments.length === 1) {
+            if (stringWidth(ellipsis + sep) >= width) {
+                showEllipsis = false;
+            }
+        }
         
         let currentX = x;
         const renderList: Array<{ type: 'normal' | 'separator' | 'active', text: string }> = [];
 
-        if (hasTruncated) {
+        if (showEllipsis) {
             renderList.push({ type: 'normal', text: ellipsis });
         }
 
         for (let i = 0; i < visibleSegments.length; i++) {
-            if (i > 0 || hasTruncated) {
+            if (i > 0 || (showEllipsis && hasTruncated)) {
                 renderList.push({ type: 'separator', text: sep });
             }
             const isLast = i === visibleSegments.length - 1;

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -119,6 +119,9 @@ export { Hexdump } from './data/Hexdump.js';
 export type { HexdumpOptions } from './data/Hexdump.js';
 
 // ── New Display Widgets ───────────────────────────────
+export { Breadcrumbs } from './display/Breadcrumbs.js';
+export type { BreadcrumbsOptions } from './display/Breadcrumbs.js';
+
 export { BigText } from './display/BigText.js';
 export type { BigTextOptions } from './display/BigText.js';
 export { Gradient } from './display/Gradient.js';


### PR DESCRIPTION
## Description

Implements the Breadcrumbs widget as per the spec in #471.
- Renders non-interactive trail of segments separated by a custom or default separator (❯ or > based on caps.unicode)
- Colors the last segment with the activeColor (default: cyan)
- Truncates leading segments to an ellipsis if width is insufficient
- Handles zero width or empty segments gracefully

## Related Issue

Closes #471

## Which package(s)?

@termuijs/widgets

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/Satvik-art-creator`

## Screenshots / Recordings (UI changes)

N/A — No UI changes to existing apps; this is a new widget component.

## Notes for the Reviewer

All acceptance criteria from the issue are met, and the test suite covers rendering, truncation, color updates, and ASCII fallbacks. No external packages were modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New breadcrumb navigation widget with configurable separator (Unicode or ASCII), active-segment color, and dynamic segment updates.
  * Automatic left-side truncation with ellipsis for narrow displays, preserving the last segment.

* **Tests**
  * Added test coverage verifying separators, active-color rendering, truncation/ellipsis behavior, segment replacement, and ASCII fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->