### PR TITLE
feat(ui): add TextArea widget

### DIFF
--- a/packages/ui/src/TextArea.test.ts
+++ b/packages/ui/src/TextArea.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { Screen, KeyEvent } from '@termuijs/core';
 
 afterEach(() => {
-    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
 });
 
 describe('TextArea', () => {
@@ -14,7 +14,7 @@ describe('TextArea', () => {
         const screen = new Screen(25, 4);
         textarea.render(screen);
 
-        const renderedRow = screen.back[1].map((c: any) => c.char).join('');
+        const renderedRow = screen.back[1].map((c: any /* test buffer shape not typed */) => c.char).join('');
         expect(renderedRow).toContain('Write your message');
     });
 
@@ -25,15 +25,15 @@ describe('TextArea', () => {
         textarea.isFocused = true;
         textarea.updateRect({ x: 0, y: 0, width: 20, height: 4 });
         
-        textarea.handleKey({ key: 'h' } as KeyEvent);
-        textarea.handleKey({ key: 'i' } as KeyEvent);
+        textarea.handleKey({ key: 'h' } as KeyEvent /* test supplies needed fields; omit raw/propagation */);
+        textarea.handleKey({ key: 'i' } as KeyEvent /* test supplies needed fields; omit raw/propagation */);
 
         expect(textarea.value).toBe('hi');
         expect(val).toBe('hi');
 
         const screen = new Screen(20, 4);
         textarea.render(screen);
-        const renderedRow = screen.back[1].map((c: any) => c.char).join('');
+        const renderedRow = screen.back[1].map((c: any /* test buffer shape not typed */) => c.char).join('');
         expect(renderedRow).toContain('hi');
     });
 
@@ -42,9 +42,9 @@ describe('TextArea', () => {
         const textarea = new TextArea();
         textarea.isFocused = true;
         
-        textarea.handleKey({ key: 'a' } as KeyEvent);
-        textarea.handleKey({ key: 'enter' } as KeyEvent);
-        textarea.handleKey({ key: 'b' } as KeyEvent);
+        textarea.handleKey({ key: 'a' } as KeyEvent /* test supplies needed fields; omit raw/propagation */);
+        textarea.handleKey({ key: 'enter' } as KeyEvent /* test supplies needed fields; omit raw/propagation */);
+        textarea.handleKey({ key: 'b' } as KeyEvent /* test supplies needed fields; omit raw/propagation */);
 
         expect(textarea.value).toBe('a\nb');
     });
@@ -54,23 +54,23 @@ describe('TextArea', () => {
         const textarea = new TextArea();
         textarea.isFocused = true;
 
-        textarea.handleKey({ key: '1' } as KeyEvent);
-        textarea.handleKey({ key: 'enter' } as KeyEvent);
-        textarea.handleKey({ key: '2' } as KeyEvent);
+        textarea.handleKey({ key: '1' } as KeyEvent /* test supplies needed fields; omit raw/propagation */);
+        textarea.handleKey({ key: 'enter' } as KeyEvent /* test supplies needed fields; omit raw/propagation */);
+        textarea.handleKey({ key: '2' } as KeyEvent /* test supplies needed fields; omit raw/propagation */);
         // lines are now: "1", "2"
         // cursor is at { row: 1, col: 1 }
 
-        textarea.handleKey({ key: 'up' } as KeyEvent);
+        textarea.handleKey({ key: 'up' } as KeyEvent /* test supplies needed fields; omit raw/propagation */);
         // cursor is at { row: 0, col: 1 }
-        textarea.handleKey({ key: 'left' } as KeyEvent);
+        textarea.handleKey({ key: 'left' } as KeyEvent /* test supplies needed fields; omit raw/propagation */);
         // cursor is at { row: 0, col: 0 }
-        textarea.handleKey({ key: 'x' } as KeyEvent);
+        textarea.handleKey({ key: 'x' } as KeyEvent /* test supplies needed fields; omit raw/propagation */);
 
         expect(textarea.value).toBe('x1\n2');
 
-        textarea.handleKey({ key: 'down' } as KeyEvent);
-        textarea.handleKey({ key: 'right' } as KeyEvent);
-        textarea.handleKey({ key: 'y' } as KeyEvent);
+        textarea.handleKey({ key: 'down' } as KeyEvent /* test supplies needed fields; omit raw/propagation */);
+        textarea.handleKey({ key: 'right' } as KeyEvent /* test supplies needed fields; omit raw/propagation */);
+        textarea.handleKey({ key: 'y' } as KeyEvent /* test supplies needed fields; omit raw/propagation */);
 
         expect(textarea.value).toBe('x1\n2y');
     });
@@ -81,13 +81,13 @@ describe('TextArea', () => {
         const textarea = new TextArea({}, { onSubmit: (v) => { submitted = v; } });
         textarea.isFocused = true;
         
-        textarea.handleKey({ key: 't' } as KeyEvent);
-        textarea.handleKey({ key: 'e' } as KeyEvent);
-        textarea.handleKey({ key: 's' } as KeyEvent);
-        textarea.handleKey({ key: 't' } as KeyEvent);
+        textarea.handleKey({ key: 't' } as KeyEvent /* test supplies needed fields; omit raw/propagation */);
+        textarea.handleKey({ key: 'e' } as KeyEvent /* test supplies needed fields; omit raw/propagation */);
+        textarea.handleKey({ key: 's' } as KeyEvent /* test supplies needed fields; omit raw/propagation */);
+        textarea.handleKey({ key: 't' } as KeyEvent /* test supplies needed fields; omit raw/propagation */);
 
         // Submit via Ctrl+Enter
-        textarea.handleKey({ key: 'enter', ctrl: true } as KeyEvent);
+        textarea.handleKey({ key: 'enter', ctrl: true } as KeyEvent /* test supplies needed fields; omit raw/propagation */);
 
         expect(submitted).toBe('test');
     });

--- a/packages/ui/src/TextArea.test.ts
+++ b/packages/ui/src/TextArea.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Screen, KeyEvent } from '@termuijs/core';
+
+afterEach(() => {
+    vi.unstubAllEnvs();
+});
+
+describe('TextArea', () => {
+    it('initial render shows placeholder when empty and unfocused', async () => {
+        const { TextArea } = await import('./TextArea.js');
+        const textarea = new TextArea({}, { placeholder: 'Write your message...' });
+        textarea.updateRect({ x: 0, y: 0, width: 25, height: 4 });
+        
+        const screen = new Screen(25, 4);
+        textarea.render(screen);
+
+        const renderedRow = screen.back[1].map((c: any) => c.char).join('');
+        expect(renderedRow).toContain('Write your message');
+    });
+
+    it('typing text updates the value and renders correctly', async () => {
+        const { TextArea } = await import('./TextArea.js');
+        let val = '';
+        const textarea = new TextArea({}, { onChange: (v) => { val = v; } });
+        textarea.isFocused = true;
+        textarea.updateRect({ x: 0, y: 0, width: 20, height: 4 });
+        
+        textarea.handleKey({ key: 'h' } as KeyEvent);
+        textarea.handleKey({ key: 'i' } as KeyEvent);
+
+        expect(textarea.value).toBe('hi');
+        expect(val).toBe('hi');
+
+        const screen = new Screen(20, 4);
+        textarea.render(screen);
+        const renderedRow = screen.back[1].map((c: any) => c.char).join('');
+        expect(renderedRow).toContain('hi');
+    });
+
+    it('Enter key adds a newline at the cursor position', async () => {
+        const { TextArea } = await import('./TextArea.js');
+        const textarea = new TextArea();
+        textarea.isFocused = true;
+        
+        textarea.handleKey({ key: 'a' } as KeyEvent);
+        textarea.handleKey({ key: 'enter' } as KeyEvent);
+        textarea.handleKey({ key: 'b' } as KeyEvent);
+
+        expect(textarea.value).toBe('a\nb');
+    });
+
+    it('cursor moves with up/down/left/right arrow keys', async () => {
+        const { TextArea } = await import('./TextArea.js');
+        const textarea = new TextArea();
+        textarea.isFocused = true;
+
+        textarea.handleKey({ key: '1' } as KeyEvent);
+        textarea.handleKey({ key: 'enter' } as KeyEvent);
+        textarea.handleKey({ key: '2' } as KeyEvent);
+        // lines are now: "1", "2"
+        // cursor is at { row: 1, col: 1 }
+
+        textarea.handleKey({ key: 'up' } as KeyEvent);
+        // cursor is at { row: 0, col: 1 }
+        textarea.handleKey({ key: 'left' } as KeyEvent);
+        // cursor is at { row: 0, col: 0 }
+        textarea.handleKey({ key: 'x' } as KeyEvent);
+
+        expect(textarea.value).toBe('x1\n2');
+
+        textarea.handleKey({ key: 'down' } as KeyEvent);
+        textarea.handleKey({ key: 'right' } as KeyEvent);
+        textarea.handleKey({ key: 'y' } as KeyEvent);
+
+        expect(textarea.value).toBe('x1\n2y');
+    });
+
+    it('Ctrl+Enter fires onSubmit', async () => {
+        const { TextArea } = await import('./TextArea.js');
+        let submitted = '';
+        const textarea = new TextArea({}, { onSubmit: (v) => { submitted = v; } });
+        textarea.isFocused = true;
+        
+        textarea.handleKey({ key: 't' } as KeyEvent);
+        textarea.handleKey({ key: 'e' } as KeyEvent);
+        textarea.handleKey({ key: 's' } as KeyEvent);
+        textarea.handleKey({ key: 't' } as KeyEvent);
+
+        // Submit via Ctrl+Enter
+        textarea.handleKey({ key: 'enter', ctrl: true } as KeyEvent);
+
+        expect(submitted).toBe('test');
+    });
+});

--- a/packages/ui/src/TextArea.ts
+++ b/packages/ui/src/TextArea.ts
@@ -1,0 +1,209 @@
+import { type Screen, type Style, type KeyEvent, styleToCellAttrs, caps, truncate } from '@termuijs/core';
+import { Widget } from '@termuijs/widgets';
+
+export interface TextAreaOptions {
+    /** Number of visible rows (default: 4) */
+    rows?: number;
+    placeholder?: string;
+    onChange?: (value: string) => void;
+    onSubmit?: (value: string) => void;
+}
+
+/**
+ * TextArea - a multi-line text input field.
+ *
+ * Supports:
+ * - Multi-line editing (Enter for newline)
+ * - Cursor movement (up/down/left/right)
+ * - Ctrl+Enter to submit
+ * - Horizontal/Vertical scrolling when content overflows
+ */
+export class TextArea extends Widget {
+    private _lines: string[] = [''];
+    private _cursor = { row: 0, col: 0 };
+    private _placeholder: string;
+    private _onChange?: (value: string) => void;
+    private _onSubmit?: (value: string) => void;
+
+    constructor(style: Partial<Style> = {}, options: TextAreaOptions = {}) {
+        // default rows = 4, add 2 for top/bottom single borders
+        super({ border: 'single', height: (options.rows ?? 4) + 2, ...style });
+        this._placeholder = options.placeholder ?? '';
+        this._onChange = options.onChange;
+        this._onSubmit = options.onSubmit;
+        this.focusable = true;
+    }
+
+    get value(): string {
+        return this._lines.join('\n');
+    }
+
+    set value(v: string) {
+        this._lines = v.split('\n');
+        if (this._lines.length === 0) this._lines = [''];
+        this._cursor.row = Math.min(this._cursor.row, this._lines.length - 1);
+        this._cursor.col = Math.min(this._cursor.col, this._lines[this._cursor.row].length);
+        this.markDirty();
+    }
+
+    insertChar(char: string): void {
+        const line = this._lines[this._cursor.row];
+        this._lines[this._cursor.row] = line.slice(0, this._cursor.col) + char + line.slice(this._cursor.col);
+        this._cursor.col++;
+        this._notify();
+    }
+
+    insertNewline(): void {
+        const line = this._lines[this._cursor.row];
+        const before = line.slice(0, this._cursor.col);
+        const after = line.slice(this._cursor.col);
+        this._lines[this._cursor.row] = before;
+        this._lines.splice(this._cursor.row + 1, 0, after);
+        this._cursor.row++;
+        this._cursor.col = 0;
+        this._notify();
+    }
+
+    deleteBack(): void {
+        if (this._cursor.col > 0) {
+            const line = this._lines[this._cursor.row];
+            this._lines[this._cursor.row] = line.slice(0, this._cursor.col - 1) + line.slice(this._cursor.col);
+            this._cursor.col--;
+            this._notify();
+        } else if (this._cursor.row > 0) {
+            const prevLine = this._lines[this._cursor.row - 1];
+            const curLine = this._lines[this._cursor.row];
+            this._lines.splice(this._cursor.row, 1);
+            this._cursor.row--;
+            this._cursor.col = prevLine.length;
+            this._lines[this._cursor.row] = prevLine + curLine;
+            this._notify();
+        }
+    }
+
+    moveCursorLeft(): void {
+        if (this._cursor.col > 0) {
+            this._cursor.col--;
+            this.markDirty();
+        } else if (this._cursor.row > 0) {
+            this._cursor.row--;
+            this._cursor.col = this._lines[this._cursor.row].length;
+            this.markDirty();
+        }
+    }
+
+    moveCursorRight(): void {
+        const line = this._lines[this._cursor.row];
+        if (this._cursor.col < line.length) {
+            this._cursor.col++;
+            this.markDirty();
+        } else if (this._cursor.row < this._lines.length - 1) {
+            this._cursor.row++;
+            this._cursor.col = 0;
+            this.markDirty();
+        }
+    }
+
+    moveCursorUp(): void {
+        if (this._cursor.row > 0) {
+            this._cursor.row--;
+            this._cursor.col = Math.min(this._cursor.col, this._lines[this._cursor.row].length);
+            this.markDirty();
+        }
+    }
+
+    moveCursorDown(): void {
+        if (this._cursor.row < this._lines.length - 1) {
+            this._cursor.row++;
+            this._cursor.col = Math.min(this._cursor.col, this._lines[this._cursor.row].length);
+            this.markDirty();
+        }
+    }
+
+    handleKey(event: KeyEvent): void {
+        const isEnter = event.key === 'enter' || event.key === 'return' || event.key === '\r' || event.key === '\n';
+        
+        if (isEnter && (event.ctrl || event.alt)) {
+            this._onSubmit?.(this.value);
+            return;
+        }
+        if (event.key === 's' && (event.ctrl || event.alt)) {
+            this._onSubmit?.(this.value);
+            return;
+        }
+        if (isEnter) {
+            this.insertNewline();
+            return;
+        }
+
+        switch (event.key) {
+            case 'up':    this.moveCursorUp();    break;
+            case 'down':  this.moveCursorDown();  break;
+            case 'left':  this.moveCursorLeft();  break;
+            case 'right': this.moveCursorRight(); break;
+            case 'backspace': this.deleteBack();  break;
+            case 'space': this.insertChar(' ');   break;
+            default:
+                if (event.key && event.key.length === 1 && !event.ctrl && !event.alt) {
+                    this.insertChar(event.key);
+                }
+                break;
+        }
+    }
+
+    private _notify(): void {
+        this._onChange?.(this.value);
+        this.markDirty();
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const rect = this._getContentRect();
+        const { x, y, width, height } = rect;
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this._style);
+
+        const isEmpty = this._lines.length === 1 && this._lines[0] === '';
+        if (isEmpty && !this.isFocused && this._placeholder) {
+            screen.writeString(x, y, truncate(this._placeholder, width), { ...attrs, dim: true });
+            return;
+        }
+
+        // Scroll Y to keep cursor visible
+        let scrollY = 0;
+        if (this._cursor.row >= height) {
+            scrollY = this._cursor.row - height + 1;
+        }
+
+        // Scroll X to keep cursor visible
+        let scrollX = 0;
+        if (this._cursor.col >= width) {
+            scrollX = this._cursor.col - width + 1;
+        }
+
+        // Render visible lines
+        for (let r = 0; r < height; r++) {
+            const lineIdx = r + scrollY;
+            if (lineIdx >= this._lines.length) break;
+            const lineStr = this._lines[lineIdx];
+            const visibleText = lineStr.slice(scrollX, scrollX + width).padEnd(width, ' ').slice(0, width);
+            screen.writeString(x, y + r, visibleText, attrs);
+        }
+
+        // Draw cursor
+        if (this.isFocused) {
+            const screenRow = this._cursor.row - scrollY;
+            const screenCol = this._cursor.col - scrollX;
+            if (screenRow >= 0 && screenRow < height && screenCol >= 0 && screenCol < width) {
+                const lineStr = this._lines[this._cursor.row] || '';
+                const cursorChar = this._cursor.col < lineStr.length ? lineStr[this._cursor.col] : ' ';
+                const cursorGlyph = caps.unicode ? cursorChar : cursorChar;
+                screen.setCell(x + screenCol, y + screenRow, {
+                    char: cursorGlyph,
+                    ...attrs,
+                    inverse: true,
+                });
+            }
+        }
+    }
+}

--- a/packages/ui/src/TextArea.ts
+++ b/packages/ui/src/TextArea.ts
@@ -197,7 +197,8 @@ export class TextArea extends Widget {
             if (screenRow >= 0 && screenRow < height && screenCol >= 0 && screenCol < width) {
                 const lineStr = this._lines[this._cursor.row] || '';
                 const cursorChar = this._cursor.col < lineStr.length ? lineStr[this._cursor.col] : ' ';
-                const cursorGlyph = caps.unicode ? cursorChar : cursorChar;
+                const asciiFallback = cursorChar === ' ' ? '_' : cursorChar;
+                const cursorGlyph = caps.unicode ? cursorChar : asciiFallback;
                 screen.setCell(x + screenCol, y + screenRow, {
                     char: cursorGlyph,
                     ...attrs,

--- a/packages/ui/src/TextArea.ts
+++ b/packages/ui/src/TextArea.ts
@@ -1,4 +1,4 @@
-import { type Screen, type Style, type KeyEvent, styleToCellAttrs, caps, truncate } from '@termuijs/core';
+import { type Screen, type Style, type KeyEvent, styleToCellAttrs, caps, truncate, mergeStyles, defaultStyle } from '@termuijs/core';
 import { Widget } from '@termuijs/widgets';
 
 export interface TextAreaOptions {
@@ -27,7 +27,7 @@ export class TextArea extends Widget {
 
     constructor(style: Partial<Style> = {}, options: TextAreaOptions = {}) {
         // default rows = 4, add 2 for top/bottom single borders
-        super({ border: 'single', height: (options.rows ?? 4) + 2, ...style });
+        super(mergeStyles(defaultStyle(), { border: 'single', height: (options.rows ?? 4) + 2, ...style }));
         this._placeholder = options.placeholder ?? '';
         this._onChange = options.onChange;
         this._onSubmit = options.onSubmit;
@@ -121,6 +121,7 @@ export class TextArea extends Widget {
     }
 
     handleKey(event: KeyEvent): void {
+        this.markDirty();
         const isEnter = event.key === 'enter' || event.key === 'return' || event.key === '\r' || event.key === '\n';
         
         if (isEnter && (event.ctrl || event.alt)) {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -161,6 +161,9 @@ export type { MultilineTextInputOptions } from './MultilineTextInput.js';
 export {BasicAuthPrompt} from './BasicAuthPrompt.js';
 export type {BasicAuthCredentials,BasicAuthPromptOptions} from './BasicAuthPrompt.js'
 
+export { TextArea } from './TextArea.js';
+export type { TextAreaOptions } from './TextArea.js';
+
 
 export { Stepper } from './Stepper.js';
 export type { StepperOptions } from './Stepper.js';


### PR DESCRIPTION
Closes #36 

This PR introduces the `TextArea` widget to the `@termuijs/ui` package, implementing a multi-line editable text field.

**Changes made:**
- Created `TextArea.ts` adhering to the acceptance criteria (handles multi-line input, backspace, cursor movement, scrolling).
- Added `markDirty()` on all keystrokes.
- Exported the widget via `packages/ui/src/index.ts`.
- Included a comprehensive test suite in `TextArea.test.ts` with 5 passing tests covering initial render, typing, newline insertion, cursor movement, and `Ctrl+Enter`/`onSubmit`.
- Checked everything with `bun run build && bun vitest run && bun run typecheck` which passed perfectly.


Screenshot of the terminal window added here 
<img width="614" height="269" alt="Screenshot 2026-06-05 165300" src="https://github.com/user-attachments/assets/a4914dc7-ee7b-4e41-8cda-36a20a457991" />


**A note on the `Ctrl+Enter` requirement:**
The code strictly implements detection of `Ctrl+Enter` and successfully passes the automated tests for it. However, it is a known physical limitation of standard Windows terminal emulators (like Command Prompt and PowerShell) that they intercept the `Ctrl` key and send a bare `Enter` byte (`13`) instead of passing the modifier. Therefore, while `Ctrl+Enter` is perfectly implemented and tested in the code, users on standard Windows terminals will physically not be able to trigger it and must rely on `Alt+Enter` or a more advanced terminal emulator (like Alacritty/Kitty).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new TextArea widget component supporting multi-line text input with configurable placeholder text and row count.
  * TextArea includes full keyboard navigation for editing, cursor movement, newline insertion, and customizable callbacks for text changes and submission events.
  * Placeholder displays dim styling when empty and unfocused; content scrolls to keep the cursor visible.

* **Tests**
  * Added comprehensive test coverage exercising rendering, editing, keyboard navigation, newline behavior, and submit handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->