### PR TITLE
[bug] Generate-docs script lacks several validation

### DIFF
--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -4,7 +4,8 @@
 // ─────────────────────────────────────────────────────
 
 import { execFileSync } from 'node:child_process';
-import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 
 /**
  * Validate documentation target to prevent command injection
@@ -33,6 +34,15 @@ function validateDocTarget(target) {
       'Invalid documentation target. Only lowercase letters, numbers, hyphens, underscores and forward slashes are allowed.'
     );
   }
+
+  // Reject reserved directory names that could conflict with project structure
+  const RESERVED_NAMES = ['src', 'docs', 'node_modules', '.git'];
+  const topLevelSegment = target.split('/')[0];
+  if (RESERVED_NAMES.includes(topLevelSegment)) {
+    throw new Error(
+      `Documentation target "${topLevelSegment}" is a reserved directory name and cannot be used.`
+    );
+  }
 }
 
 /**
@@ -43,6 +53,20 @@ function generateDocs(target) {
   try {
     validateDocTarget(target);
 
+    // Defense-in-depth: ensure the output path stays inside the docs directory
+    const docsRoot = resolve('docs');
+    const targetOut = resolve(join('docs', target));
+    if (!targetOut.startsWith(docsRoot + '/') && targetOut !== docsRoot) {
+      throw new Error(
+        `Documentation output path "${targetOut}" escapes the docs directory.`
+      );
+    }
+
+    // Verify the source directory exists before running any tooling
+    if (!existsSync('src')) {
+      throw new Error('Source directory "src" does not exist. Cannot generate documentation.');
+    }
+
     console.log(`Generating documentation for: ${target}...`);
 
     // Use execFileSync with argument array (safe from injection)
@@ -50,6 +74,7 @@ function generateDocs(target) {
     execFileSync('tsc', ['--noEmit'], {
       stdio: 'inherit',
       encoding: 'utf-8',
+      timeout: 300000,
     });
 
     // Generate documentation using typedoc (if available)
@@ -57,6 +82,7 @@ function generateDocs(target) {
       execFileSync('typedoc', ['--out', join('docs', target), 'src'], {
         stdio: 'inherit',
         encoding: 'utf-8',
+        timeout: 300000,
       });
       console.log(`✓ Documentation generated at: docs/${target}`);
     } catch (err) {
@@ -65,12 +91,20 @@ function generateDocs(target) {
       execFileSync('jsdoc', ['-d', join('docs', target), 'src/**/*.ts'], {
         stdio: 'inherit',
         encoding: 'utf-8',
+        timeout: 300000,
       });
       console.log(`✓ Documentation generated at: docs/${target}`);
     }
   } catch (err) {
     if (err instanceof Error) {
       console.error(`✗ Failed to generate documentation: ${err.message}`);
+      // Print subprocess output when available to aid CI debugging
+      if (err.stderr) {
+        console.error('stderr:', err.stderr);
+      }
+      if (err.stdout) {
+        console.error('stdout:', err.stdout);
+      }
     } else {
       console.error('✗ Failed to generate documentation');
     }


### PR DESCRIPTION
## Description

This PR hardens the `generate-docs` script by adding additional validation, path safety checks, timeout protection, and improved error reporting. These changes improve reliability and security while preserving the existing documentation generation workflow and behavior.

## Related Issue

Closes #810 

## Which package(s)?

* Documentation tooling (`generate-docs` script)

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)
* [x] 🔒 Security (`type:security`)
* [x] 🔧 DevOps / CI (`type:devops`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md].
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.

### Changes Implemented

#### 1. Reserved Directory Validation

Enhanced `validateDocTarget()` to reject reserved directory names:

```text
src
docs
node_modules
.git
```

A descriptive error is now thrown when these names are used as documentation targets.

---

#### 2. Documentation Path Escape Protection

Added a defense-in-depth validation layer using `resolve()` from `node:path`.

The script now:

* Resolves the documentation root directory.
* Resolves the target output directory.
* Verifies that the output path remains within the documentation root.
* Rejects any path attempting to escape the docs directory.

---

#### 3. Source Directory Existence Check

Added an `existsSync('src')` validation before any documentation tooling is executed.

If the source directory is missing, the script now exits early with a clear error message instead of failing later during generation.

---

#### 4. Timeout Protection

Added:

```js
timeout: 300000
```

to all documentation generation commands:

* TypeScript (`tsc`)
* TypeDoc (`typedoc`)
* JSDoc (`jsdoc`)

This prevents hung processes from running indefinitely in local or CI environments.

---

#### 5. Improved Error Reporting

Enhanced the existing catch block to surface additional debugging information when available:

* stderr output
* stdout output

The original error message behavior is preserved, with supplemental output only shown when present.

---

### Additional Notes

New imports added:

```js
existsSync
```

from:

```js
node:fs
```

and

```js
resolve
```

from:

```js
node:path
```

No existing command flow, comments, or functionality were altered beyond the requested hardening improvements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced documentation generation validation and safety checks for improved reliability.
  * Improved error diagnostics for documentation build failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->