### PR TITLE
test(feedback): add LoadingDots mutation regression tests

### DIFF
--- a/packages/widgets/src/feedback/LoadingDots.test.ts
+++ b/packages/widgets/src/feedback/LoadingDots.test.ts
@@ -59,6 +59,37 @@ describe('LoadingDots', () => {
         expect(row).toContain('Done   ');
     });
 
+    it('tick marks widget dirty', () => {
+        const ld = new LoadingDots({}, { label: 'Loading' });
+
+        ld.clearDirty();
+        ld.tick();
+
+        expect(ld.isDirty).toBe(true);
+    });
+
+    it('setLabel marks widget dirty', () => {
+        const ld = new LoadingDots({}, { label: 'Loading' });
+
+        ld.clearDirty();
+        ld.setLabel('Done');
+
+        expect(ld.isDirty).toBe(true);
+    });
+
+    it('tick updates rendered output after mutation', () => {
+        const screen = new Screen(20, 1);
+        const ld = new LoadingDots({}, { label: 'Loading', maxDots: 3 });
+
+        ld.updateRect({ x: 0, y: 0, width: 20, height: 1 });
+
+        ld.tick();
+        ld.render(screen);
+
+        const row = screen.back[0].map(c => c.char).join('');
+        expect(row).toContain('Loading·');
+    });
+
     it('ASCII fallback dot renders when caps.unicode is false', () => {
         vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
         const screen = new Screen(20, 1);


### PR DESCRIPTION
## Description

Adds mutation-focused regression tests for `LoadingDots` to verify widget invalidation and rendering behavior after state updates.

These tests help ensure future changes continue to correctly trigger rerendering when widget state is mutated.

## Related Issue

Closes #912

## Which package(s)?

@termuijs/widgets

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

### Changes Made

* Added regression test verifying `tick()` marks the widget dirty
* Added regression test verifying `setLabel()` marks the widget dirty
* Added regression test verifying rendering updates after mutation
* Preserved existing behavior and test coverage

### Validation

✅ `bun vitest run packages/widgets/src/feedback/LoadingDots.test.ts`

### Build Note

Repository-wide build/typecheck currently reports an unrelated failure in `@termuijs/adapters` due to a missing `dotenv` dependency. This issue is outside the scope of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for the LoadingDots widget to verify state management and rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->