### PR TITLE
perf(widgets): avoid redundant markDirty calls in Callout

### DIFF
--- a/packages/widgets/src/feedback/Callout.test.ts
+++ b/packages/widgets/src/feedback/Callout.test.ts
@@ -49,4 +49,27 @@ describe('Callout', () => {
         const output = render(callout);
         expect(output).toBe('\u2139');
     });
+
+    it('does not mark dirty when message is unchanged', () => {
+        const callout = new Callout('hello');
+    
+        callout.clearDirty();
+        callout.setMessage('hello');
+    
+        expect(callout.isDirty).toBe(false);
+    });
+    
+    it('does not mark dirty when variant is unchanged', () => {
+        const callout = new Callout(
+            'hello',
+            {},
+            { variant: 'info' },
+        );
+    
+        callout.clearDirty();
+        callout.setVariant('info');
+    
+        expect(callout.isDirty).toBe(false);
+    });
+
 });

--- a/packages/widgets/src/feedback/Callout.ts
+++ b/packages/widgets/src/feedback/Callout.ts
@@ -42,11 +42,15 @@ export class Callout extends Widget {
     }
 
     setMessage(message: string): void {
+        if (message === this._message) return;
+
         this._message = message;
         this.markDirty();
     }
 
     setVariant(variant: CalloutVariant): void {
+        if (variant === this._variant) return;
+        
         this._variant = variant;
         this.markDirty();
     }


### PR DESCRIPTION

## Description

Avoids unnecessary widget invalidation in `Callout` by skipping `markDirty()` calls when state values remain unchanged.

This PR adds equality guards to `setMessage()` and `setVariant()` and introduces regression tests verifying that unchanged updates do not trigger widget invalidation.

## Related Issue

Closes #834 

## Which package(s)?

@termuijs/widgets

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [x] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md] (./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

### Changes Made

* Added equality guard in `Callout.setMessage()`
* Added equality guard in `Callout.setVariant()`
* Added regression tests ensuring unchanged values do not trigger widget invalidation
* Preserved existing dirty-state behavior for actual state changes

### Validation

✅ `bun vitest run packages/widgets/src/feedback/Callout.test.ts`

### Build Note

Repository-wide `bun run build` currently fails in `@termuijs/adapters` due to a missing `dotenv` dependency during DTS generation. This failure is unrelated to the changes in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Callout component incorrectly marking state as changed when setting the same message or variant value, improving performance and state management accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->