### PR TITLE
[bug]"Validate benchmark threshold range"

### DIFF
--- a/scripts/compare-bench.mjs
+++ b/scripts/compare-bench.mjs
@@ -19,11 +19,15 @@ const [headPath, mainPath] = args;
 const thresholdIdx = args.indexOf('--threshold');
 const threshold = thresholdIdx >= 0 ? parseFloat(args[thresholdIdx + 1]) : 0.20;
 
-if (Number.isNaN(threshold) || !Number.isFinite(threshold) || threshold < 0) {
-    console.error('Threshold must be a non-negative number');
+if (
+    Number.isNaN(threshold) ||
+    !Number.isFinite(threshold) ||
+    threshold < 0 ||
+    threshold > 1
+) {
+    console.error('Threshold must be between 0 and 1');
     process.exit(2);
 }
-
 let head, main;
 try {
     head = JSON.parse(readFileSync(headPath, 'utf8'));


### PR DESCRIPTION
Description

Validate the benchmark threshold argument to ensure it falls within a reasonable range.

Previously, the script accepted any non-negative threshold value, including values greater than "1", which could result in unrealistic regression thresholds and make benchmark comparisons less meaningful. This change adds validation to ensure the threshold remains within the expected range and provides a clear error message for invalid input.

Related Issue

Closes #794 

Which package(s)?

scripts

Type of Change

- 🐛 Bug fix ("type:bug")

Notes for the Reviewer

This change only affects command-line argument validation for the benchmark threshold. Existing benchmark comparison logic remains unchanged for valid threshold values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for benchmark threshold parameters to correctly reject values outside the valid 0-1 range, ensuring accurate benchmark comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->