### PR TITLE
feat(store): add createLogger devtools middleware (#305)

### DIFF
--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -22,3 +22,6 @@ export type { SliceDef } from './slices.js';
 
 export { createHistoryStore } from './history.js'
 export type { TemporalHistory, TemporalStoreActions } from './history.js'
+
+export { createLogger } from './logger.js';
+export type { LoggerOptions } from './logger.js';

--- a/packages/store/src/logger.test.ts
+++ b/packages/store/src/logger.test.ts
@@ -10,7 +10,7 @@ afterEach(() => {
     vi.restoreAllMocks();
 });
 
-// ── Slice type helpers ─────────────────────────────────
+// ── Type helpers ───────────────────────────────────────
 
 type CounterState = {
     count: number;

--- a/packages/store/src/logger.test.ts
+++ b/packages/store/src/logger.test.ts
@@ -1,0 +1,179 @@
+// ─────────────────────────────────────────────────────
+// Tests — devtools logger middleware
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createStore } from './store.js';
+import { createLogger } from './logger.js';
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+// ── Helpers ────────────────────────────────────────────
+
+function makeCounter() {
+    return createStore(
+        (set) => ({
+            count: 0,
+            name:  'counter',
+            inc:   () => set((s) => ({ count: s.count + 1 })),
+            reset: () => set({ count: 0 }),
+        }),
+    );
+}
+
+// ── Tests ──────────────────────────────────────────────
+
+describe('createLogger', () => {
+    it('calls output with prev and next state lines on setState', () => {
+        const output = vi.fn();
+        const useStore = createStore(
+            (set) => ({ count: 0, inc: () => set((s) => ({ count: s.count + 1 })) }),
+            { middleware: [createLogger({ output })] },
+        );
+
+        useStore.getState().inc();
+
+        // At least a "prev" and "next" line
+        expect(output).toHaveBeenCalledTimes(3); // prev + next + diff
+        const lines: string[] = output.mock.calls.map((c) => c[0]);
+        expect(lines.some((l) => l.includes('prev'))).toBe(true);
+        expect(lines.some((l) => l.includes('next'))).toBe(true);
+    });
+
+    it('prev line contains the old state and next line contains the new state', () => {
+        const output = vi.fn();
+        const useStore = createStore(
+            (set) => ({ count: 0, inc: () => set((s) => ({ count: s.count + 1 })) }),
+            { middleware: [createLogger({ output })] },
+        );
+
+        useStore.getState().inc();
+
+        const lines: string[] = output.mock.calls.map((c) => c[0]);
+        const prevLine = lines.find((l) => l.includes('prev'))!;
+        const nextLine = lines.find((l) => l.includes('next'))!;
+
+        expect(prevLine).toContain('"count":0');
+        expect(nextLine).toContain('"count":1');
+    });
+
+    it('emits a diff line with from/to for changed keys', () => {
+        const output = vi.fn();
+        const useStore = createStore(
+            (set) => ({ count: 0, inc: () => set((s) => ({ count: s.count + 1 })) }),
+            { middleware: [createLogger({ output, diff: true })] },
+        );
+
+        useStore.getState().inc();
+
+        const lines: string[] = output.mock.calls.map((c) => c[0]);
+        const diffLine = lines.find((l) => l.includes('diff'));
+        expect(diffLine).toBeDefined();
+        expect(diffLine).toContain('"from":0');
+        expect(diffLine).toContain('"to":1');
+    });
+
+    it('suppresses diff line when diff: false', () => {
+        const output = vi.fn();
+        const useStore = createStore(
+            (set) => ({ count: 0, inc: () => set((s) => ({ count: s.count + 1 })) }),
+            { middleware: [createLogger({ output, diff: false })] },
+        );
+
+        useStore.getState().inc();
+
+        const lines: string[] = output.mock.calls.map((c) => c[0]);
+        expect(lines.some((l) => l.includes('diff'))).toBe(false);
+        // Still emits prev + next
+        expect(output).toHaveBeenCalledTimes(2);
+    });
+
+    it('prepends the name label when name option is provided', () => {
+        const output = vi.fn();
+        const useStore = createStore(
+            (set) => ({ x: 0, set: (v: number) => set({ x: v }) }),
+            { middleware: [createLogger({ output, name: 'myStore' })] },
+        );
+
+        useStore.getState().set(5);
+
+        const lines: string[] = output.mock.calls.map((c) => c[0]);
+        expect(lines.every((l) => l.startsWith('[myStore]'))).toBe(true);
+    });
+
+    it('emits no label when name is omitted', () => {
+        const output = vi.fn();
+        const useStore = createStore(
+            (set) => ({ x: 0, set: (v: number) => set({ x: v }) }),
+            { middleware: [createLogger({ output })] },
+        );
+
+        useStore.getState().set(3);
+
+        const lines: string[] = output.mock.calls.map((c) => c[0]);
+        expect(lines.every((l) => !l.startsWith('['))).toBe(true);
+    });
+
+    it('does not throw when update is an empty partial', () => {
+        const output = vi.fn();
+        const useStore = createStore(
+            () => ({ value: 42 }),
+            { middleware: [createLogger({ output })] },
+        );
+
+        // setState with no actual changes — still should not throw
+        expect(() => useStore.setState({})).not.toThrow();
+    });
+
+    it('diff is not emitted when no values actually changed (Object.is bail-out)', () => {
+        const output = vi.fn();
+        const useStore = createStore(
+            () => ({ value: 42 }),
+            { middleware: [createLogger({ output, diff: true })] },
+        );
+
+        // Same value — store's Object.is bail-out means setState won't notify,
+        // but the middleware still runs. Diff section should be empty.
+        useStore.setState({ value: 42 });
+
+        const lines: string[] = output.mock.calls.map((c) => c[0]);
+        // No diff line because no keys changed
+        expect(lines.some((l) => l.includes('diff'))).toBe(false);
+    });
+
+    it('works with multiple middleware in the chain', () => {
+        const outputA = vi.fn();
+        const outputB = vi.fn();
+
+        const useStore = createStore(
+            (set) => ({ n: 0, inc: () => set((s) => ({ n: s.n + 1 })) }),
+            {
+                middleware: [
+                    createLogger({ output: outputA, name: 'A' }),
+                    createLogger({ output: outputB, name: 'B' }),
+                ],
+            },
+        );
+
+        useStore.getState().inc();
+
+        expect(outputA).toHaveBeenCalled();
+        expect(outputB).toHaveBeenCalled();
+    });
+
+    it('each log line contains an ISO timestamp', () => {
+        const output = vi.fn();
+        const useStore = createStore(
+            (set) => ({ x: 0, set: (v: number) => set({ x: v }) }),
+            { middleware: [createLogger({ output })] },
+        );
+
+        useStore.getState().set(7);
+
+        const lines: string[] = output.mock.calls.map((c) => c[0]);
+        const isoPattern = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
+        expect(lines.every((l) => isoPattern.test(l))).toBe(true);
+    });
+});

--- a/packages/store/src/logger.test.ts
+++ b/packages/store/src/logger.test.ts
@@ -10,48 +10,62 @@ afterEach(() => {
     vi.restoreAllMocks();
 });
 
-// ── Helpers ────────────────────────────────────────────
+// ── Slice type helpers ─────────────────────────────────
 
-function makeCounter() {
-    return createStore(
-        (set) => ({
-            count: 0,
-            name:  'counter',
-            inc:   () => set((s) => ({ count: s.count + 1 })),
-            reset: () => set({ count: 0 }),
-        }),
-    );
-}
+type CounterState = {
+    count: number;
+    inc: () => void;
+};
+
+type LabelState = {
+    count: number;
+    label: string;
+    setLabel: (l: string) => void;
+};
+
+type ValueState = {
+    value: number;
+};
+
+type XState = {
+    x: number;
+    set: (v: number) => void;
+};
+
+type NState = {
+    n: number;
+    inc: () => void;
+};
 
 // ── Tests ──────────────────────────────────────────────
 
 describe('createLogger', () => {
     it('calls output with prev and next state lines on setState', () => {
         const output = vi.fn();
-        const useStore = createStore(
+        const useStore = createStore<CounterState>(
             (set) => ({ count: 0, inc: () => set((s) => ({ count: s.count + 1 })) }),
             { middleware: [createLogger({ output })] },
         );
 
         useStore.getState().inc();
 
-        // At least a "prev" and "next" line
-        expect(output).toHaveBeenCalledTimes(3); // prev + next + diff
-        const lines: string[] = output.mock.calls.map((c) => c[0]);
+        // prev + next + diff lines
+        expect(output).toHaveBeenCalledTimes(3);
+        const lines: string[] = output.mock.calls.map((c) => c[0] as string);
         expect(lines.some((l) => l.includes('prev'))).toBe(true);
         expect(lines.some((l) => l.includes('next'))).toBe(true);
     });
 
     it('prev line contains the old state and next line contains the new state', () => {
         const output = vi.fn();
-        const useStore = createStore(
+        const useStore = createStore<CounterState>(
             (set) => ({ count: 0, inc: () => set((s) => ({ count: s.count + 1 })) }),
             { middleware: [createLogger({ output })] },
         );
 
         useStore.getState().inc();
 
-        const lines: string[] = output.mock.calls.map((c) => c[0]);
+        const lines: string[] = output.mock.calls.map((c) => c[0] as string);
         const prevLine = lines.find((l) => l.includes('prev'))!;
         const nextLine = lines.find((l) => l.includes('next'))!;
 
@@ -61,14 +75,14 @@ describe('createLogger', () => {
 
     it('emits a diff line with from/to for changed keys', () => {
         const output = vi.fn();
-        const useStore = createStore(
+        const useStore = createStore<CounterState>(
             (set) => ({ count: 0, inc: () => set((s) => ({ count: s.count + 1 })) }),
             { middleware: [createLogger({ output, diff: true })] },
         );
 
         useStore.getState().inc();
 
-        const lines: string[] = output.mock.calls.map((c) => c[0]);
+        const lines: string[] = output.mock.calls.map((c) => c[0] as string);
         const diffLine = lines.find((l) => l.includes('diff'));
         expect(diffLine).toBeDefined();
         expect(diffLine).toContain('"from":0');
@@ -77,69 +91,66 @@ describe('createLogger', () => {
 
     it('suppresses diff line when diff: false', () => {
         const output = vi.fn();
-        const useStore = createStore(
+        const useStore = createStore<CounterState>(
             (set) => ({ count: 0, inc: () => set((s) => ({ count: s.count + 1 })) }),
             { middleware: [createLogger({ output, diff: false })] },
         );
 
         useStore.getState().inc();
 
-        const lines: string[] = output.mock.calls.map((c) => c[0]);
+        const lines: string[] = output.mock.calls.map((c) => c[0] as string);
         expect(lines.some((l) => l.includes('diff'))).toBe(false);
-        // Still emits prev + next
+        // Still emits prev + next only
         expect(output).toHaveBeenCalledTimes(2);
     });
 
     it('prepends the name label when name option is provided', () => {
         const output = vi.fn();
-        const useStore = createStore(
+        const useStore = createStore<XState>(
             (set) => ({ x: 0, set: (v: number) => set({ x: v }) }),
             { middleware: [createLogger({ output, name: 'myStore' })] },
         );
 
         useStore.getState().set(5);
 
-        const lines: string[] = output.mock.calls.map((c) => c[0]);
+        const lines: string[] = output.mock.calls.map((c) => c[0] as string);
         expect(lines.every((l) => l.startsWith('[myStore]'))).toBe(true);
     });
 
     it('emits no label when name is omitted', () => {
         const output = vi.fn();
-        const useStore = createStore(
+        const useStore = createStore<XState>(
             (set) => ({ x: 0, set: (v: number) => set({ x: v }) }),
             { middleware: [createLogger({ output })] },
         );
 
         useStore.getState().set(3);
 
-        const lines: string[] = output.mock.calls.map((c) => c[0]);
+        const lines: string[] = output.mock.calls.map((c) => c[0] as string);
         expect(lines.every((l) => !l.startsWith('['))).toBe(true);
     });
 
     it('does not throw when update is an empty partial', () => {
         const output = vi.fn();
-        const useStore = createStore(
+        const useStore = createStore<ValueState>(
             () => ({ value: 42 }),
             { middleware: [createLogger({ output })] },
         );
 
-        // setState with no actual changes — still should not throw
         expect(() => useStore.setState({})).not.toThrow();
     });
 
     it('diff is not emitted when no values actually changed (Object.is bail-out)', () => {
         const output = vi.fn();
-        const useStore = createStore(
+        const useStore = createStore<ValueState>(
             () => ({ value: 42 }),
             { middleware: [createLogger({ output, diff: true })] },
         );
 
-        // Same value — store's Object.is bail-out means setState won't notify,
-        // but the middleware still runs. Diff section should be empty.
+        // Same value — Object.is means no key in the diff changed
         useStore.setState({ value: 42 });
 
-        const lines: string[] = output.mock.calls.map((c) => c[0]);
-        // No diff line because no keys changed
+        const lines: string[] = output.mock.calls.map((c) => c[0] as string);
         expect(lines.some((l) => l.includes('diff'))).toBe(false);
     });
 
@@ -147,7 +158,7 @@ describe('createLogger', () => {
         const outputA = vi.fn();
         const outputB = vi.fn();
 
-        const useStore = createStore(
+        const useStore = createStore<NState>(
             (set) => ({ n: 0, inc: () => set((s) => ({ n: s.n + 1 })) }),
             {
                 middleware: [
@@ -165,14 +176,14 @@ describe('createLogger', () => {
 
     it('each log line contains an ISO timestamp', () => {
         const output = vi.fn();
-        const useStore = createStore(
+        const useStore = createStore<XState>(
             (set) => ({ x: 0, set: (v: number) => set({ x: v }) }),
             { middleware: [createLogger({ output })] },
         );
 
         useStore.getState().set(7);
 
-        const lines: string[] = output.mock.calls.map((c) => c[0]);
+        const lines: string[] = output.mock.calls.map((c) => c[0] as string);
         const isoPattern = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
         expect(lines.every((l) => isoPattern.test(l))).toBe(true);
     });

--- a/packages/store/src/logger.ts
+++ b/packages/store/src/logger.ts
@@ -1,13 +1,22 @@
 // ─────────────────────────────────────────────────────
 // @termuijs/store — Devtools Logger Middleware
 //
-// A pluggable action logger that records state transitions
-// and key-level diffs to a configurable output sink.
+// Provides two exports:
 //
-// Usage:
+//   logger        — drop-in middleware constant; logs prev/next state
+//                   to the console. Intended for devtools use only —
+//                   do not enable in production terminal apps.
+//
+//   createLogger  — factory for a configurable logger: custom output
+//                   sink, optional per-key diff, optional store label.
+//
+// Usage (simple):
+//   import { createStore, logger } from '@termuijs/store';
+//   const useStore = createStore(creator, { middleware: [logger] });
+//
+// Usage (configurable):
 //   import { createStore } from '@termuijs/store';
 //   import { createLogger } from '@termuijs/store';
-//
 //   const useStore = createStore(creator, {
 //       middleware: [createLogger({ name: 'counter', diff: true })],
 //   });
@@ -23,8 +32,8 @@ import type { Middleware } from './store.js';
 export interface LoggerOptions {
     /**
      * Custom output sink — receives one formatted line at a time.
-     * Defaults to appending to `<tmpdir>/termuijs-store.log` so
-     * the terminal display is never polluted (no console.log in UI code).
+     * Defaults to appending to `<tmpdir>/termuijs-store.log`.
+     * Pass `output: (msg) => console.log(msg)` to redirect to the console.
      */
     output?: (message: string) => void;
 
@@ -41,7 +50,28 @@ export interface LoggerOptions {
     name?: string;
 }
 
-// ── Default output sink ────────────────────────────────
+// ── Simple logger constant ─────────────────────────────
+
+/**
+ * Drop-in logger middleware. Logs the previous and next state to the
+ * console on every `setState` call. Intended for devtools / debugging
+ * only — remove from production builds.
+ *
+ * ```typescript
+ * const useStore = createStore(creator, { middleware: [logger] });
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const logger: Middleware<any> = (prevState, update, next): void => {
+    // console.log is intentional here — this is a devtools-only middleware
+    // eslint-disable-next-line no-console
+    console.log('Previous State:', prevState);
+    const nextState = next(update);
+    // eslint-disable-next-line no-console
+    console.log('Next State:', nextState);
+};
+
+// ── Default output sink for createLogger ──────────────
 
 function defaultOutput(message: string): void {
     const logFile = path.join(os.tmpdir(), 'termuijs-store.log');
@@ -52,10 +82,11 @@ function defaultOutput(message: string): void {
     }
 }
 
-// ── Factory ────────────────────────────────────────────
+// ── Configurable logger factory ────────────────────────
 
 /**
- * createLogger — produce a store middleware that logs state transitions.
+ * createLogger — produce a store middleware that logs state transitions
+ * to a configurable output sink.
  *
  * ```typescript
  * const useStore = createStore(creator, {
@@ -65,17 +96,15 @@ function defaultOutput(message: string): void {
  * });
  * ```
  *
- * Every `setState` call emits three lines (when diff is enabled):
- *   `[label] <iso-timestamp> action  prev: {...}`
- *   `[label] <iso-timestamp> action  next: {...}`
- *   `[label] <iso-timestamp> diff    { key: { from: <old>, to: <new> } }`
- *
- * With `diff: false` only the prev/next lines are emitted.
+ * Every `setState` call emits two or three lines:
+ *   `[label] <iso-timestamp> prev   {...}`
+ *   `[label] <iso-timestamp> next   {...}`
+ *   `[label] <iso-timestamp> diff   { key: { from: <old>, to: <new> } }`  ← when diff: true
  */
 export function createLogger<T extends object>(options?: LoggerOptions): Middleware<T> {
-    const write   = options?.output ?? defaultOutput;
+    const write    = options?.output ?? defaultOutput;
     const showDiff = options?.diff ?? true;
-    const prefix  = options?.name ? `[${options.name}] ` : '';
+    const prefix   = options?.name ? `[${options.name}] ` : '';
 
     return (prevState, update, next): void => {
         const nextState = next(update);

--- a/packages/store/src/logger.ts
+++ b/packages/store/src/logger.ts
@@ -3,9 +3,8 @@
 //
 // Provides two exports:
 //
-//   logger        — drop-in middleware constant; logs prev/next state
-//                   to the console. Intended for devtools use only —
-//                   do not enable in production terminal apps.
+//   logger        — drop-in middleware constant; logs state transitions
+//                   to the default file sink (no console.log).
 //
 //   createLogger  — factory for a configurable logger: custom output
 //                   sink, optional per-key diff, optional store label.
@@ -15,8 +14,7 @@
 //   const useStore = createStore(creator, { middleware: [logger] });
 //
 // Usage (configurable):
-//   import { createStore } from '@termuijs/store';
-//   import { createLogger } from '@termuijs/store';
+//   import { createStore, createLogger } from '@termuijs/store';
 //   const useStore = createStore(creator, {
 //       middleware: [createLogger({ name: 'counter', diff: true })],
 //   });
@@ -33,7 +31,7 @@ export interface LoggerOptions {
     /**
      * Custom output sink — receives one formatted line at a time.
      * Defaults to appending to `<tmpdir>/termuijs-store.log`.
-     * Pass `output: (msg) => console.log(msg)` to redirect to the console.
+     * Example: `output: (msg) => process.stderr.write(msg + '\n')`
      */
     output?: (message: string) => void;
 
@@ -50,28 +48,7 @@ export interface LoggerOptions {
     name?: string;
 }
 
-// ── Simple logger constant ─────────────────────────────
-
-/**
- * Drop-in logger middleware. Logs the previous and next state to the
- * console on every `setState` call. Intended for devtools / debugging
- * only — remove from production builds.
- *
- * ```typescript
- * const useStore = createStore(creator, { middleware: [logger] });
- * ```
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const logger: Middleware<any> = (prevState, update, next): void => {
-    // console.log is intentional here — this is a devtools-only middleware
-    // eslint-disable-next-line no-console
-    console.log('Previous State:', prevState);
-    const nextState = next(update);
-    // eslint-disable-next-line no-console
-    console.log('Next State:', nextState);
-};
-
-// ── Default output sink for createLogger ──────────────
+// ── Default output sink ────────────────────────────────
 
 function defaultOutput(message: string): void {
     const logFile = path.join(os.tmpdir(), 'termuijs-store.log');
@@ -114,16 +91,20 @@ export function createLogger<T extends object>(options?: LoggerOptions): Middlew
         write(`${prefix}${ts} next   ${JSON.stringify(nextState)}`);
 
         if (showDiff) {
+            // Cast narrows Object.keys(string[]) to actual keys of T for safe indexed access
             const changedKeys = (Object.keys(update) as (keyof T)[]).filter(
+                // nextState is the value returned by next(update) in this chain — safe to treat as T
                 (k) => !Object.is(prevState[k], (nextState as T)[k]),
             );
 
             if (changedKeys.length > 0) {
+                // any required: state values are heterogeneous and cannot be statically narrowed
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 const diffObj: Record<string, { from: any; to: any }> = {};
                 for (const k of changedKeys) {
                     diffObj[k as string] = {
                         from: prevState[k],
+                        // nextState asserted as T to allow indexing with keyof T safely
                         to:   (nextState as T)[k],
                     };
                 }
@@ -132,3 +113,18 @@ export function createLogger<T extends object>(options?: LoggerOptions): Middlew
         }
     };
 }
+
+// ── Simple logger constant ─────────────────────────────
+
+/**
+ * Drop-in logger middleware. Logs the previous and next state on every
+ * `setState` call using the default file sink (`<tmpdir>/termuijs-store.log`).
+ * Pass a custom `output` via `createLogger` to redirect to a different sink.
+ *
+ * ```typescript
+ * const useStore = createStore(creator, { middleware: [logger] });
+ * ```
+ */
+// any required: logger must accept arbitrary store shapes across all generic consumers
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const logger: Middleware<any> = createLogger();

--- a/packages/store/src/logger.ts
+++ b/packages/store/src/logger.ts
@@ -1,0 +1,105 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/store — Devtools Logger Middleware
+//
+// A pluggable action logger that records state transitions
+// and key-level diffs to a configurable output sink.
+//
+// Usage:
+//   import { createStore } from '@termuijs/store';
+//   import { createLogger } from '@termuijs/store';
+//
+//   const useStore = createStore(creator, {
+//       middleware: [createLogger({ name: 'counter', diff: true })],
+//   });
+// ─────────────────────────────────────────────────────
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { Middleware } from './store.js';
+
+// ── Types ──────────────────────────────────────────────
+
+export interface LoggerOptions {
+    /**
+     * Custom output sink — receives one formatted line at a time.
+     * Defaults to appending to `<tmpdir>/termuijs-store.log` so
+     * the terminal display is never polluted (no console.log in UI code).
+     */
+    output?: (message: string) => void;
+
+    /**
+     * Emit a per-key diff entry showing `from` → `to` for every key
+     * whose value actually changed. Default: `true`.
+     */
+    diff?: boolean;
+
+    /**
+     * Label prepended to every log line, e.g. the store's name.
+     * When omitted no label is prepended.
+     */
+    name?: string;
+}
+
+// ── Default output sink ────────────────────────────────
+
+function defaultOutput(message: string): void {
+    const logFile = path.join(os.tmpdir(), 'termuijs-store.log');
+    try {
+        fs.appendFileSync(logFile, message + '\n', 'utf8');
+    } catch {
+        // Swallow write errors — never crash the terminal app
+    }
+}
+
+// ── Factory ────────────────────────────────────────────
+
+/**
+ * createLogger — produce a store middleware that logs state transitions.
+ *
+ * ```typescript
+ * const useStore = createStore(creator, {
+ *     middleware: [
+ *         createLogger({ name: 'myStore', diff: true }),
+ *     ],
+ * });
+ * ```
+ *
+ * Every `setState` call emits three lines (when diff is enabled):
+ *   `[label] <iso-timestamp> action  prev: {...}`
+ *   `[label] <iso-timestamp> action  next: {...}`
+ *   `[label] <iso-timestamp> diff    { key: { from: <old>, to: <new> } }`
+ *
+ * With `diff: false` only the prev/next lines are emitted.
+ */
+export function createLogger<T extends object>(options?: LoggerOptions): Middleware<T> {
+    const write   = options?.output ?? defaultOutput;
+    const showDiff = options?.diff ?? true;
+    const prefix  = options?.name ? `[${options.name}] ` : '';
+
+    return (prevState, update, next): void => {
+        const nextState = next(update);
+        const ts = new Date().toISOString();
+
+        write(`${prefix}${ts} prev   ${JSON.stringify(prevState)}`);
+        write(`${prefix}${ts} next   ${JSON.stringify(nextState)}`);
+
+        if (showDiff) {
+            const changedKeys = (Object.keys(update) as (keyof T)[]).filter(
+                (k) => !Object.is(prevState[k], (nextState as T)[k]),
+            );
+
+            if (changedKeys.length > 0) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const diffObj: Record<string, { from: any; to: any }> = {};
+                for (const k of changedKeys) {
+                    diffObj[k as string] = {
+                        from: prevState[k],
+                        to:   (nextState as T)[k],
+                    };
+                }
+                write(`${prefix}${ts} diff   ${JSON.stringify(diffObj)}`);
+            }
+        }
+    };
+}


### PR DESCRIPTION
## Description

Adds a pluggable `createLogger<T>(options?)` middleware factory to `@termuijs/store` that logs state transitions (prev state, next state, and a per-key diff) to a configurable output sink. Defaults to writing to `$TMPDIR/termuijs-store.log` so the terminal display is never polluted.

## Related Issue

Closes #305

## Which package(s)?

`@termuijs/store`

## Type of Change

- [x] ✨ Feature (`type:feature`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering). — N/A, store-only change
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/a8dd8aa7-2131-48b1-b6c3-4383bd6313da`

## Screenshots / Recordings (UI changes)

N/A — no UI changes. This is a pure store middleware utility.

## Notes for the Reviewer

**Pre-existing test failure:** `middleware > logger middleware receives previous and next state` in `packages/store/src/store.test.ts` fails on `main` before any of our changes (confirmed via `git stash`). The upstream `logger` stub in `store.ts` had its `console.log` removed but the corresponding test was never updated. Our work does not affect this.

**Implementation notes:**
- `createLogger` is a factory returning a `Middleware<T>` — plugs into the existing `StoreOptions.middleware` array without any changes to `createStore`
- `output` option defaults to `fs.appendFileSync` on a tmp file (no `console.log` per AGENTS.md)
- `diff: true` (default) emits a third line showing `{ key: { from, to } }` for every key whose value actually changed
- 10 new tests added in `packages/store/src/logger.test.ts`, all passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a logging middleware that records previous/next state snapshots, optional change diffs, configurable labels, and ISO-like timestamps; output destination is configurable.

* **Tests**
  * Added comprehensive tests covering diff behavior, label formatting, no-op updates, middleware chaining, and timestamped log entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->