### PR TITLE
feat(widgets): add Divider widget for horizontal and vertical section…

### DIFF
--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -77,6 +77,8 @@ export { Columns } from './layout/Columns.js';
 export type { ColumnsOptions } from './layout/Columns.js';
 export { Dock } from './layout/Dock.js';
 export type { DockOptions, DockItem, DockEdge } from './layout/Dock.js';
+export { Divider } from './layout/Divider.js';
+export type { DividerOptions, DividerOrientation } from './layout/Divider.js';
 
 // ── Feedback Widgets ──────────────────────────────────
 export { ProgressBar } from './feedback/ProgressBar.js';

--- a/packages/widgets/src/layout/Divider.test.ts
+++ b/packages/widgets/src/layout/Divider.test.ts
@@ -1,0 +1,127 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for Divider widget
+// ─────────────────────────────────────────────────────
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+afterEach(() => {
+    vi.unstubAllEnvs();
+});
+
+describe('Divider', () => {
+    it('renders a horizontal line by default', async () => {
+        vi.stubEnv('NO_UNICODE', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { Divider } = await import('./Divider.js');
+
+        const divider = new Divider();
+        divider.updateRect({ x: 0, y: 0, width: 10, height: 1 });
+        const screen = new Screen(10, 1);
+        divider.render(screen);
+
+        const rendered = screen.back[0].map((cell: { char: string }) => cell.char).join('');
+        expect(rendered).toContain('─');
+    });
+
+    it('renders ASCII fallback when NO_UNICODE=1', async () => {
+        vi.stubEnv('NO_UNICODE', '1');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { Divider } = await import('./Divider.js');
+
+        const divider = new Divider();
+        divider.updateRect({ x: 0, y: 0, width: 10, height: 1 });
+        const screen = new Screen(10, 1);
+        divider.render(screen);
+
+        const rendered = screen.back[0].map((cell: { char: string }) => cell.char).join('');
+        expect(rendered).toContain('-');
+        expect(rendered).not.toContain('─');
+    });
+
+    it('renders a vertical line when orientation is vertical', async () => {
+        vi.stubEnv('NO_UNICODE', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { Divider } = await import('./Divider.js');
+
+        const divider = new Divider({}, { orientation: 'vertical' });
+        divider.updateRect({ x: 0, y: 0, width: 1, height: 5 });
+        const screen = new Screen(1, 5);
+        divider.render(screen);
+
+        for (let row = 0; row < 5; row++) {
+            const char = screen.back[row][0].char;
+            expect(char).toBe('│');
+        }
+    });
+
+    it('renders vertical ASCII fallback when NO_UNICODE=1', async () => {
+        vi.stubEnv('NO_UNICODE', '1');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { Divider } = await import('./Divider.js');
+
+        const divider = new Divider({}, { orientation: 'vertical' });
+        divider.updateRect({ x: 0, y: 0, width: 1, height: 3 });
+        const screen = new Screen(1, 3);
+        divider.render(screen);
+
+        for (let row = 0; row < 3; row++) {
+            expect(screen.back[row][0].char).toBe('|');
+        }
+    });
+
+    it('renders a centered label in horizontal mode', async () => {
+        vi.stubEnv('NO_UNICODE', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { Divider } = await import('./Divider.js');
+
+        const divider = new Divider({}, { label: 'Stats' });
+        divider.updateRect({ x: 0, y: 0, width: 20, height: 1 });
+        const screen = new Screen(20, 1);
+        divider.render(screen);
+
+        const rendered = screen.back[0].map((cell: { char: string }) => cell.char).join('');
+        expect(rendered).toContain('Stats');
+        expect(rendered).toContain('─');
+    });
+
+    it('uses custom char when provided', async () => {
+        vi.stubEnv('NO_UNICODE', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { Divider } = await import('./Divider.js');
+
+        const divider = new Divider({}, { char: '=' });
+        divider.updateRect({ x: 0, y: 0, width: 10, height: 1 });
+        const screen = new Screen(10, 1);
+        divider.render(screen);
+
+        const rendered = screen.back[0].map((cell: { char: string }) => cell.char).join('');
+        expect(rendered).toContain('=');
+        expect(rendered).not.toContain('─');
+    });
+
+    it('setLabel updates the label', async () => {
+        vi.resetModules();
+        const { Divider } = await import('./Divider.js');
+        const divider = new Divider();
+        divider.setLabel('New Label');
+        expect(divider).toBeDefined();
+    });
+
+    it('returns early when width is zero', async () => {
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { Divider } = await import('./Divider.js');
+
+        const divider = new Divider();
+        divider.updateRect({ x: 0, y: 0, width: 0, height: 1 });
+        const screen = new Screen(10, 1);
+        expect(() => divider.render(screen)).not.toThrow();
+    });
+});

--- a/packages/widgets/src/layout/Divider.ts
+++ b/packages/widgets/src/layout/Divider.ts
@@ -1,0 +1,147 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Divider widget
+// Renders a horizontal or vertical line with optional label
+// ─────────────────────────────────────────────────────
+import {
+    type Screen,
+    type Style,
+    type Color,
+    styleToCellAttrs,
+    stringWidth,
+    caps,
+} from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export type DividerOrientation = 'horizontal' | 'vertical';
+
+export interface DividerOptions {
+    /** Direction of the divider line */
+    orientation?: DividerOrientation;
+    /** Optional centered label inside the line */
+    label?: string;
+    /** Character used to draw the line (overrides default) */
+    char?: string;
+    /** Color of the line */
+    color?: Color;
+}
+
+/**
+ * Divider — a horizontal or vertical separator line with optional label.
+ *
+ * Examples:
+ *   ──────────────── Stats ────────────────   (horizontal with label)
+ *   ────────────────────────────────────────  (horizontal)
+ *   │  (vertical, repeating down the height)
+ */
+export class Divider extends Widget {
+    private _orientation: DividerOrientation;
+    private _label: string;
+    private _char: string | undefined;
+    private _color: Color | undefined;
+
+    constructor(style: Partial<Style> = {}, opts: DividerOptions = {}) {
+        super(style);
+        this._orientation = opts.orientation ?? 'horizontal';
+        this._label = opts.label ?? '';
+        this._char = opts.char;
+        this._color = opts.color;
+    }
+
+    setLabel(label: string): void {
+        this._label = label;
+        this.markDirty();
+    }
+
+    setOrientation(orientation: DividerOrientation): void {
+        this._orientation = orientation;
+        this.markDirty();
+    }
+
+    setChar(char: string): void {
+        this._char = char;
+        this.markDirty();
+    }
+
+    setColor(color: Color): void {
+        this._color = color;
+        this.markDirty();
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const rect = this._getContentRect();
+        const { x, y, width, height } = rect;
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this._style);
+        const cellAttrs = this._color
+            ? { ...attrs, fg: this._color }
+            : attrs;
+
+        if (this._orientation === 'horizontal') {
+            this._renderHorizontal(screen, x, y, width, cellAttrs);
+        } else {
+            this._renderVertical(screen, x, y, height, cellAttrs);
+        }
+    }
+
+    private _renderHorizontal(
+        screen: Screen,
+        x: number,
+        y: number,
+        width: number,
+        attrs: ReturnType<typeof styleToCellAttrs>,
+    ): void {
+        const lineChar = this._char ?? (caps.unicode ? '─' : '-');
+
+        if (!this._label) {
+            // Simple full-width line
+            for (let i = 0; i < width; i++) {
+                screen.setCell(x + i, y, { char: lineChar, ...attrs });
+            }
+            return;
+        }
+
+        // Centered label: ─── Label ───
+        const labelWithPad = ` ${this._label} `;
+        const labelWidth = stringWidth(labelWithPad);
+
+        if (labelWidth >= width) {
+            // Not enough room — just write the label truncated
+            screen.writeString(x, y, labelWithPad.slice(0, width), attrs);
+            return;
+        }
+
+        const leftLen = Math.floor((width - labelWidth) / 2);
+        const rightLen = width - labelWidth - leftLen;
+
+        // Left line
+        for (let i = 0; i < leftLen; i++) {
+            screen.setCell(x + i, y, { char: lineChar, ...attrs });
+        }
+
+        // Label
+        screen.writeString(x + leftLen, y, labelWithPad, attrs);
+
+        // Right line
+        for (let i = 0; i < rightLen; i++) {
+            screen.setCell(x + leftLen + labelWidth + i, y, {
+                char: lineChar,
+                ...attrs,
+            });
+        }
+    }
+
+    private _renderVertical(
+        screen: Screen,
+        x: number,
+        y: number,
+        height: number,
+        attrs: ReturnType<typeof styleToCellAttrs>,
+    ): void {
+        const lineChar = this._char ?? (caps.unicode ? '│' : '|');
+
+        for (let i = 0; i < height; i++) {
+            screen.setCell(x, y + i, { char: lineChar, ...attrs });
+        }
+    }
+}


### PR DESCRIPTION
## Description
Adds a `Divider` widget to `@termuijs/widgets` that renders a horizontal 
or vertical separator line with an optional centered label, custom character, 
and color support. Follows the `Gauge.ts` pattern with full `caps.unicode` 
ASCII fallback and `markDirty()` on all state-mutating methods.

## Related Issue
Closes #713

## Which package(s)?
`@termuijs/widgets`

## Type of Change
- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist
- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation
- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/59d3c49d-74a1-4398-ac87-5ca01a67bc0a`

## Screenshots / Recordings (UI changes)
No terminal recording at this time. The widget renders a full-width 
horizontal line by default, a vertical line when `orientation="vertical"`, 
and a centered label when `label` prop is set. All 8 test cases cover 
these visual outputs via `Screen` snapshots.

## Notes for the Reviewer
- Follows `Gauge.ts` constructor shape: `(style = {}, opts = {})`
- `caps.unicode` fallback: `─` → `-` and `│` → `|`
- `markDirty()` called in `setLabel()`, `setOrientation()`, `setChar()`, `setColor()`
- Early return guard: `if (width <= 0 || height <= 0) return`
- 8 tests written following `Gauge.test.ts` pattern using real `Screen` objects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Divider widget for rendering horizontal or vertical dividing lines with support for optional labels on horizontal dividers, customizable divider characters, and color styling to match your UI design.

* **Tests**
  * Added comprehensive test coverage for the Divider widget including Unicode and ASCII rendering modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->