### PR TITLE
test(core): improve App.mount() + unmount() test to assert exit code directly (closes #996)

### DIFF
--- a/packages/core/src/app/App.test.ts
+++ b/packages/core/src/app/App.test.ts
@@ -32,7 +32,7 @@ function createMockRootWidget(): RootWidget {
 
 describe('App', () => {
     describe('unmount()', () => {
-        it('mount() promise resolves when unmount() is called directly', async () => {
+        it('mount() resolves when unmount() is called directly', async () => {
             const root = createMockRootWidget();
             const fakeStdout: any = { // minimal stdout stub — full NodeJS.WriteStream type not required here
                 writes: '',
@@ -58,12 +58,8 @@ describe('App', () => {
 
             app.unmount();
 
-            const result = await Promise.race([
-                mountPromise.then(() => 'resolved'),
-                new Promise<string>((r) => setTimeout(() => r('timeout'), 500)),
-            ]);
-
-            expect(result).toBe('resolved');
+            const code = await mountPromise;
+            expect(code).toBe(0);
         });
     });
 


### PR DESCRIPTION
## Context
The underlying fix for issue #996 was already merged in PR #778 — `unmount()` correctly resolves the `mount()` promise with exit code 0.

However the existing test used a fragile `Promise.race` with a 500ms timeout to verify this behavior, which can produce false positives if the promise resolves for the wrong reason.

## Change
Replaced the `Promise.race` timeout pattern with a direct `await mountPromise` and an explicit `expect(code).toBe(0)` assertion, making the test deterministic and self-documenting.

## Verification
- `bun vitest run packages/core` — 279 passed
- `bun run typecheck` — 27 tasks passed

Closes #996

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains no user-facing changes. Internal testing infrastructure improvements were made to streamline the application lifecycle verification process.

* **Tests**
  * Improved test reliability and simplified assertion strategy for app lifecycle verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->