### PR TITLE
perf(widgets): avoid redundant markDirty calls in StatusMessage

### DIFF
--- a/packages/widgets/src/feedback/StatusMessage.test.ts
+++ b/packages/widgets/src/feedback/StatusMessage.test.ts
@@ -159,4 +159,26 @@ describe('StatusMessage', () => {
         expect(widget.isDirty).toBe(true);
     });
     
+    it('does not mark dirty when message is unchanged', () => {
+        const widget = new StatusMessage('Saved');
+    
+        widget.clearDirty();
+        widget.setMessage('Saved');
+    
+        expect(widget.isDirty).toBe(false);
+    });
+    
+    it('does not mark dirty when variant is unchanged', () => {
+        const widget = new StatusMessage(
+            'Saved',
+            {},
+            { variant: 'success' },
+        );
+    
+        widget.clearDirty();
+        widget.setVariant('success');
+    
+        expect(widget.isDirty).toBe(false);
+    });
+
 });

--- a/packages/widgets/src/feedback/StatusMessage.ts
+++ b/packages/widgets/src/feedback/StatusMessage.ts
@@ -54,11 +54,15 @@ export class StatusMessage extends Widget {
     }
 
     setMessage(message: string): void {
+        if (this._message === message) return;
+
         this._message = message;
         this.markDirty();
     }
 
     setVariant(variant: StatusVariant): void {
+        if (this._variant === variant) return;
+        
         this._variant = variant;
         this.markDirty();
     }


### PR DESCRIPTION

## Description

Avoids unnecessary widget invalidation in `StatusMessage` by skipping `markDirty()` calls when state values remain unchanged.

This PR adds equality guards to `setMessage()` and `setVariant()` and introduces regression tests verifying that unchanged updates do not trigger widget invalidation.

## Related Issue

Closes #833 

## Which package(s)?

@termuijs/widgets

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [x] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)
N/A

## Notes for the Reviewer

### Changes Made

* Added equality guards in `StatusMessage.setMessage()`
* Added equality guards in `StatusMessage.setVariant()`
* Added regression tests verifying unchanged values do not mark the widget dirty
* Preserved existing dirty-state behavior for actual state changes

### Validation

✅ `bun vitest run packages/widgets/src/feedback/StatusMessage.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * StatusMessage component now skips unnecessary state updates when the same message or variant value is reapplied, improving performance.

* **Tests**
  * Added test coverage verifying correct state management behavior when values remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->