### PR TITLE
[bug]"Validate benchmark file paths"

### DIFF
--- a/scripts/compare-bench.mjs
+++ b/scripts/compare-bench.mjs
@@ -7,7 +7,7 @@
 //
 // Usage: node scripts/compare-bench.mjs <head.json> <main.json> [--threshold 0.20]
 
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 
 const args = process.argv.slice(2);
 if (args.length < 2) {
@@ -25,6 +25,17 @@ if (Number.isNaN(threshold) || !Number.isFinite(threshold) || threshold < 0) {
 }
 
 let head, main;
+
+if (!existsSync(headPath)) {
+    console.error(`Benchmark file not found: ${headPath}`);
+    process.exit(2);
+}
+
+if (!existsSync(mainPath)) {
+    console.error(`Benchmark file not found: ${mainPath}`);
+    process.exit(2);
+}
+
 try {
     head = JSON.parse(readFileSync(headPath, 'utf8'));
     main = JSON.parse(readFileSync(mainPath, 'utf8'));


### PR DESCRIPTION
Description

Add validation for benchmark file paths before attempting to read benchmark data.

Previously, missing benchmark files resulted in a generic parsing error. This change checks whether benchmark files exist before reading them and provides a clearer error message when a file is missing.

Related Issue

Closes #798 

Which package(s)?

scripts

Type of Change

- 🐛 Bug fix ("type:bug")

Notes for the Reviewer

This change only improves error handling for invalid file paths and does not affect benchmark comparison behavior for valid benchmark files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error handling in the benchmark comparison script with explicit file existence checks. Missing benchmark files now trigger a clear error message and exit immediately, enhancing development workflow clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->