### PR TITLE
feat(ui): add Escape key support to ConfirmDialog

### DIFF
--- a/packages/ui/src/ConfirmDialog.test.ts
+++ b/packages/ui/src/ConfirmDialog.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { type KeyEvent } from '@termuijs/core';
+import { ConfirmDialog } from './ConfirmDialog.js';
+
+function makeKey(key: string): KeyEvent {
+    return {
+        key,
+        ctrl: false,
+        shift: false,
+        alt: false,
+        raw: Buffer.from(key),
+        stopPropagation: () => {},
+        preventDefault: () => {},
+    };
+}
+
+describe('ConfirmDialog', () => {
+    it('Escape invokes cancel callback when visible', () => {
+        const onCancel = vi.fn();
+        const onConfirm = vi.fn();
+        const dialog = new ConfirmDialog({ message: 'Continue?', onCancel, onConfirm });
+        dialog.show();
+
+        dialog.handleKey(makeKey('escape'));
+
+        expect(onCancel).toHaveBeenCalled();
+        expect(onConfirm).not.toHaveBeenCalled();
+        expect(dialog.visible).toBe(false);
+    });
+
+    it('Escape does nothing when hidden', () => {
+        const onCancel = vi.fn();
+        const dialog = new ConfirmDialog({ message: 'Continue?', onCancel });
+
+        dialog.handleKey(makeKey('escape'));
+
+        expect(onCancel).not.toHaveBeenCalled();
+        expect(dialog.visible).toBe(false);
+    });
+});

--- a/packages/ui/src/ConfirmDialog.test.ts
+++ b/packages/ui/src/ConfirmDialog.test.ts
@@ -1,18 +1,17 @@
 import { describe, it, expect, vi } from 'vitest';
 import { Buffer } from 'node:buffer';
-import { type KeyEvent } from '@termuijs/core';
+import { Screen, createKeyEvent, type KeyEvent } from '@termuijs/core';
 import { ConfirmDialog } from './ConfirmDialog.js';
 
 function makeKey(key: string): KeyEvent {
-    return {
-        key,
-        ctrl: false,
-        shift: false,
-        alt: false,
-        raw: Buffer.from(key),
-        stopPropagation: () => {},
-        preventDefault: () => {},
-    };
+    return createKeyEvent({ key, ctrl: false, shift: false, alt: false, raw: Buffer.from(key) });
+}
+
+function renderDialog(dialog: ConfirmDialog): Screen {
+    const screen = new Screen(40, 10);
+    dialog.updateRect({ x: 0, y: 0, width: 40, height: 10 });
+    dialog.render(screen);
+    return screen;
 }
 
 describe('ConfirmDialog', () => {
@@ -21,8 +20,9 @@ describe('ConfirmDialog', () => {
         const onConfirm = vi.fn();
         const dialog = new ConfirmDialog({ message: 'Continue?', onCancel, onConfirm });
         dialog.show();
+        renderDialog(dialog);
 
-        dialog.handleKey(makeKey('escape'));
+        dialog.events.emit('key', makeKey('escape'));
 
         expect(onCancel).toHaveBeenCalled();
         expect(onConfirm).not.toHaveBeenCalled();
@@ -32,8 +32,9 @@ describe('ConfirmDialog', () => {
     it('Escape does nothing when hidden', () => {
         const onCancel = vi.fn();
         const dialog = new ConfirmDialog({ message: 'Continue?', onCancel });
+        renderDialog(dialog);
 
-        dialog.handleKey(makeKey('escape'));
+        dialog.events.emit('key', makeKey('escape'));
 
         expect(onCancel).not.toHaveBeenCalled();
         expect(dialog.visible).toBe(false);

--- a/packages/ui/src/ConfirmDialog.ts
+++ b/packages/ui/src/ConfirmDialog.ts
@@ -1,6 +1,6 @@
 // ConfirmDialog — yes/no prompt overlay
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Screen, mergeStyles, defaultStyle, styleToCellAttrs, getBorderChars } from '@termuijs/core';
+import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, getBorderChars } from '@termuijs/core';
 
 export interface ConfirmDialogOptions {
     message: string;
@@ -42,6 +42,14 @@ export class ConfirmDialog extends Widget {
         (this._selected === 'confirm' ? this._onConfirm : this._onCancel)?.();
         this._visible = false;
         this.markDirty();
+    }
+
+    handleKey(event: KeyEvent): void {
+        if (!this._visible) return;
+        if (event.key === 'escape') {
+            this.selectCancel();
+            this.confirm();
+        }
     }
 
     protected _renderSelf(screen: Screen): void {

--- a/packages/ui/src/ConfirmDialog.ts
+++ b/packages/ui/src/ConfirmDialog.ts
@@ -45,7 +45,7 @@ export class ConfirmDialog extends Widget {
         this.markDirty();
     }
 
-    handleKey(event: KeyEvent): void {
+    private handleKey(event: KeyEvent): void {
         if (!this._visible) return;
         if (event.key === 'escape') {
             this.selectCancel();

--- a/packages/ui/src/ConfirmDialog.ts
+++ b/packages/ui/src/ConfirmDialog.ts
@@ -30,6 +30,7 @@ export class ConfirmDialog extends Widget {
         this._borderColor = options.borderColor ?? { type: 'named', name: 'yellow' };
         this._onConfirm = options.onConfirm;
         this._onCancel = options.onCancel;
+        this.events.on('key', (event) => this.handleKey(event));
     }
 
     get visible(): boolean { return this._visible; }
@@ -49,6 +50,8 @@ export class ConfirmDialog extends Widget {
         if (event.key === 'escape') {
             this.selectCancel();
             this.confirm();
+            event.preventDefault();
+            event.stopPropagation();
         }
     }
 


### PR DESCRIPTION
## Description

Adds Escape key support to `ConfirmDialog` for improved keyboard usability and consistency with other dismissible UI components.

When the dialog is visible and the user presses `Escape`, the existing cancel flow is triggered, invoking the cancel callback and hiding the dialog. This PR also adds focused tests covering the new behavior.

## Related Issue

Closes #872 

## Which package(s)?

* `@termuijs/ui`

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [x] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run packages/ui/src/ConfirmDialog.test.ts`
* [x] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A – keyboard interaction enhancement with focused test coverage.

## Notes for the Reviewer

* Kept the implementation intentionally minimal.
* Added only Escape key handling; no Enter/Tab behavior was introduced.
* Follows the existing keyboard interaction pattern used by other UI components.
* Includes focused tests verifying:

  * Escape invokes the cancel callback when the dialog is visible.
  * Escape has no effect when the dialog is hidden.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ConfirmDialog supports keyboard interaction: pressing Escape closes the dialog, selects Cancel, and triggers the cancel action as an alternative to clicking Cancel.

* **Tests**
  * Added tests verifying Escape triggers cancel and hides the dialog when visible, and that Escape does nothing when the dialog is hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->