### PR TITLE
perf(display): avoid redundant markDirty calls in Stopwatch

### DIFF
--- a/packages/widgets/src/display/Stopwatch.test.ts
+++ b/packages/widgets/src/display/Stopwatch.test.ts
@@ -171,6 +171,7 @@ describe('Stopwatch – destroy()', () => {
         sw.destroy();
         expect((sw as any)._intervalId).toBeUndefined();
     });
+});
 
 // ── 7. setInterval() mutation behavior ───────────────────────────────────
 describe('Stopwatch – setInterval()', () => {
@@ -201,4 +202,3 @@ describe('Stopwatch – setInterval()', () => {
     });
 });
 
-});

--- a/packages/widgets/src/display/Stopwatch.test.ts
+++ b/packages/widgets/src/display/Stopwatch.test.ts
@@ -171,4 +171,34 @@ describe('Stopwatch – destroy()', () => {
         sw.destroy();
         expect((sw as any)._intervalId).toBeUndefined();
     });
+
+// ── 7. setInterval() mutation behavior ───────────────────────────────────
+describe('Stopwatch – setInterval()', () => {
+    it('setInterval marks widget dirty', () => {
+        const sw = new Stopwatch({ interval: 10 });
+
+        sw.clearDirty();
+        sw.setInterval(20);
+
+        expect(sw.isDirty).toBe(true);
+    });
+
+    it('does not mark dirty when interval is unchanged', () => {
+        const sw = new Stopwatch({ interval: 10 });
+
+        sw.clearDirty();
+        sw.setInterval(10);
+
+        expect(sw.isDirty).toBe(false);
+    });
+
+    it('updates interval value', () => {
+        const sw = new Stopwatch({ interval: 10 });
+
+        sw.setInterval(25);
+
+        expect(sw.getInterval()).toBe(25);
+    });
+});
+
 });

--- a/packages/widgets/src/display/Stopwatch.ts
+++ b/packages/widgets/src/display/Stopwatch.ts
@@ -149,4 +149,22 @@ export class Stopwatch extends Widget {
 
         screen.writeString(x, y, label, attrs);
     }
+
+    setInterval(interval: number): void {
+        if (interval === this._interval) return;
+    
+        this._interval = interval;
+    
+        if (this._running) {
+            this._clearInterval();
+            this._intervalId = setInterval(() => this._tick(), this._interval);
+        }
+    
+        this.markDirty();
+    }
+    
+    getInterval(): number {
+        return this._interval;
+    }
+
 }


### PR DESCRIPTION

## Description

Adds interval mutation support to `Stopwatch` through `setInterval()` and `getInterval()`, while avoiding redundant `markDirty()` calls when the interval value is unchanged.

Also adds regression tests covering dirty-state behavior and interval updates.

## Related Issue

Closes #1019

## Which package(s)?

@termuijs/widgets

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [x] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

### Changes Made

* Added `setInterval()` and `getInterval()` APIs to `Stopwatch`
* Added an equality guard to avoid redundant `markDirty()` calls when the interval value is unchanged
* Preserved timer restart behavior when the stopwatch is running and the interval changes
* Added regression tests covering:

  * dirty-state updates on interval changes
  * unchanged interval values not marking the widget dirty
  * interval value updates through the new API

### Validation

✅ `bun vitest run packages/widgets/src/display/Stopwatch.test.ts`

### Build Note

Repository-wide build/typecheck may still report unrelated failures outside the scope of this PR. The changes in this PR are limited to the Stopwatch widget and its tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stopwatch widget now supports dynamic interval configuration via `setInterval()` method to adjust the tick rate at runtime.
  * Added `getInterval()` method to retrieve the current interval setting.

* **Tests**
  * Added test suite to verify interval configuration and dirty state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->