### PR TITLE
feat(widgets): add PinInput widget for capturing discrete code sequences

### DIFF
--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -139,6 +139,12 @@ export class Screen {
         this.back = this._createGrid(cols, rows);
     }
 
+    /** Retrieve a read-only copy of the cell at (x, y) from the back buffer. */
+    getCell(x: number, y: number): Readonly<Cell> | undefined {
+        if (x < 0 || x >= this._cols || y < 0 || y >= this._rows) return undefined;
+        return this.back[y][x];
+    }
+
     /** Serialize a back-buffer row to a plain string (skips continuation cells). */
     getLine(row: number): string {
         if (row < 0 || row >= this._rows) return '';

--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -141,7 +141,9 @@ export class Screen {
 
     /** Retrieve a read-only copy of the cell at (x, y) from the back buffer. */
     getCell(x: number, y: number): Readonly<Cell> | undefined {
-        if (x < 0 || x >= this._cols || y < 0 || y >= this._rows) return undefined;
+        x = Math.floor(x);
+        y = Math.floor(y);
+        if (!(x >= 0 && x < this._cols && y >= 0 && y < this._rows)) return undefined;
         return this.back[y][x];
     }
 

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -46,6 +46,8 @@ export { RangeInput } from './input/RangeInput.js';
 export type { RangeInputOptions } from './input/RangeInput.js';
 export { Slider } from "./input/Slider.js";
 export type { SliderOptions } from "./input/Slider.js";
+export { PinInput } from "./input/PinInput.js";
+export type { PinInputOptions } from "./input/PinInput.js";
 
 // ── Data Widgets ──────────────────────────────────────
 export { Table } from './data/Table.js';

--- a/packages/widgets/src/input/PinInput.test.ts
+++ b/packages/widgets/src/input/PinInput.test.ts
@@ -90,9 +90,7 @@ describe("PinInput", () => {
     const screen = new Screen(40, 1);
     pin.render(screen);
 
-    const rendered = screen.back[0]
-      .map((c: { char: string }) => c.char)
-      .join("");
+    const rendered = Array.from({ length: 40 }, (_, i) => screen.getCell(i, 0)?.char ?? " ").join("");
 
     expect(rendered).toContain("[ 1 ]");
     expect(rendered).toContain("[ 2 ]");
@@ -110,9 +108,7 @@ describe("PinInput", () => {
     const screen = new Screen(40, 1);
     pin.render(screen);
 
-    const rendered = screen.back[0]
-      .map((c: { char: string }) => c.char)
-      .join("");
+    const rendered = Array.from({ length: 40 }, (_, i) => screen.getCell(i, 0)?.char ?? " ").join("");
 
     expect(rendered).toContain("[ • ]");
     expect(rendered).not.toContain("[ 1 ]");

--- a/packages/widgets/src/input/PinInput.test.ts
+++ b/packages/widgets/src/input/PinInput.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Screen, createKeyEvent } from "@termuijs/core";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const key = (name: string) =>
+  createKeyEvent({ key: name, raw: Buffer.alloc(0), ctrl: false, alt: false, shift: false });
+
+describe("PinInput", () => {
+  it("constructs with defaults", async () => {
+    const { PinInput } = await import("./PinInput.js");
+    const pin = new PinInput();
+    expect(pin.value).toBe("");
+  });
+
+  it("handles character input and auto-advances", async () => {
+    const { PinInput } = await import("./PinInput.js");
+    const onChange = vi.fn();
+    const pin = new PinInput({}, { onChange });
+
+    pin.handleKey(key("1"));
+    expect(pin.value).toBe("1");
+    expect(onChange).toHaveBeenCalledWith("1");
+
+    pin.handleKey(key("2"));
+    expect(pin.value).toBe("12");
+    expect(onChange).toHaveBeenCalledWith("12");
+  });
+
+  it("fires onComplete when length is reached", async () => {
+    const { PinInput } = await import("./PinInput.js");
+    const onComplete = vi.fn();
+    const pin = new PinInput({}, { length: 3, onComplete });
+
+    pin.handleKey(key("1"));
+    pin.handleKey(key("2"));
+    pin.handleKey(key("3"));
+    
+    expect(pin.value).toBe("123");
+    expect(onComplete).toHaveBeenCalledWith("123");
+  });
+
+  it("handles backspace properly", async () => {
+    const { PinInput } = await import("./PinInput.js");
+    const pin = new PinInput();
+
+    pin.handleKey(key("1"));
+    pin.handleKey(key("2"));
+    
+    // Deletes '2' and moves cursor back
+    pin.handleKey(key("backspace"));
+    expect(pin.value).toBe("1");
+
+    // Deletes '1'
+    pin.handleKey(key("backspace"));
+    expect(pin.value).toBe("");
+    
+    // Nothing to delete, shouldn't crash
+    pin.handleKey(key("backspace"));
+    expect(pin.value).toBe("");
+  });
+
+  it("handles arrow keys safely", async () => {
+    const { PinInput } = await import("./PinInput.js");
+    const pin = new PinInput();
+
+    pin.handleKey(key("right"));
+    pin.handleKey(key("right"));
+    pin.handleKey(key("1"));
+    // Should type at pos 2
+    expect(pin.value).toBe("1"); 
+    
+    pin.handleKey(key("left"));
+    pin.handleKey(key("left"));
+    pin.handleKey(key("left")); // Should clamp to 0
+    pin.handleKey(key("2"));
+    expect(pin.value).toBe("21"); 
+  });
+
+  it("renders correctly", async () => {
+    const { PinInput } = await import("./PinInput.js");
+    const pin = new PinInput();
+    
+    pin.handleKey(key("1"));
+    pin.handleKey(key("2"));
+    
+    pin.updateRect({ x: 0, y: 0, width: 40, height: 1 });
+    const screen = new Screen(40, 1);
+    pin.render(screen);
+
+    const rendered = screen.back[0]
+      .map((c: { char: string }) => c.char)
+      .join("");
+
+    expect(rendered).toContain("[ 1 ]");
+    expect(rendered).toContain("[ 2 ]");
+    expect(rendered).toContain("[   ]");
+  });
+
+  it("renders masked characters", async () => {
+    const { PinInput } = await import("./PinInput.js");
+    const pin = new PinInput({}, { masked: true });
+    
+    pin.handleKey(key("1"));
+    pin.handleKey(key("2"));
+    
+    pin.updateRect({ x: 0, y: 0, width: 40, height: 1 });
+    const screen = new Screen(40, 1);
+    pin.render(screen);
+
+    const rendered = screen.back[0]
+      .map((c: { char: string }) => c.char)
+      .join("");
+
+    expect(rendered).toContain("[ • ]");
+    expect(rendered).not.toContain("[ 1 ]");
+  });
+});

--- a/packages/widgets/src/input/PinInput.ts
+++ b/packages/widgets/src/input/PinInput.ts
@@ -3,6 +3,7 @@ import {
   type Style,
   type KeyEvent,
   styleToCellAttrs,
+  caps,
 } from "@termuijs/core";
 import { Widget } from "../base/Widget.js";
 
@@ -28,7 +29,7 @@ export class PinInput extends Widget {
     super(style);
     this.focusable = true;
 
-    this._length = opts.length ?? 4;
+    this._length = Math.max(1, Math.floor(opts.length ?? 4));
     this._masked = opts.masked ?? false;
     this._onChange = opts.onChange;
     this._onComplete = opts.onComplete;
@@ -101,7 +102,7 @@ export class PinInput extends Widget {
 
     for (let i = 0; i < this._length; i++) {
       // Check if this block would render out of bounds
-      if (currentX + 3 > x + width) {
+      if (currentX + 5 > x + width) {
           break; // Stop rendering if it exceeds width
       }
 
@@ -110,7 +111,7 @@ export class PinInput extends Widget {
       let displayChar = " ";
 
       if (charVal !== "") {
-          displayChar = this._masked ? "•" : charVal;
+          displayChar = this._masked ? (caps.unicode ? "•" : "*") : charVal;
       }
 
       const blockStr = `[ ${displayChar} ]`;

--- a/packages/widgets/src/input/PinInput.ts
+++ b/packages/widgets/src/input/PinInput.ts
@@ -1,0 +1,131 @@
+import {
+  type Screen,
+  type Style,
+  type KeyEvent,
+  styleToCellAttrs,
+} from "@termuijs/core";
+import { Widget } from "../base/Widget.js";
+
+export interface PinInputOptions {
+  length?: number;
+  masked?: boolean;
+  onChange?: (value: string) => void;
+  onComplete?: (value: string) => void;
+}
+
+export class PinInput extends Widget {
+  private _length: number;
+  private _masked: boolean;
+  private _value: string[];
+  private _cursorPos: number = 0;
+  private _onChange?: (value: string) => void;
+  private _onComplete?: (value: string) => void;
+
+  constructor(
+    style: Partial<Style> = {},
+    opts: PinInputOptions = {}
+  ) {
+    super(style);
+    this.focusable = true;
+
+    this._length = opts.length ?? 4;
+    this._masked = opts.masked ?? false;
+    this._onChange = opts.onChange;
+    this._onComplete = opts.onComplete;
+    
+    // Initialize empty array of correct length
+    this._value = Array(this._length).fill("");
+  }
+
+  get value(): string {
+    return this._value.join("");
+  }
+
+  handleKey(event: KeyEvent): void {
+    const key = event.key;
+
+    if (key === "left") {
+      this._cursorPos = Math.max(0, this._cursorPos - 1);
+      this.markDirty();
+      return;
+    }
+
+    if (key === "right") {
+      this._cursorPos = Math.min(this._length - 1, this._cursorPos + 1);
+      this.markDirty();
+      return;
+    }
+
+    if (key === "backspace" || key === "delete") {
+      if (this._value[this._cursorPos] !== "") {
+        // Clear current block
+        this._value[this._cursorPos] = "";
+      } else if (this._cursorPos > 0) {
+        // Move back and clear
+        this._cursorPos--;
+        this._value[this._cursorPos] = "";
+      }
+      
+      this.markDirty();
+      this._onChange?.(this.value);
+      return;
+    }
+
+    // Handle character input
+    if (key.length === 1) {
+      // Set value at current position
+      this._value[this._cursorPos] = key;
+      this.markDirty();
+      
+      const currentVal = this.value;
+      this._onChange?.(currentVal);
+
+      // Advance cursor or trigger complete
+      if (this._cursorPos < this._length - 1) {
+        this._cursorPos++;
+      } else if (currentVal.length === this._length) {
+        this._onComplete?.(currentVal);
+      }
+    }
+  }
+
+  protected _renderSelf(screen: Screen): void {
+    const rect = this._getContentRect();
+    const { x, y, width, height } = rect;
+
+    if (width <= 0 || height <= 0) return;
+
+    const attrs = styleToCellAttrs(this._style);
+
+    let currentX = x;
+
+    for (let i = 0; i < this._length; i++) {
+      // Check if this block would render out of bounds
+      if (currentX + 3 > x + width) {
+          break; // Stop rendering if it exceeds width
+      }
+
+      const isFocusedBlock = this.isFocused && this._cursorPos === i;
+      const charVal = this._value[i];
+      let displayChar = " ";
+
+      if (charVal !== "") {
+          displayChar = this._masked ? "•" : charVal;
+      }
+
+      const blockStr = `[ ${displayChar} ]`;
+
+      // Apply inverse colors for the focused block
+      const blockAttrs = {
+        ...attrs,
+        inverse: isFocusedBlock ? !attrs.inverse : attrs.inverse,
+      };
+
+      screen.writeString(currentX, y, blockStr, blockAttrs);
+      currentX += 5; // [ + space + char + space + ] -> 5 columns. We space them out.
+      
+      // Add gap between blocks
+      currentX += 1;
+    }
+  }
+}

--- a/packages/widgets/src/input/PinInput.ts
+++ b/packages/widgets/src/input/PinInput.ts
@@ -22,6 +22,12 @@ export class PinInput extends Widget {
   private _onChange?: (value: string) => void;
   private _onComplete?: (value: string) => void;
 
+  /**
+   * Creates a new PinInput widget.
+   *
+   * @param style Partial style properties for the widget.
+   * @param opts Configuration options for the PinInput.
+   */
   constructor(
     style: Partial<Style> = {},
     opts: PinInputOptions = {}
@@ -40,6 +46,10 @@ export class PinInput extends Widget {
 
   get value(): string {
     return this._value.join("");
+  }
+
+  private get _isFull(): boolean {
+    return this._value.every((v) => v !== "");
   }
 
   handleKey(event: KeyEvent): void {
@@ -82,11 +92,11 @@ export class PinInput extends Widget {
       this._onChange?.(currentVal);
 
       // Advance cursor or trigger complete
-      if (this._cursorPos < this._length - 1) {
-        this._cursorPos++;
-      } else if (currentVal.length === this._length) {
-        this._onComplete?.(currentVal);
-      }
+        this._cursorPos = Math.min(this._length - 1, this._cursorPos + 1);
+        
+        if (this._isFull) {
+          this._onComplete?.(this.value);
+        }
     }
   }
 
@@ -114,7 +124,7 @@ export class PinInput extends Widget {
           displayChar = this._masked ? (caps.unicode ? "•" : "*") : charVal;
       }
 
-      const blockStr = `[ ${displayChar} ]`;
+        const blockStr = `[ ${displayChar} ]`;
 
       // Apply inverse colors for the focused block
       const blockAttrs = {


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

This PR introduces the new `PinInput` widget for capturing discrete code sequences (like OTPs or 2FA codes). It renders visually isolated character blocks, auto-advances the cursor as the user types, handles bounded `left`/`right` keyboard navigation, processes `backspace` clearing elegantly, and natively supports masked (e.g., `•`) characters.

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #978

## Which package(s)?

`@termuijs/widgets`

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [x] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/172e996c-3943-4a86-8249-1f01922d0f64`

## Screenshots / Recordings (UI changes)

*(Reviewer: You can test the widget rendering interactively via tests, or I can provide screenshots of the visual `[ • ] [   ] [   ] [   ]` states if required).*

## Notes for the Reviewer

The implementation handles boundary conditions firmly to prevent out-of-bounds cursor index crashes. The rendering logic ensures that the individual cells are properly isolated by one space from each other with brackets (`[ x ]`) to form distinct blocks, utilizing standard cell attributes (like `inverse`) to denote the focused cell cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PinInput widget for fixed-length PIN/OTP entry with optional masking, keyboard cursor navigation, per-character entry, and onChange/onComplete callbacks.
  * Screen now provides a read-only cell retrieval API to inspect back-buffer cells by coordinates.

* **Tests**
  * Added tests covering initialization, character entry, cursor movement, deletion/backspace behavior, completion callback, and masked vs visible rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->