### PR TITLE
perf(display): avoid redundant markDirty calls in Rule

### DIFF
--- a/packages/widgets/src/display/Rule.test.ts
+++ b/packages/widgets/src/display/Rule.test.ts
@@ -122,3 +122,23 @@ describe('Rule', () => {
         expect(() => renderRule({}, { title: 'Very Long Title' }, 5, 1)).not.toThrow();
     });
 });
+
+describe('Rule – mutation regression tests', () => {
+    it('does not mark dirty when title is unchanged', () => {
+        const rule = new Rule({}, { title: 'Logs' });
+
+        rule.clearDirty();
+        rule.setTitle('Logs');
+
+        expect(rule.isDirty).toBe(false);
+    });
+
+    it('marks dirty when title changes', () => {
+        const rule = new Rule({}, { title: 'Logs' });
+
+        rule.clearDirty();
+        rule.setTitle('Errors');
+
+        expect(rule.isDirty).toBe(true);
+    });
+});

--- a/packages/widgets/src/display/Rule.ts
+++ b/packages/widgets/src/display/Rule.ts
@@ -49,7 +49,7 @@ export class Rule extends Widget {
 
     /** Update the title text. Calls markDirty(). */
     setTitle(title: string): void {
-        if (title === this._title){
+        if (title === this._title) {
             return;
         }
         this._title = title;

--- a/packages/widgets/src/display/Rule.ts
+++ b/packages/widgets/src/display/Rule.ts
@@ -49,6 +49,9 @@ export class Rule extends Widget {
 
     /** Update the title text. Calls markDirty(). */
     setTitle(title: string): void {
+        if (title === this._title){
+            return;
+        }
         this._title = title;
         this.markDirty();
     }


### PR DESCRIPTION
## Description

Avoid redundant `markDirty()` calls in the `Rule` widget by only marking the widget dirty when the title value actually changes.

Added regression tests to verify that:

* `setTitle()` does not mark the widget dirty when the title is unchanged.
* `setTitle()` marks the widget dirty when the title changes.

## Related Issue

Closes #1096

## Which package(s)?

@termuijs/widgets

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [x] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run` *(Rule widget tests pass locally; unrelated upstream test failures exist in the repository.)*
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

This PR is limited to the Rule widget.

The change prevents unnecessary dirty-state updates when setTitle() receives the same value as the current title.

Added mutation regression tests covering both unchanged and changed title scenarios.

packages/widgets/src/display/Rule.test.ts passes locally.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the Rule component stayed marked as modified when the same title was set; it now correctly avoids marking as dirty.

* **Tests**
  * Added regression tests verifying the Rule component's dirty-state behavior when clearing and resetting titles to prevent future regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->