### PR TITLE
feat(jsx): add useLatest hook

### DIFF
--- a/packages/jsx/src/hooks/useLatest.test.ts
+++ b/packages/jsx/src/hooks/useLatest.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+    createFiber,
+    setCurrentFiber,
+    clearCurrentFiber,
+} from '../hooks.js';
+import { useLatest } from './useLatest';
+
+describe('useLatest', () => {
+    let fiber = createFiber();
+
+    beforeEach(() => {
+        fiber = createFiber();
+        setCurrentFiber(fiber);
+    });
+
+    afterEach(() => {
+        clearCurrentFiber();
+    });
+
+    it('returns a ref with the initial value', () => {
+        const ref = useLatest('initial');
+
+        expect(ref.current).toBe('initial');
+    });
+
+    it('updates current on subsequent renders', () => {
+        useLatest('initial');
+
+        fiber.hookIndex = 0;
+
+        const ref = useLatest('updated');
+
+        expect(ref.current).toBe('updated');
+    });
+
+    it('preserves ref identity across renders', () => {
+        const first = useLatest('initial');
+
+        fiber.hookIndex = 0;
+
+        const second = useLatest('updated');
+
+        expect(first).toBe(second);
+    });
+
+    it('works with any value type', () => {
+        const value = { count: 1 };
+
+        const ref = useLatest(value);
+
+        expect(ref.current).toBe(value);
+    });
+});

--- a/packages/jsx/src/hooks/useLatest.ts
+++ b/packages/jsx/src/hooks/useLatest.ts
@@ -1,0 +1,9 @@
+import { useRef } from '../hooks';
+
+export function useLatest<T>(value: T): { readonly current: T } {
+    const ref = useRef(value);
+
+    ref.current = value;
+
+    return ref;
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -96,6 +96,7 @@ export { setRequestRender, getRequestRender, setInsertBefore, collectInputHandle
 /** h() — shorthand for createElement */
 export { createElement as h } from './createElement.js';
 export { usePrevious } from './hooks/usePrevious.js';
+export { useLatest } from './hooks/useLatest.js';
 export { useFirstRender } from './hooks/useFirstRender.js';
 export { useSyncExternalStore } from './hooks/useSyncExternalStore.js';
 export { useHover } from './hooks/useHover.js';


### PR DESCRIPTION
## Description

Adds a new `useLatest` hook to `@termuijs/jsx` that returns a stable ref object containing the latest value passed to it. The hook updates the ref during render and includes test coverage for initial values, updates across renders, stable identity, and generic value support.

## Related Issue

Closes #446

## Which package(s)?

* `@termuijs/jsx`

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [x] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [ ] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md](https://chatgpt.com/c/CONTRIBUTING.md)`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/18507c29-4949-45a4-8946-f46458f84e31`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

* Added `useLatest` in `packages/jsx/src/hooks/useLatest.ts`
* Added corresponding tests in `packages/jsx/src/hooks/useLatest.test.ts`
* Exported the hook from `packages/jsx/src/index.ts`
* Verified with `bun vitest run packages/jsx` and `bun run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `useLatest` hook to the JSX package, now available in the public API.

* **Tests**
  * Added comprehensive test suite validating hook behavior across render cycles and with various value types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->