### PR TITLE
fix(dev-server): avoid debounce collisions across watched directories

### DIFF
--- a/packages/dev-server/src/watcher.test.ts
+++ b/packages/dev-server/src/watcher.test.ts
@@ -315,6 +315,32 @@ describe('FileWatcher', () => {
         expect(changeSpy).toHaveBeenCalledTimes(3);
     });
 
+    it('does not collide when different watched dirs contain the same filename', () => {
+        // Simulate two separate watchers (different directories) both reporting
+        // a change for a file with the same basename. They should produce
+        // two independent onChange events, not be coalesced by the debounce map.
+        const emitters = [new EventEmitter(), new EventEmitter()];
+        let callCount = 0;
+        vi.mocked(watch).mockImplementation(() => emitters[callCount++] as any);
+
+        const watcher = new FileWatcher(['./src', './tests']);
+        const changeSpy = vi.fn();
+
+        watcher.onChange(changeSpy);
+        watcher.start();
+
+        // Both directories emit a change for "index.ts"
+        emitters[0].emit('change', 'change', 'index.ts');
+        emitters[1].emit('change', 'change', 'index.ts');
+
+        vi.advanceTimersByTime(100);
+
+        // Expect two separate events (one per directory/file), not one.
+        expect(changeSpy).toHaveBeenCalledTimes(2);
+        const filenames = changeSpy.mock.calls.map(([c]) => c.filename);
+        expect(filenames).toEqual(['index.ts', 'index.ts']);
+    });
+
     it('skips non-existent directories but still watches valid ones', () => {
         // First dir missing, second exists
         vi.mocked(existsSync).mockImplementation((p) => String(p).includes('components'));

--- a/packages/dev-server/src/watcher.ts
+++ b/packages/dev-server/src/watcher.ts
@@ -48,11 +48,17 @@ export class FileWatcher {
                     else if (ext === '.tss') type = 'tss';
                     if (!type) return;
 
-                    // Debounce: coalesce rapid saves
-                    const existing = this._debounceTimers.get(filename);
+                    // Use a per-directory resolved path as the debounce key so files with
+                    // the same basename in different watched directories don't collide.
+                    const resolved = resolve(dir, filename);
+
+                    // Debounce: coalesce rapid saves for the same resolved file path
+                    const existing = this._debounceTimers.get(resolved);
                     if (existing) clearTimeout(existing);
-                    this._debounceTimers.set(filename, setTimeout(() => {
-                        this._debounceTimers.delete(filename);
+                    this._debounceTimers.set(resolved, setTimeout(() => {
+                        this._debounceTimers.delete(resolved);
+                        // Preserve the original filename in the emitted FileChange to
+                        // avoid changing the public API observed by callers/tests.
                         const change: FileChange = { filename, type: type!, timestamp: Date.now() };
                         for (const cb of this._onChangeCallbacks) cb(change);
                     }, 100));


### PR DESCRIPTION
## Description

Fixes a debounce collision issue in `FileWatcher` when multiple watched directories contain files with the same filename.

Previously, debounce timers were keyed only by `filename`, causing change events from different directories (for example `src/index.ts` and `tests/index.ts`) to overwrite each other within the debounce window. This PR switches internal debounce tracking to a directory-aware key while preserving the existing public API and adds regression coverage to prevent future collisions.

## Related Issue

Closes #984 

## Which package(s)?

* @termuijs/dev-server

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)
* [x] 🧪 Tests (`type:testing`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run packages/dev-server`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A – bug fix and test coverage only.

## Notes for the Reviewer

### Root Cause

`FileWatcher` used the raw `filename` emitted by `fs.watch` as the debounce-map key. When two watched directories contained files with the same basename, their debounce timers collided and one legitimate change event could suppress the other.

### Changes

* Use a directory-aware resolved path as the internal debounce key.
* Preserve the existing `FileChange.filename` API.
* Add a regression test covering identical filenames across different watched directories.

### Validation

* Added a failing test that reproduced the collision before the fix.
* Verified `bun vitest run packages/dev-server` passes after the change.
* `bun run build` and `bun run typecheck` currently fail in `@termuijs/adapters` due to existing missing optional dependencies (`zod` / `dotenv`), unrelated to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the file watcher was incorrectly coalescing separate change events for identically named files in different watched directories. Each directory's file changes are now tracked independently, ensuring no change events are lost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->