### PR TITLE
perf(display): avoid redundant markDirty calls in Badge

### DIFF
--- a/packages/widgets/src/display/Badge.test.ts
+++ b/packages/widgets/src/display/Badge.test.ts
@@ -160,4 +160,23 @@ describe('Badge', () => {
             warnSpy.mockRestore();
         }
     });
+
+    it('does not mark dirty when text is unchanged', () => {
+        const badge = new Badge('same');
+    
+        badge.clearDirty();
+        badge.setText('same');
+    
+        expect(badge.isDirty).toBe(false);
+    });
+    
+    it('does not mark dirty when variant is unchanged', () => {
+        const badge = new Badge('ok', {}, { variant: 'success' });
+    
+        badge.clearDirty();
+        badge.setVariant('success');
+    
+        expect(badge.isDirty).toBe(false);
+    });
+
 });

--- a/packages/widgets/src/display/Badge.ts
+++ b/packages/widgets/src/display/Badge.ts
@@ -61,6 +61,7 @@ export class Badge extends Widget {
 
     /** Update the badge text. */
     setText(text: string): void {
+        if (text === this._text) return; 
         this._text = text;
         this.markDirty();
     }
@@ -72,6 +73,7 @@ export class Badge extends Widget {
 
     /** Update the badge variant. */
     setVariant(variant: BadgeVariant): void {
+        if (variant === this._variant) return;
         this._variant = variant;
         this.markDirty();
     }


### PR DESCRIPTION
## Description

Adds equality guards to `Badge` state mutators to avoid redundant `markDirty()` calls when the provided value is unchanged. Also adds regression tests covering unchanged text and variant updates to ensure unnecessary invalidation does not occur.

## Related Issue

Closes #1085

## Which package(s)?

@termuijs/widgets

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [ ] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [x] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

* Added equality guards in `setText()` and `setVariant()` to prevent unnecessary widget invalidation when values are unchanged.
* Added regression tests verifying that unchanged updates do not mark the widget dirty.
* Existing behavior for actual state changes remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The Badge is now smarter about unchanged updates: applying the same text or style no longer triggers unnecessary reflows or rerenders, improving UI responsiveness and rendering efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->