### PR TITLE
fix(data): useWebSocket generation counter, close on error, stale callback guard

### DIFF
--- a/packages/data/src/hooks.ts
+++ b/packages/data/src/hooks.ts
@@ -264,6 +264,7 @@ export function useWebSocket(url: string): UseWebSocketReturn {
     useEffect(() => {
         let isMounted = true;
         const thisGeneration = ++generationRef.current;
+        retryCountRef.current = 0;
 
         function connect() {
             if (socketRef.current) {
@@ -295,6 +296,11 @@ export function useWebSocket(url: string): UseWebSocketReturn {
             socket.onclose = () => {
                 if (!isMounted || thisGeneration !== generationRef.current) return;
                 setState('closed')
+
+                if (reconnectTimeoutRef.current) {
+                    clearTimeout(reconnectTimeoutRef.current);
+                    reconnectTimeoutRef.current = null;
+                }
 
                 const timeout = Math.min(1000 * Math.pow(2, retryCountRef.current), 10000);
                 retryCountRef.current += 1;

--- a/packages/data/src/hooks.ts
+++ b/packages/data/src/hooks.ts
@@ -259,42 +259,56 @@ export function useWebSocket(url: string): UseWebSocketReturn {
     const socketRef = useRef<WebSocket | null>(null)
     const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
     const retryCountRef = useRef(0)
+    const generationRef = useRef(0)
 
     useEffect(() => {
         let isMounted = true;
+        const thisGeneration = ++generationRef.current;
 
         function connect() {
+            if (socketRef.current) {
+                socketRef.current.onopen = null;
+                socketRef.current.onmessage = null;
+                socketRef.current.onclose = null;
+                socketRef.current.onerror = null;
+                if (socketRef.current.readyState === WebSocket.OPEN ||
+                    socketRef.current.readyState === WebSocket.CONNECTING) {
+                    socketRef.current.close();
+                }
+            }
+
             const socket = new WebSocket(url);
             socketRef.current = socket;
             setState('connecting')
 
             socket.onopen = () => {
-                if (!isMounted) return;
+                if (!isMounted || thisGeneration !== generationRef.current) return;
                 setState('open');
                 retryCountRef.current = 0;
             }
 
             socket.onmessage = (e) => {
-                if (!isMounted) return;
+                if (!isMounted || thisGeneration !== generationRef.current) return;
                 setMessage(e.data)
             }
 
             socket.onclose = () => {
-                if (!isMounted) return;
+                if (!isMounted || thisGeneration !== generationRef.current) return;
                 setState('closed')
 
                 const timeout = Math.min(1000 * Math.pow(2, retryCountRef.current), 10000);
                 retryCountRef.current += 1;
 
                 reconnectTimeoutRef.current = setTimeout(() => {
+                    if (!isMounted || thisGeneration !== generationRef.current) return;
                     connect();
                 }, timeout)
             }
 
             socket.onerror = () => {
-                if (!isMounted) return;
+                if (!isMounted || thisGeneration !== generationRef.current) return;
                 setState('error')
-
+                socket.close();
             }
         }
 
@@ -302,11 +316,18 @@ export function useWebSocket(url: string): UseWebSocketReturn {
 
         return () => {
             isMounted = false;
+            generationRef.current += 1;
             if (reconnectTimeoutRef.current) {
                 clearTimeout(reconnectTimeoutRef.current)
+                reconnectTimeoutRef.current = null;
             }
             if (socketRef.current) {
+                socketRef.current.onopen = null;
+                socketRef.current.onmessage = null;
+                socketRef.current.onclose = null;
+                socketRef.current.onerror = null;
                 socketRef.current.close();
+                socketRef.current = null;
             }
         }
     }, [url])

--- a/packages/data/src/useWebSocket.test.tsx
+++ b/packages/data/src/useWebSocket.test.tsx
@@ -121,4 +121,62 @@ describe('useWebSocket hook', () => {
         // The cleanup function should have fired
         expect(socket.isClosed).toBe(true)
     })
+
+    it('url change mid-connection resets retry count and uses new url', () => {
+        const { rerender } = render(<TestComponent url="wss://old.com" />)
+        activeSockets[0].onopen?.()
+        activeSockets[0].onclose?.()
+
+        // Advance past the reconnect timeout so a failed retry increments retryCount
+        vi.advanceTimersByTime(2000) // after reconnect timeout
+        expect(activeSockets.length).toBe(2)
+
+        // Now change URL — should reset retryCount and create new connection
+        rerender(<TestComponent url="wss://new.com" />)
+        // After rerender, cleanup closes old socket, then effect runs again
+        // The new effect should create a new socket
+        expect(activeSockets[2].url).toBe('wss://new.com')
+    })
+
+    it('rapid url changes do not accumulate reconnect timers', () => {
+        const { rerender } = render(<TestComponent url="wss://a.com" />)
+        // Simulate disconnect which schedules reconnect
+        activeSockets[0].onclose?.()
+        // Rerender with a new URL quickly
+        rerender(<TestComponent url="wss://b.com" />)
+        // The pending reconnect timer from old URL should be cleared
+        // Only one new socket should exist (for b.com), not two
+        const socketsForB = activeSockets.filter(s => s.url === 'wss://b.com')
+        expect(socketsForB.length).toBe(1)
+    })
+
+    it('unmount with pending reconnect clears timer and closes socket', () => {
+        const { unmount } = render(<TestComponent url="wss://test.com" />)
+        activeSockets[0].onclose?.() // triggers reconnect scheduling
+
+        // Unmount before reconnect fires
+        unmount()
+
+        // Advance past the reconnect timeout
+        vi.advanceTimersByTime(5000)
+
+        // No new socket should be created because unmount cleared the timer
+        expect(activeSockets.length).toBe(1)
+    })
+
+    it('recovers from error after a failed connection', () => {
+        render(<TestComponent url="wss://test.com" />)
+        const socket = activeSockets[0]
+
+        // Simulate connection error — error handler closes the socket
+        socket.onerror?.()
+        // Closing the socket triggers onclose which schedules the reconnect
+        socket.onclose?.()
+        // The error handler should close the socket
+        expect(socket.isClosed).toBe(true)
+
+        // Should have scheduled a reconnect
+        vi.advanceTimersByTime(1000)
+        expect(activeSockets.length).toBe(2)
+    })
 })


### PR DESCRIPTION
### Description

Prevents stale callbacks from operating on superseded WebSocket instances during rapid reconnections. Adds a generation counter incremented before each connect attempt, explicit socket.close() on error to ensure reconnect fires, and guards on all event handlers that skip processing if the generation no longer matches.

### Related Issue

Closes #1038

### Which package(s)?

@termuijs/data

### Type of Change

- [x] 🐛 Bug fix (`type:bug`)

### Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read `CONTRIBUTING.md`.
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

### GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.

### Screenshots / Recordings (UI changes)

N/A — internal state management, no UI change.

### Notes for the Reviewer

The generation counter pattern avoids the complexity of tracking pending async operations or implementing a full state machine. Each generation is a monotonically increasing integer; when a handler fires, it compares its captured generation against the ref's current value. Any mismatch means the handler is stale and should bail out. The `socket.close()` call on the error handler was missing, which meant certain error paths never triggered the close handler's reconnect logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed WebSocket hook to properly clean up event handlers and reconnect timers when components unmount or connection URLs change, preventing memory leaks and stale state updates.

* **Tests**
  * Added comprehensive test coverage for WebSocket reconnection behavior, timer management, and cleanup scenarios during component lifecycle changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->