### PR TITLE
fix(data): buffer partial lines across chunk boundaries in tail()

### DIFF
--- a/packages/data/src/tail.test.ts
+++ b/packages/data/src/tail.test.ts
@@ -93,4 +93,31 @@ describe('tail', () => {
         appendAndWatch('line1\nline2\nline3\n', stream);
         expect(stream.lines).toEqual(['line1', 'line2', 'line3']);
     });
+
+    it('resets partial buffer on file truncation', () => {
+        fileContent = '\n\n\n\n\n';
+        vi.mocked(fs.readFileSync).mockImplementation(() => fileContent);
+        vi.mocked(fs.statSync).mockReturnValue(stats(fileContent.length));
+
+        const stream = tail('/tmp/test.log', { initialLines: 100 });
+
+        // Write a partial line with no newline
+        appendAndWatch('incomplete', stream);
+        expect(stream.lines).toEqual([]);
+
+        // Simulate file truncation — curr.size < fileSize
+        // Set fileContent to new truncated content
+        const prevSize = fileContent.length;
+        fileContent = 'new content\n';
+        vi.mocked(fs.readFileSync).mockImplementation(() => fileContent);
+        vi.mocked(fs.statSync).mockReturnValue(stats(fileContent.length));
+        watchCallback!(stats(fileContent.length), stats(prevSize));
+
+        // Truncation resets partialLine and loads new content via readFileSync
+        expect(stream.lines).toEqual(['new content']);
+
+        // Next append must NOT prepend old partial fragment
+        appendAndWatch('fresh line\n', stream);
+        expect(stream.lines).toEqual(['new content', 'fresh line']);
+    });
 });

--- a/packages/data/src/tail.test.ts
+++ b/packages/data/src/tail.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Stats } from 'node:fs';
+
+let watchCallback: ((curr: Stats, prev: Stats) => void) | null = null;
+let fileContent = '';
+
+vi.mock('node:fs', () => ({
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+    statSync: vi.fn(),
+    watchFile: vi.fn(),
+    unwatchFile: vi.fn(),
+    openSync: vi.fn(),
+    readSync: vi.fn(),
+    closeSync: vi.fn(),
+}));
+
+const fs = await import('node:fs');
+const { tail } = await import('./tail.js');
+
+function stats(size: number): Stats {
+    return { size } as Stats;
+}
+
+function appendAndWatch(text: string, stream: ReturnType<typeof tail>): void {
+    const prevSize = fileContent.length;
+    fileContent += text;
+    vi.mocked(fs.statSync).mockReturnValue(stats(fileContent.length));
+    watchCallback!(stats(fileContent.length), stats(prevSize));
+}
+
+describe('tail', () => {
+    beforeEach(() => {
+        fileContent = '';
+        watchCallback = null;
+
+        vi.mocked(fs.existsSync).mockReturnValue(true);
+        vi.mocked(fs.readFileSync).mockImplementation(() => fileContent);
+        vi.mocked(fs.statSync).mockReturnValue(stats(0));
+        vi.mocked(fs.openSync).mockReturnValue(1);
+        vi.mocked(fs.readSync).mockImplementation((_fd, buffer, offset, length, position) => {
+            const start = position ?? 0;
+            const slice = fileContent.slice(start, start + length);
+            Buffer.from(slice).copy(buffer, offset, 0, slice.length);
+            return slice.length;
+        });
+        vi.mocked(fs.watchFile).mockImplementation((_path, _opts, cb) => {
+            watchCallback = cb;
+        });
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('reassembles lines split across two chunks', () => {
+        const stream = tail('/tmp/test.log', { initialLines: 100 });
+        expect(watchCallback).not.toBeNull();
+
+        appendAndWatch('hel', stream);
+        expect(stream.lines).toEqual([]);
+
+        appendAndWatch('lo\nworld\n', stream);
+        expect(stream.lines).toEqual(['hello', 'world']);
+    });
+
+    it('buffers incomplete lines until a newline arrives', () => {
+        const stream = tail('/tmp/test.log', { initialLines: 100 });
+
+        appendAndWatch('partial line without newline', stream);
+        expect(stream.lines).toEqual([]);
+
+        appendAndWatch(' complete\n', stream);
+        expect(stream.lines).toEqual(['partial line without newline complete']);
+    });
+
+    it('preserves partial buffer across an empty growth read', () => {
+        const stream = tail('/tmp/test.log', { initialLines: 100 });
+
+        appendAndWatch('start', stream);
+        expect(stream.lines).toEqual([]);
+
+        watchCallback!(stats(fileContent.length), stats(fileContent.length));
+        expect(stream.lines).toEqual([]);
+
+        appendAndWatch(' end\n', stream);
+        expect(stream.lines).toEqual(['start end']);
+    });
+
+    it('emits multiple complete lines from a single chunk', () => {
+        const stream = tail('/tmp/test.log', { initialLines: 100 });
+
+        appendAndWatch('line1\nline2\nline3\n', stream);
+        expect(stream.lines).toEqual(['line1', 'line2', 'line3']);
+    });
+});

--- a/packages/data/src/tail.ts
+++ b/packages/data/src/tail.ts
@@ -51,6 +51,7 @@ export function tail(filePath: string, opts: TailOptions = {}): TailStream {
             let fileSize = fs.statSync(filePath).size;
             stream.active = true;
             (stream as any)._watchPath = filePath;
+            let partialLine = '';
 
             // Watch for changes
             const watcher = fs.watchFile(filePath, { interval: 500 }, (curr) => {
@@ -67,7 +68,10 @@ export function tail(filePath: string, opts: TailOptions = {}): TailStream {
                         const buffer = Buffer.alloc(curr.size - fileSize);
                         fs.readSync(fd, buffer, 0, buffer.length, fileSize);
 
-                        const newLines = buffer.toString('utf-8').split('\n').filter(l => l.length > 0);
+                        const text = partialLine + buffer.toString('utf-8');
+                        const lines = text.split('\n');
+                        partialLine = lines.pop() ?? '';
+                        const newLines = lines.filter(l => l.length > 0);
                         stream.lines.push(...newLines);
 
                         // Trim to max
@@ -83,6 +87,7 @@ export function tail(filePath: string, opts: TailOptions = {}): TailStream {
                     }
                 } else if (curr.size < fileSize) {
                     // File was truncated — re-read
+                    partialLine = '';
                     const content = fs.readFileSync(filePath, 'utf-8');
                     stream.lines = content.split('\n').filter(l => l.length > 0).slice(-maxLines);
                     fileSize = curr.size;


### PR DESCRIPTION
## Summary

Closes #935

## Problem

`tail()` called `buffer.toString().split('\n')` on each file read
independently. When a line spanned two consecutive reads, the two
halves were emitted as separate invalid entries — silently corrupting
log output with no error.

## Fix

Added a `partialLine` variable scoped per `tail()` call that persists
between reads:

1. Prepends `partialLine` to each new chunk before splitting on `\n`
2. Pops the last element (incomplete fragment) back into `partialLine`
3. Emits only complete lines
4. Resets `partialLine` to `''` on file truncation

## Files Changed

- `packages/data/src/tail.ts` — partial line buffer added
- `packages/data/src/tail.test.ts` — 4 new tests covering chunk boundary behavior

## Test Results

- `bun vitest run packages/data` — 80/80 passed 
- `bun run typecheck` — passed 
- `bun run build` — all packages built successfully 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tailing to reassemble lines split across multiple file-growth events.
  * Buffering now preserves partial data across non-growing checks and resets correctly on truncation to avoid leaking stale fragments.
  * Ensures multiple complete lines emitted from a single growth are handled reliably.

* **Tests**
  * Added comprehensive tests covering fragmentation, buffering, truncation reset, and multi-line emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->