### PR TITLE
feat(jsx): add useMount hook

### DIFF
--- a/packages/jsx/src/hooks/useMount.test.ts
+++ b/packages/jsx/src/hooks/useMount.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  createFiber,
+  setCurrentFiber,
+  clearCurrentFiber,
+  runEffects,
+} from '../hooks.js';
+import { useMount } from './useMount';
+
+describe('useMount', () => {
+  let fiber = createFiber();
+
+  beforeEach(() => {
+    fiber = createFiber();
+    setCurrentFiber(fiber);
+  });
+
+  afterEach(() => {
+    clearCurrentFiber();
+  });
+
+  it('runs the callback after the first render', () => {
+    let calls = 0;
+
+    useMount(() => {
+      calls++;
+    });
+
+    expect(calls).toBe(0);
+
+    runEffects(fiber);
+
+    expect(calls).toBe(1);
+  });
+
+  it('runs the callback only once across re-renders', () => {
+    let calls = 0;
+
+    useMount(() => {
+      calls++;
+    });
+
+    runEffects(fiber);
+
+    fiber.hookIndex = 0;
+
+    useMount(() => {
+      calls++;
+    });
+
+    runEffects(fiber);
+
+    expect(calls).toBe(1);
+  });
+
+  it('does not rerun when callback identity changes', () => {
+    let calls = 0;
+
+    useMount(() => {
+      calls++;
+    });
+
+    runEffects(fiber);
+
+    fiber.hookIndex = 0;
+
+    useMount(() => {
+      calls += 10;
+    });
+
+    runEffects(fiber);
+
+    expect(calls).toBe(1);
+  });
+
+  it('returns undefined', () => {
+    const result = useMount(() => {});
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/jsx/src/hooks/useMount.ts
+++ b/packages/jsx/src/hooks/useMount.ts
@@ -1,0 +1,7 @@
+import { useEffect } from '../hooks';
+
+export function useMount(callback: () => void): void {
+  useEffect(() => {
+    callback();
+  }, []);
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -95,6 +95,7 @@ export { setRequestRender, getRequestRender, setInsertBefore, collectInputHandle
 // ── Convenience alias ──
 /** h() — shorthand for createElement */
 export { createElement as h } from './createElement.js';
+export { useMount } from './hooks/useMount.js';
 export { usePrevious } from './hooks/usePrevious.js';
 export { useFirstRender } from './hooks/useFirstRender.js';
 export { useSyncExternalStore } from './hooks/useSyncExternalStore.js';


### PR DESCRIPTION
## Description

Adds a new `useMount` hook to `@termuijs/jsx` that runs a callback once after the component mounts. The hook is implemented using an effect with an empty dependency array and includes tests to verify mount-only execution behavior.

## Related Issue

Closes #441

## Which package(s)?

* `@termuijs/jsx`

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [x] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [ ] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md](https://chatgpt.com/c/CONTRIBUTING.md)`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/18507c29-4949-45a4-8946-f46458f84e31`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

* Added `useMount` in `packages/jsx/src/hooks/useMount.ts`
* Added tests in `packages/jsx/src/hooks/useMount.test.ts`
* Exported the hook from `packages/jsx/src/index.ts`
* Verified with `bun vitest run packages/jsx`
* Verified with `bun run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `useMount` hook for executing callbacks once when a component mounts, providing a simple lifecycle solution.

* **Tests**
  * Added comprehensive test suite for the `useMount` hook to verify callback execution behavior and timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->