### PR TITLE
fix: resolve windows path validation failure in create-termui-app

### DIFF
--- a/packages/create-termui-app/src/validate.test.ts
+++ b/packages/create-termui-app/src/validate.test.ts
@@ -180,4 +180,19 @@ describe("validateResolvedPath", () => {
         expect(() => validateResolvedPath(cwd, "project-1")).not.toThrow();
         expect(() => validateResolvedPath(cwd, "my_app")).not.toThrow();
     });
+
+    it("rejects traversal escaping cwd", () => {
+        expect(() => validateResolvedPath(cwd, "../evil")).toThrow(
+            /escapes current working directory/
+        );
+        expect(() => validateResolvedPath(cwd, "../../hack")).toThrow(
+            /escapes current working directory/
+        );
+    });
+
+    it("rejects absolute paths", () => {
+        expect(() => validateResolvedPath(cwd, "/etc/passwd")).toThrow(
+            /escapes current working directory/
+        );
+    });
 });

--- a/packages/create-termui-app/src/validate.ts
+++ b/packages/create-termui-app/src/validate.ts
@@ -2,7 +2,7 @@
 // Project name validation to prevent path traversal attacks
 // ─────────────────────────────────────────────────────
 
-import { resolve } from "node:path";
+import { resolve, relative, isAbsolute, sep } from "node:path";
 
 // Regex allows: lowercase letters, numbers, hyphens, underscores
 // Must start with a lowercase letter or number
@@ -65,11 +65,10 @@ export function validateResolvedPath(cwd: string, projectName: string): void {
     const resolved = resolve(cwd, projectName);
     const cwdNorm = resolve(cwd);
 
-    if (
-        resolved !== cwdNorm &&
-        !resolved.startsWith(cwdNorm + "\\") &&
-        !resolved.startsWith(cwdNorm + "/")
-    ) {
+    const rel = relative(cwdNorm, resolved);
+
+    // If relative path starts with '..' or is absolute, it escapes cwd
+    if (rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
         throw new Error(
             "Security check failed: resolved path escapes current working directory"
         );


### PR DESCRIPTION
## Commit Message

- Replace hardcoded forward slashes with platform-agnostic path.sep in validation logic.
- Fix security check failures on Windows when validating file paths.

Closes #1069

<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

<!-- What does this PR do? 1 to 3 sentences. -->
This PR fixes a bug in `create-termui-app` where the path validation security check would fail on Windows due to hardcoded forward slashes. By using `path.sep`, the validation logic now correctly handles both POSIX and Windows-style paths.

## Related Issue

[bug: security check fails on Windows in create-termui-app #1069](https://github.com/Karanjot786/TermUI/issues/1069)

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #1069

## Which package(s)?

<!-- Example: @termuijs/core, @termuijs/widgets, website. -->
@termuijs/create-termui-app

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/16Rohan`

## Screenshots / Recordings (UI changes)

None.

## Notes for the Reviewer

The fix was verified on Windows by running the validation logic against paths containing both `\` and `/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Strengthened path validation so inputs that escape the current working directory are more reliably rejected across platforms.

* **Tests**
  * Added negative tests to confirm invalid relative and absolute paths are rejected, while existing valid-name tests remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->