### PR TITLE
perf(display): avoid redundant markDirty calls in Tag

### DIFF
--- a/packages/widgets/src/display/Tag.test.ts
+++ b/packages/widgets/src/display/Tag.test.ts
@@ -100,10 +100,12 @@ describe('Tag', () => {
     });
 
     // ── 4. Setters call markDirty ────────────────────────────────────────
+
     it('setText marks widget dirty', () => {
         const tag = new Tag('old');
         tag.clearDirty();
         tag.setText('new');
+
         expect(tag.isDirty).toBe(true);
         expect(tag.getText()).toBe('new');
     });
@@ -112,8 +114,27 @@ describe('Tag', () => {
         const tag = new Tag('ok');
         tag.clearDirty();
         tag.setVariant('error');
+
         expect(tag.isDirty).toBe(true);
         expect(tag.getVariant()).toBe('error');
+    });
+
+    it('does not mark dirty when text is unchanged', () => {
+        const tag = new Tag('Hello');
+
+        tag.clearDirty();
+        tag.setText('Hello');
+
+        expect(tag.isDirty).toBe(false);
+    });
+
+    it('does not mark dirty when variant is unchanged', () => {
+        const tag = new Tag('Hello', { variant: 'success' });
+
+        tag.clearDirty();
+        tag.setVariant('success');
+
+        expect(tag.isDirty).toBe(false);
     });
 
     // ── 5. Edge cases ────────────────────────────────────────────────────
@@ -124,4 +145,5 @@ describe('Tag', () => {
     it('handles zero-size rect without error', () => {
         expect(() => renderTag('test', {}, {}, 0, 0)).not.toThrow();
     });
+
 });

--- a/packages/widgets/src/display/Tag.ts
+++ b/packages/widgets/src/display/Tag.ts
@@ -40,6 +40,8 @@ export class Tag extends Widget {
 
     /** Update the tag text. */
     setText(text: string): void {
+        if (text === this._text) return;
+
         this._text = text;
         this.markDirty();
     }
@@ -51,6 +53,8 @@ export class Tag extends Widget {
 
     /** Update the tag variant. */
     setVariant(variant: TagVariant): void {
+        if (variant === this._variant) return;
+
         this._variant = variant;
         this.markDirty();
     }


### PR DESCRIPTION
## Description

Avoids unnecessary widget invalidation in `Tag` by skipping `markDirty()` calls when text or variant values remain unchanged.

This PR adds equality guards to `setText()` and `setVariant()` and introduces regression tests verifying that unchanged updates do not trigger widget invalidation.

## Related Issue

Closes #911 

## Which package(s)?

@termuijs/widgets

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [x] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

### Changes Made

* Added equality guard in `Tag.setText()`
* Added equality guard in `Tag.setVariant()`
* Added regression test verifying unchanged text does not mark the widget dirty
* Added regression test verifying unchanged variants do not mark the widget dirty
* Preserved existing dirty-state behavior for actual state changes

### Validation

✅ `bun vitest run packages/widgets/src/display/Tag.test.ts`

### Build Note

Repository-wide build/typecheck currently reports an unrelated failure in `@termuijs/adapters` due to a missing `dotenv` dependency. This issue is outside the scope of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized the Tag widget to prevent unnecessary re-renders when setting unchanged text or variant values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->