### PR TITLE
perf(widgets): avoid redundant markDirty calls in EmptyState

### DIFF
--- a/packages/widgets/src/feedback/EmptyState.test.ts
+++ b/packages/widgets/src/feedback/EmptyState.test.ts
@@ -61,4 +61,49 @@ describe('EmptyState', () => {
         const hintRow = 6;
         expect(row(screen, hintRow).trim()).toContain('Press F5 to refresh');
     });
+
+    it('setTitle marks widget dirty', () => {
+        const es = new EmptyState('Old title');
+    
+        es.clearDirty();
+        es.setTitle('New title');
+    
+        expect(es.isDirty).toBe(true);
+    });
+    
+    it('setDescription marks widget dirty', () => {
+        const es = new EmptyState(
+            'Title',
+            {},
+            { description: 'Old description' },
+        );
+    
+        es.clearDirty();
+        es.setDescription('New description');
+    
+        expect(es.isDirty).toBe(true);
+    });
+    
+    it('does not mark dirty when title is unchanged', () => {
+        const es = new EmptyState('Same title');
+    
+        es.clearDirty();
+        es.setTitle('Same title');
+    
+        expect(es.isDirty).toBe(false);
+    });
+    
+    it('does not mark dirty when description is unchanged', () => {
+        const es = new EmptyState(
+            'Title',
+            {},
+            { description: 'Same description' },
+        );
+    
+        es.clearDirty();
+        es.setDescription('Same description');
+    
+        expect(es.isDirty).toBe(false);
+    });
+    
 });

--- a/packages/widgets/src/feedback/EmptyState.ts
+++ b/packages/widgets/src/feedback/EmptyState.ts
@@ -22,11 +22,15 @@ export class EmptyState extends Widget {
     }
 
     setTitle(title: string): void {
+        if (this._title === title) return;
+
         this._title = title;
         this.markDirty();
     }
 
     setDescription(description: string): void {
+        if (this._description === description) return;
+
         this._description = description;
         this.markDirty();
     }


### PR DESCRIPTION
## Description

Avoids unnecessary widget invalidation in `EmptyState` by skipping `markDirty()` calls when state values remain unchanged.

This PR adds equality guards to `setTitle()` and `setDescription()` and introduces regression tests verifying that unchanged updates do not trigger widget invalidation.

## Related Issue

Closes #853  

## Which package(s)?

@termuijs/widgets

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [x] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md] (./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

### Changes Made

* Added equality guard in `EmptyState.setTitle()`
* Added equality guard in `EmptyState.setDescription()`
* Added regression tests ensuring unchanged values do not trigger widget invalidation
* Added dirty-state tests for actual state changes
* Preserved existing rendering behavior

### Validation

✅ `bun vitest run packages/widgets/src/feedback/EmptyState.test.ts`

### Build Note

Repository-wide editor/type diagnostics currently report unrelated `@termuijs/core` declaration and `Screen` typing issues in the monorepo. The EmptyState test suite passes successfully and the changes in this PR are limited to `EmptyState.ts` and `EmptyState.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized empty state component to prevent triggering unnecessary internal state updates when setting titles or descriptions to values that remain unchanged from current state.

* **Tests**
  * Added comprehensive test coverage for empty state behavior, verifying that internal state management correctly responds only when component values actually change after being cleared or reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->