### PR TITLE
feat(widgets): implement RangeInput widget

### DIFF
--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -44,6 +44,8 @@ export type { ButtonOptions, ButtonVariant } from './input/Button.js';
 
 export { Slider } from "./input/Slider.js";
 export type { SliderOptions } from "./input/Slider.js";
+export { RangeInput } from "./input/RangeInput.js";
+export type { RangeInputOptions } from "./input/RangeInput.js";
 
 // ── Data Widgets ──────────────────────────────────────
 export { Table } from './data/Table.js';

--- a/packages/widgets/src/input/RangeInput.test.ts
+++ b/packages/widgets/src/input/RangeInput.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("RangeInput", () => {
+  it("constructs with defaults", async () => {
+    const { RangeInput } = await import("./RangeInput.js");
+    const range = new RangeInput("Filter");
+    expect(range.getValue()).toEqual([0, 100]);
+  });
+
+  it("setValue updates value within bounds", async () => {
+    const { RangeInput } = await import("./RangeInput.js");
+    const range = new RangeInput("Filter", {}, { min: 0, max: 100 });
+    
+    range.setValue([20, 80]);
+    expect(range.getValue()).toEqual([20, 80]);
+  });
+
+  it("clamps below min and above max", async () => {
+    const { RangeInput } = await import("./RangeInput.js");
+    const range = new RangeInput("Filter", {}, { min: 0, max: 100 });
+
+    range.setValue([-10, 150]);
+    expect(range.getValue()).toEqual([0, 100]);
+  });
+
+  it("prevents crossing bounds", async () => {
+    const { RangeInput } = await import("./RangeInput.js");
+    const range = new RangeInput("Filter", {}, { min: 0, max: 100 });
+
+    range.setValue([80, 20]);
+    // lower gets clamped to upper if it exceeds
+    expect(range.getValue()).toEqual([20, 20]);
+  });
+
+  it("arrow right increments active thumb", async () => {
+    const { RangeInput } = await import("./RangeInput.js");
+    const range = new RangeInput("Filter", {}, { step: 5 });
+
+    // Active thumb defaults to 0 (lower bound)
+    range.setValue([20, 80]);
+    range.handleKey({ key: "right" } as any);
+    expect(range.getValue()).toEqual([25, 80]);
+  });
+
+  it("arrow left decrements active thumb", async () => {
+    const { RangeInput } = await import("./RangeInput.js");
+    const range = new RangeInput("Filter", {}, { step: 5 });
+
+    // Active thumb defaults to 0 (lower bound)
+    range.setValue([20, 80]);
+    range.handleKey({ key: "left" } as any);
+    expect(range.getValue()).toEqual([15, 80]);
+  });
+
+  it("tab switches active thumb", async () => {
+    const { RangeInput } = await import("./RangeInput.js");
+    const range = new RangeInput("Filter", {}, { step: 5 });
+
+    range.setValue([20, 80]);
+    range.handleKey({ key: "tab" } as any); // Switches to upper bound
+    
+    range.handleKey({ key: "right" } as any);
+    expect(range.getValue()).toEqual([20, 85]);
+
+    range.handleKey({ key: "left" } as any);
+    expect(range.getValue()).toEqual([20, 80]);
+  });
+
+  it("renders ascii mode", async () => {
+    vi.stubEnv("NO_UNICODE", "1");
+    vi.stubEnv("TERM", "");
+    vi.resetModules();
+
+    const { Screen } = await import("@termuijs/core");
+    const { RangeInput } = await import("./RangeInput.js");
+
+    const range = new RangeInput("Filter");
+    range.setValue([20, 80]);
+    range.updateRect({ x: 0, y: 0, width: 40, height: 1 });
+
+    const screen = new Screen(40, 1);
+    range.render(screen);
+
+    const rendered = screen.back[0]
+      .map((c: { char: string }) => c.char)
+      .join("");
+
+    expect(rendered).toContain("#");
+    expect(rendered).toContain("-");
+    expect(rendered).toContain("O");
+  });
+
+  it("renders unicode mode", async () => {
+    vi.stubEnv("NO_UNICODE", "");
+    vi.stubEnv("TERM", "");
+    vi.resetModules();
+
+    const { Screen } = await import("@termuijs/core");
+    const { RangeInput } = await import("./RangeInput.js");
+
+    const range = new RangeInput("Filter");
+    range.setValue([20, 80]);
+    range.updateRect({ x: 0, y: 0, width: 40, height: 1 });
+
+    const screen = new Screen(40, 1);
+    range.render(screen);
+
+    const rendered = screen.back[0]
+      .map((c: { char: string }) => c.char)
+      .join("");
+
+    expect(rendered).toMatch(/[█░]/);
+  });
+});

--- a/packages/widgets/src/input/RangeInput.test.ts
+++ b/packages/widgets/src/input/RangeInput.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { Screen, caps, createKeyEvent } from "@termuijs/core";
 
 afterEach(() => {
-  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
 });
+
+const key = (name: string) =>
+  createKeyEvent({ key: name, raw: Buffer.alloc(0), ctrl: false, alt: false, shift: false });
 
 describe("RangeInput", () => {
   it("constructs with defaults", async () => {
@@ -42,7 +46,7 @@ describe("RangeInput", () => {
 
     // Active thumb defaults to 0 (lower bound)
     range.setValue([20, 80]);
-    range.handleKey({ key: "right" } as any);
+    range.handleKey(key("right"));
     expect(range.getValue()).toEqual([25, 80]);
   });
 
@@ -52,7 +56,7 @@ describe("RangeInput", () => {
 
     // Active thumb defaults to 0 (lower bound)
     range.setValue([20, 80]);
-    range.handleKey({ key: "left" } as any);
+    range.handleKey(key("left"));
     expect(range.getValue()).toEqual([15, 80]);
   });
 
@@ -61,21 +65,18 @@ describe("RangeInput", () => {
     const range = new RangeInput("Filter", {}, { step: 5 });
 
     range.setValue([20, 80]);
-    range.handleKey({ key: "tab" } as any); // Switches to upper bound
+    range.handleKey(key("tab")); // Switches to upper bound
     
-    range.handleKey({ key: "right" } as any);
+    range.handleKey(key("right"));
     expect(range.getValue()).toEqual([20, 85]);
 
-    range.handleKey({ key: "left" } as any);
+    range.handleKey(key("left"));
     expect(range.getValue()).toEqual([20, 80]);
   });
 
   it("renders ascii mode", async () => {
-    vi.stubEnv("NO_UNICODE", "1");
-    vi.stubEnv("TERM", "");
-    vi.resetModules();
+    vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
 
-    const { Screen } = await import("@termuijs/core");
     const { RangeInput } = await import("./RangeInput.js");
 
     const range = new RangeInput("Filter");
@@ -95,11 +96,8 @@ describe("RangeInput", () => {
   });
 
   it("renders unicode mode", async () => {
-    vi.stubEnv("NO_UNICODE", "");
-    vi.stubEnv("TERM", "");
-    vi.resetModules();
+    vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
 
-    const { Screen } = await import("@termuijs/core");
     const { RangeInput } = await import("./RangeInput.js");
 
     const range = new RangeInput("Filter");

--- a/packages/widgets/src/input/RangeInput.test.ts
+++ b/packages/widgets/src/input/RangeInput.test.ts
@@ -74,6 +74,18 @@ describe("RangeInput", () => {
     expect(range.getValue()).toEqual([20, 80]);
   });
 
+  it("fires onChange callback", async () => {
+    const { RangeInput } = await import("./RangeInput.js");
+    const onChange = vi.fn();
+    const range = new RangeInput("Filter", {}, { step: 5, onChange });
+
+    range.setValue([20, 80]);
+    expect(onChange).toHaveBeenCalledWith([20, 80]);
+
+    range.handleKey(key("right"));
+    expect(onChange).toHaveBeenCalledWith([25, 80]);
+  });
+
   it("renders ascii mode", async () => {
     vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
 

--- a/packages/widgets/src/input/RangeInput.ts
+++ b/packages/widgets/src/input/RangeInput.ts
@@ -15,6 +15,7 @@ export interface RangeInputOptions {
   step?: number;
   color?: Color;
   showValue?: boolean;
+  onChange?: (value: [number, number]) => void;
 }
 
 export class RangeInput extends Widget {
@@ -26,6 +27,7 @@ export class RangeInput extends Widget {
   private _step: number;
   private _color: Color;
   private _showValue: boolean;
+  private _onChange?: (value: [number, number]) => void;
 
   constructor(
     label?: string,
@@ -41,6 +43,7 @@ export class RangeInput extends Widget {
     this._step = opts.step ?? 1;
     this._color = opts.color ?? { type: "named", name: "cyan" };
     this._showValue = opts.showValue ?? true;
+    this._onChange = opts.onChange;
   }
 
   getValue(): [number, number] {
@@ -52,12 +55,13 @@ export class RangeInput extends Widget {
     let upper = Math.max(this._min, Math.min(this._max, value[1]));
 
     if (lower > upper) {
-        // Enforce lower <= upper
-        lower = upper;
+      // Enforce lower <= upper
+      lower = upper;
     }
 
     this._value = [lower, upper];
     this.markDirty();
+    this._onChange?.(this._value);
   }
 
   setLabel(label: string): void {
@@ -74,28 +78,14 @@ export class RangeInput extends Widget {
       case "right": {
         const newValue: [number, number] = [this._value[0], this._value[1]];
         newValue[this._activeThumb] += this._step;
-        
-        // Prevent active thumb from crossing the other
-        if (this._activeThumb === 0 && newValue[0] > newValue[1]) {
-            newValue[0] = newValue[1];
-        } else if (this._activeThumb === 1 && newValue[1] > this._max) {
-            newValue[1] = this._max;
-        }
-
+        // let setValue() handle all boundary enforcement
         this.setValue(newValue);
         break;
       }
       case "left": {
         const newValue: [number, number] = [this._value[0], this._value[1]];
         newValue[this._activeThumb] -= this._step;
-        
-        // Prevent active thumb from crossing the other
-        if (this._activeThumb === 1 && newValue[1] < newValue[0]) {
-            newValue[1] = newValue[0];
-        } else if (this._activeThumb === 0 && newValue[0] < this._min) {
-            newValue[0] = this._min;
-        }
-
+        // let setValue() handle all boundary enforcement
         this.setValue(newValue);
         break;
       }
@@ -155,7 +145,7 @@ export class RangeInput extends Widget {
       let charToRender = isFilled ? filledChar : emptyChar;
       
       if (isThumb) {
-          charToRender = caps.unicode ? "█" : "O"; // Thumbs are always distinct
+        charToRender = caps.unicode ? "█" : "O"; // Thumbs are always distinct
       }
 
       screen.setCell(trackX + i, y, {

--- a/packages/widgets/src/input/RangeInput.ts
+++ b/packages/widgets/src/input/RangeInput.ts
@@ -28,15 +28,16 @@ export class RangeInput extends Widget {
   private _showValue: boolean;
 
   constructor(
-    label: string,
+    label?: string,
     style: Partial<Style> = {},
     opts: RangeInputOptions = {}
   ) {
     super(style);
 
-    this._label = label;
+    this._label = label ?? "";
     this._min = opts.min ?? 0;
     this._max = opts.max ?? 100;
+    this._value = [this._min, this._max];
     this._step = opts.step ?? 1;
     this._color = opts.color ?? { type: "named", name: "cyan" };
     this._showValue = opts.showValue ?? true;
@@ -71,7 +72,7 @@ export class RangeInput extends Widget {
         this.markDirty();
         break;
       case "right": {
-        const newValue = [...this._value] as [number, number];
+        const newValue: [number, number] = [this._value[0], this._value[1]];
         newValue[this._activeThumb] += this._step;
         
         // Prevent active thumb from crossing the other
@@ -85,7 +86,7 @@ export class RangeInput extends Widget {
         break;
       }
       case "left": {
-        const newValue = [...this._value] as [number, number];
+        const newValue: [number, number] = [this._value[0], this._value[1]];
         newValue[this._activeThumb] -= this._step;
         
         // Prevent active thumb from crossing the other

--- a/packages/widgets/src/input/RangeInput.ts
+++ b/packages/widgets/src/input/RangeInput.ts
@@ -59,6 +59,10 @@ export class RangeInput extends Widget {
       lower = upper;
     }
 
+    if (this._value[0] === lower && this._value[1] === upper) {
+      return;
+    }
+
     this._value = [lower, upper];
     this.markDirty();
     this._onChange?.(this._value);

--- a/packages/widgets/src/input/RangeInput.ts
+++ b/packages/widgets/src/input/RangeInput.ts
@@ -132,8 +132,9 @@ export class RangeInput extends Widget {
     const ratioStart = (this._value[0] - this._min) / rangeSize;
     const ratioEnd = (this._value[1] - this._min) / rangeSize;
 
-    const trackStart = Math.round(trackWidth * ratioStart);
-    const trackEnd = Math.round(trackWidth * ratioEnd);
+    const maxTrackIndex = Math.max(0, trackWidth - 1);
+    const trackStart = Math.min(maxTrackIndex, Math.round(maxTrackIndex * ratioStart));
+    const trackEnd = Math.min(maxTrackIndex, Math.round(maxTrackIndex * ratioEnd));
 
     screen.writeString(x, y, prefix, {
       ...attrs,

--- a/packages/widgets/src/input/RangeInput.ts
+++ b/packages/widgets/src/input/RangeInput.ts
@@ -1,0 +1,172 @@
+import {
+  type Screen,
+  type Style,
+  type Color,
+  type KeyEvent,
+  styleToCellAttrs,
+  stringWidth,
+  caps,
+} from "@termuijs/core";
+import { Widget } from "../base/Widget.js";
+
+export interface RangeInputOptions {
+  min?: number;
+  max?: number;
+  step?: number;
+  color?: Color;
+  showValue?: boolean;
+}
+
+export class RangeInput extends Widget {
+  private _label: string;
+  private _value: [number, number] = [0, 100];
+  private _activeThumb: 0 | 1 = 0;
+  private _min: number;
+  private _max: number;
+  private _step: number;
+  private _color: Color;
+  private _showValue: boolean;
+
+  constructor(
+    label: string,
+    style: Partial<Style> = {},
+    opts: RangeInputOptions = {}
+  ) {
+    super(style);
+
+    this._label = label;
+    this._min = opts.min ?? 0;
+    this._max = opts.max ?? 100;
+    this._step = opts.step ?? 1;
+    this._color = opts.color ?? { type: "named", name: "cyan" };
+    this._showValue = opts.showValue ?? true;
+  }
+
+  getValue(): [number, number] {
+    return [this._value[0], this._value[1]];
+  }
+
+  setValue(value: [number, number]): void {
+    let lower = Math.max(this._min, Math.min(this._max, value[0]));
+    let upper = Math.max(this._min, Math.min(this._max, value[1]));
+
+    if (lower > upper) {
+        // Enforce lower <= upper
+        lower = upper;
+    }
+
+    this._value = [lower, upper];
+    this.markDirty();
+  }
+
+  setLabel(label: string): void {
+    this._label = label;
+    this.markDirty();
+  }
+
+  handleKey(event: KeyEvent): void {
+    switch (event.key) {
+      case "tab":
+        this._activeThumb = this._activeThumb === 0 ? 1 : 0;
+        this.markDirty();
+        break;
+      case "right": {
+        const newValue = [...this._value] as [number, number];
+        newValue[this._activeThumb] += this._step;
+        
+        // Prevent active thumb from crossing the other
+        if (this._activeThumb === 0 && newValue[0] > newValue[1]) {
+            newValue[0] = newValue[1];
+        } else if (this._activeThumb === 1 && newValue[1] > this._max) {
+            newValue[1] = this._max;
+        }
+
+        this.setValue(newValue);
+        break;
+      }
+      case "left": {
+        const newValue = [...this._value] as [number, number];
+        newValue[this._activeThumb] -= this._step;
+        
+        // Prevent active thumb from crossing the other
+        if (this._activeThumb === 1 && newValue[1] < newValue[0]) {
+            newValue[1] = newValue[0];
+        } else if (this._activeThumb === 0 && newValue[0] < this._min) {
+            newValue[0] = this._min;
+        }
+
+        this.setValue(newValue);
+        break;
+      }
+    }
+  }
+
+  protected _renderSelf(screen: Screen): void {
+    const rect = this._getContentRect();
+    const { x, y, width, height } = rect;
+
+    if (width <= 0 || height <= 0) return;
+
+    const attrs = styleToCellAttrs(this._style);
+
+    const leftArrow = caps.unicode ? "◄" : "<";
+    const rightArrow = caps.unicode ? "►" : ">";
+
+    const activeIndicator = this._activeThumb === 0 ? leftArrow : rightArrow;
+    
+    const valueStr = this._showValue ? ` [${this._value[0]}, ${this._value[1]}]` : "";
+    const prefix = `${this._label} ${activeIndicator} `;
+    const suffix = `${valueStr}`;
+
+    const prefixWidth = stringWidth(prefix);
+    const suffixWidth = stringWidth(suffix);
+
+    const trackWidth = Math.max(
+      0,
+      width - prefixWidth - suffixWidth
+    );
+
+    const rangeSize = Math.max(1, this._max - this._min);
+    
+    const ratioStart = (this._value[0] - this._min) / rangeSize;
+    const ratioEnd = (this._value[1] - this._min) / rangeSize;
+
+    const trackStart = Math.round(trackWidth * ratioStart);
+    const trackEnd = Math.round(trackWidth * ratioEnd);
+
+    screen.writeString(x, y, prefix, {
+      ...attrs,
+      bold: true,
+      fg: this._color // Highlight prefix to show it's active
+    });
+
+    const trackX = x + prefixWidth;
+
+    for (let i = 0; i < trackWidth; i++) {
+      const isFilled = i >= trackStart && i <= trackEnd;
+      const isThumb = i === trackStart || i === trackEnd;
+      const isActiveThumb = (this._activeThumb === 0 && i === trackStart) || (this._activeThumb === 1 && i === trackEnd);
+
+      const filledChar = caps.unicode ? "█" : "#";
+      const emptyChar = caps.unicode ? "░" : "-";
+      
+      let charToRender = isFilled ? filledChar : emptyChar;
+      
+      if (isThumb) {
+          charToRender = caps.unicode ? "█" : "O"; // Thumbs are always distinct
+      }
+
+      screen.setCell(trackX + i, y, {
+        char: charToRender,
+        fg: isFilled
+              ? (isActiveThumb ? { type: "named", name: "white" } : this._color)
+              : { type: "named", name: "brightBlack" },
+      });
+    }
+
+    screen.writeString(trackX + trackWidth, y, suffix, {
+      ...attrs,
+      bold: true,
+    });
+  }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

This PR introduces the `RangeInput` widget as requested in Wave 6 of the TermUI roadmap. The `RangeInput` allows users to select a lower and upper bounded range using a dual-thumb slider track. It fully supports `tab` focus switching between the min and max thumbs, arrow key bound increments, constraints preventing overlapping boundaries, and native ASCI/Unicode adaptive rendering capabilities.

## Related Issue

Closes #948 

## Which package(s)?

`@termuijs/widgets`

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/172e996c-3943-4a86-8249-1f01922d0f64`

## Screenshots / Recordings (UI changes)

*(Since this renders natively into the ANSI buffer, automated visual layout constraints have been asserted in the `RangeInput.test.ts` file covering both ASCII fallback lines and primary Unicode character lines).*

## Notes for the Reviewer

The implementation mimics the architectural style used by `Slider.ts` to maintain consistency across `@termuijs/widgets/input`. Arrow rendering uses `◄` and `►` characters to denote which thumb is currently active in keyboard focus, dynamically updating fg color variables dynamically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Range input widget for selecting a two-value interval with min/max, step, color, and optional value display; ASCII/Unicode rendering with active-thumb highlight.
  * Keyboard: Tab switches active thumb; arrow keys adjust the active endpoint with automatic clamping and ordering.

* **Public API**
  * Range input exported for library consumers.

* **Tests**
  * Added tests for initialization, clamping, keyboard interactions, callbacks, and rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->