### PR TITLE
perf(display): avoid redundant markDirty calls in Gradient

### DIFF
--- a/packages/widgets/src/display/Gradient.test.ts
+++ b/packages/widgets/src/display/Gradient.test.ts
@@ -135,4 +135,40 @@ describe("Gradient Widget — Layout & Alignment", () => {
         widgetLeft.render(screen);
         expect(screen.back[0][0].char).toBe('A');
     });
+
+    it("does not mark dirty when text is unchanged", () => {
+        const widget = new Gradient("Hello");
+
+        widget.clearDirty();
+        widget.setText("Hello");
+
+        expect(widget.isDirty).toBe(false);
+    });
+
+    it("does not mark dirty when colors are unchanged", () => {
+        const widget = new Gradient("Hello", {}, { startColor: "#ff0000", endColor: "#0000ff" });
+
+        widget.clearDirty();
+        widget.setColors("#ff0000", "#0000ff");
+
+        expect(widget.isDirty).toBe(false);
+    });
+
+    it("marks dirty when text changes", () => {
+        const widget = new Gradient("Hello");
+
+        widget.clearDirty();
+        widget.setText("World");
+
+        expect(widget.isDirty).toBe(true);
+    });
+
+    it("marks dirty when colors change", () => {
+        const widget = new Gradient("Hello", {}, { startColor: "#ff0000", endColor: "#0000ff" });
+
+        widget.clearDirty();
+        widget.setColors("#00ff00", "#ffff00");
+
+        expect(widget.isDirty).toBe(true);
+    });
 });

--- a/packages/widgets/src/display/Gradient.ts
+++ b/packages/widgets/src/display/Gradient.ts
@@ -55,11 +55,13 @@ export class Gradient extends Widget {
     }
 
     setText(text: string): void {
+        if (text === this._text) return;
         this._text = text;
         this.markDirty();
     }
 
     setColors(start: string, end: string): void {
+        if (start === this._startColor && end === this._endColor) return;
         this._startColor = start;
         this._endColor = end;
         this.markDirty();


### PR DESCRIPTION
## Description

This PR optimizes the `Gradient` widget by avoiding unnecessary `markDirty()` calls when the text or color values remain unchanged. It also adds regression tests to verify that dirty state updates only occur when widget state actually changes.

## Related Issue

Closes #1091

## Which package(s)?

@termuijs/widgets

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [x] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build` *(fails due to existing repository issue: missing `dotenv` dependency in `@termuijs/adapters`)*
* [ ] Typecheck passes: `bun run typecheck` *(fails due to existing repository issue: missing `dotenv` dependency in `@termuijs/adapters`)*
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

Added regression tests covering unchanged and changed text/color updates. The optimization prevents redundant dirty-state updates while preserving existing rendering behavior.## Description

This PR optimizes the `Gradient` widget by avoiding unnecessary `markDirty()` calls when the text or color values remain unchanged. It also adds regression tests to verify that dirty state updates only occur when widget state actually changes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gradient widget now skips unnecessary updates when text or colors remain unchanged.

* **Tests**
  * Added test cases for the Gradient widget's dirty-tracking behavior to verify proper change detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->