### PR TITLE
[bug]: "Validate benchmark result entries"

### DIFF
--- a/scripts/compare-bench.mjs
+++ b/scripts/compare-bench.mjs
@@ -46,6 +46,38 @@ function validateBench(data, name) {
         console.error(`${name}: missing results array`);
         process.exit(2);
     }
+
+    for (const [index, result] of data.results.entries()) {
+        if (
+            typeof result.cols !== 'number' ||
+            !Number.isFinite(result.cols)
+        ) {
+            console.error(
+                `${name}: result[${index}] has invalid cols value`
+            );
+            process.exit(2);
+        }
+
+        if (
+            typeof result.rows !== 'number' ||
+            !Number.isFinite(result.rows)
+        ) {
+            console.error(
+                `${name}: result[${index}] has invalid rows value`
+            );
+            process.exit(2);
+        }
+
+        if (
+            typeof result.cellsPerSec !== 'number' ||
+            !Number.isFinite(result.cellsPerSec)
+        ) {
+            console.error(
+                `${name}: result[${index}] has invalid cellsPerSec value`
+            );
+            process.exit(2);
+        }
+    }
 }
 
 validateBench(head, 'head benchmark');


### PR DESCRIPTION
Description

Add validation for benchmark result entries in "compare-bench.mjs".

The script previously only checked whether the "results" field existed and was an array. This change validates that each benchmark result contains valid numeric values for "cols", "rows", and "cellsPerSec", preventing invalid benchmark data from producing incorrect output.

Related Issue

Closes #791 

Which package(s)?

scripts

Type of Change

- 🐛 Bug fix ("type:bug")

Checklist

⭐starred the repo. The "needs-star" check blocks your merge otherwise.
Tests pass locally: "bun vitest run"
Build passes: "bun run build"
 Typecheck passes: "bun run typecheck"
read "CONTRIBUTING.md".
 PR title follows "type: short description".
No new "any" types without an inline comment explaining why.
No unrelated refactors bundled into this PR.

Screenshots / Recordings (UI changes)

N/A

Notes for the Reviewer

This change only affects benchmark result validation and does not modify benchmark comparison logic. Invalid benchmark entries now fail early with a clear error message instead of producing incorrect calculations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved validation in benchmark comparison tooling to detect and handle invalid data before processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->