### PR TITLE
security: restrict installation to supported themes

### DIFF
--- a/scripts/install-theme.js
+++ b/scripts/install-theme.js
@@ -10,7 +10,6 @@ import { execFileSync } from 'node:child_process';
  * Allows: lowercase letters, numbers, hyphens, underscores
  * @throws Error if invalid
  */
-function validateThemeName(name) {
   const VALID_THEME_RE = /^[a-z0-9_-]+$/;
   const ALLOWED_THEMES = new Set([
     'dark',
@@ -18,6 +17,7 @@ function validateThemeName(name) {
     'solarized',
     'dracula',
   ]);
+function validateThemeName(name) {
 
   if (!name || name.length === 0) {
     throw new Error('Theme name cannot be empty');

--- a/scripts/install-theme.js
+++ b/scripts/install-theme.js
@@ -12,6 +12,12 @@ import { execFileSync } from 'node:child_process';
  */
 function validateThemeName(name) {
   const VALID_THEME_RE = /^[a-z0-9_-]+$/;
+  const ALLOWED_THEMES = new Set([
+    'dark',
+    'light',
+    'solarized',
+    'dracula',
+  ]);
 
   if (!name || name.length === 0) {
     throw new Error('Theme name cannot be empty');
@@ -25,6 +31,9 @@ function validateThemeName(name) {
     throw new Error(
       'Invalid theme name. Only lowercase letters, numbers, hyphens and underscores are allowed.'
     );
+  }
+  if (!ALLOWED_THEMES.has(name)) {
+    throw new Error(`Unsupported theme: ${name}`);
   }
 }
 

--- a/scripts/install-theme.test.js
+++ b/scripts/install-theme.test.js
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { validateThemeName } from './install-theme.js';
+
+describe('validateThemeName', () => {
+  it('allows supported themes', () => {
+    expect(() => validateThemeName('dark')).not.toThrow();
+  });
+
+  it('rejects unsupported themes', () => {
+    expect(() => validateThemeName('hacker')).toThrow(
+      'Unsupported theme: hacker'
+    );
+  });
+});


### PR DESCRIPTION
Description

Restrict theme installation to supported themes by introducing an allowlist validation step before invoking npm. This prevents installation of unsupported theme packages while preserving existing input validation.

Related Issue

Closes #931 

Which package(s)?

- CLI / theme installer package

Type of Change

- [ ] 🐛 Bug fix ("type:bug")
- [ ] ✨ Feature ("type:feature")
- [ ] 📝 Docs ("type:docs")
- [ ] 🧪 Tests ("type:testing")
- [ ] ♻️ Refactor ("type:refactor")
- [ ] 🎨 Design / UX ("type:design")
- [ ] ♿ Accessibility ("type:accessibility")
- [ ] ⚡ Performance ("type:performance")
- [ ] 🔧 DevOps / CI ("type:devops")
- [x] 🔒 Security ("type:security")

Checklist

- [x] ⭐ You starred the repo. The "needs-star" check blocks your merge otherwise.
- [x] Tests pass locally: "bun vitest run"
- [x] Build passes: "bun run build"
- [x] Typecheck passes: "bun run typecheck"
- [x] You read "CONTRIBUTING.md".
- [x] Your PR title follows "type: short description".
- [x] No unrelated refactors bundled into this PR.

GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.

Screenshots / Recordings (UI changes)

Not applicable. This change only affects CLI validation logic.

Notes for the Reviewer

Added an allowlist check in "validateThemeName()" to ensure only supported themes can be installed. Existing regex validation remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Theme installation now restricts choices to supported themes: dark, light, solarized, and dracula. Attempts to install any other theme are blocked and show a clear "Unsupported theme" error.
* **Tests**
  * Added automated tests to verify supported themes succeed and unsupported themes surface the "Unsupported theme" error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->