### PR TITLE
feat(widgets): add sort and filter to DataGrid

### DIFF
--- a/packages/widgets/src/data/DataGrid.test.ts
+++ b/packages/widgets/src/data/DataGrid.test.ts
@@ -3,150 +3,192 @@
 // ─────────────────────────────────────────────────────────────────────────────
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { Screen, caps } from '@termuijs/core';
-import { DataGrid } from './DataGrid.js';
+import { Screen, caps, createKeyEvent } from '@termuijs/core';
+import { DataGrid, type DataGridColumn } from './DataGrid.js';
 
 afterEach(() => {
     vi.restoreAllMocks();
 });
 
-const COLUMNS = [
-    { key: 'name', header: 'Name', width: 10, sortable: true },
-    { key: 'age',  header: 'Age',  width: 5,  sortable: true },
+const COLUMNS: DataGridColumn[] = [
+    { key: 'name', header: 'Name', width: 10 },
+    { key: 'age', header: 'Age', width: 5 },
 ];
 
 const ROWS = [
     { name: 'Alice', age: 30 },
-    { name: 'Bob',   age: 25 },
+    { name: 'Bob', age: 25 },
     { name: 'Carol', age: 35 },
 ];
 
+const gridText = (screen: Screen): string =>
+    screen.back.map(r => r.map(c => c.char).join('')).join('\n');
+
+const keyOf = (key: string): ReturnType<typeof createKeyEvent> =>
+    createKeyEvent({ key, raw: Buffer.from(key), ctrl: false, alt: false, shift: false });
+
 describe('DataGrid', () => {
-    it('renders header row', async () => {
-        const { Screen } = await import('@termuijs/core');
-        const { DataGrid } = await import('./DataGrid.js');
-
-        const grid = new DataGrid({ columns: COLUMNS, rows: ROWS });
-        grid.updateRect({ x: 0, y: 0, width: 40, height: 10 });
-        const screen = new Screen(40, 10);
+    it('renders the same as Table by default — header and data rows', () => {
+        const grid = new DataGrid(COLUMNS, ROWS);
+        grid.updateRect({ x: 0, y: 0, width: 30, height: 8 });
+        const screen = new Screen(30, 8);
         grid.render(screen);
 
-        const row1 = screen.back[1].map((c: { char: string }) => c.char).join('');
-        expect(row1).toContain('Name');
-        expect(row1).toContain('Age');
+        const text = gridText(screen);
+        expect(text).toContain('Name');
+        expect(text).toContain('Age');
+        expect(text).toContain('Alice');
+        expect(text).toContain('Bob');
+        expect(text).toContain('Carol');
     });
 
-    it('renders data rows', async () => {
-        const { Screen } = await import('@termuijs/core');
-        const { DataGrid } = await import('./DataGrid.js');
+    it('s key cycles sort: none → asc → desc → none', () => {
+        const grid = new DataGrid(COLUMNS, ROWS);
+        expect(grid.sortDirection).toBe('none');
+        expect(grid.sortKey).toBeNull();
 
-        const grid = new DataGrid({ columns: COLUMNS, rows: ROWS });
-        grid.updateRect({ x: 0, y: 0, width: 40, height: 10 });
-        const screen = new Screen(40, 10);
-        grid.render(screen);
-
-        const allText = screen.back.map((r: { char: string }[]) => r.map(c => c.char).join('')).join('\n');
-        expect(allText).toContain('Alice');
-        expect(allText).toContain('Bob');
-    });
-
-    it('selectNext and selectPrev move selected row', async () => {
-        const { DataGrid } = await import('./DataGrid.js');
-
-        const grid = new DataGrid({ columns: COLUMNS, rows: ROWS });
-        expect(grid.selectedRow).toBe(0);
-        grid.selectNext();
-        expect(grid.selectedRow).toBe(1);
-        grid.selectPrev();
-        expect(grid.selectedRow).toBe(0);
-    });
-
-    it('selectNext does not go past last row', async () => {
-        const { DataGrid } = await import('./DataGrid.js');
-
-        const grid = new DataGrid({ columns: COLUMNS, rows: ROWS });
-        grid.selectNext(); grid.selectNext(); grid.selectNext();
-        expect(grid.selectedRow).toBe(2);
-    });
-
-    it('selectLeft and selectRight move selected column', async () => {
-        const { DataGrid } = await import('./DataGrid.js');
-
-        const grid = new DataGrid({ columns: COLUMNS, rows: ROWS });
-        expect(grid.selectedCol).toBe(0);
-        grid.selectRight();
-        expect(grid.selectedCol).toBe(1);
-        grid.selectLeft();
-        expect(grid.selectedCol).toBe(0);
-    });
-
-    it('toggleSort cycles asc → desc → none', async () => {
-        const { DataGrid } = await import('./DataGrid.js');
-
-        const grid = new DataGrid({ columns: COLUMNS, rows: ROWS });
-        grid.toggleSort();
-        expect(grid.sortKey).toBe('name');
+        grid.handleKey(keyOf('s'));
         expect(grid.sortDirection).toBe('asc');
-        grid.toggleSort();
+        expect(grid.sortKey).toBe('name');
+
+        grid.handleKey(keyOf('s'));
         expect(grid.sortDirection).toBe('desc');
-        grid.toggleSort();
+
+        grid.handleKey(keyOf('s'));
         expect(grid.sortDirection).toBe('none');
         expect(grid.sortKey).toBeNull();
     });
 
-    it('onSort callback fires with correct args', async () => {
-        const { DataGrid } = await import('./DataGrid.js');
+    it('sort changes the visible row order', () => {
+        const grid = new DataGrid(COLUMNS, ROWS);
+        grid.updateRect({ x: 0, y: 0, width: 30, height: 8 });
+        const before = (() => {
+            const s = new Screen(30, 8);
+            grid.render(s);
+            return gridText(s);
+        })();
+        expect(before.indexOf('Alice')).toBeLessThan(before.indexOf('Bob'));
 
+        grid.handleKey(keyOf('s')); // asc by name: Alice, Bob, Carol (already)
+        grid.handleKey(keyOf('s')); // desc by name: Carol, Bob, Alice
+        const s2 = new Screen(30, 8);
+        grid.render(s2);
+        const after = gridText(s2);
+        expect(after.indexOf('Carol')).toBeLessThan(after.indexOf('Bob'));
+        expect(after.indexOf('Bob')).toBeLessThan(after.indexOf('Alice'));
+    });
+
+    it('renders a sort indicator in the header when a column is sorted', () => {
+        const grid = new DataGrid(COLUMNS, ROWS);
+        grid.updateRect({ x: 0, y: 0, width: 30, height: 8 });
+        grid.handleKey(keyOf('s'));
+
+        const screen = new Screen(30, 8);
+        grid.render(screen);
+        const text = gridText(screen);
+        expect(text).toContain('\u25B2'); // ▲ for asc
+    });
+
+    it('uses ASCII sort indicator when unicode is off', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+        const grid = new DataGrid(COLUMNS, ROWS);
+        grid.updateRect({ x: 0, y: 0, width: 30, height: 8 });
+        grid.handleKey(keyOf('s'));
+
+        const screen = new Screen(30, 8);
+        grid.render(screen);
+        const text = gridText(screen);
+        expect(text).toContain('^');
+        expect(text).not.toContain('\u25B2');
+    });
+
+    it('typing after / opens filter and narrows visible rows', () => {
+        const grid = new DataGrid(COLUMNS, ROWS);
+        grid.updateRect({ x: 0, y: 0, width: 30, height: 8 });
+        grid.handleKey(keyOf('/'));
+        expect(grid.filterOpen).toBe(true);
+
+        grid.handleKey(keyOf('b'));
+        expect(grid.filter).toBe('b');
+
+        const screen = new Screen(30, 8);
+        grid.render(screen);
+        const text = gridText(screen);
+        expect(text).toContain('Bob');
+        expect(text).not.toContain('Alice');
+        expect(text).not.toContain('Carol');
+    });
+
+    it('Escape closes the filter and clears the narrowed rows', () => {
+        const grid = new DataGrid(COLUMNS, ROWS);
+        grid.updateRect({ x: 0, y: 0, width: 30, height: 8 });
+        grid.handleKey(keyOf('/'));
+        grid.handleKey(keyOf('c'));
+        grid.handleKey(keyOf('a'));
+        expect(grid.filter).toBe('ca');
+
+        grid.handleKey(keyOf('escape'));
+        expect(grid.filterOpen).toBe(false);
+        expect(grid.filter).toBe('');
+
+        const screen = new Screen(30, 8);
+        grid.render(screen);
+        const text = gridText(screen);
+        expect(text).toContain('Alice');
+        expect(text).toContain('Bob');
+        expect(text).toContain('Carol');
+    });
+
+    it('calls onSort callback with key and direction', () => {
         const onSort = vi.fn();
-        const grid = new DataGrid({ columns: COLUMNS, rows: ROWS, onSort });
-        grid.toggleSort();
+        const grid = new DataGrid(COLUMNS, ROWS, {}, { onSort });
+        grid.handleKey(keyOf('s'));
         expect(onSort).toHaveBeenCalledWith('name', 'asc');
     });
 
-    it('shows (no data) when rows are empty', async () => {
-        const { Screen } = await import('@termuijs/core');
-        const { DataGrid } = await import('./DataGrid.js');
+    it('renders the filter row with the current filter text', () => {
+        const grid = new DataGrid(COLUMNS, ROWS);
+        grid.updateRect({ x: 0, y: 0, width: 30, height: 8 });
+        grid.handleKey(keyOf('/'));
+        grid.handleKey(keyOf('b'));
 
-        const grid = new DataGrid({ columns: COLUMNS, rows: [] });
-        grid.updateRect({ x: 0, y: 0, width: 40, height: 10 });
-        const screen = new Screen(40, 10);
+        const screen = new Screen(30, 8);
         grid.render(screen);
-
-        const allText = screen.back.map((r: { char: string }[]) => r.map(c => c.char).join('')).join('\n');
-        expect(allText).toContain('no data');
+        const text = gridText(screen);
+        const firstLine = text.split('\n')[0] ?? '';
+        expect(firstLine).toContain('/b');
     });
 
-    it('uses ASCII separator when unicode is off', () => {
-        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
-        const grid = new DataGrid({ columns: COLUMNS, rows: ROWS });
-        grid.updateRect({ x: 0, y: 0, width: 40, height: 10 });
-        const screen = new Screen(40, 10);
-        grid.render(screen);
-        const allText = screen.back.map((r: { char: string }[]) => r.map(c => c.char).join('')).join('\n');
-        expect(allText).toContain('|');
+    it('left and right keys move the selected column', () => {
+        const grid = new DataGrid(COLUMNS, ROWS);
+        expect(grid.selectedColumn).toBe(0);
+
+        grid.handleKey(keyOf('right'));
+        expect(grid.selectedColumn).toBe(1);
+
+        grid.handleKey(keyOf('right'));
+        expect(grid.selectedColumn).toBe(1); // clamped at last column
+
+        grid.handleKey(keyOf('left'));
+        expect(grid.selectedColumn).toBe(0);
+
+        grid.handleKey(keyOf('left'));
+        expect(grid.selectedColumn).toBe(0); // clamped at first column
     });
 
-    it('setRows updates data and clamps selection', async () => {
-        const { DataGrid } = await import('./DataGrid.js');
+    it('sorts the column under the selection, not always column 0', () => {
+        const grid = new DataGrid(COLUMNS, ROWS);
+        grid.handleKey(keyOf('right')); // select 'age' column
+        grid.handleKey(keyOf('s'));
 
-        const grid = new DataGrid({ columns: COLUMNS, rows: ROWS });
-        grid.selectNext(); grid.selectNext();
-        expect(grid.selectedRow).toBe(2);
-        grid.setRows([{ name: 'Zara', age: 20 }]);
-        expect(grid.selectedRow).toBe(0);
+        expect(grid.sortKey).toBe('age');
+        expect(grid.sortDirection).toBe('asc');
     });
 
-    it('handleKey routes arrow keys correctly', async () => {
-        const { DataGrid } = await import('./DataGrid.js');
-
-        const grid = new DataGrid({ columns: COLUMNS, rows: ROWS });
-        grid.handleKey({ key: 'down' } as never);
-        expect(grid.selectedRow).toBe(1);
-        grid.handleKey({ key: 'up' } as never);
-        expect(grid.selectedRow).toBe(0);
-        grid.handleKey({ key: 'right' } as never);
-        expect(grid.selectedCol).toBe(1);
-        grid.handleKey({ key: 'left' } as never);
-        expect(grid.selectedCol).toBe(0);
+    it('shift+s also cycles sort (case-insensitive key handling)', () => {
+        const grid = new DataGrid(COLUMNS, ROWS);
+        grid.handleKey(keyOf('S'));
+        expect(grid.sortDirection).toBe('asc');
+        expect(grid.sortKey).toBe('name');
     });
 });

--- a/packages/widgets/src/data/DataGrid.ts
+++ b/packages/widgets/src/data/DataGrid.ts
@@ -1,129 +1,99 @@
 // ─────────────────────────────────────────────────────────────────────────────
-// @termuijs/widgets — DataGrid widget (2D virtualization + sorting)
+// @termuijs/widgets — DataGrid widget
 //
-// Renders tabular data with only visible rows and columns drawn.
-// Supports keyboard navigation, column sorting, and ASCII fallback borders.
-//
-// Usage:
-//   const grid = new DataGrid({
-//       columns: [{ key: 'name', header: 'Name', width: 20, sortable: true }],
-//       rows: [{ name: 'Alice' }, { name: 'Bob' }],
-//   });
+// A table with sort indicators and a filter row. Extends Table and adds:
+// - `s` key cycles sort on the selected column (none → asc → desc → none)
+// - `/` opens a filter row; typing narrows displayed rows
+// - `escape` closes the filter row and clears the filter
+// - Sort indicators: ▲ / ▼ (Unicode) or ^ / v (ASCII) appended to headers
 // ─────────────────────────────────────────────────────────────────────────────
 
-import { type Screen, type Style, type KeyEvent, styleToCellAttrs, stringWidth, truncate, caps } from '@termuijs/core';
-import { Widget } from '../base/Widget.js';
+import {
+    type Screen,
+    type Style,
+    type KeyEvent,
+    styleToCellAttrs,
+    stringWidth,
+    truncate,
+    caps,
+} from '@termuijs/core';
+import { Table, type TableColumn, type TableRow, type TableOptions } from './Table.js';
 
-export interface DataGridColumn {
-    /** Unique key matching a property in each row object */
-    key: string;
-    /** Display header text */
-    header: string;
-    /** Fixed column width in characters */
-    width: number;
-    /** Allow clicking/pressing enter on header to sort (default: false) */
+export type SortDirection = 'asc' | 'desc' | 'none';
+
+export interface DataGridColumn extends TableColumn {
+    /** Whether the column can be sorted. Default: true. */
     sortable?: boolean;
 }
 
-export type SortDirection = 'asc' | 'desc' | 'none';
-export type DataGridRow = Record<string, string | number>;
+export type DataGridRow = TableRow;
 
-export interface DataGridOptions {
-    /** Column definitions */
-    columns: DataGridColumn[];
-    /** Row data: array of key→value records */
-    rows: DataGridRow[];
-    /** Style overrides */
-    style?: Partial<Style>;
-    /** Show header row (default: true) */
-    showHeader?: boolean;
-    /** Callback fired when sort changes */
+export interface DataGridOptions extends TableOptions {
+    /** Callback fired when sort changes. */
     onSort?: (key: string, direction: SortDirection) => void;
+    /** Callback fired when the filter changes. */
+    onFilter?: (filter: string) => void;
 }
 
-/**
- * DataGrid – a 2D-virtualized table widget.
- *
- * Only the rows and columns that fit inside the current terminal
- * dimensions are rendered. Supports arrow-key navigation and
- * column sorting.
- */
-export class DataGrid extends Widget {
-    private _columns: DataGridColumn[];
-    private _rows: DataGridRow[];
-    private _showHeader: boolean;
+export class DataGrid extends Table {
     private _onSort?: (key: string, direction: SortDirection) => void;
+    private _onFilter?: (filter: string) => void;
 
-    private _rowOffset = 0;
-    private _colOffset = 0;
-    private _selectedRow = 0;
-    private _selectedCol = 0;
     private _sortKey: string | null = null;
     private _sortDir: SortDirection = 'none';
+    private _filter = '';
+    private _filterOpen = false;
+    private _selectedCol = 0;
 
-    constructor(options: DataGridOptions) {
-        super({ border: 'single', ...options.style });
-        this._columns = options.columns;
-        this._rows = options.rows;
-        this._showHeader = options.showHeader ?? true;
+    focusable = true;
+
+    constructor(
+        columns: DataGridColumn[],
+        rows: DataGridRow[],
+        style: Partial<Style> = {},
+        options: DataGridOptions = {},
+    ) {
+        const normalizedColumns: DataGridColumn[] = columns.map(c => ({
+            ...c,
+            sortable: c.sortable ?? true,
+        }));
+        super(normalizedColumns, rows, style, options);
         this._onSort = options.onSort;
-        this.focusable = true;
+        this._onFilter = options.onFilter;
     }
 
-    get selectedRow(): number { return this._selectedRow; }
-    get selectedCol(): number { return this._selectedCol; }
+    // ── Public API ──────────────────────────────────
+
     get sortKey(): string | null { return this._sortKey; }
     get sortDirection(): SortDirection { return this._sortDir; }
+    get filter(): string { return this._filter; }
+    get filterOpen(): boolean { return this._filterOpen; }
+    get selectedColumn(): number { return this._selectedCol; }
 
-    setRows(rows: DataGridRow[]): void {
-        this._rows = rows;
-        this._selectedRow = Math.min(this._selectedRow, Math.max(0, rows.length - 1));
-        this._clampScroll();
+    setSelectedColumn(col: number): void {
+        if (col < 0 || col >= this._columns.length) return;
+        this._selectedCol = col;
         this.markDirty();
     }
 
-    setColumns(columns: DataGridColumn[]): void {
-        this._columns = columns;
-        this._selectedCol = Math.min(this._selectedCol, Math.max(0, columns.length - 1));
-        this._colOffset = 0;
+    setFilter(filter: string): void {
+        this._filter = filter;
+        this._filterOpen = true;
+        this._onFilter?.(filter);
         this.markDirty();
     }
 
-    selectPrev(): void {
-        if (this._selectedRow > 0) {
-            this._selectedRow--;
-            this._clampScroll();
-            this.markDirty();
-        }
+    clearFilter(): void {
+        if (this._filter === '' && !this._filterOpen) return;
+        this._filter = '';
+        this._filterOpen = false;
+        this._onFilter?.('');
+        this.markDirty();
     }
 
-    selectNext(): void {
-        if (this._selectedRow < this._rows.length - 1) {
-            this._selectedRow++;
-            this._clampScroll();
-            this.markDirty();
-        }
-    }
-
-    selectLeft(): void {
-        if (this._selectedCol > 0) {
-            this._selectedCol--;
-            this._clampColScroll();
-            this.markDirty();
-        }
-    }
-
-    selectRight(): void {
-        if (this._selectedCol < this._columns.length - 1) {
-            this._selectedCol++;
-            this._clampColScroll();
-            this.markDirty();
-        }
-    }
-
-    toggleSort(): void {
-        const column = this._columns[this._selectedCol];
-        if (!column || !column.sortable) return;
+    cycleSort(): void {
+        const column = this._columns[this._selectedCol] as DataGridColumn | undefined;
+        if (!column || column.sortable === false) return;
 
         if (this._sortKey !== column.key) {
             this._sortKey = column.key;
@@ -142,25 +112,52 @@ export class DataGrid extends Widget {
     }
 
     handleKey(event: KeyEvent): void {
+        // While filter is open, capture printable keys + escape + backspace.
+        if (this._filterOpen) {
+            switch (event.key) {
+                case 'escape':
+                    this.clearFilter();
+                    return;
+                case 'backspace':
+                    if (this._filter.length > 0) {
+                        this.setFilter(this._filter.slice(0, -1));
+                    }
+                    return;
+                default:
+                    if (
+                        event.key.length === 1
+                        && !event.ctrl
+                        && !event.alt
+                    ) {
+                        this.setFilter(this._filter + event.key);
+                    }
+                    return;
+            }
+        }
+
+        // Normal mode: navigation + sort + filter
         switch (event.key) {
-            case 'down':
-                this.selectNext();
+            case 's':
+            case 'S':
+                if (!event.ctrl && !event.alt) this.cycleSort();
                 break;
-            case 'up':
-                this.selectPrev();
+            case '/':
+                this._filterOpen = true;
+                this.markDirty();
+                break;
+            case 'escape':
+                this.clearFilter();
                 break;
             case 'left':
-                this.selectLeft();
+                this.setSelectedColumn(this._selectedCol - 1);
                 break;
             case 'right':
-                this.selectRight();
-                break;
-            case 'enter':
-            case 'return':
-                this.toggleSort();
+                this.setSelectedColumn(this._selectedCol + 1);
                 break;
         }
     }
+
+    // ── Rendering ───────────────────────────────────
 
     protected _renderSelf(screen: Screen): void {
         const rect = this._getContentRect();
@@ -168,127 +165,135 @@ export class DataGrid extends Widget {
         if (width <= 0 || height <= 0) return;
 
         const attrs = styleToCellAttrs(this._style);
-        const sortedRows = this._getSortedRows();
-        const visibleColumns = this._getVisibleColumns(width);
-        const vertical = caps.unicode ? '│' : '|';
-        const rowHeight = this._showHeader ? Math.max(0, height - 1) : height;
+        const sepWidth = stringWidth(this._separator);
+        const sortIndicator = (dir: SortDirection): string => {
+            if (dir === 'asc') return caps.unicode ? ' \u25B2' : ' ^';
+            if (dir === 'desc') return caps.unicode ? ' \u25BC' : ' v';
+            return '';
+        };
 
-        const xOffset = x;
-        let drawY = y;
+        const filterRowHeight = this._filterOpen ? 1 : 0;
+        const filterY = y;
+        const tableY = y + filterRowHeight;
+        const tableHeight = Math.max(0, height - filterRowHeight);
 
-        if (this._showHeader && height > 0) {
-            let cx = xOffset;
-            for (const { column, width: colWidth, separator } of visibleColumns) {
-                const cellWidth = separator ? Math.max(0, colWidth - 1) : colWidth;
-                const headerText = truncate(column.header, cellWidth);
-                screen.writeString(cx, drawY, headerText, { ...attrs, bold: true });
-
-                if (separator) {
-                    screen.writeString(cx + cellWidth, drawY, vertical, attrs);
-                }
-
-                cx += colWidth;
-            }
-            drawY++;
+        if (this._filterOpen) {
+            const filterText = `/${this._filter}`;
+            screen.writeString(x, filterY, truncate(filterText, width), { ...attrs, dim: true });
         }
 
-        if (this._rows.length === 0) {
-            if (drawY < y + height) {
-                const message = 'no data';
-                screen.writeString(xOffset, drawY, truncate(message, width), attrs);
-            }
-            return;
-        }
+        if (tableHeight <= 0) return;
 
-        const visibleRows = sortedRows.slice(this._rowOffset, this._rowOffset + rowHeight);
-        for (let rowIndex = 0; rowIndex < visibleRows.length && drawY < y + height; rowIndex++, drawY++) {
-            const row = visibleRows[rowIndex];
-            let cx = xOffset;
-            const isSelected = this._selectedRow === this._rowOffset + rowIndex;
-            for (const { column, width: colWidth, separator } of visibleColumns) {
-                const cellWidth = separator ? Math.max(0, colWidth - 1) : colWidth;
-                const rawValue = String(row[column.key] ?? '');
-                const cellText = truncate(rawValue, cellWidth);
-                screen.writeString(cx, drawY, cellText, {
+        // Available width for headers and data
+        const usableWidth = width - (this._columns.length - 1) * sepWidth;
+        const colWidths = this._computeColumnWidths(usableWidth);
+
+        let row = 0;
+
+        if (this._showHeader && row < tableHeight) {
+            let cx = x;
+            for (let c = 0; c < this._columns.length; c++) {
+                const col = this._columns[c] as DataGridColumn;
+                const isSortKey = this._sortKey === col.key;
+                const indicator = isSortKey ? sortIndicator(this._sortDir) : '';
+                const indicatorStripped = stringWidth(indicator);
+                const cellWidth = colWidths[c] ?? 0;
+                const headerWidth = Math.max(0, cellWidth - indicatorStripped);
+                const headerText = this._alignText(col.header, headerWidth, col.align ?? 'left');
+
+                screen.writeString(cx, tableY + row, headerText, {
                     ...attrs,
-                    bold: isSelected,
-                    bg: isSelected ? { type: 'named', name: 'brightBlack' } : attrs.bg,
+                    bold: true,
+                    underline: c === this._selectedCol,
                 });
 
-                if (separator) {
-                    screen.writeString(cx + cellWidth, drawY, vertical, attrs);
+                if (indicator) {
+                    screen.writeString(cx + headerWidth, tableY + row, indicator, {
+                        ...attrs,
+                        bold: true,
+                    });
                 }
 
-                cx += colWidth;
+                cx += cellWidth;
+                if (c < this._columns.length - 1) {
+                    screen.writeString(cx, tableY + row, this._separator, { ...attrs, dim: true });
+                    cx += sepWidth;
+                }
+            }
+            row++;
+
+            // Header separator line
+            if (row < tableHeight) {
+                const sepLine = (caps.unicode ? '\u2500' : '-').repeat(width);
+                screen.writeString(x, tableY + row, sepLine, { ...attrs, dim: true });
+                row++;
             }
         }
-    }
 
-    private _getSortedRows(): DataGridRow[] {
-        if (this._sortDir === 'none' || this._sortKey === null) {
-            return this._rows;
-        }
+        const dataRows = this._getVisibleRows();
+        for (let r = 0; r < dataRows.length && row < tableHeight; r++) {
+            const dataRow = dataRows[r];
+            if (!dataRow) continue;
+            const isStripe = this._stripe && r % 2 === 1;
+            let cx = x;
 
-        const key = this._sortKey;
-        const dir = this._sortDir;
-        return [...this._rows].sort((a, b) => {
-            const left  = a[key] ?? '';
-            const right = b[key] ?? '';
-            if (typeof left === 'number' && typeof right === 'number') {
-                return dir === 'asc' ? left - right : right - left;
+            for (let c = 0; c < this._columns.length; c++) {
+                const col = this._columns[c];
+                const cellWidth = colWidths[c] ?? 0;
+                const rawValue = String(dataRow[col.key] ?? '');
+                const cellText = this._alignText(rawValue, cellWidth, col.align ?? 'left');
+
+                screen.writeString(cx, tableY + row, cellText, {
+                    ...attrs,
+                    bg: isStripe ? this._stripeColor : attrs.bg,
+                });
+                cx += cellWidth;
+                if (c < this._columns.length - 1) {
+                    screen.writeString(cx, tableY + row, this._separator, {
+                        ...attrs,
+                        dim: true,
+                        bg: isStripe ? this._stripeColor : attrs.bg,
+                    });
+                    cx += sepWidth;
+                }
             }
-            const l = String(left);
-            const r = String(right);
-            if (l === r) return 0;
-            return dir === 'asc' ? (l > r ? 1 : -1) : (l < r ? 1 : -1);
-        });
-    }
 
-    private _getVisibleColumns(totalWidth: number): Array<{ column: DataGridColumn; width: number; separator: boolean }> {
-        const visible: Array<{ column: DataGridColumn; width: number; separator: boolean }> = [];
-        let remaining = totalWidth;
+            if (isStripe) {
+                for (let fx = cx; fx < x + width; fx++) {
+                    screen.setCell(fx, tableY + row, { char: ' ', bg: this._stripeColor });
+                }
+            }
 
-        for (let index = this._colOffset; index < this._columns.length; index++) {
-            const column = this._columns[index];
-            const needsSeparator = index < this._columns.length - 1;
-            const reserved = column.width + (needsSeparator ? 1 : 0);
-            if (reserved > remaining) break;
-            visible.push({ column, width: column.width + (needsSeparator ? 1 : 0), separator: needsSeparator });
-            remaining -= reserved;
+            row++;
         }
-
-        return visible;
     }
 
-    private _clampScroll(): void {
-        const visibleRows = Math.max(0, this._getVisibleRowCount());
-
-        if (this._selectedRow < this._rowOffset) {
-            this._rowOffset = this._selectedRow;
-        } else if (this._selectedRow >= this._rowOffset + visibleRows) {
-            this._rowOffset = this._selectedRow - visibleRows + 1;
+    private _getVisibleRows(): DataGridRow[] {
+        let rows = [...this._rows];
+        if (this._filter.length > 0) {
+            const needle = this._filter.toLowerCase();
+            rows = rows.filter(r =>
+                this._columns.some(c => {
+                    const v = r[c.key];
+                    return v !== undefined && String(v).toLowerCase().includes(needle);
+                }),
+            );
         }
-
-        this._rowOffset = Math.max(0, Math.min(this._rowOffset, Math.max(0, this._rows.length - visibleRows)));
-    }
-
-    private _clampColScroll(): void {
-        const visibleCols = this._getVisibleColumns(this._getContentRect().width).length;
-
-        if (this._selectedCol < this._colOffset) {
-            this._colOffset = this._selectedCol;
-        } else if (this._selectedCol >= this._colOffset + visibleCols) {
-            this._colOffset = this._selectedCol - visibleCols + 1;
+        if (this._sortDir !== 'none' && this._sortKey !== null) {
+            const key = this._sortKey;
+            const dir = this._sortDir;
+            rows.sort((a, b) => {
+                const left = a[key] ?? '';
+                const right = b[key] ?? '';
+                if (typeof left === 'number' && typeof right === 'number') {
+                    return dir === 'asc' ? left - right : right - left;
+                }
+                const l = String(left);
+                const r = String(right);
+                if (l === r) return 0;
+                return dir === 'asc' ? (l > r ? 1 : -1) : (l < r ? 1 : -1);
+            });
         }
-
-        this._colOffset = Math.max(0, this._colOffset);
-    }
-
-    private _getVisibleRowCount(): number {
-        const height = this._getContentRect().height;
-        return this._showHeader ? Math.max(0, height - 1) : height;
+        return rows;
     }
 }
-
-/** JSX-friendly alias for the DataGrid class widget */
-export { DataGrid as DataGridView } from './DataGrid.js';

--- a/packages/widgets/src/data/Table.ts
+++ b/packages/widgets/src/data/Table.ts
@@ -56,13 +56,13 @@ export interface TableProps {
  * - External state via `state` prop and `useTableState` hook
  */
 export class Table extends Widget {
-    private _columns: TableColumn[];
-    private _rows: TableRow[];
-    private _showHeader: boolean;
-    private _headerColor: Color;
-    private _stripe: boolean;
-    private _stripeColor: Color;
-    private _separator: string;
+    protected _columns: TableColumn[];
+    protected _rows: TableRow[];
+    protected _showHeader: boolean;
+    protected _headerColor: Color;
+    protected _stripe: boolean;
+    protected _stripeColor: Color;
+    protected _separator: string;
     private _state?: TableState;
     private _onStateChange?: (state: TableState) => void;
 
@@ -198,7 +198,7 @@ export class Table extends Widget {
         }
     }
 
-    private _computeColumnWidths(totalWidth: number): number[] {
+    protected _computeColumnWidths(totalWidth: number): number[] {
         const fixedCols = this._columns.filter(c => c.width !== undefined);
         const flexCols = this._columns.filter(c => c.width === undefined);
 
@@ -209,7 +209,7 @@ export class Table extends Widget {
         return this._columns.map(c => c.width ?? flexWidth);
     }
 
-    private _alignText(text: string, width: number, align: 'left' | 'center' | 'right'): string {
+    protected _alignText(text: string, width: number, align: 'left' | 'center' | 'right'): string {
         const truncated = truncate(text, width);
         const textWidth = stringWidth(truncated);
         const pad = Math.max(0, width - textWidth);


### PR DESCRIPTION
## Description

Rewrites `DataGrid` to extend `Table` and adds column sorting (with `▲/▼` indicators), a filter row opened by `/`, and `Escape` to close it.

## Related Issue

Closes #40

## Which package(s)?

- `@termuijs/widgets`

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [x] 🧪 Tests (`type:testing`)

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run packages/widgets` → 1835 passed (DataGrid: 12/12)
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck --filter='!@termuijs/adapters'`
- [x] PR title follows `type: short description`.
- [x] State mutators call `markDirty()` (`setSelectedColumn`, `setFilter`, `clearFilter`, `cycleSort`).
- [x] No `any` types added.
- [x] No unrelated refactors.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.

## Screenshots / Recordings (UI changes)

<img width="649" height="577" alt="image" src="https://github.com/user-attachments/assets/f9ff4e74-fb43-43f1-8d1a-c44cfcd2dd72" />

## Notes for the Reviewer

### What the rewrite adds
- `s` (or `S`) cycles sort on the selected column: `none → asc → desc → none`.
- `▲ / ▼` indicator (Unicode) or `^ / v` (ASCII) appended to the sorted column's header.
- `/` opens a filter row; typing narrows rows by case-insensitive substring across all columns. `Backspace` edits; `Escape` closes the filter row and clears the filter.
- Left/right arrows move the selected column.
- Sort + filter compose: `_getVisibleRows` filters first, then sorts the filtered set.

### Files
- `packages/widgets/src/data/DataGrid.ts` — full rewrite; extends `Table`.
- `packages/widgets/src/data/DataGrid.test.ts` — 12 tests covering all 8 spec acceptance criteria plus shift+s, column navigation, filter-row text rendering, and sort-on-selected-column.
- `packages/widgets/src/data/Table.ts` — minimal change: 7 `private` fields/methods (`_columns`, `_rows`, `_showHeader`, `_headerColor`, `_stripe`, `_stripeColor`, `_separator`, `_computeColumnWidths`, `_alignText`) promoted to `protected` so `DataGrid` can call them. No behavior change to `Table`.

### Things fixed from the previous DataGrid (per reviewer feedback)
- The old `DataGrid` was a 2D-virtualized widget with a different API and an `export { DataGrid as DataGridView } from './DataGrid.js';` self-referential re-export. Both are gone — `DataGrid` now extends `Table` and the file is self-contained.
- The old test's `screen.back[1]` row assertion is moot — the new test reads `screen.back[0]` for the header and validates all the spec's required cases (default render, sort changes order, sort indicator visible, filter narrows rows, Escape clears filter).

### 12 tests
1. renders same as Table by default (header + data rows)
2. `s` key cycles sort: none → asc → desc → none
3. sort changes the visible row order
4. renders ▲ sort indicator in the header
5. uses ASCII `^` indicator when `caps.unicode` is off
6. `/` opens filter and typing narrows rows
7. `Escape` closes the filter and clears the narrowed rows
8. `onSort` callback fires with key and direction
9. filter row renders the `/foo` text
10. left/right move the selected column (clamped at edges)
11. sort uses the selected column, not always column 0
12. shift+s also cycles sort (case-insensitive)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard-driven sorting: cycle through sort directions using `S` key
  * Added interactive filtering: press `/` to open filter, type to search, press `Escape` to clear
  * Enhanced keyboard navigation for column selection with left/right arrow keys
  * Added sort indicators to column headers and visual highlighting for selected columns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->