### PR TITLE
refactor(ui): use node:fs and node:path imports

### DIFF
--- a/packages/ui/src/FilePicker.test.ts
+++ b/packages/ui/src/FilePicker.test.ts
@@ -3,14 +3,14 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { Dirent } from 'fs';
+import type { Dirent } from 'node:fs';
 import { createKeyEvent } from '@termuijs/core';
 
 // ── fs mock setup ────────────────────────────────────
-// We mock the 'fs' module (matching FilePicker.ts's import * as fs from 'fs')
+// We mock the 'node:fs' module (matching FilePicker.ts's import * as fs from 'node:fs')
 // so no real filesystem IO happens in CI.
 
-vi.mock('fs', () => {
+vi.mock('node:fs', () => {
     return {
         default: {},
         readdirSync: vi.fn(),
@@ -19,8 +19,8 @@ vi.mock('fs', () => {
 });
 
 // Must import after vi.mock is hoisted
-import * as fsMod from 'fs';
-import * as nodePath from 'path';
+import * as fsMod from 'node:fs';
+import * as nodePath from 'node:path';
 // Cast through unknown so vi.mocked() doesn't fight the overloaded fs signatures
 const readdirSync = fsMod.readdirSync as unknown as ReturnType<typeof vi.fn>;
 const statSync    = fsMod.statSync    as unknown as ReturnType<typeof vi.fn>;

--- a/packages/ui/src/FilePicker.ts
+++ b/packages/ui/src/FilePicker.ts
@@ -8,8 +8,8 @@
 //   Escape    Fire onCancel
 // ─────────────────────────────────────────────────────
 
-import * as fs from 'fs';
-import * as nodePath from 'path';
+import * as fs from 'node:fs';
+import * as nodePath from 'node:path';
 import { Widget } from '@termuijs/widgets';
 import {
     type Style,

--- a/packages/ui/src/PathInput.test.ts
+++ b/packages/ui/src/PathInput.test.ts
@@ -2,12 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render } from '@termuijs/testing';
 import { createElement, useRef } from '@termuijs/jsx';
 import { PathInput } from './PathInput.js';
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 // Mock fs module
-vi.mock('fs', async (importOriginal) => {
-    const actual = await importOriginal<typeof import('fs')>();
+vi.mock('node:fs', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('node:fs')>();
     return {
         ...actual,
         readdirSync: vi.fn(),

--- a/packages/ui/src/PathInput.ts
+++ b/packages/ui/src/PathInput.ts
@@ -9,8 +9,8 @@
 // - Handles relative and absolute paths gracefully
 // ─────────────────────────────────────────────────────
 
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { Widget } from '@termuijs/widgets';
 import { type Style, type Screen, type KeyEvent, styleToCellAttrs, truncate, caps } from '@termuijs/core';
 


### PR DESCRIPTION
## Description

This PR updates Node.js built-in module imports to use the required `node:` prefix in `FilePicker.ts`, `PathInput.ts`, and their corresponding test files. It also updates test mocks from `vi.mock('fs')` to `vi.mock('node:fs')` to ensure consistency and compliance with the project's import guidelines.

## Related Issue

Closes #1008 

## Which package(s)?

@termuijs/ui

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [ ] 🧪 Tests (`type:testing`)
* [x] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md](https://chatgpt.com/CONTRIBUTING.md)`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/2a6d533b-763b-42cc-9654-68d00f391e45`

## Screenshots / Recordings (UI changes)

N/A – No UI changes.

## Notes for the Reviewer

* Updated `packages/ui/src/FilePicker.ts` to use `node:fs` and `node:path`.
* Updated `packages/ui/src/PathInput.ts` to use `node:fs` and `node:path`.
* Updated `FilePicker.test.ts` and `PathInput.test.ts` to use the same import convention.
* Replaced `vi.mock('fs')` with `vi.mock('node:fs')` where applicable.
* No functional changes were introduced; this PR only aligns imports and test mocks with the repository's coding standards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js module imports across UI components to use standardized module specifiers.

* **Tests**
  * Updated test configuration to align with standardized module import patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->