### PR TITLE
fix(widgets): fix CandlestickChart runtime crash from incorrect setCell API usage

### DIFF
--- a/packages/widgets/src/data/CandlestickChart.test.ts
+++ b/packages/widgets/src/data/CandlestickChart.test.ts
@@ -1,41 +1,179 @@
-import { describe, it, expect, vi } from 'vitest';
-import { Screen, caps } from '@termuijs/core';
-import { CandlestickChart } from './CandlestickChart.js';
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for CandlestickChart widget
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+});
 
 describe('CandlestickChart', () => {
-    it('renders a single bullish candle without error', () => {
-        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
-        const screen = new Screen();
-        
+    it('renders nothing when data is empty', async () => {
+        const { Screen } = await import('@termuijs/core');
+        const { CandlestickChart } = await import('./CandlestickChart.js');
+
         const chart = new CandlestickChart({ width: 10, height: 10 });
-        
+        chart.updateRect({ x: 0, y: 0, width: 10, height: 10 });
+        const screen = new Screen(10, 10);
+        chart.render(screen);
+
+        // All cells should remain empty (spaces)
+        const row0 = screen.back[0].map((c: { char: string }) => c.char).join('');
+        expect(row0.trim()).toBe('');
+    });
+
+    it('renders a single bullish candle with body and wick characters', async () => {
+        vi.stubEnv('NO_UNICODE', '');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { CandlestickChart } = await import('./CandlestickChart.js');
+
+        const chart = new CandlestickChart({ width: 10, height: 10 });
         chart.setData([{ open: 1, high: 4, low: 0, close: 3 }]);
-        chart['_renderSelf'](screen);
+        chart.updateRect({ x: 0, y: 0, width: 10, height: 10 });
+        const screen = new Screen(10, 10);
+        chart.render(screen);
+
+        // Collect all non-space characters in column 0
+        const col0Chars: string[] = [];
+        for (let row = 0; row < 10; row++) {
+            const ch = screen.back[row][0].char;
+            if (ch !== ' ') col0Chars.push(ch);
+        }
+
+        // Should have rendered some candle characters
+        expect(col0Chars.length).toBeGreaterThan(0);
+        // Body uses ┃ (unicode) or =, wick uses |
+        expect(col0Chars.some(ch => ch === '┃' || ch === '=')).toBe(true);
     });
 
-    it('renders a single bearish candle without error', () => {
-        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
-        const screen = new Screen();
+    it('renders bearish candle (close < open)', async () => {
+        vi.stubEnv('NO_UNICODE', '');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { CandlestickChart } = await import('./CandlestickChart.js');
+
         const chart = new CandlestickChart({ width: 10, height: 10 });
-        
         chart.setData([{ open: 3, high: 4, low: 0, close: 1 }]);
-        chart['_renderSelf'](screen);
+        chart.updateRect({ x: 0, y: 0, width: 10, height: 10 });
+        const screen = new Screen(10, 10);
+        chart.render(screen);
+
+        // Collect non-space characters in column 0
+        const col0Chars: string[] = [];
+        for (let row = 0; row < 10; row++) {
+            const ch = screen.back[row][0].char;
+            if (ch !== ' ') col0Chars.push(ch);
+        }
+
+        expect(col0Chars.length).toBeGreaterThan(0);
     });
 
-    it('setData triggers markDirty', () => {
+    it('setData triggers markDirty', async () => {
+        const { CandlestickChart } = await import('./CandlestickChart.js');
         const chart = new CandlestickChart();
         const spy = vi.spyOn(chart, 'markDirty');
-        
+
         chart.setData([{ open: 1, high: 2, low: 1, close: 2 }]);
         expect(spy).toHaveBeenCalled();
     });
 
-    it('ASCII fallback when caps.unicode is false', () => {
-        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
-        const screen = new Screen();
+    it('uses ASCII fallback when caps.unicode is false', async () => {
+        vi.stubEnv('NO_UNICODE', '1');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { CandlestickChart } = await import('./CandlestickChart.js');
+
         const chart = new CandlestickChart({ width: 5, height: 5 });
-        
         chart.setData([{ open: 1, high: 4, low: 0, close: 3 }]);
-        chart['_renderSelf'](screen);
+        chart.updateRect({ x: 0, y: 0, width: 5, height: 5 });
+        const screen = new Screen(5, 5);
+        chart.render(screen);
+
+        // Collect all non-space characters
+        const allChars: string[] = [];
+        for (let row = 0; row < 5; row++) {
+            const ch = screen.back[row][0].char;
+            if (ch !== ' ') allChars.push(ch);
+        }
+
+        // ASCII mode: body should use '=' not '┃'
+        expect(allChars).not.toContain('┃');
+        // Should contain '=' for body and/or '|' for wick
+        expect(allChars.some(ch => ch === '=' || ch === '|')).toBe(true);
+    });
+
+    it('renders multiple candles limited by width', async () => {
+        vi.stubEnv('NO_UNICODE', '1');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { CandlestickChart } = await import('./CandlestickChart.js');
+
+        const chart = new CandlestickChart({ width: 3, height: 10 });
+        chart.setData([
+            { open: 1, high: 4, low: 0, close: 3 },
+            { open: 2, high: 5, low: 1, close: 4 },
+            { open: 3, high: 6, low: 2, close: 5 },
+            { open: 4, high: 7, low: 3, close: 6 }, // should be clipped (width=3)
+        ]);
+        chart.updateRect({ x: 0, y: 0, width: 3, height: 10 });
+        const screen = new Screen(3, 10);
+        chart.render(screen);
+
+        // Column 3 does not exist (width=3 means cols 0,1,2), so the 4th candle
+        // should not render. Check that cols 0-2 have content.
+        for (let col = 0; col < 3; col++) {
+            const colChars: string[] = [];
+            for (let row = 0; row < 10; row++) {
+                const ch = screen.back[row][col].char;
+                if (ch !== ' ') colChars.push(ch);
+            }
+            expect(colChars.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('applies correct fg color for bullish vs bearish candles', async () => {
+        vi.stubEnv('NO_UNICODE', '1');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { CandlestickChart } = await import('./CandlestickChart.js');
+
+        const chart = new CandlestickChart({ width: 2, height: 10 });
+        chart.setData([
+            { open: 1, high: 4, low: 0, close: 3 }, // bullish (close > open)
+            { open: 3, high: 4, low: 0, close: 1 }, // bearish (close < open)
+        ]);
+        chart.updateRect({ x: 0, y: 0, width: 2, height: 10 });
+        const screen = new Screen(2, 10);
+        chart.render(screen);
+
+        // Find a non-space cell in col 0 (bullish) — should have green fg
+        let bullishColor = null;
+        for (let row = 0; row < 10; row++) {
+            const cell = screen.back[row][0];
+            if (cell.char !== ' ') {
+                bullishColor = cell.fg;
+                break;
+            }
+        }
+        expect(bullishColor).toEqual({ type: 'named', name: 'green' });
+
+        // Find a non-space cell in col 1 (bearish) — should have red fg
+        let bearishColor = null;
+        for (let row = 0; row < 10; row++) {
+            const cell = screen.back[row][1];
+            if (cell.char !== ' ') {
+                bearishColor = cell.fg;
+                break;
+            }
+        }
+        expect(bearishColor).toEqual({ type: 'named', name: 'red' });
     });
 });

--- a/packages/widgets/src/data/CandlestickChart.test.ts
+++ b/packages/widgets/src/data/CandlestickChart.test.ts
@@ -25,10 +25,8 @@ describe('CandlestickChart', () => {
     });
 
     it('renders a single bullish candle with body and wick characters', async () => {
-        vi.stubEnv('NO_UNICODE', '');
-        vi.stubEnv('TERM', '');
-        vi.resetModules();
-        const { Screen } = await import('@termuijs/core');
+        const { Screen, caps } = await import('@termuijs/core');
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
         const { CandlestickChart } = await import('./CandlestickChart.js');
 
         const chart = new CandlestickChart({ width: 10, height: 10 });
@@ -51,10 +49,8 @@ describe('CandlestickChart', () => {
     });
 
     it('renders bearish candle (close < open)', async () => {
-        vi.stubEnv('NO_UNICODE', '');
-        vi.stubEnv('TERM', '');
-        vi.resetModules();
-        const { Screen } = await import('@termuijs/core');
+        const { Screen, caps } = await import('@termuijs/core');
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
         const { CandlestickChart } = await import('./CandlestickChart.js');
 
         const chart = new CandlestickChart({ width: 10, height: 10 });
@@ -83,10 +79,8 @@ describe('CandlestickChart', () => {
     });
 
     it('uses ASCII fallback when caps.unicode is false', async () => {
-        vi.stubEnv('NO_UNICODE', '1');
-        vi.stubEnv('TERM', '');
-        vi.resetModules();
-        const { Screen } = await import('@termuijs/core');
+        const { Screen, caps } = await import('@termuijs/core');
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
         const { CandlestickChart } = await import('./CandlestickChart.js');
 
         const chart = new CandlestickChart({ width: 5, height: 5 });
@@ -109,10 +103,8 @@ describe('CandlestickChart', () => {
     });
 
     it('renders multiple candles limited by width', async () => {
-        vi.stubEnv('NO_UNICODE', '1');
-        vi.stubEnv('TERM', '');
-        vi.resetModules();
-        const { Screen } = await import('@termuijs/core');
+        const { Screen, caps } = await import('@termuijs/core');
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
         const { CandlestickChart } = await import('./CandlestickChart.js');
 
         const chart = new CandlestickChart({ width: 3, height: 10 });
@@ -139,10 +131,8 @@ describe('CandlestickChart', () => {
     });
 
     it('applies correct fg color for bullish vs bearish candles', async () => {
-        vi.stubEnv('NO_UNICODE', '1');
-        vi.stubEnv('TERM', '');
-        vi.resetModules();
-        const { Screen } = await import('@termuijs/core');
+        const { Screen, caps } = await import('@termuijs/core');
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
         const { CandlestickChart } = await import('./CandlestickChart.js');
 
         const chart = new CandlestickChart({ width: 2, height: 10 });

--- a/packages/widgets/src/data/CandlestickChart.ts
+++ b/packages/widgets/src/data/CandlestickChart.ts
@@ -57,11 +57,17 @@ export class CandlestickChart extends Widget {
 
         const attrs = styleToCellAttrs(this._style);
 
-        const maxHigh = Math.max(...this._candles.map(c => c.high));
-        const minLow = Math.min(...this._candles.map(c => c.low));
-        const priceRange = maxHigh - minLow || 1;
-
         const candleCount = Math.min(this._candles.length, width);
+        const visibleCandles = this._candles.slice(0, candleCount);
+
+        let maxHigh = 0;
+        let minLow = 0;
+        if (visibleCandles.length > 0) {
+            maxHigh = Math.max(...visibleCandles.map(c => c.high));
+            minLow = Math.min(...visibleCandles.map(c => c.low));
+        }
+
+        const priceRange = maxHigh - minLow || 1;
 
         for (let i = 0; i < candleCount; i++) {
             const candle = this._candles[i];

--- a/packages/widgets/src/data/CandlestickChart.ts
+++ b/packages/widgets/src/data/CandlestickChart.ts
@@ -1,5 +1,9 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — CandlestickChart widget
+// ─────────────────────────────────────────────────────
+
+import { type Screen, type Style, type Color, styleToCellAttrs, caps } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
-import { type Style, type Color, caps } from '@termuijs/core';
 
 export interface Candle {
     open: number;
@@ -9,52 +13,61 @@ export interface Candle {
 }
 
 export interface CandlestickChartOptions {
+    /** Color for bullish (close > open) candles */
     upColor?: Color;
+    /** Color for bearish (close < open) candles */
     downColor?: Color;
+    /** Color for the wick (high/low lines) */
     wickColor?: Color;
 }
 
+const DEFAULT_UP_COLOR: Color = { type: 'named', name: 'green' };
+const DEFAULT_DOWN_COLOR: Color = { type: 'named', name: 'red' };
+
+/**
+ * CandlestickChart — renders OHLC candle data as a terminal chart.
+ *
+ * Each candle occupies one column. The body shows open/close range,
+ * wicks extend to high/low. Bullish candles use upColor, bearish use downColor.
+ */
 export class CandlestickChart extends Widget {
-    private candles: Candle[] = [];
-    private options: CandlestickChartOptions;
+    private _candles: Candle[] = [];
+    private _upColor: Color;
+    private _downColor: Color;
+    private _wickColor: Color | undefined;
 
     constructor(style?: Partial<Style>, opts?: CandlestickChartOptions) {
         super(style);
-        this.options = {
-            upColor: opts?.upColor || ('green' as unknown as Color),
-            downColor: opts?.downColor || ('red' as unknown as Color),
-            wickColor: opts?.wickColor,
-            ...opts
-        };
+        this._upColor = opts?.upColor ?? DEFAULT_UP_COLOR;
+        this._downColor = opts?.downColor ?? DEFAULT_DOWN_COLOR;
+        this._wickColor = opts?.wickColor;
     }
 
     setData(candles: Candle[]): void {
-        this.candles = candles;
+        this._candles = candles;
         this.markDirty();
     }
 
-    protected _renderSelf(screen: any): void {
-        if (this.candles.length === 0) return;
+    protected _renderSelf(screen: Screen): void {
+        if (this._candles.length === 0) return;
 
-        const self = this as any;
-        const startX = self.style?.left || self.x || 0;
-        const startY = self.style?.top || self.y || 0;
-        const width = self.style?.width || self.width || 10;
-        const height = self.style?.height || self.height || 10;
+        const rect = this._getContentRect();
+        const { x: startX, y: startY, width, height } = rect;
+        if (width <= 0 || height <= 0) return;
 
-        const highs = this.candles.map(c => c.high);
-        const lows = this.candles.map(c => c.low);
-        const maxHigh = Math.max(...highs);
-        const minLow = Math.min(...lows);
+        const attrs = styleToCellAttrs(this._style);
+
+        const maxHigh = Math.max(...this._candles.map(c => c.high));
+        const minLow = Math.min(...this._candles.map(c => c.low));
         const priceRange = maxHigh - minLow || 1;
 
-        const candleCount = Math.min(this.candles.length, width);
+        const candleCount = Math.min(this._candles.length, width);
 
         for (let i = 0; i < candleCount; i++) {
-            const candle = this.candles[i];
+            const candle = this._candles[i];
             const colX = startX + i;
 
-            const mapY = (val: number) => {
+            const mapY = (val: number): number => {
                 const ratio = (val - minLow) / priceRange;
                 return Math.round(startY + height - 1 - ratio * (height - 1));
             };
@@ -68,18 +81,17 @@ export class CandlestickChart extends Widget {
             const bodyBottom = Math.max(openY, closeY);
 
             const isBullish = candle.close > candle.open;
-            const bodyColor = isBullish ? this.options.upColor : this.options.downColor;
-            const wickColor = this.options.wickColor || bodyColor;
+            const bodyColor = isBullish ? this._upColor : this._downColor;
+            const wickColor = this._wickColor ?? bodyColor;
 
-            const useUnicode = caps.unicode;
             const wickChar = '|';
-            const bodyChar = useUnicode ? '┃' : '=';
+            const bodyChar = caps.unicode ? '┃' : '=';
 
             for (let rowY = Math.min(highY, lowY); rowY <= Math.max(highY, lowY); rowY++) {
                 if (rowY >= bodyTop && rowY <= bodyBottom) {
-                    screen.setCell(colX, rowY, bodyChar, bodyColor);
+                    screen.setCell(colX, rowY, { char: bodyChar, ...attrs, fg: bodyColor });
                 } else {
-                    screen.setCell(colX, rowY, wickChar, wickColor);
+                    screen.setCell(colX, rowY, { char: wickChar, ...attrs, fg: wickColor });
                 }
             }
         }


### PR DESCRIPTION
## Description

The `CandlestickChart` widget called `screen.setCell(x, y, char, color)` which does not match the `Screen.setCell(x, y, Partial<Cell>)` API, causing a runtime crash when rendered. This PR fixes the API usage, removes all `any` types, and rewrites the tests to assert real rendered output.

## Related Issue

Closes #843 

## Which package(s)?

@termuijs/widgets

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Changes

- Replace `screen.setCell(x, y, char, color)` with correct `screen.setCell(x, y, { char, ...attrs, fg })` object form
- Type `_renderSelf` parameter as `Screen` instead of `any`
- Use `this._getContentRect()` instead of unsafe `this as any` cast for positioning
- Use proper Color type literals (`{ type: 'named', name: 'green' }`) instead of unsafe `'green' as unknown as Color` double-cast
- Use `styleToCellAttrs()` for base cell attributes
- Rewrite tests to render on a real `Screen` with `updateRect` + `render` pattern and assert cell content and colors

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/172e996c-3943-4a86-8249-1f01922d0f64`

## Screenshots / Recordings (UI changes)

N/A — no visual UI change. This is a code-level bug fix that prevented the widget from rendering at all.

## Notes for the Reviewer

- The existing `CandlestickChart._renderSelf` was passing `(x, y, string, Color)` to `screen.setCell()`, which expects `(x, y, Partial<Cell>)`. This would crash at runtime since the third arg was treated as a `Partial<Cell>` object.
- The fix follows the same pattern used by `Gauge.ts` (the canonical reference widget): `Screen` typing, `_getContentRect()`, `styleToCellAttrs()`, and `{ char, ...attrs, fg }` cell objects.
- Tests now assert actual cell characters and fg colors instead of just checking that render doesn't throw.
- All 827 widget tests pass. Build (ESM + CJS + DTS) passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Candlestick colors now display correctly (green for bullish, red for bearish).
  * Chart properly clips candles when exceeding available width.
  * ASCII rendering functions when Unicode is disabled.
  * Empty charts render correctly.
  * Updating chart data now correctly marks it for redraw.

* **Tests**
  * Expanded test coverage for candlestick rendering, clipping, color and ASCII behavior; tests reset mocks between runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->