### PR TITLE
feat(jsx): support event delegation with from prop

### DIFF
--- a/examples/jsx-dashboard/src/event-delegation-test.tsx
+++ b/examples/jsx-dashboard/src/event-delegation-test.tsx
@@ -1,8 +1,17 @@
 /* @jsxImportSource @termuijs/jsx */
 import { render, h, useInput, useState, getCurrentApp } from '@termuijs/jsx';
 
+interface ButtonProps {
+    id?: string;
+    class?: string;
+    children?: any;
+    onPress?: () => void;
+    onFocus?: () => void;
+    triggerKey: string;
+}
+
 // A simple button component that emits onPress and onFocus when its trigger key is pressed
-function Button({ id, class: className, children, onPress, onFocus, triggerKey }: any) {
+function Button({ id, class: className, children, onPress, onFocus, triggerKey }: ButtonProps) {
     // When the user types the trigger key, we simulate an event on this button
     useInput((key) => {
         if (key === triggerKey) {

--- a/examples/jsx-dashboard/src/event-delegation-test.tsx
+++ b/examples/jsx-dashboard/src/event-delegation-test.tsx
@@ -1,0 +1,59 @@
+/* @jsxImportSource @termuijs/jsx */
+import { render, h, useInput, useState, getCurrentApp } from '@termuijs/jsx';
+
+// A simple button component that emits onPress and onFocus when its trigger key is pressed
+function Button({ id, class: className, children, onPress, onFocus, triggerKey }: any) {
+    // When the user types the trigger key, we simulate an event on this button
+    useInput((key) => {
+        if (key === triggerKey) {
+            onPress?.();
+            onFocus?.();
+        }
+    });
+
+    return (
+        <box id={id} class={className} border="single" padding={1} width={30} height={3}>
+            <text>{children}</text>
+        </box>
+    );
+}
+
+function App() {
+    const [lastAction, setLastAction] = useState('Waiting for input...');
+
+    useInput((key, ev) => {
+        if (key === 'q' || key === 'escape' || (ev.ctrl && key === 'c')) {
+            getCurrentApp()?.exit(0);
+        }
+    });
+
+    return (
+        <box 
+            width="100%"
+            height="100%"
+            padding={2} 
+            border="single" 
+            borderColor="cyan"
+            flexDirection="column"
+            gap={1}
+            onPress={{ from: '#btn1', handler: () => setLastAction('Button 1 Pressed! (via ID)') }}
+            onFocus={{ from: '.input-btn', handler: () => setLastAction('Button 2 Pressed! (via Class)') }}
+        >
+            <text bold>Event Delegation Test</text>
+            <text dim>Last action: {lastAction}</text>
+            
+            <box flexDirection="row" gap={2}>
+                <Button id="btn1" class="submit-btn" triggerKey="1">Button 1 (Press '1')</Button>
+                <Button id="btn2" class="input-btn" triggerKey="2">Button 2 (Press '2')</Button>
+            </box>
+            
+            <text dim>Press '1' or '2' to trigger events. Press 'q' to quit.</text>
+        </box>
+    );
+}
+
+async function main() {
+    await render(<App />, { title: 'Delegation Test' });
+}
+
+main().catch(console.error);

--- a/packages/jsx/src/event-system.test.ts
+++ b/packages/jsx/src/event-system.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from 'vitest';
+import { matchesSelector, applyDelegatedEvents } from './event-system.js';
+import type { VElement } from './vnode.js';
+import { Fragment } from './vnode.js';
+
+describe('Event System: Selector Matching', () => {
+    it('matches #id', () => {
+        expect(matchesSelector({ id: 'submit-btn' }, '#submit-btn')).toBe(true);
+        expect(matchesSelector({ id: 'other' }, '#submit-btn')).toBe(false);
+    });
+
+    it('matches .class', () => {
+        expect(matchesSelector({ class: 'input-field' }, '.input-field')).toBe(true);
+        expect(matchesSelector({ className: 'input-field' }, '.input-field')).toBe(true);
+        expect(matchesSelector({ class: 'other input-field' }, '.input-field')).toBe(true);
+        expect(matchesSelector({ class: 'other' }, '.input-field')).toBe(false);
+    });
+});
+
+describe('Event System: Delegation', () => {
+    it('applies handler to child with matching #id', () => {
+        const handler = vi.fn();
+        const props = {
+            onPress: { from: '#submit-btn', handler }
+        };
+        const children: VElement[] = [
+            { type: 'button', props: { id: 'submit-btn' }, children: [] },
+            { type: 'button', props: { id: 'other' }, children: [] }
+        ];
+
+        applyDelegatedEvents(props, children);
+
+        expect(children[0].props.onPress).toBe(handler);
+        expect(children[1].props.onPress).toBeUndefined();
+        
+        // The delegation object should be removed from the container's props
+        expect(props.onPress).toBeUndefined();
+    });
+
+    it('applies handler to child with matching .class', () => {
+        const handler = vi.fn();
+        const props = {
+            onFocus: { from: '.input-field', handler }
+        };
+        const children: VElement[] = [
+            { type: 'input', props: { class: 'input-field' }, children: [] },
+            { type: 'input', props: { class: 'other' }, children: [] }
+        ];
+
+        applyDelegatedEvents(props, children);
+
+        expect(children[0].props.onFocus).toBe(handler);
+        expect(children[1].props.onFocus).toBeUndefined();
+    });
+
+    it('applies handler to deeply nested descendants', () => {
+        const handler = vi.fn();
+        const props = {
+            onPress: { from: '#deep-btn', handler }
+        };
+        const children: VElement[] = [
+            {
+                type: 'box',
+                props: {},
+                children: [
+                    {
+                        type: 'box',
+                        props: {},
+                        children: [
+                            { type: 'button', props: { id: 'deep-btn' }, children: [] }
+                        ]
+                    }
+                ]
+            }
+        ];
+
+        applyDelegatedEvents(props, children);
+
+        const deepBtn = (children[0].children[0] as VElement).children[0] as VElement;
+        expect(deepBtn.props.onPress).toBe(handler);
+    });
+
+    it('handles fragments correctly', () => {
+        const handler = vi.fn();
+        const props = {
+            onPress: { from: '#frag-btn', handler }
+        };
+        const children: any[] = [
+            {
+                type: Fragment,
+                props: {},
+                children: [
+                    { type: 'button', props: { id: 'frag-btn' }, children: [] }
+                ]
+            }
+        ];
+
+        applyDelegatedEvents(props, children);
+
+        const fragBtn = children[0].children[0];
+        expect(fragBtn.props.onPress).toBe(handler);
+    });
+
+    it('preserves existing handler when delegating', () => {
+        const existingHandler = vi.fn();
+        const delegatedHandler = vi.fn();
+        const props = {
+            onPress: { from: '#btn', handler: delegatedHandler }
+        };
+        const children: VElement[] = [
+            { type: 'button', props: { id: 'btn', onPress: existingHandler }, children: [] }
+        ];
+
+        applyDelegatedEvents(props, children);
+
+        expect(children[0].props.onPress).toBeTypeOf('function');
+        
+        // Call the newly bound handler
+        children[0].props.onPress();
+
+        expect(existingHandler).toHaveBeenCalled();
+        expect(delegatedHandler).toHaveBeenCalled();
+    });
+});

--- a/packages/jsx/src/event-system.test.ts
+++ b/packages/jsx/src/event-system.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { matchesSelector, applyDelegatedEvents } from './event-system.js';
-import type { VElement } from './vnode.js';
-import { Fragment } from './vnode.js';
+import type { VElement, VNode } from './vnode.js';
+import { Fragment, isVElement } from './vnode.js';
 
 describe('Event System: Selector Matching', () => {
     it('matches #id', () => {
@@ -76,7 +76,13 @@ describe('Event System: Delegation', () => {
 
         applyDelegatedEvents(props, children);
 
-        const deepBtn = (children[0].children[0] as VElement).children[0] as VElement;
+        const child1 = children[0];
+        if (!isVElement(child1)) throw new Error('Expected VElement');
+        const child2 = child1.children[0];
+        if (!isVElement(child2)) throw new Error('Expected VElement');
+        const deepBtn = child2.children[0];
+        if (!isVElement(deepBtn)) throw new Error('Expected VElement');
+        
         expect(deepBtn.props.onPress).toBe(handler);
     });
 
@@ -85,10 +91,9 @@ describe('Event System: Delegation', () => {
         const props = {
             onPress: { from: '#frag-btn', handler }
         };
-        const children: any[] = [
+        const children: VNode[] = [
             {
                 type: Fragment,
-                props: {},
                 children: [
                     { type: 'button', props: { id: 'frag-btn' }, children: [] }
                 ]
@@ -97,7 +102,9 @@ describe('Event System: Delegation', () => {
 
         applyDelegatedEvents(props, children);
 
-        const fragBtn = children[0].children[0];
+        const fragment = children[0];
+        // Fragment's children contains the button
+        const fragBtn = (fragment as any).children[0] as VElement;
         expect(fragBtn.props.onPress).toBe(handler);
     });
 

--- a/packages/jsx/src/event-system.ts
+++ b/packages/jsx/src/event-system.ts
@@ -1,0 +1,87 @@
+import { type VNode, isVElement, Fragment } from './vnode.js';
+
+export interface DelegatedEvent<E = any> {
+    from: string;
+    handler: (event?: E) => void;
+}
+
+/**
+ * Checks if a set of props matches a CSS-style selector.
+ * Supported selectors:
+ * - `#id`: matches props.id
+ * - `.class`: matches props.class or props.className
+ */
+export function matchesSelector(props: Record<string, any>, selector: string): boolean {
+    if (!selector) return false;
+
+    // ID selector
+    if (selector.startsWith('#')) {
+        const id = selector.slice(1);
+        return props.id === id;
+    }
+
+    // Class selector
+    if (selector.startsWith('.')) {
+        const className = selector.slice(1);
+        const classProp = props.class || props.className || '';
+        const classes = classProp.split(/\s+/).filter(Boolean);
+        return classes.includes(className);
+    }
+
+    return false;
+}
+
+/**
+ * Scans the props of a container element for delegated event handlers
+ * (e.g., onPress={{ from: '#btn', handler: ... }}) and applies them
+ * to any descendant VNode that matches the selector.
+ */
+export function applyDelegatedEvents(props: Record<string, any>, children: VNode[]): void {
+    const delegates: Array<{ propName: string; from: string; handler: any }> = [];
+
+    for (const key of Object.keys(props)) {
+        if (key.startsWith('on')) {
+            const value = props[key];
+            if (value && typeof value === 'object' && 'from' in value && 'handler' in value) {
+                delegates.push({
+                    propName: key,
+                    from: value.from,
+                    handler: value.handler,
+                });
+                delete props[key];
+            }
+        }
+    }
+
+    if (delegates.length === 0) return;
+
+    function traverse(nodes: VNode[]) {
+        for (const node of nodes) {
+            if (isVElement(node)) {
+                let matched = false;
+                for (const delegate of delegates) {
+                    if (matchesSelector(node.props, delegate.from)) {
+                        const existing = node.props[delegate.propName];
+                        if (existing && typeof existing === 'function') {
+                            const handler = delegate.handler;
+                            node.props[delegate.propName] = (...args: any[]) => {
+                                existing(...args);
+                                handler(...args);
+                            };
+                        } else {
+                            node.props[delegate.propName] = delegate.handler;
+                        }
+                        matched = true;
+                    }
+                }
+                if (node.children) {
+                    traverse(node.children);
+                }
+            } else if (node && typeof node === 'object' && 'type' in node && (node as any).type === Fragment) {
+                traverse((node as any).children);
+            }
+        }
+    }
+
+    traverse(children);
+}

--- a/packages/jsx/src/event-system.ts
+++ b/packages/jsx/src/event-system.ts
@@ -60,7 +60,6 @@ export function applyDelegatedEvents(props: Record<string, unknown>, children: V
     function traverse(nodes: VNode[]) {
         for (const node of nodes) {
             if (isVElement(node)) {
-                let matched = false;
                 for (const delegate of delegates) {
                     if (matchesSelector(node.props, delegate.from)) {
                         const existing = node.props[delegate.propName];
@@ -73,7 +72,6 @@ export function applyDelegatedEvents(props: Record<string, unknown>, children: V
                         } else {
                             node.props[delegate.propName] = delegate.handler;
                         }
-                        matched = true;
                     }
                 }
                 if (node.children) {

--- a/packages/jsx/src/event-system.ts
+++ b/packages/jsx/src/event-system.ts
@@ -1,6 +1,6 @@
-import { type VNode, isVElement, Fragment } from './vnode.js';
+import { type VNode, isVElement, isVFragment, Fragment } from './vnode.js';
 
-export interface DelegatedEvent<E = any> {
+export interface DelegatedEvent<E = any /* Supports various DOM/custom event shapes where type cannot be inferred */> {
     from: string;
     handler: (event?: E) => void;
 }
@@ -11,7 +11,7 @@ export interface DelegatedEvent<E = any> {
  * - `#id`: matches props.id
  * - `.class`: matches props.class or props.className
  */
-export function matchesSelector(props: Record<string, any>, selector: string): boolean {
+export function matchesSelector(props: Record<string, any /* Props are arbitrary attributes from JSX runtime */>, selector: string): boolean {
     if (!selector) return false;
 
     // ID selector
@@ -31,13 +31,15 @@ export function matchesSelector(props: Record<string, any>, selector: string): b
     return false;
 }
 
+type EventHandler = (...args: unknown[]) => unknown;
+
 /**
  * Scans the props of a container element for delegated event handlers
  * (e.g., onPress={{ from: '#btn', handler: ... }}) and applies them
  * to any descendant VNode that matches the selector.
  */
-export function applyDelegatedEvents(props: Record<string, any>, children: VNode[]): void {
-    const delegates: Array<{ propName: string; from: string; handler: any }> = [];
+export function applyDelegatedEvents(props: Record<string, unknown>, children: VNode[]): void {
+    const delegates: Array<{ propName: string; from: string; handler: EventHandler }> = [];
 
     for (const key of Object.keys(props)) {
         if (key.startsWith('on')) {
@@ -45,8 +47,8 @@ export function applyDelegatedEvents(props: Record<string, any>, children: VNode
             if (value && typeof value === 'object' && 'from' in value && 'handler' in value) {
                 delegates.push({
                     propName: key,
-                    from: value.from,
-                    handler: value.handler,
+                    from: (value as any).from, // Cast required: TS cannot infer props on 'unknown' even after 'in' check
+                    handler: (value as any).handler, // Cast required: same reason as above
                 });
                 delete props[key];
             }
@@ -64,7 +66,7 @@ export function applyDelegatedEvents(props: Record<string, any>, children: VNode
                         const existing = node.props[delegate.propName];
                         if (existing && typeof existing === 'function') {
                             const handler = delegate.handler;
-                            node.props[delegate.propName] = (...args: any[]) => {
+                            node.props[delegate.propName] = (...args: unknown[]) => {
                                 existing(...args);
                                 handler(...args);
                             };
@@ -77,8 +79,8 @@ export function applyDelegatedEvents(props: Record<string, any>, children: VNode
                 if (node.children) {
                     traverse(node.children);
                 }
-            } else if (node && typeof node === 'object' && 'type' in node && (node as any).type === Fragment) {
-                traverse((node as any).children);
+            } else if (isVFragment(node)) {
+                traverse(node.children);
             }
         }
     }

--- a/packages/jsx/src/reconciler.ts
+++ b/packages/jsx/src/reconciler.ts
@@ -267,7 +267,7 @@ export function reconcile(vnode: VNode, parentWidget?: Widget): Widget {
     // VElement
     if (isVElement(vnode)) {
         let { type, props, children } = vnode;
-        children = children ?? [];
+        children = flattenChildren(children ?? []);
 
         applyDelegatedEvents(props, children);
 

--- a/packages/jsx/src/reconciler.ts
+++ b/packages/jsx/src/reconciler.ts
@@ -15,6 +15,7 @@ import type { Style, Color } from '@termuijs/core';
 import { parseColor } from '@termuijs/core';
 import type { VNode, VElement, FC } from './vnode.js';
 import { isVElement, isVFragment, Fragment, flattenChildren } from './vnode.js';
+import { applyDelegatedEvents } from './event-system.js';
 import {
     createFiber, setCurrentFiber, clearCurrentFiber,
     runEffects, runLayoutEffects, destroyFiber, type Fiber,
@@ -267,6 +268,8 @@ export function reconcile(vnode: VNode, parentWidget?: Widget): Widget {
     if (isVElement(vnode)) {
         let { type, props, children } = vnode;
         children = children ?? [];
+
+        applyDelegatedEvents(props, children);
 
         // Map uppercase widget classes to their lowercase intrinsic tags
         const t = type as any;


### PR DESCRIPTION
Resolves #79 

### Description:

This PR extends the event system in `@termuijs/jsx` to support a `from` prop on event handlers. This allows a container to listen for events that originate from a specific child widget, identified by a CSS-style `#id` or `.class` selector.

**Acceptance criteria**
- [x] `from='#id'` fires only for widgets with that specific ID.
- [x] `from='.class'` fires for widgets with a matching class prop.
- [x] No match means the handler is not called.
- [x] Tests verify selector matching logic.

**Implementation details**
- Created `applyDelegatedEvents` in `packages/jsx/src/event-system.ts`. It parses `onEvent` props containing an object with `{ from: string, handler: Function }`.
- Hooked up delegation traversal inside the `reconciler.ts` logic. When traversing the VNode tree, it accurately matches node descendants by `id` or `class` and directly assigns the handler to their respective event prop.
- Ensured that the original `{ from, handler }` object is safely removed from the parent container props after delegation so it isn't incorrectly passed down to native components.

**Testing**
- Added robust unit tests inside `packages/jsx/src/event-system.test.ts` to assert that:
  - Selectors accurately match IDs and classes.
  - Handlers are only attached to the correct nodes.
  - The parent VNode does not incorrectly retain the delegation configuration objects.
- Added a visual JSX test script at `examples/jsx-dashboard/src/event-delegation-test.tsx` to verify interactive behaviour in the actual terminal environment.

**Checklist**
- [x] Ran `bun run build` successfully
- [x] Ran `bun vitest run packages/jsx` successfully
- [x] Ran `bun run typecheck` successfully
- [x] Confined changes to the specified packages (`packages/jsx/`, `examples/jsx-dashboard/`)
- [x] Adhered strictly to `AGENTS.md` monorepo rules.

Screenshots 
<img width="586" height="506" alt="Screenshot 2026-06-06 002907" src="https://github.com/user-attachments/assets/017231a8-6686-47e5-86e4-6f3c15ffcd04" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Declarative event delegation for JSX apps: parent containers can route events to matching descendants via ID/class selectors
  * Delegated handlers are composed with existing handlers so both run when applicable

* **Tests**
  * Added tests validating selector matching, delegation behavior across nested structures and fragments

* **Examples**
  * New dashboard example demonstrating delegated events and quit-key handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->