### PR TITLE
feat: add BulletChart widget

### DIFF
--- a/packages/widgets/src/data/BulletChart.test.ts
+++ b/packages/widgets/src/data/BulletChart.test.ts
@@ -1,0 +1,98 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for BulletChart widget
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('BulletChart', () => {
+    it('initializes with 0 value and target', async () => {
+        const { BulletChart } = await import('./BulletChart.js');
+        const chart = new BulletChart();
+        expect(chart).toBeDefined();
+    });
+
+    it('setValue and setTarget clamp and independently call markDirty', async () => {
+        const { BulletChart } = await import('./BulletChart.js');
+        const chart = new BulletChart({}, { max: 100 });
+        const markDirtySpy = vi.spyOn(chart, 'markDirty');
+        
+        chart.setValue(60);
+        expect(markDirtySpy).toHaveBeenCalledTimes(1);
+        
+        chart.setTarget(80);
+        expect(markDirtySpy).toHaveBeenCalledTimes(2);
+
+        chart.setValue(150);
+        expect(markDirtySpy).toHaveBeenCalledTimes(3);
+
+        chart.setTarget(-10);
+        expect(markDirtySpy).toHaveBeenCalledTimes(4);
+    });
+
+    it('renders value and target proportion correctly in unicode', async () => {
+        const { Screen, caps } = await import('@termuijs/core');
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+        const { BulletChart } = await import('./BulletChart.js');
+
+        const chart = new BulletChart({}, { max: 100 });
+        chart.setValue(60);
+        chart.setTarget(80);
+        chart.updateRect({ x: 0, y: 0, width: 10, height: 1 });
+        const screen = new Screen(10, 1);
+        chart.render(screen);
+
+        const rendered = screen.back[0].map((cell: { char: string }) => cell.char).join('');
+        // 60% of 10 is 6. Value bars are at indices 0-5.
+        // 80% of 10 is 8. Target marker is at index 8.
+        expect(rendered[0]).toBe('▄');
+        expect(rendered[5]).toBe('▄');
+        expect(rendered[6]).toBe(' ');
+        expect(rendered[8]).toBe('│');
+    });
+
+    it('uses ASCII chars when unicode is false', async () => {
+        const { Screen, caps } = await import('@termuijs/core');
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+        const { BulletChart } = await import('./BulletChart.js');
+
+        const chart = new BulletChart({}, { max: 100 });
+        chart.setValue(50);
+        chart.setTarget(70);
+        chart.updateRect({ x: 0, y: 0, width: 10, height: 1 });
+        const screen = new Screen(10, 1);
+        chart.render(screen);
+
+        const rendered = screen.back[0].map((cell: { char: string }) => cell.char).join('');
+        // 50% of 10 is 5. Target at 70% is 7.
+        expect(rendered).toContain('=');
+        expect(rendered).toContain('|');
+        expect(rendered).toContain('-');
+        expect(rendered).not.toMatch(/[▄│]/);
+        expect(rendered[7]).toBe('|');
+    });
+
+    it('renders range bands with correct background colors', async () => {
+        const { Screen, caps } = await import('@termuijs/core');
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+        const { BulletChart } = await import('./BulletChart.js');
+
+        const chart = new BulletChart({}, { 
+            max: 100,
+            ranges: [
+                { to: 50, color: { type: 'named', name: 'red' } },
+                { to: 100, color: { type: 'named', name: 'green' } }
+            ]
+        });
+        chart.updateRect({ x: 0, y: 0, width: 10, height: 1 });
+        const screen = new Screen(10, 1);
+        chart.render(screen);
+
+        // Indices 0-5 are <= 50%, indices 6-9 are > 50%
+        expect(screen.back[0][5].bg?.name).toBe('red');
+        expect(screen.back[0][6].bg?.name).toBe('green');
+    });
+});

--- a/packages/widgets/src/data/BulletChart.ts
+++ b/packages/widgets/src/data/BulletChart.ts
@@ -1,0 +1,117 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — BulletChart widget
+// ─────────────────────────────────────────────────────
+
+import { type Screen, type Style, type Color, styleToCellAttrs, stringWidth, caps } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export interface BulletRange {
+    to: number;
+    color?: Color;
+}
+
+export interface BulletChartOptions {
+    max?: number;
+    ranges?: BulletRange[];
+    valueColor?: Color;
+    targetColor?: Color;
+    label?: string;
+}
+
+/**
+ * BulletChart — a metric display with target marker and qualitative range bands.
+ */
+export class BulletChart extends Widget {
+    private _value: number = 0;
+    private _target: number = 0;
+    private _max: number;
+    private _ranges: BulletRange[];
+    private _valueColor: Color;
+    private _targetColor: Color;
+    private _label: string;
+
+    constructor(style: Partial<Style> = {}, opts: BulletChartOptions = {}) {
+        super(style);
+        this._max = opts.max !== undefined && opts.max > 0 ? opts.max : 100;
+        this._ranges = [...(opts.ranges ?? [])].sort((a, b) => a.to - b.to);
+        this._valueColor = opts.valueColor ?? { type: 'named', name: 'cyan' };
+        this._targetColor = opts.targetColor ?? { type: 'named', name: 'white' };
+        this._label = opts.label ?? '';
+    }
+
+    setValue(value: number): void {
+        this._value = Math.max(0, Math.min(this._max, value));
+        this.markDirty();
+    }
+
+    setTarget(target: number): void {
+        this._target = Math.max(0, Math.min(this._max, target));
+        this.markDirty();
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const rect = this._getContentRect();
+        const { x, y, width, height } = rect;
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this._style);
+
+        const labelStr = this._label ? this._label + ' ' : '';
+        const labelWidth = stringWidth(labelStr);
+        const barWidth = Math.max(0, width - labelWidth);
+
+        if (this._label) {
+            screen.writeString(x, y, labelStr, { ...attrs, bold: true });
+        }
+
+        if (barWidth <= 0) return;
+
+        const valueCells = Math.max(0, Math.min(barWidth, Math.round((this._value / this._max) * barWidth)));
+        const targetCell = Math.max(0, Math.min(barWidth - 1, Math.round((this._target / this._max) * barWidth)));
+
+        const barX = x + labelWidth;
+
+        for (let i = 0; i < barWidth; i++) {
+            const cellValue = (i / barWidth) * this._max;
+            let rangeColor: Color | undefined = undefined;
+            for (const range of this._ranges) {
+                if (cellValue <= range.to) {
+                    rangeColor = range.color;
+                    break;
+                }
+            }
+
+            let char = ' ';
+            let fg = attrs.fg;
+            let bg = rangeColor ?? attrs.bg;
+
+            if (caps.unicode) {
+                if (i === targetCell) {
+                    char = '│';
+                    fg = this._targetColor;
+                } else if (i < valueCells) {
+                    char = '▄';
+                    fg = this._valueColor;
+                } else {
+                    char = ' ';
+                }
+            } else {
+                // ASCII Fallback
+                if (i === targetCell) {
+                    char = '|';
+                    fg = this._targetColor;
+                } else if (i < valueCells) {
+                    char = '=';
+                    fg = this._valueColor;
+                } else {
+                    char = '-';
+                    if (!rangeColor) {
+                        fg = { type: 'named', name: 'brightBlack' };
+                    }
+                }
+            }
+
+            screen.setCell(barX + i, y, { char, fg, bg });
+        }
+    }
+}

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -120,6 +120,8 @@ export { Definition } from './data/Definition.js';
 export type { DefinitionPair, DefinitionOptions } from './data/Definition.js';
 export { Hexdump } from './data/Hexdump.js';
 export type { HexdumpOptions } from './data/Hexdump.js';
+export { BulletChart } from './data/BulletChart.js';
+export type { BulletChartOptions, BulletRange } from './data/BulletChart.js';
 
 // ── New Display Widgets ───────────────────────────────
 export { Breadcrumbs } from './display/Breadcrumbs.js';


### PR DESCRIPTION
## Description

This PR introduces a new `BulletChart` widget to `@termuijs/widgets` for visualizing a single metric against a target value with optional background range bands. The widget supports Unicode and ASCII rendering modes, configurable colors, target markers, and value/range clamping.

Comprehensive test coverage has been added to validate value rendering, target marker positioning, dirty state updates, and ASCII fallback behavior.

## Related Issue

Closes #249

## Which package(s)?

* @termuijs/widgets

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [x] ✨ Feature (`type:feature`)
* [x] 🧪 Tests (`type:testing`)
* [ ] 📝 Docs (`type:docs`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build` *(see Notes for Reviewer)*
* [ ] Typecheck passes: `bun run typecheck` *(see Notes for Reviewer)*
* [x] You read [CONTRIBUTING.md](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/e929c2a8-0db7-4ce0-9930-424cfc6f1426`

## Screenshots / Recordings (UI changes)

<!-- Attach BulletChart rendering screenshots here if available -->

## Notes for the Reviewer

### Added

* `packages/widgets/src/data/BulletChart.ts`
* `packages/widgets/src/data/BulletChart.test.ts`

### Exported

* `BulletChart`
* `BulletChartOptions`
* `BulletRange`

### Features

* Horizontal bullet chart rendering
* Configurable target marker
* Optional background range bands
* Unicode rendering support using block characters
* ASCII fallback using `=` and `|`
* Value and target clamping to valid bounds
* `markDirty()` triggered on both `setValue()` and `setTarget()`

### Test Coverage

* Value bar proportion rendering
* Target marker positioning
* Independent `markDirty()` verification
* ASCII fallback rendering
* Range/value behavior validation

### Validation

* All BulletChart-specific tests pass successfully.
* Changes are fully confined to `packages/widgets`.
* No dependencies were added.
* No changes were made to `bun.lock`.

### Repository Status

There is a pre-existing failure on the current `main` branch related to `packages/widgets/src/base/Widget.ts` (missing `asciiOnly` property on `Style`) that affects repository-wide `bun run build` and `bun run typecheck`. This issue exists outside the scope of this PR and no unrelated files were modified to avoid mixing fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced BulletChart widget for visualizing metrics with value and target indicators.
  * Supports customizable range bands with colors, value/target styling, and optional labels.
  * Compatible with both Unicode and ASCII rendering modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->