### PR TITLE
fix(jsx): scope memo() cache per fiber instance

### DIFF
--- a/packages/jsx/src/memo.test.ts
+++ b/packages/jsx/src/memo.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { memo, shallowEqual } from './memo.js';
+import { createFiber, setCurrentFiber, clearCurrentFiber } from './hooks.js';
 import type { VNode } from './vnode.js';
 
 describe('shallowEqual', () => {
@@ -51,9 +52,12 @@ describe('memo', () => {
     it('skips re-render when props are equal', () => {
         const component = vi.fn((props: { label: string }) => `text:${props.label}` as unknown as VNode);
         const Memoized = memo(component);
+        const fiber = createFiber();
 
+        setCurrentFiber(fiber);
         const result1 = Memoized({ label: 'hello' });
         const result2 = Memoized({ label: 'hello' });
+        clearCurrentFiber();
 
         expect(component).toHaveBeenCalledOnce();
         expect(result1).toBe(result2);
@@ -72,11 +76,75 @@ describe('memo', () => {
     it('supports custom comparison function', () => {
         const component = vi.fn((props: { id: number; label: string }) => `text:${props.label}` as unknown as VNode);
         const Memoized = memo(component, (prev, next) => prev.id === next.id);
+        const fiber = createFiber();
 
+        setCurrentFiber(fiber);
         Memoized({ id: 1, label: 'hello' });
         Memoized({ id: 1, label: 'changed' }); // same id, different label
+        clearCurrentFiber();
 
         expect(component).toHaveBeenCalledOnce(); // skipped because id is same
+    });
+
+    it('two sibling instances render their own props independently', () => {
+        const component = vi.fn((props: { text: string }) => `label:${props.text}` as unknown as VNode);
+        const MemoLabel = memo(component);
+        const fiberA = createFiber();
+        const fiberB = createFiber();
+
+        setCurrentFiber(fiberA);
+        const resultA = MemoLabel({ text: 'alpha' });
+        clearCurrentFiber();
+
+        setCurrentFiber(fiberB);
+        const resultB = MemoLabel({ text: 'beta' });
+        clearCurrentFiber();
+
+        expect(resultA).toBe('label:alpha');
+        expect(resultB).toBe('label:beta');
+        expect(component).toHaveBeenCalledTimes(2);
+    });
+
+    it('caches result per instance so same props skip re-render', () => {
+        const component = vi.fn((props: { text: string }) => `label:${props.text}` as unknown as VNode);
+        const MemoLabel = memo(component);
+        const fiber = createFiber();
+
+        setCurrentFiber(fiber);
+        const result1 = MemoLabel({ text: 'same' });
+        const result2 = MemoLabel({ text: 'same' });
+        clearCurrentFiber();
+
+        expect(component).toHaveBeenCalledOnce();
+        expect(result1).toBe(result2);
+    });
+
+    it('updating one instance does not affect sibling cache', () => {
+        const component = vi.fn((props: { text: string }) => `label:${props.text}` as unknown as VNode);
+        const MemoLabel = memo(component);
+        const fiberA = createFiber();
+        const fiberB = createFiber();
+
+        setCurrentFiber(fiberA);
+        MemoLabel({ text: 'first' });
+        clearCurrentFiber();
+
+        setCurrentFiber(fiberB);
+        const resultB1 = MemoLabel({ text: 'second' });
+        clearCurrentFiber();
+
+        setCurrentFiber(fiberA);
+        MemoLabel({ text: 'updated' });
+        clearCurrentFiber();
+
+        setCurrentFiber(fiberB);
+        const resultB2 = MemoLabel({ text: 'second' });
+        clearCurrentFiber();
+
+        expect(resultB1).toBe('label:second');
+        expect(resultB2).toBe('label:second');
+        expect(resultB2).toBe(resultB1);
+        expect(component).toHaveBeenCalledTimes(3);
     });
 
     it('has displayName', () => {

--- a/packages/jsx/src/memo.ts
+++ b/packages/jsx/src/memo.ts
@@ -14,6 +14,12 @@
 
 import type { FC, VNode } from './vnode.js';
 import type { Widget } from '@termuijs/widgets';
+import { currentFiber, type Fiber } from './hooks.js';
+
+interface MemoCacheEntry<P> {
+    prevProps: P;
+    prevResult: VNode | Widget;
+}
 
 /**
  * Shallow comparison of two objects.
@@ -57,18 +63,28 @@ export function memo<P extends Record<string, any>>(
 ): FC<P> {
     const compare = areEqual ?? shallowEqual;
 
-    // Cache the previous props and VNode output
-    let prevProps: P | null = null;
-    let prevResult: VNode | Widget | null = null;
+    // Per-instance cache keyed by fiber — avoids shared closure across siblings
+    const cache = new WeakMap<Fiber, MemoCacheEntry<P>>();
 
     const memoized: FC<P> = (props: P & { children?: VNode | VNode[] }) => {
-        // On first render, or when props change — call the component
-        if (prevProps === null || !compare(prevProps, props as P)) {
-            prevProps = { ...props } as P;
-            prevResult = component(props);
+        let fiber: Fiber | null = null;
+        try {
+            fiber = currentFiber();
+        } catch {
+            // No fiber context (e.g. direct call outside render) — skip cache
         }
 
-        return prevResult!;
+        if (fiber) {
+            const entry = cache.get(fiber);
+            if (entry && compare(entry.prevProps, props as P)) {
+                return entry.prevResult;
+            }
+            const result = component(props);
+            cache.set(fiber, { prevProps: { ...props } as P, prevResult: result });
+            return result;
+        }
+
+        return component(props);
     };
 
     // Tag for debugging


### PR DESCRIPTION

## Description
`memo()` stored `prevProps` and `prevResult` in a shared closure, so sibling instances of the same memoized component could return each other's cached output. This change keys the cache with a `WeakMap<Fiber, …>` using `currentFiber()` so each component instance has its own cache slot. Calls outside a render context still invoke the wrapped component directly (no cache). Tests cover independent siblings, per-instance cache hits, and sibling isolation.
## Related Issue
Closes #780
## Which package(s)?
`@termuijs/jsx`
## Type of Change
- [x] 🐛 Bug fix (`type:bug`)
- [x] 🧪 Tests (`type:testing`)
## Checklist
- [ ] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run packages/jsx`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` — N/A for this change
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.
## GSSoC 2026 Participation
- [ ] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`
## Screenshots / Recordings (UI changes)
N/A — internal JSX runtime fix; no terminal UI change.
## Notes for the Reviewer
- Uses `currentFiber()` from `hooks.ts` (not a new API). `currentFiber()` throws outside render, so `memo()` catches that and skips caching in that case.
- Existing cache-related tests were updated to set fiber context via `createFiber()` / `setCurrentFiber()` / `clearCurrentFiber()`, matching other jsx hook tests.
- Three new tests verify: sibling independence, per-instance cache reuse, and that updating one instance does not invalidate a sibling's cache.
## Test plan
```bash
bun vitest run packages/jsx
bun run build
bun run typecheck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved `memo()` function to properly cache results per component instance, ensuring independent instances maintain separate caches without interference.

* **Tests**
  * Added comprehensive tests verifying `memo()` instance isolation and caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->