### PR TITLE
 feat(data): add pause, resume, refresh, and paused to usePolling

### DIFF
--- a/packages/data/src/hooks/usePolling.ts
+++ b/packages/data/src/hooks/usePolling.ts
@@ -1,13 +1,18 @@
-import { useState, useEffect } from '@termuijs/jsx';
+import { useState, useEffect ,useRef } from '@termuijs/jsx';
 
 export interface UsePollingResult<T> {
     data: T | null;
     error: Error | null;
     loading: boolean;
+    paused: boolean;
+    pause: () => void;
+    resume: () => void;
+    refresh: () => void;
 }
 
 /**
  * usePolling — repeatedly execute an async function on a configurable interval.
+ * Supports pause, resume, and manual refresh without restarting the timer or resetting state.
  */
 export function usePolling<T>(
     fn: () => Promise<T>,
@@ -17,38 +22,61 @@ export function usePolling<T>(
     const [data, setData] = useState<T | null>(null);
     const [error, setError] = useState<Error | null>(null);
     const [loading, setLoading] = useState<boolean>(true);
+    const [paused, setPaused] = useState<boolean>(false);
+
+    const pausedRef = useRef(false);
+    const mountedRef = useRef(true);
+    const fnRef = useRef(fn);
+    fnRef.current = fn;
+
+    const execute = async () => {
+        try {
+            const result = await fnRef.current();
+            if (mountedRef.current) {
+                setData(result);
+                setError(null);
+                setLoading(false);
+            }
+        } catch (err) {
+            if (mountedRef.current) {
+                setError(err instanceof Error ? err : new Error(String(err)));
+                setLoading(false);
+            }
+        }
+    };
+
+    const pause = () => {
+        pausedRef.current = true;
+        setPaused(true);
+    };
+
+    const resume = () => {
+        pausedRef.current = false;
+        setPaused(false);
+    };
+
+    const refresh = () => {
+        execute();
+    };
+
 
     useEffect(() => {
-        let mounted = true;
-        let timer: ReturnType<typeof setInterval>;
-
-        const execute = async () => {
-            try {
-                const result = await fn();
-                if (mounted) {
-                    setData(result);
-                    setError(null);
-                    setLoading(false);
-                }
-            } catch (err) {
-                if (mounted) {
-                    setError(err instanceof Error ? err : new Error(String(err)));
-                    setLoading(false);
-                }
-            }
-        };
-
+        mountedRef.current = true;
         setLoading(true);
         execute();
 
-        timer = setInterval(execute, interval);
+        const timer = setInterval(() => {
+            if (!pausedRef.current) {
+                execute();
+            }
+        }, interval);
 
         return () => {
-            mounted = false;
+            mountedRef.current = false;
             clearInterval(timer);
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [interval, ...deps]);
 
-    return { data, error, loading };
+    return { data, error, loading, paused, pause, resume, refresh };
 }


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

Added pause, resume, refresh, and paused to usePolling in @termuijs/data. The interval keeps ticking internally — pause sets a ref flag that skips execution on each tick, so resume re-syncs on the next natural tick without restarting the timer or resetting state. All existing call sites are unaffected since { data, error, loading } destructuring ignores the new fields.

## Related Issue

Closes #767 

## Which package(s)?

@termuijs/data
## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [X ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [ ] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [X ] Tests pass locally: `bun vitest run`
- [X] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [X ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [X ] Your PR title follows `type: short description`.
- [X ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [X ] No new `any` types without an inline comment explaining why.
- [X ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [ X] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/048e6a97-baaf-4a03-b6e5-bdfc6c38e173`

## Screenshots / Recordings (UI changes)

Not applicable — no UI changes.

## Notes for the Reviewer

Three implementation decisions worth noting:
pausedRef instead of paused state in the interval callback — the setInterval closure reads the ref, so pause() takes effect on the very next tick with no timer restart.
fnRef for the async function — fn is stored in a ref so refresh() always calls the latest version without fn needing to be in the deps array, preventing stale closure bugs when fn is defined inline at the call site.
execute defined outside useEffect — allows refresh to call it directly. The mountedRef guard ensures neither the interval path nor refresh sets state after unmount.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Polling hook now supports pause and resume operations to control when data is fetched
  * Manual refresh capability allows immediate data updates independent of the configured polling interval
  * Pause state indicator provides visibility into current polling status for better UI control
  * Improved stability and memory management during component lifecycle transitions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->