### PR TITLE
fix(tss): prevent path traversal in resolveImports

### DIFF
--- a/packages/tss/src/importer.test.ts
+++ b/packages/tss/src/importer.test.ts
@@ -67,7 +67,41 @@ describe('TSS Importer', () => {
     it('leaves source unchanged if no imports exist', () => {
         const source = `Box { width: 100; }`;
         const result = resolveImports(source, '/mock/main.tss');
-        
+
         expect(result).toBe(source);
+    });
+
+    describe('path traversal protection', () => {
+        it('blocks ../ traversal above base directory', () => {
+            const result = resolveImports(`@import "../../../etc/passwd";`, '/mock/themes/main.tss');
+            expect(result).toContain('Path traversal blocked');
+            expect(vi.mocked(readFileSync)).not.toHaveBeenCalled();
+        });
+
+        it('blocks sibling directory with shared prefix — the startsWith vulnerability', () => {
+            // /mock/themes-evil/exploit.tss starts with /mock/themes (wrong check passes it)
+            // path.relative() correctly produces "../themes-evil/exploit.tss" which starts with ".."
+            const result = resolveImports(`@import "../themes-evil/exploit.tss";`, '/mock/themes/main.tss');
+            expect(result).toContain('Path traversal blocked');
+            expect(vi.mocked(readFileSync)).not.toHaveBeenCalled();
+        });
+
+        it('allows imports inside the base directory', () => {
+            vi.mocked(readFileSync).mockReturnValue('Button { fg: green; }');
+            const result = resolveImports(`@import "components/button.tss";`, '/mock/themes/main.tss');
+            expect(result).toContain('Button { fg: green; }');
+        });
+
+        it('blocks unsupported file extensions', () => {
+            const result = resolveImports(`@import "../../secret.sh";`, '/mock/themes/main.tss');
+            expect(result).toContain('Path traversal blocked');
+            expect(vi.mocked(readFileSync)).not.toHaveBeenCalled();
+        });
+
+        it('blocks .env files via extension check', () => {
+            const result = resolveImports(`@import "local.env";`, '/mock/themes/main.tss');
+            expect(result).toContain('Unsupported import extension');
+            expect(vi.mocked(readFileSync)).not.toHaveBeenCalled();
+        });
     });
 });

--- a/packages/tss/src/importer.ts
+++ b/packages/tss/src/importer.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { dirname, resolve, relative, isAbsolute } from 'node:path';
 
 const ALLOWED_EXTENSIONS = ['.tss', '.json', '.yaml', '.yml'];
 
@@ -22,9 +22,12 @@ export function resolveImports(source: string, basePath: string, visited = new S
         const baseDir = dirname(basePath);
         const fullPath = resolve(baseDir, importPath);
 
-        // Path traversal protection: reject any path that escapes the base directory
-        if (!fullPath.startsWith(baseDir) && !fullPath.startsWith(resolve(baseDir, '.'))) {
-            return `/* Error: Path traversal blocked: ${importPath} */`;
+        // Path traversal protection: reject any path that escapes the base directory.
+        // startsWith() is NOT safe here — "/themes-evil" starts with "/themes".
+        // path.relative() correctly detects traversal via ".." segments.
+        const rel = relative(baseDir, fullPath);
+        if (rel.startsWith('..') || isAbsolute(rel)) {
+            return `/* Error: Path traversal blocked */`;
         }
 
         // Only allow known theme file extensions

--- a/packages/tss/src/importer.ts
+++ b/packages/tss/src/importer.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
+const ALLOWED_EXTENSIONS = ['.tss', '.json', '.yaml', '.yml'];
+
 /**
  * Resolves and inlines @import statements in TSS strings.
  * Syntax supported: @import "path/to/file.tss"; or @import 'path/to/file.tss';
@@ -17,7 +19,19 @@ export function resolveImports(source: string, basePath: string, visited = new S
         const importPath = singleQuotePath || doubleQuotePath;
         if (!importPath) return match;
 
-        const fullPath = resolve(dirname(basePath), importPath);
+        const baseDir = dirname(basePath);
+        const fullPath = resolve(baseDir, importPath);
+
+        // Path traversal protection: reject any path that escapes the base directory
+        if (!fullPath.startsWith(baseDir) && !fullPath.startsWith(resolve(baseDir, '.'))) {
+            return `/* Error: Path traversal blocked: ${importPath} */`;
+        }
+
+        // Only allow known theme file extensions
+        const ext = fullPath.toLowerCase().slice(fullPath.lastIndexOf('.'));
+        if (!ALLOWED_EXTENSIONS.includes(ext)) {
+            return `/* Error: Unsupported import extension: ${importPath} */`;
+        }
 
         // Edge case: Prevent infinite loops from circular dependencies
         if (visited.has(fullPath)) {


### PR DESCRIPTION
## Description

Adds path traversal protection and file extension whitelisting to the TSS `@import` resolver (`resolveImports`), preventing attackers from reading arbitrary files outside the theme directory through crafted `@import` statements.

## Changes Made

| File | Change |
|------|--------|
| `packages/tss/src/importer.ts` | Added check that resolves the import path and rejects it if the resolved path does not start with the base directory; added whitelist of allowed file extensions (`.tss`, `.json`, `.yaml`, `.yml`) |

## Attack Scenarios

| `@import` Statement | Before | After |
|---------------------|--------|-------|
| `@import "../../etc/passwd"` | Reads and inlines `/etc/passwd` | Rejected: "Path traversal blocked" |
| `@import "sensitive.env"` | Reads arbitrary `.env` files | Rejected: unsupported extension |
| `@import "../../.ssh/id_rsa"` | Exfiltrates SSH private key | Rejected: path traversal blocked |

## Security Design

- **Path prefix check:** After resolving the import path via `path.resolve()`, verifies the result starts with the base directory — any `../` that escapes the directory is caught
- **Extension whitelist:** Only `.tss`, `.json`, `.yaml`, `.yml` are allowed — prevents reading arbitrary files even if they happen to be within the base directory
- **Graceful failure:** Traversal attempts return an inline TSS comment rather than throwing, maintaining the existing error-handling contract

Closes #1000


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented imports from escaping designated directories (path traversal blocked).
  * Enforced allowed file extensions for imports (.tss, .json, .yaml, .yml).
  * Invalid or disallowed imports now return inline error comments instead of proceeding.

* **Tests**
  * Added tests covering path traversal protection, extension validation, and successful in-base imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->