### PR TITLE
fix: correctly parse split CSI escape sequences

### DIFF
--- a/packages/core/src/input/InputParser.test.ts
+++ b/packages/core/src/input/InputParser.test.ts
@@ -111,6 +111,22 @@ describe('InputParser', () => {
         expect(handler).toHaveBeenCalledWith(expect.objectContaining({ key: 'x', alt: true }));
     });
 
+    it('does not emit Alt+[ for incomplete CSI prefix', () => {
+        const { stdin, handler } = createParser();
+        sendKey(stdin, '\x1b[');
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('parses split Arrow Up escape sequence arriving in chunks', () => {
+        const { stdin, handler } = createParser();
+        sendKey(stdin, Buffer.from([0x1b]));
+        sendKey(stdin, '[');
+        sendKey(stdin, 'A');
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(handler).toHaveBeenCalledWith(expect.objectContaining({ key: 'up' }));
+    });
+
     it('resolves cursor position reports with correct row/col', async () => {
         const stdin = createMockStdin();
         const parser = new InputParser(stdin);

--- a/packages/core/src/input/InputParser.ts
+++ b/packages/core/src/input/InputParser.ts
@@ -128,7 +128,7 @@ export class InputParser {
                 clearTimeout(this._escapeTimeout);
                 this._escapeTimeout = null;
             }
-            this._tryParseEscape(data);
+            this._tryParseEscape();
             return;
         }
 
@@ -153,7 +153,7 @@ export class InputParser {
 
         if (str.startsWith('\x1b')) {
             this._escapeBuffer = data;
-            this._tryParseEscape(data);
+            this._tryParseEscape();
             return;
         }
 
@@ -204,7 +204,7 @@ export class InputParser {
     /**
      * Try to parse buffered escape sequence.
      */
-    private _tryParseEscape(rawData: Buffer): void {
+    private _tryParseEscape(): void {
         const seq = this._escapeBuffer.toString('utf8');
 
         // Check for mouse event first
@@ -268,7 +268,7 @@ export class InputParser {
 
             this._events.emit('key', createKeyEvent({
                 key: cleanKey,
-                raw: rawData,
+                raw: this._escapeBuffer,
                 ctrl: isCtrl,
                 alt: isAlt,
                 shift: isShift,
@@ -278,11 +278,16 @@ export class InputParser {
         }
 
         // Alt+key: ESC followed by a regular character
-        if (seq.length === 2 && seq[0] === '\x1b') {
+        if (
+            seq.length === 2 &&
+            seq[0] === '\x1b' &&
+            seq[1] !== '[' &&
+            seq[1] !== 'O'
+        ) {
             const ch = seq[1];
             this._events.emit('key', createKeyEvent({
                 key: ch,
-                raw: rawData,
+                raw: this._escapeBuffer,
                 ctrl: false,
                 alt: true,
                 shift: ch !== ch.toLowerCase() && ch === ch.toUpperCase(),


### PR DESCRIPTION
## Description

This PR fixes a bug in the InputParser where CSI/SS3 escape sequences arriving in multiple stdin chunks could be incorrectly interpreted as Alt+key events.

Previously, a split Arrow Up sequence (`ESC`, `[`, `A`) could be parsed as `Alt+[` followed by `A` instead of a single `up` key event. This change ensures CSI (`ESC [`) and SS3 (`ESC O`) prefixes are not prematurely treated as completed Alt-key sequences and adds a regression test covering chunked escape-sequence delivery.

## Related Issue

Closes #1063 

## Which package(s)?

@termuijs/core

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)
* [x] 🧪 Tests (`type:testing`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

The fix is intentionally narrow and preserves existing Alt+key behavior while preventing premature parsing of partial CSI/SS3 escape-sequence prefixes.

A regression test was added to verify that a split Arrow Up sequence arriving as separate chunks (`ESC`, `[`, `A`) emits a single `up` key event.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of split escape sequences so keys are recognized when input arrives in multiple chunks.
  * Refined Alt+key detection to avoid treating certain multi-byte escape patterns as Alt combinations.

* **Tests**
  * Added tests ensuring arrow key and other escape sequences emit a single, correct key event when input is split across chunks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->