### PR TITLE
feat(core): add horizontal scroll-wheel events

### DIFF
--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -69,8 +69,12 @@ export interface MouseEvent {
     button: MouseButton;
     /** Type of mouse event */
     type: MouseEventType;
-    /** Scroll direction (-1 = up, 1 = down) */
+    /** Vertical scroll delta: -1 = up, 1 = down. Set for vertical wheel events. */
     scrollDelta?: number;
+    /** Horizontal scroll delta: -1 = left, 1 = right. Set for horizontal wheel events. */
+    scrollDeltaX?: number;
+    /** Which axis a scroll event used. Set only for type 'scroll'. */
+    scrollAxis?: 'vertical' | 'horizontal';
     /** Ctrl modifier held during the mouse event. SGR bit 0b10000. */
     ctrl?: boolean;
     /** Alt/Meta modifier held during the mouse event. SGR bit 0b1000. */

--- a/packages/core/src/input/MouseParser.test.ts
+++ b/packages/core/src/input/MouseParser.test.ts
@@ -54,6 +54,9 @@ describe('parseMouseEvent', () => {
     it('parses left button press at (10, 5) → 0-based (9, 4)', () => {
         const evt = parseMouseEvent('\x1b[<0;10;5M');
         expect(evt).toMatchObject({ x: 9, y: 4, button: 'left', type: 'mousedown' });
+        expect(evt?.scrollAxis).toBeUndefined();
+        expect(evt?.scrollDeltaX).toBeUndefined();
+        expect(evt?.scrollDelta).toBeUndefined();
     });
 
     it('parses right button release', () => {
@@ -63,12 +66,24 @@ describe('parseMouseEvent', () => {
 
     it('parses scroll up event', () => {
         const evt = parseMouseEvent('\x1b[<64;10;5M');
-        expect(evt).toMatchObject({ type: 'scroll', scrollDelta: -1 });
+        expect(evt).toMatchObject({ type: 'scroll', scrollAxis: 'vertical', scrollDelta: -1 });
     });
 
     it('parses scroll down event', () => {
         const evt = parseMouseEvent('\x1b[<65;10;5M');
-        expect(evt).toMatchObject({ type: 'scroll', scrollDelta: 1 });
+        expect(evt).toMatchObject({ type: 'scroll', scrollAxis: 'vertical', scrollDelta: 1 });
+    });
+
+    it('parses horizontal scroll left', () => {
+        const ev = parseMouseEvent('\x1b[<70;5;5M');
+        expect(ev?.scrollAxis).toBe('horizontal');
+        expect(ev?.scrollDeltaX).toBe(-1);
+    });
+
+    it('parses horizontal scroll right', () => {
+        const ev = parseMouseEvent('\x1b[<71;5;5M');
+        expect(ev?.scrollAxis).toBe('horizontal');
+        expect(ev?.scrollDeltaX).toBe(1);
     });
 
     it('parses mouse move (drag)', () => {

--- a/packages/core/src/input/MouseParser.ts
+++ b/packages/core/src/input/MouseParser.ts
@@ -27,6 +27,8 @@ export function parseMouseEvent(data: string): MouseEvent | null {
     let button: MouseButton;
     let type: MouseEventType;
     let scrollDelta: number | undefined;
+    let scrollDeltaX: number | undefined;
+    let scrollAxis: 'vertical' | 'horizontal' | undefined;
 
     // Decode button from low 2 bits
     const buttonBits = cb & 0b11;
@@ -40,7 +42,17 @@ export function parseMouseEvent(data: string): MouseEvent | null {
     if (isScroll) {
         button = 'none';
         type = 'scroll';
-        scrollDelta = buttonBits === 0 ? -1 : 1; // 0 = scroll up, 1 = scroll down
+        const lowBits = cb & 0b111;
+        if (lowBits === 6) {
+            scrollAxis = 'horizontal';
+            scrollDeltaX = -1;
+        } else if (lowBits === 7) {
+            scrollAxis = 'horizontal';
+            scrollDeltaX = 1;
+        } else {
+            scrollAxis = 'vertical';
+            scrollDelta = buttonBits === 0 ? -1 : 1;
+        }
     } else if (motion) {
         type = 'mousemove';
         button = decodeButton(buttonBits);
@@ -57,9 +69,11 @@ export function parseMouseEvent(data: string): MouseEvent | null {
         y: cy,
         button,
         type,
-        scrollDelta,
-        shift,   
-        alt,     
+        ...(scrollDelta !== undefined && { scrollDelta }),
+        ...(scrollDeltaX !== undefined && { scrollDeltaX }),
+        ...(scrollAxis !== undefined && { scrollAxis }),
+        shift,
+        alt,
         ctrl,
     };
 }


### PR DESCRIPTION
## Description

Decodes SGR mouse scroll buttons 6 and 7 into a horizontal scroll axis on `MouseEvent`. Extends the event type signature with additive optional properties and preserves existing vertical wheel event behaviors.

## Related Issue

Closes #455 

## Which package(s)?

@termuijs/core

## Type of Change

- [x] ✨ Feature (`type:feature`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/2c316a1d-e085-460f-8a32-8d3a349d6ca7`

## Notes for the Reviewer

Fully backward compatible. Confined strictly to packages/core.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced mouse scroll handling: supports both vertical and horizontal scrolling, with explicit axis tracking and separate delta values per direction.

* **Tests**
  * Updated tests to validate vertical and horizontal scroll decoding and to ensure non-scroll events omit scroll-related fields.

* **Documentation**
  * Clarified that the original scroll delta refers specifically to vertical wheel events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->