### PR TITLE
feat(widgets): add Knob widget for circular value input

### DIFF
--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -46,8 +46,6 @@ export { Slider } from "./input/Slider.js";
 export type { SliderOptions } from "./input/Slider.js";
 export { RangeInput } from "./input/RangeInput.js";
 export type { RangeInputOptions } from "./input/RangeInput.js";
-export { PinInput } from "./input/PinInput.js";
-export type { PinInputOptions } from "./input/PinInput.js";
 export { Knob } from "./input/Knob.js";
 export type { KnobOptions } from "./input/Knob.js";
 

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -42,10 +42,14 @@ export type { Command, CommandPaletteOptions } from './input/CommandPalette.js';
 export { Button } from './input/Button.js';
 export type { ButtonOptions, ButtonVariant } from './input/Button.js';
 
-export { RangeInput } from './input/RangeInput.js';
-export type { RangeInputOptions } from './input/RangeInput.js';
 export { Slider } from "./input/Slider.js";
 export type { SliderOptions } from "./input/Slider.js";
+export { RangeInput } from "./input/RangeInput.js";
+export type { RangeInputOptions } from "./input/RangeInput.js";
+export { PinInput } from "./input/PinInput.js";
+export type { PinInputOptions } from "./input/PinInput.js";
+export { Knob } from "./input/Knob.js";
+export type { KnobOptions } from "./input/Knob.js";
 
 // ── Data Widgets ──────────────────────────────────────
 export { Table } from './data/Table.js';

--- a/packages/widgets/src/input/Knob.test.ts
+++ b/packages/widgets/src/input/Knob.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Screen, caps, createKeyEvent } from "@termuijs/core";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const key = (name: string) =>
+  createKeyEvent({ key: name, raw: Buffer.alloc(0), ctrl: false, alt: false, shift: false });
+
+describe("Knob", () => {
+  it("constructs with defaults", async () => {
+    const { Knob } = await import("./Knob.js");
+    const knob = new Knob();
+    expect(knob.value).toBe(0);
+  });
+
+  it("handles key bindings to increment and decrement", async () => {
+    const { Knob } = await import("./Knob.js");
+    const onChange = vi.fn();
+    const knob = new Knob({}, { min: 0, max: 100, step: 10, onChange });
+
+    knob.handleKey(key("up"));
+    expect(knob.value).toBe(10);
+    expect(onChange).toHaveBeenCalledWith(10);
+
+    knob.handleKey(key("right"));
+    expect(knob.value).toBe(20);
+
+    knob.handleKey(key("down"));
+    expect(knob.value).toBe(10);
+
+    knob.handleKey(key("left"));
+    expect(knob.value).toBe(0);
+  });
+
+  it("clamps to min and max", async () => {
+    const { Knob } = await import("./Knob.js");
+    const knob = new Knob({}, { min: 0, max: 10, step: 8 });
+
+    knob.handleKey(key("up"));
+    expect(knob.value).toBe(8);
+
+    knob.handleKey(key("up"));
+    expect(knob.value).toBe(10); // Clamped at 10
+
+    knob.handleKey(key("down"));
+    knob.handleKey(key("down"));
+    expect(knob.value).toBe(0); // Clamped at 0
+  });
+
+  it("renders unicode correctly", async () => {
+    vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+
+    const { Knob } = await import("./Knob.js");
+    const knob = new Knob({}, { min: 0, max: 100, showValue: true });
+    
+    knob.setValue(50);
+    
+    // Create a 5x5 screen for the knob
+    knob.updateRect({ x: 0, y: 0, width: 5, height: 5 });
+    const screen = new Screen(5, 5);
+    knob.render(screen);
+
+    // Render it out to a string block
+    const output = Array.from({ length: 5 }, (_, i) => 
+      screen.back[i].map((c: { char: string }) => c.char).join("")
+    ).join("\n");
+
+    // The circle must have block characters
+    expect(output).toMatch(/█/);
+    // The value "50" must be rendered inside the knob
+    expect(output).toContain("50");
+  });
+
+  it("renders ascii correctly", async () => {
+    vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+
+    const { Knob } = await import("./Knob.js");
+    const knob = new Knob({}, { min: 0, max: 100, showValue: true });
+    
+    knob.setValue(50);
+    
+    knob.updateRect({ x: 0, y: 0, width: 5, height: 5 });
+    const screen = new Screen(5, 5);
+    knob.render(screen);
+
+    const output = Array.from({ length: 5 }, (_, i) => 
+      screen.back[i].map((c: { char: string }) => c.char).join("")
+    ).join("\n");
+
+    // The circle must use ASCII block characters
+    expect(output).toMatch(/#/);
+    expect(output).toContain("50");
+  });
+});

--- a/packages/widgets/src/input/Knob.test.ts
+++ b/packages/widgets/src/input/Knob.test.ts
@@ -18,7 +18,7 @@ describe("Knob", () => {
   it("handles key bindings to increment and decrement", async () => {
     const { Knob } = await import("./Knob.js");
     const onChange = vi.fn();
-    const knob = new Knob({}, { min: 0, max: 100, step: 10, onChange });
+    const knob = new Knob("", {}, { min: 0, max: 100, step: 10, onChange });
 
     knob.handleKey(key("up"));
     expect(knob.value).toBe(10);
@@ -36,7 +36,7 @@ describe("Knob", () => {
 
   it("clamps to min and max", async () => {
     const { Knob } = await import("./Knob.js");
-    const knob = new Knob({}, { min: 0, max: 10, step: 8 });
+    const knob = new Knob("", {}, { min: 0, max: 10, step: 8 });
 
     knob.handleKey(key("up"));
     expect(knob.value).toBe(8);
@@ -53,7 +53,7 @@ describe("Knob", () => {
     vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
 
     const { Knob } = await import("./Knob.js");
-    const knob = new Knob({}, { min: 0, max: 100, showValue: true });
+    const knob = new Knob("", {}, { min: 0, max: 100, showValue: true });
     
     knob.setValue(50);
     
@@ -77,7 +77,7 @@ describe("Knob", () => {
     vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
 
     const { Knob } = await import("./Knob.js");
-    const knob = new Knob({}, { min: 0, max: 100, showValue: true });
+    const knob = new Knob("", {}, { min: 0, max: 100, showValue: true });
     
     knob.setValue(50);
     

--- a/packages/widgets/src/input/Knob.ts
+++ b/packages/widgets/src/input/Knob.ts
@@ -19,6 +19,7 @@ export interface KnobOptions {
 }
 
 export class Knob extends Widget {
+  private _label: string;
   private _value: number;
   private _min: number;
   private _max: number;
@@ -28,16 +29,26 @@ export class Knob extends Widget {
   private _onChange?: (value: number) => void;
 
   constructor(
+    label?: string,
     style: Partial<Style> = {},
     opts: KnobOptions = {}
   ) {
     super(style);
 
     this.focusable = true;
+    this._label = label ?? "";
     this._min = opts.min ?? 0;
-    this._max = opts.max ?? 100;
+    
+    // Validate max to ensure min <= max
+    const maxVal = opts.max ?? 100;
+    this._max = maxVal >= this._min ? maxVal : this._min;
+    
     this._value = this._min;
-    this._step = opts.step ?? 1;
+    
+    // Validate step to ensure it is positive
+    const stepVal = opts.step ?? 1;
+    this._step = stepVal > 0 ? stepVal : 1;
+    
     this._color = opts.color ?? { type: "named", name: "cyan" };
     this._showValue = opts.showValue ?? true;
     this._onChange = opts.onChange;

--- a/packages/widgets/src/input/Knob.ts
+++ b/packages/widgets/src/input/Knob.ts
@@ -1,0 +1,167 @@
+import {
+  type Screen,
+  type Style,
+  type Color,
+  type KeyEvent,
+  styleToCellAttrs,
+  caps,
+  stringWidth,
+} from "@termuijs/core";
+import { Widget } from "../base/Widget.js";
+
+export interface KnobOptions {
+  min?: number;
+  max?: number;
+  step?: number;
+  color?: Color;
+  showValue?: boolean;
+  onChange?: (value: number) => void;
+}
+
+export class Knob extends Widget {
+  private _value: number;
+  private _min: number;
+  private _max: number;
+  private _step: number;
+  private _color: Color;
+  private _showValue: boolean;
+  private _onChange?: (value: number) => void;
+
+  constructor(
+    style: Partial<Style> = {},
+    opts: KnobOptions = {}
+  ) {
+    super(style);
+
+    this.focusable = true;
+    this._min = opts.min ?? 0;
+    this._max = opts.max ?? 100;
+    this._value = this._min;
+    this._step = opts.step ?? 1;
+    this._color = opts.color ?? { type: "named", name: "cyan" };
+    this._showValue = opts.showValue ?? true;
+    this._onChange = opts.onChange;
+  }
+
+  get value(): number {
+    return this._value;
+  }
+
+  setValue(value: number): void {
+    const clamped = Math.max(this._min, Math.min(this._max, value));
+    if (this._value === clamped) return;
+
+    this._value = clamped;
+    this.markDirty();
+    this._onChange?.(this._value);
+  }
+
+  handleKey(event: KeyEvent): void {
+    switch (event.key) {
+      case "up":
+      case "right":
+        this.setValue(this._value + this._step);
+        break;
+      case "down":
+      case "left":
+        this.setValue(this._value - this._step);
+        break;
+    }
+  }
+
+  protected _renderSelf(screen: Screen): void {
+    const rect = this._getContentRect();
+    const { x, y, width, height } = rect;
+
+    if (width <= 0 || height <= 0) return;
+
+    const attrs = styleToCellAttrs(this._style);
+
+    const cx = (width - 1) / 2;
+    const cy = (height - 1) / 2;
+    // Account for character aspect ratio (roughly 1:2)
+    const radiusX = Math.max(1, (width - 1) / 2);
+    const radiusY = Math.max(1, (height - 1) / 2);
+    
+    // We want the arc to sweep from bottom-left (-135 deg or ~235 deg) 
+    // to bottom-right (135 deg or ~305 deg). 
+    // In polar coordinates with Y pointing down (terminal grids):
+    // 0 rad is pointing right (3 o'clock).
+    // Math.PI/2 is pointing down (6 o'clock).
+    // We'll define startAngle = 135 deg (3/4 PI)
+    // and endAngle = 45 deg (1/4 PI) BUT looping clockwise.
+    // Meaning it spans from 135 deg -> 180 -> 270(up) -> 0 -> 45 deg.
+    // Total sweep is 270 degrees.
+    const sweepRange = 270;
+    
+    const rangeSize = Math.max(1, this._max - this._min);
+    const ratio = (this._value - this._min) / rangeSize;
+    const filledSweepDegrees = ratio * sweepRange;
+
+    for (let row = 0; row < height; row++) {
+      for (let col = 0; col < width; col++) {
+        // Normalize dx, dy to a pure circle
+        const dx = (col - cx) / radiusX;
+        const dy = (row - cy) / radiusY;
+        
+        // Distance from center in normalized space
+        const r = Math.sqrt(dx * dx + dy * dy);
+        
+        // We only draw if it's on the edge of the circle (thickness ~0.2)
+        if (r < 0.8 || r > 1.2) {
+          continue;
+        }
+
+        // Calculate angle. atan2(dy, dx) returns angle from -PI to PI.
+        // Convert to degrees 0-360 starting from 3 o'clock clockwise.
+        let angleDeg = Math.atan2(dy, dx) * (180 / Math.PI);
+        if (angleDeg < 0) {
+          angleDeg += 360;
+        }
+
+        // We shift the angle so 0 starts at bottom-left (135 deg original)
+        // 135 becomes 0.
+        // 270(up) becomes 135.
+        // 0(right) becomes 225.
+        // 45(bottom-right) becomes 270.
+        let shiftedAngle = angleDeg - 135;
+        if (shiftedAngle < 0) {
+          shiftedAngle += 360;
+        }
+
+        // If it falls in the "gap" at the bottom (between 270 and 360 in shifted coordinates)
+        if (shiftedAngle > sweepRange) {
+          continue;
+        }
+
+        const isFilled = shiftedAngle <= filledSweepDegrees;
+        const charToRender = caps.unicode ? "█" : "#";
+
+        screen.setCell(x + col, y + row, {
+          ...attrs,
+          char: charToRender,
+          fg: isFilled 
+            ? (this.isFocused ? { type: "named", name: "white" } : this._color)
+            : { type: "named", name: "brightBlack" },
+        });
+      }
+    }
+
+    if (this._showValue) {
+      const valStr = String(this._value);
+      const valWidth = stringWidth(valStr);
+      const valX = x + Math.floor((width - valWidth) / 2);
+      const valY = y + Math.floor(height / 2);
+
+      // Print in center, but only if it fits inside the circle
+      // We assume it fits if the width/height are reasonable (>4)
+      if (width >= 4 && height >= 3) {
+        screen.writeString(valX, valY, valStr, {
+          ...attrs,
+          bold: true,
+          fg: this.isFocused ? { type: "named", name: "white" } : this._color
+        });
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

This PR introduces the `Knob` widget, a visually striking circular dial control for bounded numerical inputs. It calculates the polar angle using trigonometric functions (`Math.atan2`) to map character cells mathematically around a radius, rendering a filled arc representing the `min`/`max` percentage sweep. 

Users can manipulate it using the `up`/`down` and `left`/`right` arrow keys. It naturally supports `caps.unicode` fallbacks (using `#` instead of `█`) and automatically centers the current numerical value directly inside the dial if `showValue` is true.

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #980 

## Which package(s)?

`@termuijs/widgets`

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [x] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/172e996c-3943-4a86-8249-1f01922d0f64`

## Screenshots / Recordings (UI changes)

*(Reviewer: You can spin up the widget locally to test the circular trigonometric sweeps and bounded key input, or I can provide screenshots of the dial arc if requested).*

## Notes for the Reviewer

The knob math uses an offset angle logic so that the `0` sweep originates at `-135` degrees (bottom-left) and spans `270` degrees clockwise to terminate at the bottom-right (mimicking physical audio hardware knobs). The character aspect ratio assumes `radiusX` and `radiusY` at ~1:2 ratio mappings to keep the circle relatively proportional within standard terminal fonts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Knob input widget for terminal apps with optional label, keyboard arrow controls, configurable min/max/step, color, and optional value display
  * Visual rendering selects unicode or ASCII blocks and centers the value when space permits
* **Tests**
  * Added test suite covering construction, keyboard interaction, clamping, and rendering modes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->