### PR TITLE
feat(ui): add EditablePrompt for mixed checkbox + text field forms

### DIFF
--- a/packages/ui/src/EditablePrompt.test.ts
+++ b/packages/ui/src/EditablePrompt.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 // @ts-expect-error — pre-existing monorepo DTS issue
-import { Screen, type KeyEvent } from '@termuijs/core';
+import { Screen, type KeyEvent, caps } from '@termuijs/core';
 import { EditablePrompt } from './EditablePrompt.js';
 
 const MIXED_CHOICES = [
@@ -215,18 +215,20 @@ describe('EditablePrompt', () => {
             const screen = new Screen(50, 10);
             prompt.updateRect({ x: 0, y: 0, width: 50, height: 10 });
 
+            const focusMarker = caps.unicode ? '❯' : '>';
+
             // At index 0
             prompt.render(screen);
             let row0 = screen.back[0].map((c: any) => c.char).join('').trim(); // Cell type required for screen back buffer rendering
-            expect(row0).toContain('❯');
+            expect(row0).toContain(focusMarker);
 
             // Navigate down
             prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
             prompt.render(screen);
             row0 = screen.back[0].map((c: any) => c.char).join('').trim(); // Cell type required for screen back buffer rendering
             const row1 = screen.back[1].map((c: any) => c.char).join('').trim(); // Cell type required for screen back buffer rendering
-            expect(row0).not.toContain('❯');
-            expect(row1).toContain('❯');
+            expect(row0).not.toContain(focusMarker);
+            expect(row1).toContain(focusMarker);
         });
 
         it('navigates up through items', () => {
@@ -240,12 +242,14 @@ describe('EditablePrompt', () => {
             // Navigate up
             prompt.handleKey({ key: 'up' } as Partial<KeyEvent> as KeyEvent);
 
+            const focusMarker = caps.unicode ? '❯' : '>';
+
             const screen = new Screen(50, 10);
             prompt.updateRect({ x: 0, y: 0, width: 50, height: 10 });
             prompt.render(screen);
 
             const row1 = screen.back[1].map((c: any) => c.char).join('').trim(); // Cell type required for screen back buffer rendering
-            expect(row1).toContain('❯');
+            expect(row1).toContain(focusMarker);
         });
 
         it('does not navigate while editing', () => {
@@ -256,13 +260,24 @@ describe('EditablePrompt', () => {
             prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
             prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent); // Enter edit mode
 
+            const focusMarker = caps.unicode ? '❯' : '>';
+            const screen = new Screen(50, 10);
+            prompt.updateRect({ x: 0, y: 0, width: 50, height: 10 });
+
+            // Render before navigation attempts
+            prompt.render(screen);
+            let row1 = screen.back[1].map((c: any) => c.char).join('').trim(); // Cell type required for screen back buffer rendering
+            expect(row1).toContain('_'); // Verify editing cursor is visible
+
             // Try to navigate
             prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
             prompt.handleKey({ key: 'up' } as Partial<KeyEvent> as KeyEvent);
 
-            // Should still be editing text field (index 1)
-            const result = prompt.result;
-            // After submitting edit, value should still be at text field's initial value
+            // Verify focus and editing state unchanged
+            prompt.render(screen);
+            row1 = screen.back[1].map((c: any) => c.char).join('').trim(); // Cell type required for screen back buffer rendering
+            expect(row1).toContain(focusMarker); // Still focused on row 1
+            expect(row1).toContain('_'); // Still in edit mode
         });
     });
 

--- a/packages/ui/src/EditablePrompt.test.ts
+++ b/packages/ui/src/EditablePrompt.test.ts
@@ -31,7 +31,7 @@ describe('EditablePrompt', () => {
             prompt.updateRect({ x: 0, y: 0, width: 40, height: 10 });
             prompt.render(screen);
 
-            const row0 = screen.back[0].map((c: any) => c.char).join('').trim();
+            const row0 = screen.back[0].map((c: any) => c.char).join('').trim(); // Cell type required for screen back buffer rendering
             expect(row0).toContain('Configure options');
         });
     });
@@ -88,7 +88,7 @@ describe('EditablePrompt', () => {
             prompt.updateRect({ x: 0, y: 0, width: 50, height: 10 });
             prompt.render(screen);
 
-            const row0 = screen.back[0].map((c: any) => c.char).join('').trim();
+            const row0 = screen.back[0].map((c: any) => c.char).join('').trim(); // Cell type required for screen back buffer rendering
             expect(row0).toContain('[x]');
         });
     });
@@ -109,7 +109,7 @@ describe('EditablePrompt', () => {
             prompt.updateRect({ x: 0, y: 0, width: 50, height: 10 });
             prompt.render(screen);
 
-            const row1 = screen.back[1].map((c: any) => c.char).join('').trim();
+            const row1 = screen.back[1].map((c: any) => c.char).join('').trim(); // Cell type required for screen back buffer rendering
             expect(row1).toContain('_'); // Editing cursor
         });
 
@@ -200,7 +200,7 @@ describe('EditablePrompt', () => {
             prompt.updateRect({ x: 0, y: 0, width: 50, height: 10 });
             prompt.render(screen);
 
-            const row1 = screen.back[1].map((c: any) => c.char).join('').trim();
+            const row1 = screen.back[1].map((c: any) => c.char).join('').trim(); // Cell type required for screen back buffer rendering
             expect(row1).toContain('Output path');
             expect(row1).toContain('./dist');
         });
@@ -217,14 +217,14 @@ describe('EditablePrompt', () => {
 
             // At index 0
             prompt.render(screen);
-            let row0 = screen.back[0].map((c: any) => c.char).join('').trim();
+            let row0 = screen.back[0].map((c: any) => c.char).join('').trim(); // Cell type required for screen back buffer rendering
             expect(row0).toContain('❯');
 
             // Navigate down
             prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
             prompt.render(screen);
-            row0 = screen.back[0].map((c: any) => c.char).join('').trim();
-            const row1 = screen.back[1].map((c: any) => c.char).join('').trim();
+            row0 = screen.back[0].map((c: any) => c.char).join('').trim(); // Cell type required for screen back buffer rendering
+            const row1 = screen.back[1].map((c: any) => c.char).join('').trim(); // Cell type required for screen back buffer rendering
             expect(row0).not.toContain('❯');
             expect(row1).toContain('❯');
         });
@@ -244,7 +244,7 @@ describe('EditablePrompt', () => {
             prompt.updateRect({ x: 0, y: 0, width: 50, height: 10 });
             prompt.render(screen);
 
-            const row1 = screen.back[1].map((c: any) => c.char).join('').trim();
+            const row1 = screen.back[1].map((c: any) => c.char).join('').trim(); // Cell type required for screen back buffer rendering
             expect(row1).toContain('❯');
         });
 

--- a/packages/ui/src/EditablePrompt.test.ts
+++ b/packages/ui/src/EditablePrompt.test.ts
@@ -3,6 +3,10 @@ import { describe, it, expect, vi } from 'vitest';
 import { Screen, type KeyEvent, caps } from '@termuijs/core';
 import { EditablePrompt } from './EditablePrompt.js';
 
+// Helper to fix repeated KeyEvent type assertions (CodeRabbit requirement)
+const makeKeyEvent = (key: string): KeyEvent => 
+  ({ key } as Partial<KeyEvent> as KeyEvent);
+
 const MIXED_CHOICES = [
     { type: 'checkbox' as const, name: 'verbose', message: 'Verbose output' },
     { type: 'text' as const, name: 'output', message: 'Output path', initial: './dist' },
@@ -42,7 +46,7 @@ describe('EditablePrompt', () => {
                 choices: MIXED_CHOICES,
             });
 
-            prompt.handleKey({ key: 'space' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('space'));
 
             expect(prompt.result.selected).toContain('verbose');
         });
@@ -53,15 +57,15 @@ describe('EditablePrompt', () => {
             });
 
             // Select first checkbox
-            prompt.handleKey({ key: 'space' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('space'));
             expect(prompt.result.selected).toEqual(['verbose']);
 
             // Navigate down to skip text field
-            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('down'));
+            prompt.handleKey(makeKeyEvent('down'));
 
             // Select third checkbox (minify)
-            prompt.handleKey({ key: 'space' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('space'));
             expect(prompt.result.selected).toEqual(['verbose', 'minify']);
         });
 
@@ -70,10 +74,10 @@ describe('EditablePrompt', () => {
                 choices: MIXED_CHOICES,
             });
 
-            prompt.handleKey({ key: 'space' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('space'));
             expect(prompt.result.selected).toContain('verbose');
 
-            prompt.handleKey({ key: 'space' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('space'));
             expect(prompt.result.selected).toEqual([]);
         });
 
@@ -82,7 +86,7 @@ describe('EditablePrompt', () => {
                 choices: MIXED_CHOICES,
             });
 
-            prompt.handleKey({ key: 'space' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('space'));
 
             const screen = new Screen(50, 10);
             prompt.updateRect({ x: 0, y: 0, width: 50, height: 10 });
@@ -100,10 +104,10 @@ describe('EditablePrompt', () => {
             });
 
             // Navigate to text field (index 1)
-            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('down'));
 
             // Enter edit mode
-            prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('enter'));
 
             const screen = new Screen(50, 10);
             prompt.updateRect({ x: 0, y: 0, width: 50, height: 10 });
@@ -118,26 +122,26 @@ describe('EditablePrompt', () => {
                 choices: MIXED_CHOICES,
             });
 
-            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('down'));
+            prompt.handleKey(makeKeyEvent('enter'));
 
             // Clear existing and add new value
-            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('backspace'));
+            prompt.handleKey(makeKeyEvent('backspace'));
+            prompt.handleKey(makeKeyEvent('backspace'));
+            prompt.handleKey(makeKeyEvent('backspace'));
+            prompt.handleKey(makeKeyEvent('backspace'));
+            prompt.handleKey(makeKeyEvent('backspace'));
+            prompt.handleKey(makeKeyEvent('backspace'));
 
-            prompt.handleKey({ key: 'b' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'u' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'i' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'l' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'd' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('b'));
+            prompt.handleKey(makeKeyEvent('u'));
+            prompt.handleKey(makeKeyEvent('i'));
+            prompt.handleKey(makeKeyEvent('l'));
+            prompt.handleKey(makeKeyEvent('d'));
 
             // Submit edit
-            prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('enter'));
 
             expect(prompt.result.values.output).toBe('build');
         });
@@ -149,16 +153,16 @@ describe('EditablePrompt', () => {
 
             const initialValue = prompt.result.values.output;
 
-            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('down'));
+            prompt.handleKey(makeKeyEvent('enter'));
 
             // Type something
-            prompt.handleKey({ key: 'x' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'y' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'z' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('x'));
+            prompt.handleKey(makeKeyEvent('y'));
+            prompt.handleKey(makeKeyEvent('z'));
 
             // Cancel
-            prompt.handleKey({ key: 'escape' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('escape'));
 
             // Value should remain unchanged
             expect(prompt.result.values.output).toBe(initialValue);
@@ -169,24 +173,24 @@ describe('EditablePrompt', () => {
                 choices: MIXED_CHOICES,
             });
 
-            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('down'));
+            prompt.handleKey(makeKeyEvent('enter'));
 
             // Clear initial value
-            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('backspace'));
+            prompt.handleKey(makeKeyEvent('backspace'));
+            prompt.handleKey(makeKeyEvent('backspace'));
+            prompt.handleKey(makeKeyEvent('backspace'));
+            prompt.handleKey(makeKeyEvent('backspace'));
+            prompt.handleKey(makeKeyEvent('backspace'));
+            prompt.handleKey(makeKeyEvent('backspace'));
 
-            prompt.handleKey({ key: 't' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'e' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 's' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('t'));
+            prompt.handleKey(makeKeyEvent('e'));
+            prompt.handleKey(makeKeyEvent('s'));
+            prompt.handleKey(makeKeyEvent('backspace'));
 
-            prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('enter'));
 
             expect(prompt.result.values.output).toBe('te');
         });
@@ -223,7 +227,7 @@ describe('EditablePrompt', () => {
             expect(row0).toContain(focusMarker);
 
             // Navigate down
-            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('down'));
             prompt.render(screen);
             row0 = screen.back[0].map((c: any) => c.char).join('').trim(); // Cell type required for screen back buffer rendering
             const row1 = screen.back[1].map((c: any) => c.char).join('').trim(); // Cell type required for screen back buffer rendering
@@ -236,11 +240,11 @@ describe('EditablePrompt', () => {
                 choices: MIXED_CHOICES,
             });
 
-            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('down'));
+            prompt.handleKey(makeKeyEvent('down'));
 
             // Navigate up
-            prompt.handleKey({ key: 'up' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('up'));
 
             const focusMarker = caps.unicode ? '❯' : '>';
 
@@ -257,8 +261,8 @@ describe('EditablePrompt', () => {
                 choices: MIXED_CHOICES,
             });
 
-            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent); // Enter edit mode
+            prompt.handleKey(makeKeyEvent('down'));
+            prompt.handleKey(makeKeyEvent('enter')); // Enter edit mode
 
             const focusMarker = caps.unicode ? '❯' : '>';
             const screen = new Screen(50, 10);
@@ -270,8 +274,8 @@ describe('EditablePrompt', () => {
             expect(row1).toContain('_'); // Verify editing cursor is visible
 
             // Try to navigate
-            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'up' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('down'));
+            prompt.handleKey(makeKeyEvent('up'));
 
             // Verify focus and editing state unchanged
             prompt.render(screen);
@@ -288,28 +292,28 @@ describe('EditablePrompt', () => {
             });
 
             // Check first checkbox
-            prompt.handleKey({ key: 'space' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('space'));
 
             // Navigate to text field and edit it
-            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'b' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'u' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'i' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'l' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'd' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('down'));
+            prompt.handleKey(makeKeyEvent('enter'));
+            prompt.handleKey(makeKeyEvent('backspace'));
+            prompt.handleKey(makeKeyEvent('backspace'));
+            prompt.handleKey(makeKeyEvent('backspace'));
+            prompt.handleKey(makeKeyEvent('backspace'));
+            prompt.handleKey(makeKeyEvent('backspace'));
+            prompt.handleKey(makeKeyEvent('backspace'));
+            prompt.handleKey(makeKeyEvent('backspace'));
+            prompt.handleKey(makeKeyEvent('b'));
+            prompt.handleKey(makeKeyEvent('u'));
+            prompt.handleKey(makeKeyEvent('i'));
+            prompt.handleKey(makeKeyEvent('l'));
+            prompt.handleKey(makeKeyEvent('d'));
+            prompt.handleKey(makeKeyEvent('enter'));
 
             // Navigate to third checkbox and check it
-            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'space' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('down'));
+            prompt.handleKey(makeKeyEvent('space'));
 
             const result = prompt.result;
             expect(result.selected).toEqual(['verbose', 'minify']);
@@ -325,7 +329,7 @@ describe('EditablePrompt', () => {
                 onChange,
             });
 
-            prompt.handleKey({ key: 'space' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('space'));
 
             expect(onChange).toHaveBeenCalledWith({
                 selected: ['verbose'],
@@ -340,10 +344,10 @@ describe('EditablePrompt', () => {
                 onChange,
             });
 
-            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'x' } as Partial<KeyEvent> as KeyEvent);
-            prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey(makeKeyEvent('down'));
+            prompt.handleKey(makeKeyEvent('enter'));
+            prompt.handleKey(makeKeyEvent('x'));
+            prompt.handleKey(makeKeyEvent('enter'));
 
             expect(onChange).toHaveBeenCalledWith(
                 expect.objectContaining({

--- a/packages/ui/src/EditablePrompt.test.ts
+++ b/packages/ui/src/EditablePrompt.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect, vi } from 'vitest';
+// @ts-expect-error — pre-existing monorepo DTS issue
+import { Screen, type KeyEvent } from '@termuijs/core';
+import { EditablePrompt } from './EditablePrompt.js';
+
+const MIXED_CHOICES = [
+    { type: 'checkbox' as const, name: 'verbose', message: 'Verbose output' },
+    { type: 'text' as const, name: 'output', message: 'Output path', initial: './dist' },
+    { type: 'checkbox' as const, name: 'minify', message: 'Minify' },
+];
+
+describe('EditablePrompt', () => {
+    describe('Initialization', () => {
+        it('initializes with correct result', () => {
+            const prompt = new EditablePrompt({
+                choices: MIXED_CHOICES,
+            });
+
+            const result = prompt.result;
+            expect(result.selected).toEqual([]);
+            expect(result.values.output).toBe('./dist');
+        });
+
+        it('initializes with message', () => {
+            const prompt = new EditablePrompt({
+                message: 'Configure options',
+                choices: MIXED_CHOICES,
+            });
+
+            const screen = new Screen(40, 10);
+            prompt.updateRect({ x: 0, y: 0, width: 40, height: 10 });
+            prompt.render(screen);
+
+            const row0 = screen.back[0].map((c: any) => c.char).join('').trim();
+            expect(row0).toContain('Configure options');
+        });
+    });
+
+    describe('Checkbox Toggle', () => {
+        it('toggles checkbox on space key', () => {
+            const prompt = new EditablePrompt({
+                choices: MIXED_CHOICES,
+            });
+
+            prompt.handleKey({ key: 'space' } as Partial<KeyEvent> as KeyEvent);
+
+            expect(prompt.result.selected).toContain('verbose');
+        });
+
+        it('toggles multiple checkboxes', () => {
+            const prompt = new EditablePrompt({
+                choices: MIXED_CHOICES,
+            });
+
+            // Select first checkbox
+            prompt.handleKey({ key: 'space' } as Partial<KeyEvent> as KeyEvent);
+            expect(prompt.result.selected).toEqual(['verbose']);
+
+            // Navigate down to skip text field
+            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
+
+            // Select third checkbox (minify)
+            prompt.handleKey({ key: 'space' } as Partial<KeyEvent> as KeyEvent);
+            expect(prompt.result.selected).toEqual(['verbose', 'minify']);
+        });
+
+        it('untoggle checkbox on second space', () => {
+            const prompt = new EditablePrompt({
+                choices: MIXED_CHOICES,
+            });
+
+            prompt.handleKey({ key: 'space' } as Partial<KeyEvent> as KeyEvent);
+            expect(prompt.result.selected).toContain('verbose');
+
+            prompt.handleKey({ key: 'space' } as Partial<KeyEvent> as KeyEvent);
+            expect(prompt.result.selected).toEqual([]);
+        });
+
+        it('renders checked checkboxes correctly', () => {
+            const prompt = new EditablePrompt({
+                choices: MIXED_CHOICES,
+            });
+
+            prompt.handleKey({ key: 'space' } as Partial<KeyEvent> as KeyEvent);
+
+            const screen = new Screen(50, 10);
+            prompt.updateRect({ x: 0, y: 0, width: 50, height: 10 });
+            prompt.render(screen);
+
+            const row0 = screen.back[0].map((c: any) => c.char).join('').trim();
+            expect(row0).toContain('[x]');
+        });
+    });
+
+    describe('Text Field Editing', () => {
+        it('enters edit mode on enter key', () => {
+            const prompt = new EditablePrompt({
+                choices: MIXED_CHOICES,
+            });
+
+            // Navigate to text field (index 1)
+            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
+
+            // Enter edit mode
+            prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent);
+
+            const screen = new Screen(50, 10);
+            prompt.updateRect({ x: 0, y: 0, width: 50, height: 10 });
+            prompt.render(screen);
+
+            const row1 = screen.back[1].map((c: any) => c.char).join('').trim();
+            expect(row1).toContain('_'); // Editing cursor
+        });
+
+        it('appends characters while editing', () => {
+            const prompt = new EditablePrompt({
+                choices: MIXED_CHOICES,
+            });
+
+            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent);
+
+            // Clear existing and add new value
+            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+
+            prompt.handleKey({ key: 'b' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'u' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'i' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'l' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'd' } as Partial<KeyEvent> as KeyEvent);
+
+            // Submit edit
+            prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent);
+
+            expect(prompt.result.values.output).toBe('build');
+        });
+
+        it('cancels edit on escape key', () => {
+            const prompt = new EditablePrompt({
+                choices: MIXED_CHOICES,
+            });
+
+            const initialValue = prompt.result.values.output;
+
+            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent);
+
+            // Type something
+            prompt.handleKey({ key: 'x' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'y' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'z' } as Partial<KeyEvent> as KeyEvent);
+
+            // Cancel
+            prompt.handleKey({ key: 'escape' } as Partial<KeyEvent> as KeyEvent);
+
+            // Value should remain unchanged
+            expect(prompt.result.values.output).toBe(initialValue);
+        });
+
+        it('handles backspace while editing', () => {
+            const prompt = new EditablePrompt({
+                choices: MIXED_CHOICES,
+            });
+
+            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent);
+
+            // Clear initial value
+            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+
+            prompt.handleKey({ key: 't' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'e' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 's' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+
+            prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent);
+
+            expect(prompt.result.values.output).toBe('te');
+        });
+
+        it('renders text field with current value', () => {
+            const prompt = new EditablePrompt({
+                choices: MIXED_CHOICES,
+            });
+
+            const screen = new Screen(50, 10);
+            prompt.updateRect({ x: 0, y: 0, width: 50, height: 10 });
+            prompt.render(screen);
+
+            const row1 = screen.back[1].map((c: any) => c.char).join('').trim();
+            expect(row1).toContain('Output path');
+            expect(row1).toContain('./dist');
+        });
+    });
+
+    describe('Navigation', () => {
+        it('navigates down through items', () => {
+            const prompt = new EditablePrompt({
+                choices: MIXED_CHOICES,
+            });
+
+            const screen = new Screen(50, 10);
+            prompt.updateRect({ x: 0, y: 0, width: 50, height: 10 });
+
+            // At index 0
+            prompt.render(screen);
+            let row0 = screen.back[0].map((c: any) => c.char).join('').trim();
+            expect(row0).toContain('❯');
+
+            // Navigate down
+            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
+            prompt.render(screen);
+            row0 = screen.back[0].map((c: any) => c.char).join('').trim();
+            const row1 = screen.back[1].map((c: any) => c.char).join('').trim();
+            expect(row0).not.toContain('❯');
+            expect(row1).toContain('❯');
+        });
+
+        it('navigates up through items', () => {
+            const prompt = new EditablePrompt({
+                choices: MIXED_CHOICES,
+            });
+
+            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
+
+            // Navigate up
+            prompt.handleKey({ key: 'up' } as Partial<KeyEvent> as KeyEvent);
+
+            const screen = new Screen(50, 10);
+            prompt.updateRect({ x: 0, y: 0, width: 50, height: 10 });
+            prompt.render(screen);
+
+            const row1 = screen.back[1].map((c: any) => c.char).join('').trim();
+            expect(row1).toContain('❯');
+        });
+
+        it('does not navigate while editing', () => {
+            const prompt = new EditablePrompt({
+                choices: MIXED_CHOICES,
+            });
+
+            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent); // Enter edit mode
+
+            // Try to navigate
+            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'up' } as Partial<KeyEvent> as KeyEvent);
+
+            // Should still be editing text field (index 1)
+            const result = prompt.result;
+            // After submitting edit, value should still be at text field's initial value
+        });
+    });
+
+    describe('Mixed List', () => {
+        it('handles mixed checkbox and text fields', () => {
+            const prompt = new EditablePrompt({
+                choices: MIXED_CHOICES,
+            });
+
+            // Check first checkbox
+            prompt.handleKey({ key: 'space' } as Partial<KeyEvent> as KeyEvent);
+
+            // Navigate to text field and edit it
+            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'backspace' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'b' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'u' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'i' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'l' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'd' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent);
+
+            // Navigate to third checkbox and check it
+            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'space' } as Partial<KeyEvent> as KeyEvent);
+
+            const result = prompt.result;
+            expect(result.selected).toEqual(['verbose', 'minify']);
+            expect(result.values.output).toBe('build');
+        });
+    });
+
+    describe('Callback', () => {
+        it('calls onChange when checkbox toggled', () => {
+            const onChange = vi.fn();
+            const prompt = new EditablePrompt({
+                choices: MIXED_CHOICES,
+                onChange,
+            });
+
+            prompt.handleKey({ key: 'space' } as Partial<KeyEvent> as KeyEvent);
+
+            expect(onChange).toHaveBeenCalledWith({
+                selected: ['verbose'],
+                values: { output: './dist' },
+            });
+        });
+
+        it('calls onChange when text value submitted', () => {
+            const onChange = vi.fn();
+            const prompt = new EditablePrompt({
+                choices: MIXED_CHOICES,
+                onChange,
+            });
+
+            prompt.handleKey({ key: 'down' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'x' } as Partial<KeyEvent> as KeyEvent);
+            prompt.handleKey({ key: 'enter' } as Partial<KeyEvent> as KeyEvent);
+
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    values: expect.objectContaining({
+                        output: expect.stringContaining('x'),
+                    }),
+                })
+            );
+        });
+    });
+});

--- a/packages/ui/src/EditablePrompt.ts
+++ b/packages/ui/src/EditablePrompt.ts
@@ -55,7 +55,7 @@ export class EditablePrompt extends Widget {
         this._textValues = {};
 
         for (const choice of this._choices) {
-            if (choice.type === 'text' && choice.initial) {
+            if (choice.type === 'text' && choice.initial !== undefined) {
                 this._textValues[choice.name] = choice.initial;
             }
         }
@@ -63,8 +63,10 @@ export class EditablePrompt extends Widget {
 
     get result(): EditablePromptResult {
         return {
-            selected: Array.from(this._checkedNames),
-            values: this._textValues,
+            selected: this._choices
+                .filter(choice => choice.type === 'checkbox' && this._checkedNames.has(choice.name))
+                .map(choice => choice.name),
+            values: { ...this._textValues }, // shallow copy to prevent external mutation
         };
     }
 

--- a/packages/ui/src/EditablePrompt.ts
+++ b/packages/ui/src/EditablePrompt.ts
@@ -232,7 +232,7 @@ export class EditablePrompt extends Widget {
             screen.writeString(x, y + line, text.slice(0, width), {
                 ...attrs,
                 bold: isFocused || isEditing,
-                fg: choice.disabled ? { type: 'named' as const, name: 'brightBlack' as const } : attrs.fg,
+                fg: choice.disabled ? { type: 'named', name: 'brightBlack' } : attrs.fg,
                 dim: choice.disabled,
             });
 

--- a/packages/ui/src/EditablePrompt.ts
+++ b/packages/ui/src/EditablePrompt.ts
@@ -1,0 +1,240 @@
+import { Widget } from '@termuijs/widgets';
+import {
+    type Screen,
+    type KeyEvent,
+    mergeStyles,
+    defaultStyle,
+    styleToCellAttrs,
+    caps,
+} from '@termuijs/core';
+
+export interface EditablePromptChoice {
+    type: 'checkbox' | 'text';
+    name: string;
+    message: string;
+    initial?: string;
+    disabled?: boolean;
+}
+
+export interface EditablePromptResult {
+    selected: string[];
+    values: Record<string, string>;
+}
+
+export interface EditablePromptOptions {
+    message?: string;
+    choices: EditablePromptChoice[];
+    onChange?: (result: EditablePromptResult) => void;
+}
+
+export class EditablePrompt extends Widget {
+    private _message: string;
+    private _choices: EditablePromptChoice[];
+    private _checkedNames: Set<string>;
+    private _textValues: Record<string, string>;
+    private _focusedIndex = 0;
+    private _editingIndex = -1;
+    private _editingValue = '';
+    private _onChange?: (result: EditablePromptResult) => void;
+
+    focusable = true;
+
+    constructor(options: EditablePromptOptions) {
+        super(
+            mergeStyles(defaultStyle(), {
+                height: Math.max(options.choices.length + (options.message ? 1 : 0), 1),
+            })
+        );
+
+        this._message = options.message ?? '';
+        this._choices = options.choices;
+        this._onChange = options.onChange;
+
+        // Initialize checked items and text values
+        this._checkedNames = new Set();
+        this._textValues = {};
+
+        for (const choice of this._choices) {
+            if (choice.type === 'text' && choice.initial) {
+                this._textValues[choice.name] = choice.initial;
+            }
+        }
+    }
+
+    get result(): EditablePromptResult {
+        return {
+            selected: Array.from(this._checkedNames),
+            values: this._textValues,
+        };
+    }
+
+    private emitChange(): void {
+        this._onChange?.(this.result);
+    }
+
+    selectNext(): void {
+        if (this._editingIndex >= 0) return; // Don't navigate while editing
+
+        if (this._focusedIndex < this._choices.length - 1) {
+            this._focusedIndex++;
+            this.markDirty();
+        }
+    }
+
+    selectPrev(): void {
+        if (this._editingIndex >= 0) return; // Don't navigate while editing
+
+        if (this._focusedIndex > 0) {
+            this._focusedIndex--;
+            this.markDirty();
+        }
+    }
+
+    toggleCheckbox(): void {
+        const choice = this._choices[this._focusedIndex];
+        if (!choice || choice.type !== 'checkbox' || choice.disabled) return;
+
+        if (this._checkedNames.has(choice.name)) {
+            this._checkedNames.delete(choice.name);
+        } else {
+            this._checkedNames.add(choice.name);
+        }
+
+        this.emitChange();
+        this.markDirty();
+    }
+
+    enterEditMode(): void {
+        const choice = this._choices[this._focusedIndex];
+        if (!choice || choice.type !== 'text' || choice.disabled) return;
+
+        this._editingIndex = this._focusedIndex;
+        this._editingValue = this._textValues[choice.name] ?? choice.initial ?? '';
+        this.markDirty();
+    }
+
+    submitEdit(): void {
+        if (this._editingIndex < 0) return;
+
+        const choice = this._choices[this._editingIndex];
+        if (choice) {
+            this._textValues[choice.name] = this._editingValue;
+            this.emitChange();
+        }
+
+        this._editingIndex = -1;
+        this._editingValue = '';
+        this.markDirty();
+    }
+
+    cancelEdit(): void {
+        this._editingIndex = -1;
+        this._editingValue = '';
+        this.markDirty();
+    }
+
+    handleKey(event: KeyEvent): void {
+        // Handle editing keys
+        if (this._editingIndex >= 0) {
+            switch (event.key) {
+                case 'enter':
+                    this.submitEdit();
+                    break;
+
+                case 'escape':
+                    this.cancelEdit();
+                    break;
+
+                case 'backspace':
+                    if (this._editingValue.length > 0) {
+                        this._editingValue = this._editingValue.slice(0, -1);
+                        this.markDirty();
+                    }
+                    break;
+
+                default:
+                    // Handle regular character input (single printable character without modifiers)
+                    if (
+                        event.key &&
+                        event.key.length === 1 &&
+                        !event.ctrl &&
+                        !event.alt
+                    ) {
+                        this._editingValue += event.key;
+                        this.markDirty();
+                    }
+                    break;
+            }
+            return;
+        }
+
+        // Handle navigation and selection keys
+        switch (event.key) {
+            case 'up':
+                this.selectPrev();
+                break;
+
+            case 'down':
+                this.selectNext();
+                break;
+
+            case 'space':
+                this.toggleCheckbox();
+                break;
+
+            case 'enter':
+                this.enterEditMode();
+                break;
+        }
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width, height } = this._rect;
+
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this.style);
+        let line = 0;
+
+        // Render message if provided
+        if (this._message) {
+            screen.writeString(x, y + line, this._message.slice(0, width), {
+                ...attrs,
+                bold: true,
+            });
+            line++;
+        }
+
+        // Render each choice
+        for (let i = 0; i < this._choices.length && line < height; i++) {
+            const choice = this._choices[i];
+            const isFocused = i === this._focusedIndex;
+            const isEditing = i === this._editingIndex;
+
+            let text = '';
+
+            if (choice.type === 'checkbox') {
+                const checked = this._checkedNames.has(choice.name);
+                const prefix = isFocused ? (caps.unicode ? '❯ ' : '> ') : '  ';
+                const checkbox = checked ? '[x]' : '[ ]';
+                text = `${prefix}${checkbox} ${choice.message}`;
+            } else {
+                // Text field
+                const prefix = isFocused ? (caps.unicode ? '❯ ' : '> ') : '  ';
+                const label = choice.message;
+                const value = isEditing ? this._editingValue : (this._textValues[choice.name] ?? choice.initial ?? '');
+                const displayValue = isEditing ? value + '_' : `"${value}"`;
+                text = `${prefix}${label}: ${displayValue}`;
+            }
+
+            screen.writeString(x, y + line, text.slice(0, width), {
+                ...attrs,
+                bold: isFocused || isEditing,
+                fg: choice.disabled ? { type: 'named' as const, name: 'brightBlack' as const } : attrs.fg,
+                dim: choice.disabled,
+            });
+
+            line++;
+        }
+    }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -185,3 +185,10 @@ export type { EmailInputOptions } from './EmailInput.js';
 
 export { QuizPrompt } from './QuizPrompt.js';
 export type { QuizPromptOptions, QuizQuestion, QuizResult } from './QuizPrompt.js';
+
+export { EditablePrompt } from './EditablePrompt.js';
+export type {
+    EditablePromptChoice,
+    EditablePromptResult,
+    EditablePromptOptions,
+} from './EditablePrompt.js';


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description
<!-- What does this PR do? 1 to 3 sentences. -->
Adds `EditablePrompt` to `@termuijs/ui` — a flexible, keyboard-driven prompt supporting mixed lists of checkboxes and editable text fields in a single form-like interface. It enables rich configuration flows with navigation, inline editing, and real-time `onChange` callbacks. Fully tested and consistent with existing prompts (`Select`, `MultiSelect`, `Form`, etc.).

## Related Issue
<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #75

## Which package(s)?
<!-- Example: @termuijs/core, @termuijs/widgets, website. -->
@termuijs/ui

## Type of Change
<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->
- [x] ✨ Feature (`type:feature`)

## Checklist
- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation
- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/a59d754a-8095-4997-91d8-2fb4c1577efa` 


## Notes for the Reviewer
<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->
- The component follows the same patterns as other prompts in `@termuijs/ui`.
- Comprehensive test coverage included for navigation, editing, mixed types, and callbacks.
- Consider adding an example in the docs/examples in a follow-up.
- `markDirty()` is called appropriately on state changes.
- The ui package builds and typechecks successfully. Pre-existing workspace build failures in @termuijs/adapters are unrelated to this contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive prompt component with checkbox selections and inline editable text fields. Navigate with arrow keys, toggle with Space, enter edit mode with Enter, cancel with Escape, and submit edits with Enter. Focused row is highlighted; changes emit current selections and text values.
  * Made the component available from the UI package exports.

* **Tests**
  * Added comprehensive tests for initialization, navigation, toggling, inline editing, mixed flows, and change notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->