### PR TITLE
fix(dev-server): avoid theme watcher debounce collisions

### DIFF
--- a/packages/dev-server/src/theme-watcher.test.ts
+++ b/packages/dev-server/src/theme-watcher.test.ts
@@ -52,4 +52,27 @@ describe('ThemeWatcher', () => {
         expect(arg).toHaveProperty('filename', 'styles.tss');
         expect(arg).toHaveProperty('timestamp');
     });
+
+    it('does not collide when different watched dirs contain the same filename', () => {
+        // Simulate two separate watchers (different directories) both reporting
+        // a change for the same basename. They should produce two onChange events.
+        const emitters = [new EventEmitter(), new EventEmitter()];
+        let callCount = 0;
+        vi.mocked(watch).mockImplementation(() => emitters[callCount++] as any);
+
+        const watcher = new ThemeWatcher({ watchDirs: ['./themes', './more-themes'] });
+        const changeSpy = vi.fn();
+
+        watcher.onChange(changeSpy);
+        watcher.start();
+
+        // Both directories emit a change for "index.tss"
+        emitters[0].emit('change', 'change', 'index.tss');
+        emitters[1].emit('change', 'change', 'index.tss');
+
+        vi.advanceTimersByTime(100);
+
+        // Expect two separate events (one per directory/file), not one.
+        expect(changeSpy).toHaveBeenCalledTimes(2);
+    });
 });

--- a/packages/dev-server/src/theme-watcher.test.ts
+++ b/packages/dev-server/src/theme-watcher.test.ts
@@ -58,7 +58,11 @@ describe('ThemeWatcher', () => {
         // a change for the same basename. They should produce two onChange events.
         const emitters = [new EventEmitter(), new EventEmitter()];
         let callCount = 0;
-        vi.mocked(watch).mockImplementation(() => emitters[callCount++] as any);
+        vi.mocked(watch).mockImplementation(
+            // EventEmitter provides the on/emit behavior needed for this test,
+            // but watch() is typed to return FSWatcher.
+            () => emitters[callCount++] as any
+        );
 
         const watcher = new ThemeWatcher({ watchDirs: ['./themes', './more-themes'] });
         const changeSpy = vi.fn();

--- a/packages/dev-server/src/theme-watcher.ts
+++ b/packages/dev-server/src/theme-watcher.ts
@@ -45,11 +45,15 @@ export class ThemeWatcher {
                     const ext = extname(filename);
                     if (ext !== '.tss') return;
 
-                    // Debounce: coalesce rapid saves
-                    const existing = this._debounceTimers.get(filename);
+                    // Use a per-directory resolved path as the debounce key so files
+                    // with the same basename in different watched directories don't collide.
+                    const resolved = resolve(dir, filename);
+
+                    // Debounce: coalesce rapid saves for the same resolved file path
+                    const existing = this._debounceTimers.get(resolved);
                     if (existing) clearTimeout(existing);
-                    this._debounceTimers.set(filename, setTimeout(() => {
-                        this._debounceTimers.delete(filename);
+                    this._debounceTimers.set(resolved, setTimeout(() => {
+                        this._debounceTimers.delete(resolved);
                         const change: ThemeChange = { filename, timestamp: Date.now() };
 
                         // Notify listeners


### PR DESCRIPTION
## Description

Fixes a debounce key collision in ThemeWatcher when multiple watched directories contain files with the same basename.

This PR uses a directory-aware debounce key internally while preserving the existing public API, ensuring valid theme change events are not dropped. It also adds regression coverage reproducing and preventing the issue.

## Related Issue

Closes #987 

## Which package(s)?

* @termuijs/dev-server

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)
* [x] 🧪 Tests (`type:testing`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A – bug fix and regression test coverage only.

## Notes for the Reviewer

* Root cause: debounce timers were keyed only by the basename reported by fs.watch, causing collisions when different watched directories emitted the same filename (for example, index.tss).
* The fix uses a directory-resolved path as the internal debounce key while continuing to emit the original `filename` to consumers.
* Added a focused regression test reproducing the collision scenario and verifying that independent change events are emitted.
* No public API changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved incorrect debouncing when watching multiple directories so identical filenames in different folders no longer interfere with each other; file change notifications are now per-path.

* **Tests**
  * Added test coverage for multi-directory watch scenarios to ensure change events from different directories are handled independently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->