### PR TITLE
feature: support vim and emacs keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ TERMUI_KEYBINDINGS=emacs
 import { caps } from '@termuijs/core'
 
 const bullet = caps.unicode ? '●' : '*'
-console.log(caps.keybindingMode) // 'default', 'vim', or 'emacs'
+// caps.keybindingMode → "default", "vim", or "emacs"
 ```
 
 ### Notifications

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ import { ErrorBoundary } from '@termuijs/jsx'
 
 ### Capability flags
 
-TermUI checks the terminal environment before rendering unicode or animations. Set environment variables to get ASCII output in CI or reduced-motion output for accessibility.
+TermUI checks the terminal environment before rendering unicode or animations. Set environment variables to get ASCII output in CI or reduced-motion output for accessibility. You can also configure standard keyboard navigation schemes.
 
 ```bash
 NO_UNICODE=1  # ASCII fallbacks for all widgets
@@ -208,10 +208,17 @@ NO_MOTION=1   # Skip all animations; static output
 NO_COLOR=1    # Disable ANSI color sequences
 ```
 
+Configure global navigation modes (`default` arrow keys, `vim` j/k/h/l, or `emacs` ctrl+n/p):
+```bash
+TERMUI_KEYBINDINGS=vim
+TERMUI_KEYBINDINGS=emacs
+```
+
 ```typescript
 import { caps } from '@termuijs/core'
 
 const bullet = caps.unicode ? '●' : '*'
+console.log(caps.keybindingMode) // 'default', 'vim', or 'emacs'
 ```
 
 ### Notifications

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,7 +19,7 @@ export { mergeBorders } from './renderer/border-merge.js';
 
 // ── Input ─────────────────────────────────────────────
 export { InputParser } from './input/InputParser.js';
-export { ESCAPE_SEQUENCES, CTRL_KEYS, SPECIAL_KEYS } from './input/KeyMap.js';
+export { ESCAPE_SEQUENCES, CTRL_KEYS, SPECIAL_KEYS, normalizeNavigationKey } from './input/KeyMap.js';
 export { parseMouseEvent, isMouseSequence } from './input/MouseParser.js';
 export { MouseGestures } from './input/MouseGestures.js';
 export type { MouseGesturesOptions } from './input/MouseGestures.js';

--- a/packages/core/src/input/KeyMap.test.ts
+++ b/packages/core/src/input/KeyMap.test.ts
@@ -2,8 +2,9 @@
 // @termuijs/core — Tests for KeyMap constants
 // ─────────────────────────────────────────────────────
 
-import { describe, it, expect } from 'vitest';
-import { ESCAPE_SEQUENCES, CTRL_KEYS, SPECIAL_KEYS } from './KeyMap.js';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ESCAPE_SEQUENCES, CTRL_KEYS, SPECIAL_KEYS, normalizeNavigationKey } from './KeyMap.js';
+import { caps } from '../terminal/env-caps.js';
 
 describe('KeyMap constants', () => {
     it('ESCAPE_SEQUENCES contains correct mappings', () => {
@@ -62,5 +63,43 @@ describe('KeyMap constants', () => {
         expect(SPECIAL_KEYS[0x0D]).toBe('enter');
         expect(SPECIAL_KEYS[0x0A]).toBe('enter');
         expect(SPECIAL_KEYS[0x20]).toBe('space');
+    });
+});
+
+describe('normalizeNavigationKey', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('returns unmodified keys by default', () => {
+        vi.spyOn(caps, 'keybindingMode', 'get').mockReturnValue('default');
+
+        expect(normalizeNavigationKey('up')).toBe('up');
+        expect(normalizeNavigationKey('j')).toBe('j');
+        expect(normalizeNavigationKey('ctrl+n')).toBe('ctrl+n');
+    });
+
+    it('maps vim keys to directions when in vim mode', () => {
+        vi.spyOn(caps, 'keybindingMode', 'get').mockReturnValue('vim');
+
+        expect(normalizeNavigationKey('k')).toBe('up');
+        expect(normalizeNavigationKey('j')).toBe('down');
+        expect(normalizeNavigationKey('h')).toBe('left');
+        expect(normalizeNavigationKey('l')).toBe('right');
+
+        // Unrelated keys should remain unchanged
+        expect(normalizeNavigationKey('enter')).toBe('enter');
+        expect(normalizeNavigationKey('up')).toBe('up');
+    });
+
+    it('maps emacs keys to directions when in emacs mode', () => {
+        vi.spyOn(caps, 'keybindingMode', 'get').mockReturnValue('emacs');
+
+        expect(normalizeNavigationKey('ctrl+p')).toBe('up');
+        expect(normalizeNavigationKey('ctrl+n')).toBe('down');
+
+        // Unrelated keys should remain unchanged
+        expect(normalizeNavigationKey('j')).toBe('j');
+        expect(normalizeNavigationKey('up')).toBe('up');
     });
 });

--- a/packages/core/src/input/KeyMap.ts
+++ b/packages/core/src/input/KeyMap.ts
@@ -2,6 +2,8 @@
 // @termuijs/core — Key mapping constants
 // ─────────────────────────────────────────────────────
 
+import { caps } from '../terminal/env-caps.js';
+
 /**
  * Maps raw byte sequences to human-readable key names.
  * These are standard VT100/xterm escape sequences.
@@ -88,3 +90,27 @@ export const SPECIAL_KEYS: Record<number, string> = {
     0x0A: 'enter',
     0x20: 'space',
 };
+
+/**
+ * Normalizes navigation key names based on the active keybinding mode.
+ * Useful for mapping vim (j/k/h/l) or emacs (ctrl+n/ctrl+p) keys to standard
+ * arrow key intents (up/down/left/right).
+ * 
+ * @param keyName The raw key name from KeyEvent.name
+ * @returns The normalized directional key name, or the original key name
+ */
+export function normalizeNavigationKey(keyName: string): string {
+    const mode = caps.keybindingMode;
+    
+    if (mode === 'vim') {
+        if (keyName === 'k') return 'up';
+        if (keyName === 'j') return 'down';
+        if (keyName === 'h') return 'left';
+        if (keyName === 'l') return 'right';
+    } else if (mode === 'emacs') {
+        if (keyName === 'ctrl+p') return 'up';
+        if (keyName === 'ctrl+n') return 'down';
+    }
+    
+    return keyName;
+}

--- a/packages/core/src/terminal/env-caps.ts
+++ b/packages/core/src/terminal/env-caps.ts
@@ -17,6 +17,11 @@ export const caps = {
 
     return 'dark';
   },
+  get keybindingMode(): 'vim' | 'emacs' | 'default' {
+    const mode = process.env.TERMUI_KEYBINDINGS;
+    if (mode === 'vim' || mode === 'emacs') return mode;
+    return 'default';
+  },
 } as const;
 
 /**

--- a/packages/jsx/src/hooks/useKeyboardNavigation.ts
+++ b/packages/jsx/src/hooks/useKeyboardNavigation.ts
@@ -15,6 +15,7 @@
 // ─────────────────────────────────────────────────────
 
 import { useState, useInput } from '../hooks.js';
+import { normalizeNavigationKey } from '@termuijs/core';
 
 export interface KeyboardNavigationOptions {
     /** Total number of items in the list */
@@ -86,7 +87,7 @@ export function useKeyboardNavigation({
             });
         };
 
-        switch (key) {
+        switch (normalizeNavigationKey(key)) {
             case 'up':
                 move(-1);
                 break;

--- a/packages/widgets/src/display/Tree.test.ts
+++ b/packages/widgets/src/display/Tree.test.ts
@@ -2,9 +2,9 @@
 // @termuijs/widgets — Tests for Tree widget
 // ─────────────────────────────────────────────────────
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Tree, type TreeNode } from './Tree.js';
-import { Screen } from '@termuijs/core';
+import { Screen, caps } from '@termuijs/core';
 
 // ── Helpers ──────────────────────────────────────────
 
@@ -154,11 +154,13 @@ describe('Tree', () => {
         });
 
         it('j moves cursor down (vim keybinding)', () => {
+            vi.spyOn(caps, 'keybindingMode', 'get').mockReturnValue('vim');
             const nodes = makeNodes();
             const tree = makeTree(nodes);
 
             tree.handleKey('j');
             expect(tree.selectedIndex).toBe(1);
+            vi.restoreAllMocks();
         });
 
         it('up moves cursor up', () => {
@@ -171,12 +173,14 @@ describe('Tree', () => {
         });
 
         it('k moves cursor up (vim keybinding)', () => {
+            vi.spyOn(caps, 'keybindingMode', 'get').mockReturnValue('vim');
             const nodes = makeNodes();
             const tree = makeTree(nodes);
 
             tree.handleKey('j'); // → 1
             tree.handleKey('k'); // → 0
             expect(tree.selectedIndex).toBe(0);
+            vi.restoreAllMocks();
         });
 
         it('up at first item is a no-op', () => {
@@ -207,12 +211,14 @@ describe('Tree', () => {
         });
 
         it('l expands collapsed parent (vim keybinding)', () => {
+            vi.spyOn(caps, 'keybindingMode', 'get').mockReturnValue('vim');
             const nodes = makeNodes();
             const tree = makeTree(nodes);
 
             tree.handleKey('l');
 
             expect(nodes[0].expanded).toBe(true);
+            vi.restoreAllMocks();
         });
 
         it('right on already-expanded parent is a no-op', () => {
@@ -242,6 +248,7 @@ describe('Tree', () => {
         });
 
         it('h collapses expanded parent (vim keybinding)', () => {
+            vi.spyOn(caps, 'keybindingMode', 'get').mockReturnValue('vim');
             const nodes = makeNodes();
             nodes[0].expanded = true;
             const tree = makeTree(nodes);
@@ -249,6 +256,7 @@ describe('Tree', () => {
             tree.handleKey('h');
 
             expect(nodes[0].expanded).toBe(false);
+            vi.restoreAllMocks();
         });
 
         it('left on collapsed node moves to parent', () => {

--- a/packages/widgets/src/display/Tree.ts
+++ b/packages/widgets/src/display/Tree.ts
@@ -9,6 +9,7 @@ import {
     truncate,
     stringWidth,
     caps,
+    normalizeNavigationKey,
 } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
@@ -169,16 +170,14 @@ export class Tree extends Widget {
      * when this widget is focused.
      */
     handleKey(key: string): void {
-        const normalized = key.toLowerCase();
+        const normalized = normalizeNavigationKey(key.toLowerCase());
         switch (normalized) {
             case 'arrowup':
             case 'up':
-            case 'k':
                 this.movePrev();
                 break;
             case 'arrowdown':
             case 'down':
-            case 'j':
                 this.moveNext();
                 break;
             case 'enter':
@@ -188,12 +187,10 @@ export class Tree extends Widget {
                 break;
             case 'arrowleft':
             case 'left':
-            case 'h':
                 this.collapse();
                 break;
             case 'arrowright':
             case 'right':
-            case 'l':
                 this.expand();
                 break;
             case 'home':

--- a/packages/widgets/src/layout/ScrollView.test.ts
+++ b/packages/widgets/src/layout/ScrollView.test.ts
@@ -2,9 +2,9 @@
 // @termuijs/widgets — Tests for ScrollView widget
 // ─────────────────────────────────────────────────────
 
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { ScrollView } from "./ScrollView.js";
-import { Screen, type KeyEvent } from "@termuijs/core";
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ScrollView } from './ScrollView.js';
+import { Screen, caps, type KeyEvent } from '@termuijs/core';
 
 const key = (k: string): KeyEvent => ({
     key: k,
@@ -203,5 +203,36 @@ describe("ScrollView", () => {
         view.setContentHeight(10);
     
         expect(view.isDirty).toBe(false);
+    });
+
+    describe('keybindingMode integration', () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it('down scrolls down by 1 in vim mode using j', () => {
+            vi.spyOn(caps, 'keybindingMode', 'get').mockReturnValue('vim');
+            const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
+            sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
+            sv.handleKey(key('j'));
+            expect(sv.scrollOffset).toBe(1);
+        });
+
+        it('up scrolls up by 1 in emacs mode using ctrl+p', () => {
+            vi.spyOn(caps, 'keybindingMode', 'get').mockReturnValue('emacs');
+            const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
+            sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
+            sv.scrollBy(5);
+            sv.handleKey(key('ctrl+p'));
+            expect(sv.scrollOffset).toBe(4);
+        });
+
+        it('j does not scroll down in default mode', () => {
+            vi.spyOn(caps, 'keybindingMode', 'get').mockReturnValue('default');
+            const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
+            sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
+            sv.handleKey(key('j'));
+            expect(sv.scrollOffset).toBe(0);
+        });
     });
 });

--- a/packages/widgets/src/layout/ScrollView.ts
+++ b/packages/widgets/src/layout/ScrollView.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets — ScrollView widget
 // ─────────────────────────────────────────────────────
 
-import { type Screen, type Style, styleToCellAttrs, type KeyEvent } from '@termuijs/core';
+import { type Screen, type Style, styleToCellAttrs, type KeyEvent, normalizeNavigationKey } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 import { ScrollAcceleration } from './scroll-acceleration.js';
 
@@ -89,7 +89,7 @@ export class ScrollView extends Widget {
 }
     /** Handle keyboard navigation */
     handleKey(event: KeyEvent): void {
-        switch (event.key) {
+        switch (normalizeNavigationKey(event.key)) {
             case 'up':       this.scrollBy(-this.getScrollDelta(1)); break;
             case 'down':     this.scrollBy(this.getScrollDelta(1)); break;
             case 'pageup':   this.scrollBy(-this.getScrollDelta(Math.max(1, this._rect.height - 1))); break;


### PR DESCRIPTION
## Description

This PR adds support for configurable keyboard navigation modes through the `TERMUI_KEYBINDINGS` environment variable. A new `caps.keybindingMode` capability has been introduced to detect and expose the active keybinding mode (`default`, `vim`, or `emacs`). A centralized `normalizeNavigationKey()` helper was added to normalize navigation intent across widgets, along with unit and integration tests. Foundational navigation components were updated to respect the configured keybinding mode, and README documentation was added with usage examples.

## Related Issue

Closes #61

## Which package(s)?

@termuijs/core, @termuijs/widgets, @termuijs/jsx, README

## Type of Change

* [x] ✨ Feature (`type:feature`)
* [x] 🧪 Tests (`type:testing`)
* [x] 📝 Docs (`type:docs`)
* [x] ♻️ Refactor (`type:refactor`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read `CONTRIBUTING.md`.
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if applicable).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.

Your GSSoC profile: `https://gssoc.girlscript.org/profile/asthasingh011`

## Screenshots / Recordings (UI changes)

No visual UI changes. This PR introduces keyboard navigation mode support and related infrastructure.

## Notes for the Reviewer

This implementation introduces a centralized navigation-key normalization layer to avoid duplicating vim/emacs mapping logic across widgets. The PR includes support for `TERMUI_KEYBINDINGS=vim` and `TERMUI_KEYBINDINGS=emacs`, falls back safely to default arrow-key navigation, adds tests covering all supported modes, and documents the feature in the README. Core navigation integrations have been updated, and the implementation is designed to be easily extended to additional widgets if broader adoption is desired.


## Notes for the Reviewer

This implementation introduces a centralized navigation-key normalization layer to support configurable keyboard navigation modes through `TERMUI_KEYBINDINGS`. The PR adds `caps.keybindingMode`, a reusable `normalizeNavigationKey()` helper, unit and integration tests, foundational navigation integrations, and README documentation.

While implementing the feature, I identified additional widgets with independent keyboard-navigation handling. The current implementation updates the shared navigation infrastructure and core navigation components, establishing the pattern for broader adoption across widgets. I would appreciate guidance on whether the current scope is sufficient for Issue #61 or if a repository-wide migration of all navigation widgets is preferred.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added vim and emacs keybinding modes for terminal navigation (configurable via TERMUI_KEYBINDINGS); navigation keys are normalized across the UI.

* **Documentation**
  * Expanded README: explains capability flags for unicode/motion/color, documents TERMUI_KEYBINDINGS with vim/emacs examples, and updates the TypeScript example.

* **Tests**
  * Added/updated tests validating keybinding-mode normalization and integration across navigation and scrolling behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->