### PR TITLE
test(jsx): add useFocus test

### DIFF
--- a/packages/jsx/src/hooks/useFocus.test.ts
+++ b/packages/jsx/src/hooks/useFocus.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createFiber, setCurrentFiber, clearCurrentFiber, setRequestRender, runEffects } from '../hooks.js';
+import { FocusContext } from '../focus-context.js';
+import { useFocus } from './useFocus.js';
+
+describe('useFocus', () => {
+    let fiber = createFiber();
+    let mockContextValue: {
+        focused: string | null;
+        focus: ReturnType<typeof vi.fn>;
+        blur: ReturnType<typeof vi.fn>;
+    };
+
+    beforeEach(() => {
+        fiber = createFiber();
+        setRequestRender(() => {});
+        setCurrentFiber(fiber);
+
+        mockContextValue = {
+            focused: null,
+            focus: vi.fn((id: string) => {
+                mockContextValue.focused = id;
+            }),
+            blur: vi.fn(() => {
+                mockContextValue.focused = null;
+            }),
+        };
+
+        // Inject the mock FocusContext value directly into the active fiber
+        fiber.contextValues.set(FocusContext._id, mockContextValue);
+    });
+
+    afterEach(() => {
+        clearCurrentFiber();
+        vi.restoreAllMocks();
+    });
+
+    it('returns isFocused as false if another ID is focused', () => {
+        mockContextValue.focused = 'other-id';
+        const result = useFocus({ id: 'my-id' });
+        expect(result.isFocused).toBe(false);
+    });
+
+    it('returns isFocused as true if its ID is focused', () => {
+        mockContextValue.focused = 'my-id';
+        const result = useFocus({ id: 'my-id' });
+        expect(result.isFocused).toBe(true);
+    });
+
+    it('focus() calls context focus with correct ID', () => {
+        const result = useFocus({ id: 'my-id' });
+        result.focus();
+        expect(mockContextValue.focus).toHaveBeenCalledWith('my-id');
+    });
+
+    it('blur() calls context blur', () => {
+        const result = useFocus({ id: 'my-id' });
+        result.blur();
+        expect(mockContextValue.blur).toHaveBeenCalled();
+    });
+
+    it('autoFocuses on mount if focused is null', () => {
+        mockContextValue.focused = null;
+        
+        useFocus({ id: 'my-id', autoFocus: true });
+        
+        // Trigger mounting effects
+        runEffects(fiber);
+
+        expect(mockContextValue.focus).toHaveBeenCalledWith('my-id');
+    });
+
+    it('does not autoFocus on mount if another element is already focused', () => {
+        mockContextValue.focused = 'other-id';
+
+        useFocus({ id: 'my-id', autoFocus: true });
+        runEffects(fiber);
+
+        expect(mockContextValue.focus).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

Added a unit test suite for the `useFocus` hook in `@termuijs/jsx`. The tests verify:
- Focus state detection (`isFocused` true/false based on ID match)
- `focus()` and `blur()` callbacks correctly triggering context functions
- `autoFocus` on mount behaviors under different initial focus states
The tests are written using the framework's native Fiber test harness and a mocked `FocusContext`.

Files Created: `packages/jsx/src/hooks/useFocus.test.ts` (No changes in other files)

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #743 

## Which package(s)?

`@termuijs/jsx`

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/9440c0f2-4d37-4e76-b1d3-cc1f490858ca`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for the focus hook functionality, verifying focus state management, focus/blur operations, and auto-focus behavior on component mount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->