### PR TITLE
feat(ui): add Breadcrumb component

### DIFF
--- a/packages/ui/src/Breadcrumb.test.ts
+++ b/packages/ui/src/Breadcrumb.test.ts
@@ -1,0 +1,107 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/ui — Tests for Breadcrumb
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Screen, caps, createKeyEvent } from '@termuijs/core';
+import { Breadcrumb } from './Breadcrumb.js';
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+const keyOf = (key: string): ReturnType<typeof createKeyEvent> =>
+    createKeyEvent({ key, raw: Buffer.from(key), ctrl: false, alt: false, shift: false });
+
+const rowText = (screen: Screen, row: number): string =>
+    screen.back[row].map(c => c.char).join('');
+
+describe('Breadcrumb', () => {
+    it('renders all items in order separated by a separator', () => {
+        const breadcrumb = new Breadcrumb({
+            items: [
+                { label: 'Home' },
+                { label: 'Projects' },
+                { label: 'TermUI' },
+            ],
+        });
+        breadcrumb.updateRect({ x: 0, y: 0, width: 30, height: 1 });
+        const screen = new Screen(30, 1);
+        breadcrumb.render(screen);
+
+        const row = rowText(screen, 0);
+        expect(row).toContain('Home');
+        expect(row).toContain('Projects');
+        expect(row).toContain('TermUI');
+        // Unicode separator: ›
+        expect(row).toContain('›');
+    });
+
+    it('uses ASCII separator when unicode is off', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+        const breadcrumb = new Breadcrumb({
+            items: [
+                { label: 'A' },
+                { label: 'B' },
+                { label: 'C' },
+            ],
+        });
+        breadcrumb.updateRect({ x: 0, y: 0, width: 20, height: 1 });
+        const screen = new Screen(20, 1);
+        breadcrumb.render(screen);
+
+        const row = rowText(screen, 0);
+        expect(row).toContain('>');
+        expect(row).not.toContain('›');
+    });
+
+    it('renders the last item in a distinct (bold) style', () => {
+        const breadcrumb = new Breadcrumb({
+            items: [
+                { label: 'Home' },
+                { label: 'Projects' },
+                { label: 'TermUI' },
+            ],
+        });
+        breadcrumb.updateRect({ x: 0, y: 0, width: 30, height: 1 });
+        const screen = new Screen(30, 1);
+        breadcrumb.render(screen);
+
+        // Find the column of the last item's first character
+        const row = screen.back[0];
+        const lastItemStart = rowText(screen, 0).lastIndexOf('TermUI');
+        expect(lastItemStart).toBeGreaterThanOrEqual(0);
+        const firstCell = row[lastItemStart];
+        expect(firstCell).toBeDefined();
+        expect(firstCell?.bold).toBe(true);
+
+        // A non-last item should not be bold
+        const firstItemStart = rowText(screen, 0).indexOf('Home');
+        const firstCellOfFirst = row[firstItemStart];
+        expect(firstCellOfFirst?.bold).not.toBe(true);
+    });
+
+    it('left/right arrows move focus and Enter fires onSelect', () => {
+        const onHome = vi.fn();
+        const onProjects = vi.fn();
+        const breadcrumb = new Breadcrumb({
+            items: [
+                { label: 'Home', onSelect: onHome },
+                { label: 'Projects', onSelect: onProjects },
+                { label: 'TermUI' },
+            ],
+        });
+
+        expect(breadcrumb.focusedIndex).toBe(0);
+        breadcrumb.handleKey(keyOf('right'));
+        expect(breadcrumb.focusedIndex).toBe(1);
+        breadcrumb.handleKey(keyOf('enter'));
+        expect(onProjects).toHaveBeenCalledTimes(1);
+        expect(onHome).not.toHaveBeenCalled();
+
+        // Left wraps
+        breadcrumb.handleKey(keyOf('left'));
+        breadcrumb.handleKey(keyOf('left'));
+        expect(breadcrumb.focusedIndex).toBe(2);
+    });
+});

--- a/packages/ui/src/Breadcrumb.ts
+++ b/packages/ui/src/Breadcrumb.ts
@@ -1,0 +1,117 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/ui — Breadcrumb component
+//
+// A horizontal path navigator. Left/right arrows move
+// focus; Enter fires the focused item's onSelect.
+// ─────────────────────────────────────────────────────
+
+import { Widget } from '@termuijs/widgets';
+import {
+    type Screen,
+    type KeyEvent,
+    type Style,
+    type Color,
+    mergeStyles,
+    defaultStyle,
+    styleToCellAttrs,
+    caps,
+    stringWidth,
+    truncate,
+} from '@termuijs/core';
+
+export interface BreadcrumbItem {
+    label: string;
+    onSelect?: () => void;
+}
+
+export interface BreadcrumbOptions {
+    items: BreadcrumbItem[];
+    currentColor?: Color;
+    inactiveColor?: Color;
+    separatorColor?: Color;
+}
+
+export class Breadcrumb extends Widget {
+    private _items: BreadcrumbItem[];
+    private _focusedIndex = 0;
+    private _currentColor: Color;
+    private _inactiveColor: Color;
+    private _separatorColor: Color;
+
+    focusable = true;
+
+    constructor(options: BreadcrumbOptions) {
+        super(mergeStyles(defaultStyle(), { height: 1 }));
+        this._items = options.items;
+        this._currentColor = options.currentColor ?? { type: 'named', name: 'cyan' };
+        this._inactiveColor = options.inactiveColor ?? { type: 'named', name: 'brightBlack' };
+        this._separatorColor = options.separatorColor ?? { type: 'named', name: 'brightBlack' };
+    }
+
+    get items(): ReadonlyArray<BreadcrumbItem> { return this._items; }
+    get focusedIndex(): number { return this._focusedIndex; }
+
+    setItems(items: BreadcrumbItem[]): void {
+        this._items = items;
+        this._focusedIndex = Math.min(this._focusedIndex, Math.max(0, items.length - 1));
+        this.markDirty();
+    }
+
+    handleKey(event: KeyEvent): void {
+        if (this._items.length === 0) return;
+        switch (event.key) {
+            case 'right':
+                this._focusedIndex = (this._focusedIndex + 1) % this._items.length;
+                this.markDirty();
+                break;
+            case 'left':
+                this._focusedIndex = (this._focusedIndex - 1 + this._items.length) % this._items.length;
+                this.markDirty();
+                break;
+            case 'enter':
+            case 'return':
+                this._items[this._focusedIndex]?.onSelect?.();
+                break;
+        }
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width } = this._getContentRect();
+        if (width <= 0) return;
+
+        const attrs = styleToCellAttrs(this.style);
+        const sep = caps.unicode ? '›' : '>';
+        const sepWithSpaces = ` ${sep} `;
+
+        let cx = x;
+        for (let i = 0; i < this._items.length; i++) {
+            const item = this._items[i];
+            if (!item) continue;
+            const isLast = i === this._items.length - 1;
+            const isFocused = i === this._focusedIndex;
+
+            const itemWidth = stringWidth(item.label);
+            if (cx + itemWidth > x + width) {
+                const remaining = x + width - cx;
+                screen.writeString(cx, y, truncate(item.label, remaining), attrs);
+                return;
+            }
+
+            const itemAttrs = isLast
+                ? { ...attrs, fg: this._currentColor, bold: true }
+                : isFocused
+                    ? { ...attrs, fg: this._currentColor, underline: true }
+                    : { ...attrs, fg: this._inactiveColor };
+
+            screen.writeString(cx, y, item.label, itemAttrs);
+            cx += itemWidth;
+
+            if (!isLast) {
+                const sepWidth = stringWidth(sepWithSpaces);
+                if (cx + sepWidth > x + width) return;
+                screen.writeString(cx, y, sepWithSpaces, { ...attrs, fg: this._separatorColor, dim: true });
+                cx += sepWidth;
+            }
+        }
+    }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -185,3 +185,6 @@ export type { EmailInputOptions } from './EmailInput.js';
 
 export { QuizPrompt } from './QuizPrompt.js';
 export type { QuizPromptOptions, QuizQuestion, QuizResult } from './QuizPrompt.js';
+
+export { Breadcrumb } from './Breadcrumb.js';
+export type { BreadcrumbItem, BreadcrumbOptions } from './Breadcrumb.js';


### PR DESCRIPTION
## Description

`Breadcrumb` renders a horizontal path navigator. Items are separated by `›` (Unicode) or `>` (ASCII). The last item is rendered in bold and represents the current location. Left/right arrows move focus (wraps around); Enter fires the focused item's `onSelect` callback.

## Related Issue

Closes #37

## Which package(s)?

`@termuijs/ui`

## Type of Change
- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ Starred the repo
- [x] Tests pass locally: `bun vitest run packages/ui` → 481 passed
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck --filter='!@termuijs/adapters'`
- [x] Read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] PR title follows `type: short description`
- [x] State mutators call `markDirty()` (`setItems`, `handleKey` left/right)
- [x] No new `any` types
- [x] No unrelated refactors

## GSSoC 2026 Participation
- [x] GSSoC 2026 contributor


## Screenshots / Recordings (UI changes)
<img width="626" height="236" alt="image" src="https://github.com/user-attachments/assets/1f88a8b6-66f8-4c97-919a-b1db45fd6131" />


## Notes for the Reviewer

- `_renderSelf` uses `this._getContentRect()` (not `this._rect`) so the path honors padding/border.
- When an item doesn't fit, the visible remainder is truncated and the rest of the row is left blank. No separator is drawn past the truncation point.
- `setItems` clamps `focusedIndex` so a shorter list can't leave the focus out of bounds.
- Focus wraps around on left/right (more intuitive than clamping at the edges for a small set of items).
- The last item is always bold; the focused (non-last) item is underlined. They don't compose — being focused on the last item shows the bold "current" style.
- 4 tests cover: all items + Unicode separator, ASCII separator fallback, last item bold, left/right navigation + Enter fires `onSelect`.
- Note: `origin/main` already has a non-interactive `Breadcrumbs` widget (plural, `packages/widgets/src/display/Breadcrumbs.ts`) from PR #748. This PR is a separate interactive `Breadcrumb` (singular, `packages/ui/`) per the original spec — it takes `{ label, onSelect? }` items and supports left/right focus + Enter to fire `onSelect`, which the existing `Breadcrumbs` widget does not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a Breadcrumb navigation component that displays a horizontal list of items with visual separators, customizable colors, and supports keyboard navigation (left/right arrows) and Enter to select.
* **Tests**
  * Added test coverage verifying separator rendering (Unicode/ASCII), item ordering and styling (last item bold), focus changes via keyboard, and selection via Enter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->