### PR TITLE
fix(widgets): standardize constructor signatures - Badge/Tag overloads, Modal/Select style param, Widget docs

### DIFF
--- a/packages/ui/src/Modal.ts
+++ b/packages/ui/src/Modal.ts
@@ -19,8 +19,8 @@ export class Modal extends Widget {
     private _visible = false;
     private _content: Widget | null = null;
 
-    constructor(options: ModalOptions = {}) {
-        super(mergeStyles(defaultStyle(), {}));
+    constructor(options: ModalOptions = {}, style?: Partial<Style>) {
+        super(mergeStyles(defaultStyle(), style ?? {}));
         this._title = options.title ?? '';
         this._modalWidth = options.width ?? 50;
         this._modalHeight = options.height ?? 15;

--- a/packages/ui/src/Select.ts
+++ b/packages/ui/src/Select.ts
@@ -19,7 +19,7 @@ export class Select extends Widget {
     focusable = true;
 
     constructor(options: SelectOption[], config: SelectOptions = {}, style?: Partial<Style>) {
-        super(mergeStyles(defaultStyle(), { height: 1 }, style));
+        super(mergeStyles(mergeStyles(defaultStyle(), { height: 1 }), style ?? {}));
         this._options = options;
         this._placeholder = config.placeholder ?? 'Select...';
         this._activeColor = config.activeColor ?? { type: 'named', name: 'cyan' };

--- a/packages/ui/src/Select.ts
+++ b/packages/ui/src/Select.ts
@@ -18,8 +18,8 @@ export class Select extends Widget {
     private _onSelect?: (option: SelectOption, index: number) => void;
     focusable = true;
 
-    constructor(options: SelectOption[], config: SelectOptions = {}) {
-        super(mergeStyles(defaultStyle(), { height: 1 }));
+    constructor(options: SelectOption[], config: SelectOptions = {}, style?: Partial<Style>) {
+        super(mergeStyles(defaultStyle(), { height: 1 }, style));
         this._options = options;
         this._placeholder = config.placeholder ?? 'Select...';
         this._activeColor = config.activeColor ?? { type: 'named', name: 'cyan' };

--- a/packages/widgets/src/base/Widget.ts
+++ b/packages/widgets/src/base/Widget.ts
@@ -42,6 +42,20 @@ export function _resetWidgetIdCounter(): void {
 /**
  * Base class for all TermUI widgets.
  *
+ * CONSTRUCTOR SIGNATURE CONVENTION:
+ * - Simple display widgets: (content?, style?: Partial<Style>, opts?: SpecificOptions)
+ * - Data widgets:           (data, style?: Partial<Style>, opts?: SpecificOptions)
+ * - Compound UI widgets:    (options: SpecificOptions, style?: Partial<Style>)
+ *
+ * FOCUSABLE PATTERN:
+ * Set `focusable = true` as a class field initializer, OR in the constructor
+ * body after calling `super()`. Do NOT set it inside `_renderSelf()`.
+ *
+ * STYLE MERGE PATTERN:
+ * All widgets should call `super(mergeStyles(defaultStyle(), { ...defaults }, style))`
+ * to produce consistent base styles. For widgets that accept `style` as the
+ * second parameter, pass it directly through to `super()`.
+ *
  * Provides:
  * - Unique ID generation
  * - Style management and merging

--- a/packages/widgets/src/display/Badge.test.ts
+++ b/packages/widgets/src/display/Badge.test.ts
@@ -2,19 +2,20 @@
 // @termuijs/widgets — Tests for Badge widget
 // ─────────────────────────────────────────────────────
 
-import { describe, it, expect } from 'vitest';
-import { Badge } from './Badge.js';
+import { describe, it, expect, vi } from 'vitest';
+import { Badge, type BadgeOptions } from './Badge.js';
 import { Screen, caps } from '@termuijs/core';
+import type { Style } from '@termuijs/core';
 
 /** Helper: create widget, set rect, render to a screen, return both. */
 function renderBadge(
     text: string,
-    opts: ConstructorParameters<typeof Badge>[1] = {},
-    style: ConstructorParameters<typeof Badge>[2] = {},
+    style: Partial<Style> = {},
+    opts: BadgeOptions = {},
     width = 20,
     height = 3,
 ) {
-    const badge = new Badge(text, opts, style);
+    const badge = new Badge(text, style, opts);
     const screen = new Screen(width, height);
     badge.updateRect({ x: 0, y: 0, width, height });
     badge.render(screen);
@@ -49,29 +50,29 @@ describe('Badge', () => {
 
     // ── 2. Variant colors ────────────────────────────────────────────────
     it('applies cyan background for info variant', () => {
-        const { screen } = renderBadge('info', { variant: 'info' });
+        const { screen } = renderBadge('info', {}, { variant: 'info' });
         // Content cell (row 1, col 1 = first char of padded text " info ")
         // The space char at col 1 should have the cyan background
         expect(screen.back[1][1].bg).toEqual({ type: 'named', name: 'cyan' });
     });
 
     it('applies green background for success variant', () => {
-        const { screen } = renderBadge('ok', { variant: 'success' });
+        const { screen } = renderBadge('ok', {}, { variant: 'success' });
         expect(screen.back[1][1].bg).toEqual({ type: 'named', name: 'green' });
     });
 
     it('applies yellow background for warning variant', () => {
-        const { screen } = renderBadge('warn', { variant: 'warning' });
+        const { screen } = renderBadge('warn', {}, { variant: 'warning' });
         expect(screen.back[1][1].bg).toEqual({ type: 'named', name: 'yellow' });
     });
 
     it('applies red background for error variant', () => {
-        const { screen } = renderBadge('err', { variant: 'error' });
+        const { screen } = renderBadge('err', {}, { variant: 'error' });
         expect(screen.back[1][1].bg).toEqual({ type: 'named', name: 'red' });
     });
 
     it('applies white background for neutral variant', () => {
-        const { screen } = renderBadge('ok', { variant: 'neutral' });
+        const { screen } = renderBadge('ok', {}, { variant: 'neutral' });
         expect(screen.back[1][1].bg).toEqual({ type: 'named', name: 'white' });
     });
 
@@ -117,5 +118,46 @@ describe('Badge', () => {
 
     it('handles zero-size rect without error', () => {
         expect(() => renderBadge('test', {}, {}, 0, 0)).not.toThrow();
+    });
+
+    // ── 6. Constructor overloads ──────────────────────────────────────────
+    it('deprecated signature Badge(text, opts) produces console.warn', () => {
+        const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            new Badge('dep', { variant: 'info' });
+            expect(spy).toHaveBeenCalledWith(
+                'Badge(text, opts, style) is deprecated. Use Badge(text, style, opts) instead.',
+            );
+        } finally {
+            spy.mockRestore();
+        }
+    });
+
+    it('canonical signature Badge(text, style, opts) does not produce console.warn', () => {
+        const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            new Badge('canon', {}, { variant: 'info' });
+            expect(spy).not.toHaveBeenCalled();
+        } finally {
+            spy.mockRestore();
+        }
+    });
+
+    it('deprecated and canonical signatures produce equivalent output', () => {
+        const { screen: screen1 } = renderBadge('same', {}, { variant: 'error' });
+        // Construct with deprecated overload (opts as second arg)
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            const badge2 = new Badge('same', { variant: 'error' });
+            const screen2 = new Screen(20, 3);
+            badge2.updateRect({ x: 0, y: 0, width: 20, height: 3 });
+            badge2.render(screen2);
+            // First row should match
+            expect(screen2.back[0][0].char).toBe(screen1.back[0][0].char);
+            expect(screen2.back[1][2].char).toBe(screen1.back[1][2].char);
+            expect(warnSpy).toHaveBeenCalled();
+        } finally {
+            warnSpy.mockRestore();
+        }
     });
 });

--- a/packages/widgets/src/display/Badge.ts
+++ b/packages/widgets/src/display/Badge.ts
@@ -30,15 +30,32 @@ const FG_COLOR: Color = { type: 'named', name: 'black' };
  * Used for status indicators such as "online", "error", "beta".
  * Renders a bordered box with the text on a colored background.
  * Uses `caps.unicode` to choose between Unicode box-drawing and ASCII fallback.
+ *
+ * CONSTRUCTOR (canonical): (text, style?, opts?)
+ * @deprecated Badge(text, opts, style) is deprecated. Use Badge(text, style, opts) instead.
  */
 export class Badge extends Widget {
     private _text: string;
     private _variant: BadgeVariant;
 
-    constructor(text: string, opts: BadgeOptions = {}, style: Partial<Style> = {}) {
-        super(style);
-        this._text = text;
-        this._variant = opts.variant ?? 'neutral';
+    constructor(text: string, style?: Partial<Style>, opts?: BadgeOptions);
+    /** @deprecated Use Badge(text, style?, opts?) instead */
+    constructor(text: string, opts: BadgeOptions, style?: Partial<Style>);
+    constructor(text: string, styleOrOpts?: Partial<Style> | BadgeOptions, optsOrStyle?: BadgeOptions | Partial<Style>) {
+        // Detect old deprecated signature: Badge(text, opts, style)
+        if (styleOrOpts && 'variant' in styleOrOpts) {
+            const opts = styleOrOpts as BadgeOptions;
+            const style = optsOrStyle as Partial<Style> | undefined;
+            super(style ?? {});
+            this._text = text;
+            this._variant = opts.variant ?? 'neutral';
+        } else {
+            const style = styleOrOpts as Partial<Style> | undefined;
+            const opts = optsOrStyle as BadgeOptions | undefined;
+            super(style ?? {});
+            this._text = text;
+            this._variant = opts?.variant ?? 'neutral';
+        }
     }
 
     /** Update the badge text. */

--- a/packages/widgets/src/display/Badge.ts
+++ b/packages/widgets/src/display/Badge.ts
@@ -44,6 +44,7 @@ export class Badge extends Widget {
     constructor(text: string, styleOrOpts?: Partial<Style> | BadgeOptions, optsOrStyle?: BadgeOptions | Partial<Style>) {
         // Detect old deprecated signature: Badge(text, opts, style)
         if (styleOrOpts && 'variant' in styleOrOpts) {
+            console.warn('Badge(text, opts, style) is deprecated. Use Badge(text, style, opts) instead.');
             const opts = styleOrOpts as BadgeOptions;
             const style = optsOrStyle as Partial<Style> | undefined;
             super(style ?? {});

--- a/packages/widgets/src/display/Tag.test.ts
+++ b/packages/widgets/src/display/Tag.test.ts
@@ -2,19 +2,20 @@
 // @termuijs/widgets — Tests for Tag widget
 // ─────────────────────────────────────────────────────
 
-import { describe, it, expect } from 'vitest';
-import { Tag } from './Tag.js';
+import { describe, it, expect, vi } from 'vitest';
+import { Tag, type TagOptions } from './Tag.js';
 import { Screen, caps } from '@termuijs/core';
+import type { Style } from '@termuijs/core';
 
 /** Helper: create widget, set rect, render to a screen, return both. */
 function renderTag(
     text: string,
-    opts: ConstructorParameters<typeof Tag>[1] = {},
-    style: ConstructorParameters<typeof Tag>[2] = {},
+    style: Partial<Style> = {},
+    opts: TagOptions = {},
     width = 20,
     height = 3,
 ) {
-    const tag = new Tag(text, opts, style);
+    const tag = new Tag(text, style, opts);
     const screen = new Screen(width, height);
     tag.updateRect({ x: 0, y: 0, width, height });
     tag.render(screen);
@@ -46,7 +47,7 @@ describe('Tag', () => {
     });
 
     it('does not apply a background fill to content cells', () => {
-        const { screen } = renderTag('ts', { variant: 'info' });
+        const { screen } = renderTag('ts', {}, { variant: 'info' });
         // Tag should NOT set a bg color on content cells (unlike Badge)
         // The bg should remain the default (type: 'none')
         expect(screen.back[1][2].bg).toEqual({ type: 'none' });
@@ -54,7 +55,7 @@ describe('Tag', () => {
 
     // ── 2. Variant colors (foreground) ───────────────────────────────────
     it('applies cyan foreground for info variant', () => {
-        const { screen } = renderTag('info', { variant: 'info' });
+        const { screen } = renderTag('info', {}, { variant: 'info' });
         // Border corner should have cyan foreground
         expect(screen.back[0][0].fg).toEqual({ type: 'named', name: 'cyan' });
         // Text cell should also have cyan foreground
@@ -62,22 +63,22 @@ describe('Tag', () => {
     });
 
     it('applies green foreground for success variant', () => {
-        const { screen } = renderTag('ok', { variant: 'success' });
+        const { screen } = renderTag('ok', {}, { variant: 'success' });
         expect(screen.back[0][0].fg).toEqual({ type: 'named', name: 'green' });
     });
 
     it('applies yellow foreground for warning variant', () => {
-        const { screen } = renderTag('warn', { variant: 'warning' });
+        const { screen } = renderTag('warn', {}, { variant: 'warning' });
         expect(screen.back[0][0].fg).toEqual({ type: 'named', name: 'yellow' });
     });
 
     it('applies red foreground for error variant', () => {
-        const { screen } = renderTag('err', { variant: 'error' });
+        const { screen } = renderTag('err', {}, { variant: 'error' });
         expect(screen.back[0][0].fg).toEqual({ type: 'named', name: 'red' });
     });
 
     it('applies white foreground for neutral variant', () => {
-        const { screen } = renderTag('ok', { variant: 'neutral' });
+        const { screen } = renderTag('ok', {}, { variant: 'neutral' });
         expect(screen.back[0][0].fg).toEqual({ type: 'named', name: 'white' });
     });
 
@@ -146,4 +147,42 @@ describe('Tag', () => {
         expect(() => renderTag('test', {}, {}, 0, 0)).not.toThrow();
     });
 
+    // ── 6. Constructor overloads ──────────────────────────────────────────
+    it('deprecated signature Tag(text, opts) produces console.warn', () => {
+        const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            new Tag('dep', { variant: 'info' });
+            expect(spy).toHaveBeenCalledWith(
+                'Tag(text, opts, style) is deprecated. Use Tag(text, style, opts) instead.',
+            );
+        } finally {
+            spy.mockRestore();
+        }
+    });
+
+    it('canonical signature Tag(text, style, opts) does not produce console.warn', () => {
+        const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            new Tag('canon', {}, { variant: 'info' });
+            expect(spy).not.toHaveBeenCalled();
+        } finally {
+            spy.mockRestore();
+        }
+    });
+
+    it('deprecated and canonical signatures produce equivalent output', () => {
+        const { screen: screen1 } = renderTag('same', {}, { variant: 'error' });
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            const tag2 = new Tag('same', { variant: 'error' });
+            const screen2 = new Screen(20, 3);
+            tag2.updateRect({ x: 0, y: 0, width: 20, height: 3 });
+            tag2.render(screen2);
+            expect(screen2.back[0][0].char).toBe(screen1.back[0][0].char);
+            expect(screen2.back[1][2].char).toBe(screen1.back[1][2].char);
+            expect(warnSpy).toHaveBeenCalled();
+        } finally {
+            warnSpy.mockRestore();
+        }
+    });
 });

--- a/packages/widgets/src/display/Tag.ts
+++ b/packages/widgets/src/display/Tag.ts
@@ -27,15 +27,31 @@ const FG_COLORS: Record<TagVariant, Color> = {
  * Used for categorical labels such as "typescript", "react", "v2.0".
  * Renders a bordered box with the text colored by variant but no background.
  * Uses `caps.unicode` to choose between Unicode box-drawing and ASCII fallback.
+ *
+ * CONSTRUCTOR (canonical): (text, style?, opts?)
+ * @deprecated Tag(text, opts, style) is deprecated. Use Tag(text, style, opts) instead.
  */
 export class Tag extends Widget {
     private _text: string;
     private _variant: TagVariant;
 
-    constructor(text: string, opts: TagOptions = {}, style: Partial<Style> = {}) {
-        super(style);
-        this._text = text;
-        this._variant = opts.variant ?? 'neutral';
+    constructor(text: string, style?: Partial<Style>, opts?: TagOptions);
+    /** @deprecated Use Tag(text, style?, opts?) instead */
+    constructor(text: string, opts: TagOptions, style?: Partial<Style>);
+    constructor(text: string, styleOrOpts?: Partial<Style> | TagOptions, optsOrStyle?: TagOptions | Partial<Style>) {
+        if (styleOrOpts && 'variant' in styleOrOpts) {
+            const opts = styleOrOpts as TagOptions;
+            const style = optsOrStyle as Partial<Style> | undefined;
+            super(style ?? {});
+            this._text = text;
+            this._variant = opts.variant ?? 'neutral';
+        } else {
+            const style = styleOrOpts as Partial<Style> | undefined;
+            const opts = optsOrStyle as TagOptions | undefined;
+            super(style ?? {});
+            this._text = text;
+            this._variant = opts?.variant ?? 'neutral';
+        }
     }
 
     /** Update the tag text. */

--- a/packages/widgets/src/display/Tag.ts
+++ b/packages/widgets/src/display/Tag.ts
@@ -40,6 +40,7 @@ export class Tag extends Widget {
     constructor(text: string, opts: TagOptions, style?: Partial<Style>);
     constructor(text: string, styleOrOpts?: Partial<Style> | TagOptions, optsOrStyle?: TagOptions | Partial<Style>) {
         if (styleOrOpts && 'variant' in styleOrOpts) {
+            console.warn('Tag(text, opts, style) is deprecated. Use Tag(text, style, opts) instead.');
             const opts = styleOrOpts as TagOptions;
             const style = optsOrStyle as Partial<Style> | undefined;
             super(style ?? {});


### PR DESCRIPTION
## Description

Standardizes widget constructor signatures across the library by documenting the canonical parameter ordering in Widget.ts, adding backward-compatible overloads to Badge and Tag, and adding missing `style` parameters to Modal and Select.

## Related Issue

Closes #938

## Which package(s)?

@termuijs/widgets

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [x] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## Notes for the Reviewer

- Badge and Tag detect the old calling convention via runtime parameter shape check (`'variant' in arg`). A `console.warn` is emitted when the deprecated ordering is used.
- Modal and Select's new `style` parameter is optional and backward-compatible — existing consumers passing no style work unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modal and Select accept optional per-instance styling for visual customization.
  * Badge and Tag constructors standardized to a canonical parameter order while retaining a deprecated order (deprecated usage emits a warning).

* **Documentation**
  * Added guidance on widget constructor patterns and style-merging conventions.

* **Tests**
  * Updated and added tests covering Badge/Tag overloads, deprecation warnings, and rendering equivalence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->