### PR TITLE
fix(core): reject and clear pending cursor requests on InputParser.stop() (closes #993)

### DIFF
--- a/packages/core/src/input/InputParser.test.ts
+++ b/packages/core/src/input/InputParser.test.ts
@@ -134,6 +134,18 @@ describe('InputParser', () => {
         await expect(positionPromise).rejects.toThrow('Cursor position request timed out');
     });
 
+    it('rejects pending cursor position requests immediately when stop() is called', async () => {
+        vi.useFakeTimers();
+        const stdin = createMockStdin();
+        const parser = new InputParser(stdin);
+        parser.start();
+
+        const positionPromise = parser.requestCursorPosition(200);
+        parser.stop();
+
+        await expect(positionPromise).rejects.toThrow('InputParser stopped');
+    });
+
     it('does not emit a key event for cursor position reports', async () => {
         const stdin = createMockStdin();
         const parser = new InputParser(stdin);

--- a/packages/core/src/input/InputParser.ts
+++ b/packages/core/src/input/InputParser.ts
@@ -98,6 +98,11 @@ export class InputParser {
             this._escapeTimeout = null;
         }
         this._escapeBuffer = Buffer.alloc(0);
+        for (const req of this._cursorRequests) {
+            clearTimeout(req.timeout);
+            req.reject(new Error('InputParser stopped'));
+        }
+        this._cursorRequests = [];
     }
 
     /**


### PR DESCRIPTION
## Problem
`InputParser.stop()` cleared the data handler and escape buffer but never rejected or cleared `_cursorRequests` or their timeout handles. Pending `requestCursorPosition()` promises hung until their 200ms timeout fired, leaking timer handles on every shutdown.

## Fix
In `stop()`, after resetting the escape buffer, iterate `_cursorRequests`, call `clearTimeout` on each timeout handle, reject with `'InputParser stopped'`, and reset the array.

## Changes
- `packages/core/src/input/InputParser.ts` — cleanup loop added to `stop()`
- `packages/core/src/input/InputParser.test.ts` — test verifying immediate rejection with correct message when `stop()` is called

## Verification
- `bun vitest run packages/core` — 280 passed
- `bun run typecheck` — 27 tasks passed

Closes #993

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where pending cursor position requests were not properly terminated when stopping the input parser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->