### PR TITLE
perf(display): avoid redundant markDirty calls in Timer

### DIFF
--- a/packages/widgets/src/display/Timer.test.ts
+++ b/packages/widgets/src/display/Timer.test.ts
@@ -174,3 +174,26 @@ describe('Timer – destroy()', () => {
         expect((timer as any)._intervalId).toBeUndefined();
     });
 });
+
+// ── 5. reset() optimization ───────────────────────────────────────────────
+describe('Timer – reset() optimization', () => {
+    it('marks dirty when reset changes state', () => {
+        const timer = new Timer({ duration: 5000 });
+
+        (timer as any)._remaining = 3000;
+
+        timer.clearDirty();
+        timer.reset();
+
+        expect(timer.isDirty).toBe(true);
+    });
+
+    it('does not mark dirty when already reset', () => {
+        const timer = new Timer({ duration: 5000 });
+
+        timer.clearDirty();
+        timer.reset();
+
+        expect(timer.isDirty).toBe(false);
+    });
+});

--- a/packages/widgets/src/display/Timer.ts
+++ b/packages/widgets/src/display/Timer.ts
@@ -76,7 +76,14 @@ export class Timer extends Widget {
      * running countdown.
      */
     reset(): void {
+        const wasRunning = this._running;
+    
         this.stop();
+    
+        if (!wasRunning && this._remaining === this._duration) {
+            return;
+        }
+    
         this._remaining = this._duration;
         this.markDirty();
     }


### PR DESCRIPTION

## Description

Avoids unnecessary widget invalidation in `Timer.reset()` when the timer is already stopped and already at its initial duration.

This PR adds an early-return guard to skip redundant `markDirty()` calls and introduces regression tests verifying both the changed-state and unchanged-state reset paths.

## Related Issue

Closes #1021

## Which package(s)?

@termuijs/widgets

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [x] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

### Changes Made

* Added an early-return guard in `Timer.reset()`
* Avoided redundant `markDirty()` calls when reset is a no-op
* Added regression test verifying reset marks dirty when state changes
* Added regression test verifying reset does not mark dirty when already in the default state

### Validation

✅ `bun vitest run packages/widgets/src/display/Timer.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized Timer reset to avoid unnecessary state updates when already in the reset state.

* **Tests**
  * Added tests to verify Timer reset behavior under various conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->