### PR TITLE
perf(display): avoid redundant markDirty calls in StreamingText

### DIFF
--- a/packages/widgets/src/display/StreamingText.test.ts
+++ b/packages/widgets/src/display/StreamingText.test.ts
@@ -146,6 +146,16 @@ describe('StreamingText – setText()', () => {
         widget.setText('World');
         expect(widget.isDirty).toBe(true);
     });
+
+    it('does not mark widget dirty when text is unchanged', () => {
+        const widget = new StreamingText({ text: 'Hello', speed: 3 });
+    
+        widget.clearDirty();
+        widget.setText('Hello');
+    
+        expect(widget.isDirty).toBe(false);
+    });
+    
 });
 
 // ── 6. Cursor appears when _cursorVisible = true ──────────────────────────────

--- a/packages/widgets/src/display/StreamingText.ts
+++ b/packages/widgets/src/display/StreamingText.ts
@@ -48,6 +48,7 @@ export class StreamingText extends Widget {
 
     /** Replace text content and reset the revealed counter to 0. */
     setText(text: string): void {
+        if (text === this._text) return;
         this._text = text;
         this._revealed = 0;
         this.markDirty();


### PR DESCRIPTION
## Description

Avoids unnecessary widget invalidation in StreamingText by skipping `markDirty()` calls when the text value remains unchanged.

This PR adds an equality guard to `setText()` and introduces a regression test verifying that unchanged updates do not trigger widget invalidation.

## Related Issue

Closes #1017

## Which package(s)?

@termuijs/widgets

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [x] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.

Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

### Changes Made

* Added equality guard in `StreamingText.setText()`
* Added regression test verifying unchanged text does not mark the widget dirty
* Preserved existing dirty-state behavior for actual text changes

### Validation

✅ `bun vitest run packages/widgets/src/display/StreamingText.test.ts`

### Build Note

Repository-wide build/typecheck currently reports an unrelated failure in `@termuijs/adapters` due to a missing `dotenv` dependency. This issue is outside the scope of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved StreamingText widget efficiency by preventing unnecessary state updates when identical text values are applied consecutively, reducing redundant processing overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->