### PR TITLE
chore: improve and standardize .gitignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,26 @@
+# Dependencies
 node_modules/
+
+# Build outputs
 dist/
 .turbo/
-*.tsbuildinfo
 coverage/
+
+# TypeScript
+*.tsbuildinfo
+
+# Environment
+.env
+.env.*
+!.env.example
+
+# Logs
+*.log
+
+# OS
 .DS_Store
 
-website/
-scratch/
-.worktrees/
-
-# Bench artifacts
-bench-head.json
-bench-main.json
-bench-head.txt
-bench-main.txt
+# Bench artifacts (only if generated)
+bench-*.json
+bench-*.txt
 bench-comment.md
-docs/superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,21 @@
-# Dependencies
 node_modules/
-
-# Build outputs
 dist/
 .turbo/
+*.tsbuildinfo
 coverage/
+.DS_Store
+
+website/
+scratch/
+.worktrees/
+
+# Bench artifacts
+bench-head.json
+bench-main.json
+bench-head.txt
+bench-main.txt
+bench-comment.md
+docs/superpowers/
 
 # TypeScript
 *.tsbuildinfo
@@ -12,15 +23,6 @@ coverage/
 # Environment
 .env
 .env.*
-!.env.example
 
 # Logs
 *.log
-
-# OS
-.DS_Store
-
-# Bench artifacts (only if generated)
-bench-*.json
-bench-*.txt
-bench-comment.md


### PR DESCRIPTION
This PR improves the existing .gitignore by cleaning up duplicates and standardizing ignore rules for a production-ready setup.

### Changes made:
- Removed duplicate entries
- Ensured proper separation of concerns (dependencies, build outputs, logs, environment files, OS files)
- Added safe and commonly used ignore patterns
- Prevented accidental tracking of generated and sensitive files

### Included ignores:
- Dependencies: node_modules/
- Build outputs: dist/, .turbo/, coverage/
- TypeScript cache: *.tsbuildinfo
- Environment files: .env, .env.*
- Logs: *.log
- OS files: .DS_Store
- Bench-generated artifacts: bench-*.json, bench-*.txt, bench-comment.md

### Notes:
- Only generated artifacts and system files are ignored.
- No project source directories are ignored to avoid merge conflicts.
- This keeps the repository clean and safe for collaboration.

Issue closed #871 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized repository ignore rules into clear, sectioned blocks.
  * Added explicit ignores for build artifacts, environment files, and log files.
  * Consolidated benchmark and OS ignore patterns while preserving example env files and selected exceptions to avoid committing sensitive or platform-specific files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->