### PR TITLE
feat(examples): add Callout and StatusMessage to feedback gallery

### DIFF
--- a/examples/widget-gallery/src/tabs/feedback-tab.ts
+++ b/examples/widget-gallery/src/tabs/feedback-tab.ts
@@ -12,7 +12,6 @@ import {
     StatusMessage 
 } from '@termuijs/widgets';
 
-// import { MultiProgress, CommandPalette } from '@termuijs/widgets';
 import type { Command } from '@termuijs/widgets';
 import type { Screen } from '@termuijs/core';
 

--- a/examples/widget-gallery/src/tabs/feedback-tab.ts
+++ b/examples/widget-gallery/src/tabs/feedback-tab.ts
@@ -2,8 +2,17 @@
 // Feedback Tab — MultiProgress, CommandPalette
 // ─────────────────────────────────────────────────────
 
-import { Widget, Box, Text } from '@termuijs/widgets';
-import { MultiProgress, CommandPalette } from '@termuijs/widgets';
+import { 
+    Widget, 
+    Box, 
+    Text, 
+    MultiProgress, 
+    CommandPalette, 
+    Callout, 
+    StatusMessage 
+} from '@termuijs/widgets';
+
+// import { MultiProgress, CommandPalette } from '@termuijs/widgets';
 import type { Command } from '@termuijs/widgets';
 import type { Screen } from '@termuijs/core';
 
@@ -32,7 +41,9 @@ export class FeedbackTab extends Widget {
         super({ flexDirection: 'column', flexGrow: 1 });
 
         // Header
-        const header = new Text('Feedback Tab — MultiProgress  |  CommandPalette', {
+        const header = new Text(
+        'Feedback Tab — MultiProgress  |  Callout  |  StatusMessage  |  CommandPalette',
+        {
             bold: true,
             fg: { type: 'named', name: 'magenta' },
             height: 1,
@@ -60,7 +71,7 @@ export class FeedbackTab extends Widget {
                 labelWidth: 12,
                 showValues: true,
             },
-            { border: 'single', height: 8 },
+            { border: 'single', height: 10 },
         );
 
         // Animate progress values
@@ -71,6 +82,55 @@ export class FeedbackTab extends Widget {
             this._multiProgress.updateItem(2, Math.min(1, this._tick / 100));
             this._multiProgress.updateItem(3, Math.min(1, this._tick / 120));
         }, 100);
+
+        // ── Callout + StatusMessage ────────────────────
+
+        const feedbackLabel = new Text(
+            ' Callout & StatusMessage — Feedback widgets:',
+            {
+                height: 1,
+                bold: true,
+                fg: { type: 'named', name: 'cyan' },
+            },
+        );
+        
+        const feedbackBox = new Box({
+            border: 'single',
+            flexDirection: 'column',
+            height: 10,
+        });
+        
+        feedbackBox.addChild(
+            new StatusMessage(
+                'Operation completed successfully',
+                {},
+                { variant: 'success' },
+            ),
+        );
+        
+        feedbackBox.addChild(
+            new StatusMessage(
+                'Build failed',
+                {},
+                { variant: 'error' },
+            ),
+        );
+        
+        feedbackBox.addChild(
+            new Callout(
+                'Configuration saved',
+                {},
+                { variant: 'success', title: 'Success' },
+            ),
+        );
+        
+        feedbackBox.addChild(
+            new Callout(
+                'Please review settings',
+                {},
+                { variant: 'warn', title: 'Warning' },
+            ),
+        );    
 
         // ── CommandPalette ─────────────────────────────
         const paletteLabel = new Text(' CommandPalette — Fuzzy search (type to filter):', {
@@ -88,6 +148,8 @@ export class FeedbackTab extends Widget {
         this.addChild(hint);
         this.addChild(progressLabel);
         this.addChild(this._multiProgress);
+        this.addChild(feedbackLabel);
+        this.addChild(feedbackBox);
         this.addChild(paletteLabel);
         this.addChild(this._cmdPalette);
     }


### PR DESCRIPTION

## Description

Adds `Callout` and `StatusMessage` widget examples to the Widget Gallery Feedback tab.

This improves widget discoverability by showcasing common informational, success, warning, and error feedback patterns alongside the existing feedback widgets.

## Related Issue

Closes #837 

## Which package(s)?

examples/widget-gallery

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [x] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [ ] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read  [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

### Changes Made

* Added `StatusMessage` examples to the Feedback tab
* Added `Callout` examples to the Feedback tab
* Added a dedicated feedback showcase section
* Updated the Feedback tab header to include the newly showcased widgets

### Validation

✅ Existing widget tests pass locally

### Build Note

Repository-wide `bun run build` / `bun run typecheck` currently reports an unrelated failure in `@termuijs/adapters` due to a missing `dotenv` dependency. This issue is outside the scope of this PR, which only modifies the widget gallery example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the example gallery’s feedback section to include Callout and StatusMessage widgets.
  * Added a "Callout + StatusMessage" showcase demonstrating combined success, error, and warning messages.
  * Increased the multi-progress display height for improved clarity and presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->