### PR TITLE
perf: avoid redundant markDirty calls in Text

### DIFF
--- a/packages/widgets/src/display/Text.test.ts
+++ b/packages/widgets/src/display/Text.test.ts
@@ -43,3 +43,60 @@ describe('Text', () => {
         expect(screen.back[1][0].char).not.toBe(' ');
     });
 });
+
+describe('Text – mutation regression tests', () => {
+    it('does not mark dirty when content is unchanged', () => {
+        const text = new Text('hello');
+
+        text.clearDirty();
+        text.setContent('hello');
+
+        expect(text.isDirty).toBe(false);
+    });
+
+    it('marks dirty when content changes', () => {
+        const text = new Text('hello');
+
+        text.clearDirty();
+        text.setContent('world');
+
+        expect(text.getContent()).toBe('world');
+        expect(text.isDirty).toBe(true);
+    });
+
+    it('does not mark dirty when scrollY is unchanged', () => {
+        const text = new Text('hello', {}, { scrollY: 2 });
+
+        text.clearDirty();
+        text.setScrollY(2);
+
+        expect(text.isDirty).toBe(false);
+    });
+
+    it('marks dirty when scrollY changes', () => {
+        const text = new Text('hello', {}, { scrollY: 0 });
+
+        text.clearDirty();
+        text.setScrollY(3);
+
+        expect(text.isDirty).toBe(true);
+    });
+
+    it('does not mark dirty when scrollX is unchanged', () => {
+        const text = new Text('hello', {}, { scrollX: 2 });
+
+        text.clearDirty();
+        text.setScrollX(2);
+
+        expect(text.isDirty).toBe(false);
+    });
+
+    it('marks dirty when scrollX changes', () => {
+        const text = new Text('hello', {}, { scrollX: 0 });
+
+        text.clearDirty();
+        text.setScrollX(4);
+
+        expect(text.isDirty).toBe(true);
+    });
+});

--- a/packages/widgets/src/display/Text.ts
+++ b/packages/widgets/src/display/Text.ts
@@ -36,7 +36,7 @@ export class Text extends Widget {
 
     /** Update the text content */
     setContent(content: string): void {
-        if (content === this._content){
+        if (content === this._content) {
             return;
         }
         this._content = content;

--- a/packages/widgets/src/display/Text.ts
+++ b/packages/widgets/src/display/Text.ts
@@ -36,6 +36,9 @@ export class Text extends Widget {
 
     /** Update the text content */
     setContent(content: string): void {
+        if (content === this._content){
+            return;
+        }
         this._content = content;
         this.markDirty();
     }
@@ -47,13 +50,21 @@ export class Text extends Widget {
 
     /** Set vertical scroll offset (lines to skip). */
     setScrollY(offset: number): void {
-        this._scrollY = Math.max(0, offset);
+        const normalized = Math.max(0, offset);
+        if (normalized === this._scrollY) {
+            return;
+        }
+        this._scrollY = normalized;
         this.markDirty();
     }
 
     /** Set horizontal scroll offset (columns to skip). */
     setScrollX(offset: number): void {
-        this._scrollX = Math.max(0, offset);
+        const normalized = Math.max(0, offset);
+        if (normalized === this._scrollX) {
+            return;
+        }
+        this._scrollX = normalized;
         this.markDirty();
     }
 


### PR DESCRIPTION
## Description

Avoid redundant `markDirty()` calls in the `Text` widget by checking whether content and scroll offsets have actually changed before marking the widget dirty.

Added mutation regression tests covering:

* Unchanged content
* Changed content
* Unchanged vertical scroll offset
* Changed vertical scroll offset
* Unchanged horizontal scroll offset
* Changed horizontal scroll offset

## Related Issue

Closes #1095

## Which package(s)?

@termuijs/widgets

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [x] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

* Added early-return guards in `setContent`, `setScrollY`, and `setScrollX` to avoid unnecessary dirty-state updates.
* Added mutation regression tests to ensure `markDirty()` is triggered only when state changes.
* `bun vitest run` passes locally.
* Repository-wide build/typecheck failures are caused by an existing `@termuijs/adapters` dotenv dependency issue unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary state updates for the Text widget when content or scroll positions haven't actually changed; scroll offsets are now normalized to non-negative values before applying.

* **Tests**
  * Added regression tests covering Text widget state handling, including reset behavior and when changes should or should not mark the widget as dirty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->