### PR TITLE
test(widgets): add StatusMessage test coverage

### DIFF
--- a/packages/widgets/src/feedback/StatusMessage.test.ts
+++ b/packages/widgets/src/feedback/StatusMessage.test.ts
@@ -158,4 +158,5 @@ describe('StatusMessage', () => {
     
         expect(widget.isDirty).toBe(true);
     });
+    
 });

--- a/packages/widgets/src/feedback/StatusMessage.test.ts
+++ b/packages/widgets/src/feedback/StatusMessage.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { caps, Screen } from '@termuijs/core';
+import { StatusMessage, type StatusVariant } from './StatusMessage.js';
+
+type TestCell = {
+    char: string;
+    fg?: unknown;
+    bold?: boolean;
+};
+
+const variantColors: Record<StatusVariant, { type: 'named'; name: string }> = {
+    success: { type: 'named', name: 'green' },
+    error: { type: 'named', name: 'red' },
+    warning: { type: 'named', name: 'yellow' },
+    info: { type: 'named', name: 'cyan' },
+};
+
+function renderStatus(
+    widget: StatusMessage,
+    width = 30,
+    height = 1,
+): Screen {
+    const screen = new Screen(width, height);
+
+    widget.updateRect({
+        x: 0,
+        y: 0,
+        width,
+        height,
+    });
+
+    widget.render(screen);
+    return screen;
+}
+
+function rowText(screen: Screen, y: number): string {
+    return screen.back[y]
+        .map((cell: TestCell) => cell.char)
+        .join('');
+}
+
+function cell(screen: Screen, x: number, y: number): TestCell {
+    return screen.back[y][x] as TestCell;
+}
+
+describe('StatusMessage', () => {
+    beforeEach(() => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('renders message text', () => {
+        const screen = renderStatus(
+            new StatusMessage('Saved'),
+        );
+
+        expect(rowText(screen, 0)).toContain('Saved');
+    });
+
+    it('renders success variant', () => {
+        const screen = renderStatus(
+            new StatusMessage('Done', {}, { variant: 'success' }),
+        );
+
+        expect(cell(screen, 0, 0).char).toBe('✓');
+        expect(cell(screen, 0, 0).fg).toEqual(variantColors.success);
+    });
+
+    it('renders error variant', () => {
+        const screen = renderStatus(
+            new StatusMessage('Failed', {}, { variant: 'error' }),
+        );
+
+        expect(cell(screen, 0, 0).char).toBe('✗');
+        expect(cell(screen, 0, 0).fg).toEqual(variantColors.error);
+    });
+
+    it('renders warning variant', () => {
+        const screen = renderStatus(
+            new StatusMessage('Careful', {}, { variant: 'warning' }),
+        );
+
+        expect(cell(screen, 0, 0).char).toBe('⚠');
+        expect(cell(screen, 0, 0).fg).toEqual(variantColors.warning);
+    });
+
+    it('renders info variant', () => {
+        const screen = renderStatus(
+            new StatusMessage('Info'),
+        );
+
+        expect(cell(screen, 0, 0).char).toBe('ℹ');
+        expect(cell(screen, 0, 0).fg).toEqual(variantColors.info);
+    });
+
+    it('setMessage updates rendered text', () => {
+        const widget = new StatusMessage('Old');
+
+        widget.setMessage('New');
+
+        const screen = renderStatus(widget);
+
+        expect(rowText(screen, 0)).toContain('New');
+        expect(rowText(screen, 0)).not.toContain('Old');
+    });
+
+    it('setVariant updates icon and color', () => {
+        const widget = new StatusMessage(
+            'Message',
+            {},
+            { variant: 'info' },
+        );
+
+        widget.setVariant('success');
+
+        const screen = renderStatus(widget);
+
+        expect(cell(screen, 0, 0).char).toBe('✓');
+        expect(cell(screen, 0, 0).fg).toEqual(variantColors.success);
+    });
+
+    it('renders ASCII fallback icons', () => {
+        vi.restoreAllMocks();
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+
+        const screen = renderStatus(
+            new StatusMessage(
+                'Done',
+                {},
+                { variant: 'success' },
+            ),
+        );
+
+        expect(cell(screen, 0, 0).char).toBe('+');
+    });
+
+    it('setMessage marks widget dirty', () => {
+        const widget = new StatusMessage('Old');
+    
+        widget.clearDirty();
+        widget.setMessage('New');
+    
+        expect(widget.isDirty).toBe(true);
+    });
+    
+    it('setVariant marks widget dirty', () => {
+        const widget = new StatusMessage(
+            'Message',
+            {},
+            { variant: 'info' },
+        );
+    
+        widget.clearDirty();
+        widget.setVariant('success');
+    
+        expect(widget.isDirty).toBe(true);
+    });
+});


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

Adds dedicated test coverage for the StatusMessage widget in @termuijs/widgets. <br>
The new test suite verifies:

- message rendering
- variant rendering (success, error, warning, info)
- Unicode icon rendering
- ASCII fallback rendering
- setMessage() updates
- setVariant() updates
- dirty-state propagation after state changes

<!-- What does this PR do? 1 to 3 sentences. -->

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #762 

## Which package(s)?
@termuijs/widgets
<!-- Example: @termuijs/core, @termuijs/widgets, website. -->

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)
N/A
<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->
**Validation** <br>
✅ bun vitest run packages/widgets/src/feedback/StatusMessage.test.ts
All 10 tests pass successfully, including variant rendering, icon rendering, ASCII fallbacks, and dirty-state propagation.
<br>
**Repository Observation** <br>
While validating this contribution, I also ran repository-wide build and typecheck commands.
Both currently fail in @termuijs/adapters due to an existing missing dotenv dependency:
src/dotenv/index.ts:3:21 - error TS2307: <br>
Cannot find module 'dotenv' or its corresponding type declarations.
This issue appears unrelated to the changes in this PR, which only add test coverage for StatusMessage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive test suite for the StatusMessage widget covering Unicode vs ASCII rendering, icon and color mapping for all variants (success, error, warning, info), updates to message and variant, and dirty-state tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->