### PR TITLE
perf(feedback): avoid redundant markDirty calls in LoadingDots

### DIFF
--- a/packages/widgets/src/feedback/LoadingDots.test.ts
+++ b/packages/widgets/src/feedback/LoadingDots.test.ts
@@ -69,4 +69,23 @@ describe('LoadingDots', () => {
         const row = screen.back[0].map(c => c.char).join('');
         expect(row).toContain('Thinking.  ');
     });
+
+    it('setLabel marks widget dirty', () => {
+        const ld = new LoadingDots({}, { label: 'Loading' });
+    
+        ld.clearDirty();
+        ld.setLabel('Updated');
+    
+        expect(ld.isDirty).toBe(true);
+    });
+    
+    it('does not mark dirty when label is unchanged', () => {
+        const ld = new LoadingDots({}, { label: 'Loading' });
+    
+        ld.clearDirty();
+        ld.setLabel('Loading');
+    
+        expect(ld.isDirty).toBe(false);
+    });
+    
 });

--- a/packages/widgets/src/feedback/LoadingDots.ts
+++ b/packages/widgets/src/feedback/LoadingDots.ts
@@ -33,6 +33,8 @@ export class LoadingDots extends Widget {
     }
 
     setLabel(label: string): void {
+        if (label === this._label) return;
+        
         this._label = label;
         this.markDirty();
     }


### PR DESCRIPTION
## Description

Avoids unnecessary widget invalidation in `LoadingDots` by skipping `markDirty()` calls when the label value remains unchanged.

This PR adds an equality guard to `setLabel()` and introduces regression tests verifying that unchanged updates do not trigger widget invalidation.

## Related Issue

Closes #909 

## Which package(s)?

@termuijs/widgets

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [x] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

### Changes Made

* Added equality guard in `LoadingDots.setLabel()`
* Added regression test verifying label updates mark the widget dirty
* Added regression test verifying unchanged labels do not mark the widget dirty
* Preserved existing dirty-state behavior for actual state changes

### Validation

✅ `bun vitest run packages/widgets/src/feedback/LoadingDots.test.ts`

### Build Note

Repository-wide build/typecheck currently reports an unrelated failure in `@termuijs/adapters` due to a missing `dotenv` dependency. This issue is outside the scope of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for the LoadingDots widget, verifying proper label update handling and ensuring state management behaves correctly when labels change or when the same label is set again.

* **Performance**
  * Optimized LoadingDots to prevent redundant updates and improve overall efficiency when a label is set to its current value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->