### PR TITLE
perf(widgets): skip redundant markDirty calls

### DIFF
--- a/packages/widgets/src/feedback/Banner.test.ts
+++ b/packages/widgets/src/feedback/Banner.test.ts
@@ -245,4 +245,22 @@ describe('Banner', () => {
         banner.setVariant('success');
         expect(spy).toHaveBeenCalledTimes(3);
     });
+
+    it('does not mark dirty when title is unchanged', () => {
+        const banner = new Banner({}, { title: 'Hello' });
+    
+        banner.clearDirty();
+        banner.setTitle('Hello');
+    
+        expect(banner.isDirty).toBe(false);
+    });
+    
+    it('does not mark dirty when body is unchanged', () => {
+        const banner = new Banner({}, { body: 'World' });
+    
+        banner.clearDirty();
+        banner.setBody('World');
+    
+        expect(banner.isDirty).toBe(false);
+    });
 });

--- a/packages/widgets/src/feedback/Banner.ts
+++ b/packages/widgets/src/feedback/Banner.ts
@@ -47,16 +47,22 @@ export class Banner extends Widget {
     }
 
     setTitle(title: string): void {
+        if (this._title === title) return;
+
         this._title = title;
         this.markDirty();
     }
 
     setBody(body: string): void {
+        if (this._body === body) return;
+
         this._body = body;
         this.markDirty();
     }
 
     setVariant(variant: StatusVariant): void {
+        if (this._variant === variant) return;
+        
         this._variant = variant;
         this.markDirty();
     }

--- a/packages/widgets/src/input/Button.test.ts
+++ b/packages/widgets/src/input/Button.test.ts
@@ -157,4 +157,22 @@ describe('Button', () => {
         expect(screen.back[0][1].char).toBe('-');
         expect(screen.back[1][0].char).toBe('|');
     });
+
+    it('does not mark dirty when label is unchanged', () => {
+        const button = new Button('Save');
+    
+        button.clearDirty();
+        button.setLabel('Save');
+    
+        expect(button.isDirty).toBe(false);
+    });
+    
+    it('does not mark dirty when disabled state is unchanged', () => {
+        const button = new Button('Save');
+    
+        button.clearDirty();
+        button.setDisabled(false);
+    
+        expect(button.isDirty).toBe(false);
+    });
 });

--- a/packages/widgets/src/input/Button.ts
+++ b/packages/widgets/src/input/Button.ts
@@ -53,11 +53,15 @@ export class Button extends Widget {
     }
 
     setLabel(label: string): void {
+        if (this._label === label) return;
+
         this._label = label;
         this.markDirty();
     }
 
     setDisabled(disabled: boolean): void {
+        if (this._disabled === disabled) return;
+        
         this._disabled = disabled;
         this.markDirty();
     }

--- a/packages/widgets/src/layout/ScrollView.test.ts
+++ b/packages/widgets/src/layout/ScrollView.test.ts
@@ -151,4 +151,13 @@ describe('ScrollView', () => {
         sv.handleKey(key('pageup'));
         expect(sv.scrollOffset).toBe(6);
     });
+
+    it('does not mark dirty when content height is unchanged', () => {
+        const view = new ScrollView({}, { contentHeight: 10 });
+    
+        view.clearDirty();
+        view.setContentHeight(10);
+    
+        expect(view.isDirty).toBe(false);
+    });
 });

--- a/packages/widgets/src/layout/ScrollView.ts
+++ b/packages/widgets/src/layout/ScrollView.ts
@@ -32,6 +32,8 @@ export class ScrollView extends Widget {
 
     /** Set the total content height (in rows) */
     setContentHeight(h: number): void {
+        if (this._contentHeight === h) return;
+
         this._contentHeight = h;
         this._clampOffset();
         this.markDirty();
@@ -49,9 +51,14 @@ export class ScrollView extends Widget {
 
     /** Scroll to absolute offset */
     scrollTo(offset: number): void {
+        const previousOffset = this._scrollOffset;
+    
         this._scrollOffset = offset;
         this._clampOffset();
-        this.markDirty();
+    
+        if (previousOffset !== this._scrollOffset) {
+            this.markDirty();
+        }
     }
 
     private _clampOffset(): void {


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description
Avoids unnecessary widget invalidation by skipping markDirty() calls when state values remain unchanged.

This PR adds equality guards to Button, Banner, and ScrollView setters so widgets are only marked dirty when their state actually changes. It also adds regression tests to ensure unchanged updates do not trigger unnecessary invalidation.

<!-- What does this PR do? 1 to 3 sentences. -->

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #752 

## Which package(s)?
@termuijs/widgets
<!-- Example: @termuijs/core, @termuijs/widgets, website. -->

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [x] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)
N/A
<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->
**Changes Made**

- Added equality guards in Button.setLabel() and Button.setDisabled()
- Added equality guards in Banner.setTitle(), Banner.setBody(), and Banner.setVariant()
- Avoided redundant invalidation in ScrollView.setContentHeight() and ScrollView.scrollTo()
- Added regression tests covering unchanged-state updates

**Validation**
✅ bun vitest run packages/widgets
<br>

**Notes**

Repository-wide typecheck currently fails in @termuijs/adapters due to an existing missing dotenv dependency, which is unrelated to this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized Banner, Button, and ScrollView widgets to skip redundant state changes when setter values remain unchanged from current values.

* **Tests**
  * Comprehensive test coverage added to verify that setter methods with unchanged values do not trigger unnecessary state updates across multiple widget types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->