### PR TITLE
feat(examples): accept --lat, --lon, --city CLI args in weather example

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -330,6 +330,9 @@
         "@termuijs/core": "workspace:*",
         "@termuijs/quick": "workspace:*",
       },
+      "devDependencies": {
+        "@types/node": "^25.9.2",
+      },
     },
     "examples/widget-gallery": {
       "name": "@termuijs/example-widget-gallery",
@@ -346,6 +349,8 @@
       "name": "@termuijs/adapters",
       "version": "0.1.0",
       "dependencies": {
+        "@termuijs/core": "workspace:*",
+        "@termuijs/widgets": "workspace:*",
         "commander": "^15.0.0",
       },
       "devDependencies": {
@@ -1041,13 +1046,15 @@
 
     "@termuijs/core/@types/node": ["@types/node@22.19.20", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw=="],
 
-    "@termuijs/data/@types/node": ["@types/node@22.19.19", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew=="],
+    "@termuijs/data/@types/node": ["@types/node@22.19.20", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw=="],
 
     "@termuijs/example-todo/@types/node": ["@types/node@22.19.19", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew=="],
 
-    "@termuijs/quick/@types/node": ["@types/node@22.19.19", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew=="],
+    "@termuijs/quick/@types/node": ["@types/node@22.19.20", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw=="],
 
     "@termuijs/ui/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "examples-weather/@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
 
     "onetime/mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 

--- a/examples/weather/package.json
+++ b/examples/weather/package.json
@@ -9,5 +9,8 @@
   "dependencies": {
     "@termuijs/quick": "workspace:*",
     "@termuijs/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.2"
   }
 }

--- a/examples/weather/src/index.tsx
+++ b/examples/weather/src/index.tsx
@@ -6,8 +6,14 @@ import { app, row, gauge, progressBar, text, status } from "@termuijs/quick";
 // Default: Purnea (lat=25.6, lon=87.5)
 
 const args = process.argv.slice(2);
-const getArg = (name: string) =>
-  args.find((a: string) => a.startsWith(`--${name}=`))?.split("=")[1];
+const getArg = (name: string) => {
+  const value = args
+    .find((a: string) => a.startsWith(`--${name}=`))
+    ?.split("=")[1]
+    ?.trim();
+
+  return value || undefined;
+};
 
 const lat = getArg("lat") ?? "25.6";
 const lon = getArg("lon") ?? "87.5";

--- a/examples/weather/src/index.tsx
+++ b/examples/weather/src/index.tsx
@@ -1,8 +1,19 @@
 import { caps } from "@termuijs/core";
 import { app, row, gauge, progressBar, text, status } from "@termuijs/quick";
 
+// Usage: bun run dev -- --lat=<latitude> --lon=<longitude> --city=<name>
+// Example: bun run dev -- --lat=21.25 --lon=81.63 --city=Raipur
+// Default: Purnea (lat=25.6, lon=87.5)
+
+const args = process.argv.slice(2);
+const getArg = (name: string) =>
+  args.find((a: string) => a.startsWith(`--${name}=`))?.split("=")[1];
+
+const lat = getArg("lat") ?? "25.6";
+const lon = getArg("lon") ?? "87.5";
+const city = getArg("city") ?? "Purnea";
 const API =
-  "https://api.open-meteo.com/v1/forecast?latitude=25.6&longitude=87.5&current=temperature_2m,apparent_temperature,relative_humidity_2m,wind_speed_10m,wind_direction_10m,weather_code&timezone=auto";
+  `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,apparent_temperature,relative_humidity_2m,wind_speed_10m,wind_direction_10m,weather_code&timezone=auto`;
 
 let weather: any = null;
 let lastFetch = 0;
@@ -55,12 +66,12 @@ async function fetchWeather() {
 setInterval(fetchWeather, 5000);
 fetchWeather();
 
-app(caps.unicode ? "🌤 Weather Dashboard • Purnea, India" : "* Weather Dashboard • Purnea, India")
+app(caps.unicode ? `🌤 Weather Dashboard • ${city}, India` : `* Weather Dashboard • ${city}, India`)
   .rows(
     row(
       text(() => {
         const icon = weather ? weatherIcon(weather.current?.weather_code ?? 0) : "⏳";
-        return `${icon} Weather Dashboard • Purnea, India`;
+        return `${icon} Weather Dashboard • ${city}, India`;
       }, { bold: true, color: { type: "named", name: "cyan" } })
     ),
 

--- a/examples/weather/tsconfig.json
+++ b/examples/weather/tsconfig.json
@@ -5,7 +5,8 @@
     "moduleResolution": "Bundler",
     "strict": true,
     "skipLibCheck": true,
-    "noEmit": true
+    "noEmit": true,
+    "types" : ["node"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Description

Replaces hardcoded Purnea coordinates in `examples/weather/src/index.tsx` with CLI arguments `--lat`, `--lon`, and `--city`. Falls back to Purnea defaults if no args are provided, so existing behaviour is unchanged.

## Related Issue

Closes #775

## Which package(s)?

`examples/weather`

## Type of Change
- [x] ✨ Feature (`type:feature`)

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read `CONTRIBUTING.md`.
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] I'm a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/6e1bbb53-448c-4f69-962a-dfe4a0e6a325`

## Screenshots / Recordings (UI changes)
<img width="1366" height="720" alt="Screenshot (25)" src="https://github.com/user-attachments/assets/c6dda342-3eb5-4939-8b17-ee3a1e0ab704" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weather example accepts command-line parameters (--lat, --lon, --city) to customize location and dashboard title at runtime.

* **Chores**
  * Added development typing support for Node.
  * TypeScript config updated to restrict global types to Node and to prevent emit during development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->