### PR TITLE
perf(display): avoid redundant markDirty calls in BigText

### DIFF
--- a/packages/widgets/src/display/BigText.test.ts
+++ b/packages/widgets/src/display/BigText.test.ts
@@ -121,3 +121,32 @@ describe('BigText', () => {
         expect(screen.back[0][1].char).toBe('█');
     });
 });
+
+describe('BigText – mutation regression tests', () => {
+    it('does not mark dirty when text is unchanged', () => {
+        const widget = new BigText('HELLO');
+
+        widget.clearDirty();
+        widget.setText('HELLO');
+
+        expect(widget.isDirty).toBe(false);
+    });
+
+    it('does not mark dirty when text differs only by case', () => {
+        const widget = new BigText('HELLO');
+
+        widget.clearDirty();
+        widget.setText('hello');
+
+        expect(widget.isDirty).toBe(false);
+    });
+
+    it('marks dirty when text changes', () => {
+        const widget = new BigText('HELLO');
+
+        widget.clearDirty();
+        widget.setText('WORLD');
+
+        expect(widget.isDirty).toBe(true);
+    });
+});

--- a/packages/widgets/src/display/BigText.ts
+++ b/packages/widgets/src/display/BigText.ts
@@ -76,7 +76,11 @@ export class BigText extends Widget {
     }
 
     setText(text: string): void {
-        this._text = text.toUpperCase();
+        const normalized = text.toUpperCase();
+        if (normalized === this._text){
+            return
+        }
+        this._text = normalized;
         this.markDirty();
     }
 

--- a/packages/widgets/src/display/BigText.ts
+++ b/packages/widgets/src/display/BigText.ts
@@ -77,8 +77,8 @@ export class BigText extends Widget {
 
     setText(text: string): void {
         const normalized = text.toUpperCase();
-        if (normalized === this._text){
-            return
+        if (normalized === this._text) {
+            return;
         }
         this._text = normalized;
         this.markDirty();


### PR DESCRIPTION
## Description

Avoid redundant `markDirty()` calls in `BigText#setText` by checking whether the normalized uppercase text has actually changed before marking the widget dirty.

Added mutation regression tests to verify that:

* `markDirty()` is not called when the text is unchanged.
* `markDirty()` is not called when the text differs only by case.
* `markDirty()` is called when the rendered text changes.

## Related Issue

Closes #1094

## Which package(s)?

@termuijs/widgets

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [x] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

* `bun vitest run` passes locally.
* Repository-wide `build` and `typecheck` currently fail due to an existing issue in `@termuijs/adapters` (`Cannot find module 'dotenv'`), which is unrelated to this change.
* This optimization prevents unnecessary re-renders when `setText()` receives the same value or a value that normalizes to the same uppercase representation.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dirty-state tracking in the BigText component to treat text comparisons case-insensitively, preventing casing-only edits from marking it modified while still detecting real content changes to avoid unnecessary updates.

* **Tests**
  * Added regression tests verifying dirty-state behavior for unchanged text, casing-only changes, and actual text changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->