### PR TITLE
feat(widgets): add ShortcutBar widget

### DIFF
--- a/packages/widgets/src/display/ShortcutBar.test.ts
+++ b/packages/widgets/src/display/ShortcutBar.test.ts
@@ -8,12 +8,12 @@ import { Screen, caps, createKeyEvent } from '@termuijs/core';
 
 function renderShortcutBar(
     items: ShortcutItem[],
-    opts: ConstructorParameters<typeof ShortcutBar>[1] = {},
-    style: ConstructorParameters<typeof ShortcutBar>[2] = {},
+    style: Partial<Style> = {},
+    opts: ShortcutBarOptions = {},
     width = 40,
     height = 1,
 ) {
-    const bar = new ShortcutBar(items, opts, style);
+    const bar = new ShortcutBar(items, style, opts);
     const screen = new Screen(width, height);
     bar.updateRect({ x: 0, y: 0, width, height });
     bar.render(screen);
@@ -42,7 +42,7 @@ describe('ShortcutBar', () => {
             { key: 'F1', label: 'Help' },
             { key: 'F10', label: 'Quit' },
         ];
-        const { screen } = renderShortcutBar(items, { separator: ' | ' });
+        const { screen } = renderShortcutBar(items, {}, { separator: ' | ' });
         const text = rowText(screen, 0);
 
         expect(text).toContain('[F1] Help | [F10] Quit');
@@ -52,13 +52,14 @@ describe('ShortcutBar', () => {
         const items = [{ key: 'F1', label: 'Help' }];
         const keyStyle = { fg: { type: 'named' as const, name: 'green' as const } };
         const labelStyle = { fg: { type: 'named' as const, name: 'yellow' as const } };
-        const { screen } = renderShortcutBar(items, { keyStyle, labelStyle });
+        const { screen } = renderShortcutBar(items, {}, { keyStyle, labelStyle });
 
         // First bracket at [0][0]
         expect(screen.back[0][0].fg).toEqual({ type: 'named', name: 'green' });
         // The space and H at [0][4] and [0][5] should have the label style
         expect(screen.back[0][5].fg).toEqual({ type: 'named', name: 'yellow' });
     });
+
 
     it('truncates labels if screen size is too small', () => {
         const items = [{ key: 'F1', label: 'SuperLongLabelString' }];

--- a/packages/widgets/src/display/ShortcutBar.test.ts
+++ b/packages/widgets/src/display/ShortcutBar.test.ts
@@ -1,0 +1,110 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for ShortcutBar widget
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import { ShortcutBar, type ShortcutItem } from './ShortcutBar.js';
+import { Screen, caps, createKeyEvent } from '@termuijs/core';
+
+function renderShortcutBar(
+    items: ShortcutItem[],
+    opts: ConstructorParameters<typeof ShortcutBar>[1] = {},
+    style: ConstructorParameters<typeof ShortcutBar>[2] = {},
+    width = 40,
+    height = 1,
+) {
+    const bar = new ShortcutBar(items, opts, style);
+    const screen = new Screen(width, height);
+    bar.updateRect({ x: 0, y: 0, width, height });
+    bar.render(screen);
+    return { bar, screen };
+}
+
+function rowText(screen: Screen, row: number): string {
+    return screen.back[row].map(c => c.char).join('').trimEnd();
+}
+
+describe('ShortcutBar', () => {
+    it('renders horizontal items with default keys and labels', () => {
+        const items = [
+            { key: 'F1', label: 'Help' },
+            { key: 'F10', label: 'Quit' },
+        ];
+        const { screen } = renderShortcutBar(items);
+        const text = rowText(screen, 0);
+
+        expect(text).toContain('[F1] Help');
+        expect(text).toContain('[F10] Quit');
+    });
+
+    it('renders separator between items', () => {
+        const items = [
+            { key: 'F1', label: 'Help' },
+            { key: 'F10', label: 'Quit' },
+        ];
+        const { screen } = renderShortcutBar(items, { separator: ' | ' });
+        const text = rowText(screen, 0);
+
+        expect(text).toContain('[F1] Help | [F10] Quit');
+    });
+
+    it('uses custom styles for key and labels', () => {
+        const items = [{ key: 'F1', label: 'Help' }];
+        const keyStyle = { fg: { type: 'named' as const, name: 'green' as const } };
+        const labelStyle = { fg: { type: 'named' as const, name: 'yellow' as const } };
+        const { screen } = renderShortcutBar(items, { keyStyle, labelStyle });
+
+        // First bracket at [0][0]
+        expect(screen.back[0][0].fg).toEqual({ type: 'named', name: 'green' });
+        // The space and H at [0][4] and [0][5] should have the label style
+        expect(screen.back[0][5].fg).toEqual({ type: 'named', name: 'yellow' });
+    });
+
+    it('truncates labels if screen size is too small', () => {
+        const items = [{ key: 'F1', label: 'SuperLongLabelString' }];
+        // Total width 10: "[F1] " is 5 chars, leaving 5 chars for label
+        const { screen } = renderShortcutBar(items, {}, {}, 10);
+        const text = rowText(screen, 0);
+
+        expect(text).toContain('[F1]');
+        expect(text).not.toContain('SuperLongLabelString');
+    });
+
+    it('delegates and triggers matching actions in handleKey', () => {
+        let helpTriggered = false;
+        let quitTriggered = false;
+        const items = [
+            { key: 'F1', label: 'Help', action: () => { helpTriggered = true; } },
+            { key: 'F10', label: 'Quit', action: () => { quitTriggered = true; } },
+        ];
+        const bar = new ShortcutBar(items);
+
+        bar.handleKey(createKeyEvent({ key: 'F1' }));
+        expect(helpTriggered).toBe(true);
+        expect(quitTriggered).toBe(false);
+
+        bar.handleKey(createKeyEvent({ key: 'f10' })); // test case-insensitive matching
+        expect(quitTriggered).toBe(true);
+    });
+
+    it('mutators mark widget as dirty', () => {
+        const bar = new ShortcutBar([]);
+        expect(bar.isDirty).toBe(true);
+
+        bar.clearDirty();
+        expect(bar.isDirty).toBe(false);
+
+        bar.setItems([{ key: 'F1', label: 'Help' }]);
+        expect(bar.isDirty).toBe(true);
+        expect(bar.getItems().length).toBe(1);
+
+        bar.clearDirty();
+        bar.setSeparator('---');
+        expect(bar.isDirty).toBe(true);
+        expect(bar.getSeparator()).toBe('---');
+
+        bar.clearDirty();
+        bar.setStyles({ fg: { type: 'named', name: 'red' } });
+        expect(bar.isDirty).toBe(true);
+    });
+});

--- a/packages/widgets/src/display/ShortcutBar.ts
+++ b/packages/widgets/src/display/ShortcutBar.ts
@@ -13,6 +13,9 @@ import {
 } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
+/**
+ * Represents an individual shortcut item in the shortcut bar.
+ */
 export interface ShortcutItem {
     /** Keyboard key character/name (e.g. 'F1', 'q', 'ctrl+c') */
     key: string;
@@ -22,6 +25,9 @@ export interface ShortcutItem {
     action?: () => void;
 }
 
+/**
+ * Options to configure styling and behavior of the ShortcutBar.
+ */
 export interface ShortcutBarOptions {
     /** Custom styles for the key (e.g., fg/bg colors). Default: cyan, bold */
     keyStyle?: Partial<Style>;
@@ -41,6 +47,12 @@ export class ShortcutBar extends Widget {
     private _labelStyle: Partial<Style>;
     private _separator: string;
 
+    /**
+     * Creates an instance of ShortcutBar.
+     * @param items Initial list of shortcut items.
+     * @param style Partial widget style object.
+     * @param opts Custom options for key styling, label styling, and separator.
+     */
     constructor(
         items: ShortcutItem[] = [],
         style: Partial<Style> = {},
@@ -54,36 +66,56 @@ export class ShortcutBar extends Widget {
         this.focusable = false; // Usually not focused; key events are delegated or run globally
     }
 
-    /** Set/replace all shortcut items. */
+    /**
+     * Sets or replaces the current list of shortcut items.
+     * @param items The new list of shortcut items.
+     */
     setItems(items: ShortcutItem[]): void {
         this._items = items;
         this.markDirty();
     }
 
-    /** Get the current shortcut items. */
+    /**
+     * Retrieves the current list of shortcut items.
+     * @returns The list of shortcut items.
+     */
     getItems(): ShortcutItem[] {
         return this._items;
     }
 
-    /** Set separator between shortcut items. */
+    /**
+     * Updates the horizontal separator string printed between shortcut segments.
+     * @param separator The new separator string.
+     */
     setSeparator(separator: string): void {
         this._separator = separator;
         this.markDirty();
     }
 
-    /** Get the current separator. */
+    /**
+     * Retrieves the current horizontal separator string.
+     * @returns The separator string.
+     */
     getSeparator(): string {
         return this._separator;
     }
 
-    /** Update key and label styles. */
+    /**
+     * Updates the custom styles applied to keys and label segments.
+     * @param keyStyle Partial styling to apply to keys.
+     * @param labelStyle Partial styling to apply to labels.
+     */
     setStyles(keyStyle?: Partial<Style>, labelStyle?: Partial<Style>): void {
         if (keyStyle) this._keyStyle = keyStyle;
         if (labelStyle) this._labelStyle = labelStyle;
         this.markDirty();
     }
 
-    /** Check if key event matches any of the shortcut keys and trigger action. */
+    /**
+     * Handles keyboard keypress events. Triggers the action callback of the
+     * shortcut item matching the pressed key (case-insensitively).
+     * @param event The key event triggered by the user.
+     */
     handleKey(event: KeyEvent): void {
         const matchingItem = this._items.find(
             item => item.key.toLowerCase() === event.key.toLowerCase(),
@@ -92,6 +124,7 @@ export class ShortcutBar extends Widget {
             matchingItem.action();
         }
     }
+
 
     protected _renderSelf(screen: Screen): void {
         const rect = this._getContentRect();

--- a/packages/widgets/src/display/ShortcutBar.ts
+++ b/packages/widgets/src/display/ShortcutBar.ts
@@ -1,0 +1,148 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — ShortcutBar widget
+// ─────────────────────────────────────────────────────
+
+import {
+    type Screen,
+    type Style,
+    type KeyEvent,
+    styleToCellAttrs,
+    mergeStyles,
+    stringWidth,
+    truncate,
+} from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export interface ShortcutItem {
+    /** Keyboard key character/name (e.g. 'F1', 'q', 'ctrl+c') */
+    key: string;
+    /** Labeled explanation (e.g. 'Help', 'Quit') */
+    label: string;
+    /** Optional callback triggered on matching key press */
+    action?: () => void;
+}
+
+export interface ShortcutBarOptions {
+    /** Custom styles for the key (e.g., fg/bg colors). Default: cyan, bold */
+    keyStyle?: Partial<Style>;
+    /** Custom styles for the label text. Default: white */
+    labelStyle?: Partial<Style>;
+    /** Horizontal separator string. Default: '   ' (three spaces) */
+    separator?: string;
+}
+
+/**
+ * ShortcutBar — a horizontal footer bar that displays quick key bindings.
+ * Matches design aesthetics of classic terminal tools (like nano, htop).
+ */
+export class ShortcutBar extends Widget {
+    private _items: ShortcutItem[];
+    private _keyStyle: Partial<Style>;
+    private _labelStyle: Partial<Style>;
+    private _separator: string;
+
+    constructor(
+        items: ShortcutItem[] = [],
+        opts: ShortcutBarOptions = {},
+        style: Partial<Style> = {},
+    ) {
+        super(style);
+        this._items = items;
+        this._keyStyle = opts.keyStyle ?? { fg: { type: 'named', name: 'cyan' }, bold: true };
+        this._labelStyle = opts.labelStyle ?? { fg: { type: 'named', name: 'white' } };
+        this._separator = opts.separator ?? '   ';
+        this.focusable = false; // Usually not focused; key events are delegated or run globally
+    }
+
+    /** Set/replace all shortcut items. */
+    setItems(items: ShortcutItem[]): void {
+        this._items = items;
+        this.markDirty();
+    }
+
+    /** Get the current shortcut items. */
+    getItems(): ShortcutItem[] {
+        return this._items;
+    }
+
+    /** Set separator between shortcut items. */
+    setSeparator(separator: string): void {
+        this._separator = separator;
+        this.markDirty();
+    }
+
+    /** Get the current separator. */
+    getSeparator(): string {
+        return this._separator;
+    }
+
+    /** Update key and label styles. */
+    setStyles(keyStyle?: Partial<Style>, labelStyle?: Partial<Style>): void {
+        if (keyStyle) this._keyStyle = keyStyle;
+        if (labelStyle) this._labelStyle = labelStyle;
+        this.markDirty();
+    }
+
+    /** Check if key event matches any of the shortcut keys and trigger action. */
+    handleKey(event: KeyEvent): void {
+        const matchingItem = this._items.find(
+            item => item.key.toLowerCase() === event.key.toLowerCase(),
+        );
+        if (matchingItem && matchingItem.action) {
+            matchingItem.action();
+        }
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const rect = this._getContentRect();
+        const { x, y, width, height } = rect;
+        if (width <= 0 || height <= 0) return;
+
+        const baseAttrs = styleToCellAttrs(this._style);
+        const keyAttrs = styleToCellAttrs(mergeStyles(this._style, this._keyStyle));
+        const labelAttrs = styleToCellAttrs(mergeStyles(this._style, this._labelStyle));
+
+        let currentX = x;
+        const separatorWidth = stringWidth(this._separator);
+
+        for (let i = 0; i < this._items.length; i++) {
+            const item = this._items[i];
+            
+            const keyText = `[${item.key}]`;
+            const labelText = item.label;
+
+            const keyLen = stringWidth(keyText);
+            const labelLen = stringWidth(labelText);
+
+            // Write separator if this is not the first item
+            if (i > 0) {
+                if (currentX + separatorWidth > x + width) break;
+                screen.writeString(currentX, y, this._separator, baseAttrs);
+                currentX += separatorWidth;
+            }
+
+            // Render key indicator (e.g. "[F1]")
+            if (currentX + keyLen > x + width) break;
+            screen.writeString(currentX, y, keyText, keyAttrs);
+            currentX += keyLen;
+
+            // Render label text (e.g. " Help")
+            if (labelText) {
+                if (currentX + 1 + labelLen > x + width) {
+                    const spaceLeft = x + width - currentX - 1;
+                    if (spaceLeft > 0) {
+                        screen.writeString(currentX, y, ' ', baseAttrs);
+                        currentX += 1;
+                        const truncatedLabel = truncate(labelText, spaceLeft);
+                        screen.writeString(currentX, y, truncatedLabel, labelAttrs);
+                        currentX += stringWidth(truncatedLabel);
+                    }
+                    break;
+                } else {
+                    screen.writeString(currentX, y, ' ' + labelText, labelAttrs);
+                    currentX += 1 + labelLen;
+                }
+            }
+        }
+    }
+}

--- a/packages/widgets/src/display/ShortcutBar.ts
+++ b/packages/widgets/src/display/ShortcutBar.ts
@@ -43,8 +43,8 @@ export class ShortcutBar extends Widget {
 
     constructor(
         items: ShortcutItem[] = [],
-        opts: ShortcutBarOptions = {},
         style: Partial<Style> = {},
+        opts: ShortcutBarOptions = {},
     ) {
         super(style);
         this._items = items;
@@ -107,7 +107,7 @@ export class ShortcutBar extends Widget {
 
         for (let i = 0; i < this._items.length; i++) {
             const item = this._items[i];
-            
+
             const keyText = `[${item.key}]`;
             const labelText = item.label;
 

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -165,6 +165,10 @@ export type { ClockOptions } from './display/Clock.js';
 export { Link } from './display/Link.js';
 export type { LinkOptions } from './display/Link.js';
 
+export { ShortcutBar } from './display/ShortcutBar.js';
+export type { ShortcutItem, ShortcutBarOptions } from './display/ShortcutBar.js';
+
+
 // ── Missing layout elements restored ──
 export { QRCodePattern, QRCode } from './display/QRCode.js';
 export type { QRCodePatternOptions, QRCodeOptions } from './display/QRCode.js';


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

Adds a new horizontal `ShortcutBar` widget to the `@termuijs/widgets` package. This component allows CLI applications to display a horizontal row of action keyboard shortcut hints (like `[F1] Help  [F10] Quit`) at the bottom of the screen, matching the design aesthetics of classic terminal tools (like `nano` or `htop`).

## Related Issue

Closes #989

## Which package(s)?

`@termuijs/widgets`

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/901726b7-d593-41ba-b695-a4b8000cb3ff` <!-- Replace ____ with your GSSoC username/id -->

## Screenshots / Recordings (UI changes)

<img width="1064" height="734" alt="Screenshot 2026-06-07 110857" src="https://github.com/user-attachments/assets/0a97136a-bb35-4d63-a59c-745ec3533330" />

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

- Uses the standard TermUI double-buffered render cycle via `Screen`.
- Supports setting custom keys, labels, separators, and specific styling for key tags and labels.
- Handles keys case-insensitively when using `handleKey()`.
- Automatically truncates labels responsively if the available width is too narrow for all shortcut segments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a ShortcutBar widget to display keyboard shortcuts with customizable key and label styling, configurable separators, and automatic label truncation to fit available width.
  * Case-insensitive key handling to trigger associated actions.
  * ShortcutBar and its types are now part of the package API for use in apps.
* **Tests**
  * Added tests covering rendering, styling, truncation, separator behavior, input handling, and state updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->