### PR TITLE
perf(display): avoid redundant markDirty calls in Tooltip

### DIFF
--- a/packages/widgets/src/display/Tooltip.test.ts
+++ b/packages/widgets/src/display/Tooltip.test.ts
@@ -94,3 +94,55 @@ describe("Tooltip", () => {
         expect(tooltip.getVisible()).toBe(false);
     });
 });
+
+describe("Tooltip – mutation regression tests", () => {
+    it("does not mark dirty when text is unchanged", () => {
+        const tooltip = new Tooltip({
+            text: "help",
+            visible: true,
+        });
+
+        tooltip.clearDirty();
+        tooltip.setText("help");
+
+        expect(tooltip.isDirty).toBe(false);
+    });
+
+    it("does not mark dirty when visibility is unchanged", () => {
+        const tooltip = new Tooltip({
+            text: "help",
+            visible: true,
+        });
+
+        tooltip.clearDirty();
+        tooltip.setVisible(true);
+
+        expect(tooltip.isDirty).toBe(false);
+    });
+
+    it("marks dirty when text changes", () => {
+        const tooltip = new Tooltip({
+            text: "old",
+            visible: true,
+        });
+
+        tooltip.clearDirty();
+        tooltip.setText("new");
+
+        expect(tooltip.getText()).toBe("new");
+        expect(tooltip.isDirty).toBe(true);
+    });
+
+    it("marks dirty when visibility changes", () => {
+        const tooltip = new Tooltip({
+            text: "help",
+            visible: true,
+        });
+
+        tooltip.clearDirty();
+        tooltip.setVisible(false);
+
+        expect(tooltip.getVisible()).toBe(false);
+        expect(tooltip.isDirty).toBe(true);
+    });
+});

--- a/packages/widgets/src/display/Tooltip.ts
+++ b/packages/widgets/src/display/Tooltip.ts
@@ -82,6 +82,7 @@ export class Tooltip extends Widget {
     }
 
     setText(text: string): void {
+        if (this._text === text) return;
         this._text = text;
         this.markDirty();
     }
@@ -91,6 +92,7 @@ export class Tooltip extends Widget {
     }
 
     setVisible(visible: boolean): void {
+        if (this._visible === visible) return;
         this._visible = visible;
         this.markDirty();
     }


### PR DESCRIPTION
## Description

Optimizes `Tooltip` state setters by avoiding redundant `markDirty()` calls when the incoming value matches the current state. Adds regression tests to verify dirty-state behavior for both changed and unchanged text/visibility updates.

## Related Issue

Closes #1090

## Which package(s)?

@termuijs/widgets

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [x] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A (performance and test-only change)

## Notes for the Reviewer

This change adds equality guards to `setText()` and `setVisible()` to prevent unnecessary dirty-state updates when values remain unchanged. Regression tests cover both mutation and no-op setter paths to guard against future regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tooltip now avoids unnecessary state updates and re-renders by not marking itself dirty when text or visibility are set to unchanged values.

* **Tests**
  * Added regression tests verifying Tooltip skips redundant updates (and remains unchanged) and correctly marks dirty when text or visibility actually change, with assertions on resulting getters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->