### PR TITLE
feat(widgets): add PieChart widget

### DIFF
--- a/packages/widgets/src/data/PieChart.test.ts
+++ b/packages/widgets/src/data/PieChart.test.ts
@@ -1,0 +1,90 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for PieChart
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Screen, caps } from '@termuijs/core';
+import { PieChart } from './PieChart.js';
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+const gridText = (screen: Screen): string =>
+    screen.back.map(row => row.map(c => c.char).join('')).join('\n');
+
+describe('PieChart', () => {
+    it('renders a legend below the chart with label and percentage', () => {
+        const pie = new PieChart({
+            slices: [
+                { label: 'TypeScript', value: 60, color: 'blue' },
+                { label: 'JavaScript', value: 30, color: 'yellow' },
+                { label: 'Other', value: 10, color: 'gray' },
+            ],
+        });
+        pie.updateRect({ x: 0, y: 0, width: 20, height: 10 });
+        const screen = new Screen(20, 10);
+        pie.render(screen);
+
+        const text = gridText(screen);
+        expect(text).toContain('TypeScript');
+        expect(text).toContain('JavaScript');
+        expect(text).toContain('Other');
+        expect(text).toContain('60%');
+        expect(text).toContain('30%');
+        expect(text).toContain('10%');
+    });
+
+    it('renders proportional slices using unicode block chars', () => {
+        const pie = new PieChart({
+            slices: [
+                { label: 'Big', value: 90, color: 'red' },
+                { label: 'Tiny', value: 10, color: 'green' },
+            ],
+        });
+        pie.updateRect({ x: 0, y: 0, width: 20, height: 10 });
+        const screen = new Screen(20, 10);
+        pie.render(screen);
+
+        const allText = gridText(screen);
+        // The unicode pie should produce block characters
+        expect(allText).toContain('\u2588');
+        // The percentages in the legend should round to the expected values
+        expect(allText).toContain('90%');
+        expect(allText).toContain('10%');
+    });
+
+    it('uses ASCII bar chart fallback when unicode is off', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+        const pie = new PieChart({
+            slices: [
+                { label: 'A', value: 70, color: 'red' },
+                { label: 'B', value: 30, color: 'blue' },
+            ],
+        });
+        pie.updateRect({ x: 0, y: 0, width: 30, height: 10 });
+        const screen = new Screen(30, 10);
+        pie.render(screen);
+
+        const allText = gridText(screen);
+        // No block char, only ASCII '#'
+        expect(allText).not.toContain('\u2588');
+        expect(allText).toContain('#');
+    });
+
+    it('a single slice fills 100% of the pie', () => {
+        const pie = new PieChart({
+            slices: [
+                { label: 'All', value: 100, color: 'cyan' },
+            ],
+        });
+        pie.updateRect({ x: 0, y: 0, width: 20, height: 10 });
+        const screen = new Screen(20, 10);
+        pie.render(screen);
+
+        const allText = gridText(screen);
+        expect(allText).toContain('100%');
+        // The pie portion should be filled with the block char
+        expect(allText).toContain('\u2588');
+    });
+});

--- a/packages/widgets/src/data/PieChart.ts
+++ b/packages/widgets/src/data/PieChart.ts
@@ -1,0 +1,156 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — PieChart widget
+//
+// Renders proportional slices using block characters
+// (Unicode) or a horizontal bar chart (ASCII fallback),
+// with a legend below.
+// ─────────────────────────────────────────────────────
+
+import {
+    type Screen,
+    type Style,
+    type Color,
+    styleToCellAttrs,
+    caps,
+    parseColor,
+    truncate,
+} from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export interface PieSlice {
+    label: string;
+    value: number;
+    color: string | Color;
+}
+
+export interface PieChartOptions {
+    slices?: PieSlice[];
+    style?: Partial<Style>;
+    showLegend?: boolean;
+}
+
+const LEGEND_BULLET_UNICODE = '\u25CF';
+const LEGEND_BULLET_ASCII = '*';
+
+export class PieChart extends Widget {
+    private _slices: PieSlice[];
+    private _showLegend: boolean;
+
+    constructor(options: PieChartOptions = {}) {
+        super(options.style);
+        this._slices = options.slices ?? [];
+        this._showLegend = options.showLegend ?? true;
+    }
+
+    get slices(): ReadonlyArray<PieSlice> { return this._slices; }
+
+    setSlices(slices: PieSlice[]): void {
+        this._slices = slices;
+        this.markDirty();
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const rect = this._getContentRect();
+        const { x, y, width, height } = rect;
+        if (width <= 0 || height <= 0) return;
+
+        if (this._slices.length === 0) return;
+
+        const totalHeight = this._showLegend ? Math.max(0, height - this._slices.length) : height;
+        if (totalHeight <= 0) {
+            this._renderLegend(screen, x, y, width);
+            return;
+        }
+
+        if (caps.unicode) {
+            this._renderPie(screen, x, y, width, totalHeight);
+        } else {
+            this._renderBars(screen, x, y, width, totalHeight);
+        }
+
+        if (this._showLegend) {
+            this._renderLegend(screen, x, y + totalHeight, width);
+        }
+    }
+
+    // ── Unicode pie ──────────────────────────────────
+
+    private _renderPie(screen: Screen, ox: number, oy: number, width: number, height: number): void {
+        const total = this._total();
+        if (total <= 0) return;
+
+        const cx = (width - 1) / 2;
+        const cy = (height - 1) / 2;
+        // Each cell is ~2x taller than wide; scale vertical to match.
+        const radius = Math.min(cx, cy * 2);
+
+        for (let row = 0; row < height; row++) {
+            for (let col = 0; col < width; col++) {
+                const dx = col - cx;
+                const dy = (row - cy) * 2;
+                const r = Math.sqrt(dx * dx + dy * dy);
+                if (r > radius) continue;
+
+                const slice = this._findSliceAt(dx, dy, total);
+                if (!slice) continue;
+                screen.setCell(ox + col, oy + row, { char: '\u2588', fg: this._colorOf(slice) });
+            }
+        }
+    }
+
+    private _findSliceAt(dx: number, dy: number, total: number): PieSlice | null {
+        // 0 rad = up, clockwise
+        const angle = Math.atan2(dx, -dy);
+        const normalized = (angle + Math.PI * 2) % (Math.PI * 2);
+        let cumulative = 0;
+        for (const slice of this._slices) {
+            if (slice.value <= 0) continue;
+            const sliceAngle = (slice.value / total) * Math.PI * 2;
+            if (normalized < cumulative + sliceAngle) return slice;
+            cumulative += sliceAngle;
+        }
+        return this._slices[this._slices.length - 1] ?? null;
+    }
+
+    // ── ASCII bar fallback ──────────────────────────
+
+    private _renderBars(screen: Screen, ox: number, oy: number, width: number, height: number): void {
+        const total = this._total();
+        if (total <= 0) return;
+        const maxValue = Math.max(...this._slices.map(s => s.value));
+        if (maxValue <= 0) return;
+
+        const usable = Math.max(1, width - 8);
+        for (let i = 0; i < this._slices.length && i < height; i++) {
+            const slice = this._slices[i];
+            if (!slice) continue;
+            const barLen = Math.round((slice.value / maxValue) * usable);
+            const pct = Math.round((slice.value / total) * 100);
+            const line = '#'.repeat(barLen).padEnd(usable) + ` ${String(pct).padStart(3)}%`;
+            screen.writeString(ox, oy + i, line.slice(0, width), { ...styleToCellAttrs(this._style), fg: this._colorOf(slice) });
+        }
+    }
+
+    // ── Legend ───────────────────────────────────────
+
+    private _renderLegend(screen: Screen, ox: number, oy: number, width: number): void {
+        const total = this._total();
+        const bullet = caps.unicode ? LEGEND_BULLET_UNICODE : LEGEND_BULLET_ASCII;
+        const attrs = styleToCellAttrs(this._style);
+        for (let i = 0; i < this._slices.length; i++) {
+            const slice = this._slices[i];
+            if (!slice) continue;
+            const pct = total > 0 ? Math.round((slice.value / total) * 100) : 0;
+            const text = `${bullet} ${slice.label} ${pct}%`;
+            screen.writeString(ox, oy + i, truncate(text, width), { ...attrs, fg: this._colorOf(slice) });
+        }
+    }
+
+    private _total(): number {
+        return this._slices.reduce((s, x) => s + (x.value > 0 ? x.value : 0), 0);
+    }
+
+    private _colorOf(slice: PieSlice): Color {
+        return typeof slice.color === 'string' ? parseColor(slice.color) : slice.color;
+    }
+}

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -175,6 +175,8 @@ export type { MarqueeDirection, MarqueeOptions } from './display/Marquee.js';
 export { DataGrid } from './data/DataGrid.js';
 export { DataGrid as DataGridView } from './data/DataGrid.js';
 export type { DataGridColumn, DataGridRow, DataGridOptions, SortDirection } from './data/DataGrid.js';
+export { PieChart } from './data/PieChart.js';
+export type { PieSlice, PieChartOptions } from './data/PieChart.js';
 
 export {
     BarColumn,


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description
Adds `PieChart` to `@termuijs/widgets` — proportional slices rendered as a Unicode block pie or ASCII horizontal bars, with a percentage legend below.

<!-- What does this PR do? 1 to 3 sentences. -->

## Related Issue
<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #39

## Which package(s)?
- `@termuijs/widgets`

<!-- Example: @termuijs/core, @termuijs/widgets, website. -->

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist
- [x] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run packages/widgets/src/data/PieChart.test.ts` — 4/4
- [x] Build passes
- [x] Typecheck passes
- [x] PR title follows `type: short description`.
- [x] State mutators call `markDirty()`.
- [x] No `any` types added.
- [x] No unrelated refactors.

## GSSoC 2026 Participation
- [x] You are a GSSoC 2026 contributor.

## Screenshots / Recordings (UI changes)
<img width="636" height="450" alt="image" src="https://github.com/user-attachments/assets/bd0a497c-5091-4c96-bc51-2b480715a656" />

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer
## Notes for the Reviewer
- API: `new PieChart({ slices: [{ label, value, color }], showLegend? })`.
- `color` accepts a `Color` object or a string (parsed via `parseColor`).
- Unicode pie uses `█` block chars; ASCII fallback is a `#` bar chart with `value%` per row.
- Each cell treated as 1 col × 2 rows (terminal aspect) for circular geometry.

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added PieChart widget for visualizing data with customizable slices and values
  * Automatic legend rendering with slice labels and percentages
  * Intelligent rendering that adapts between Unicode and ASCII display based on terminal capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->