### PR TITLE
feat(ui): add Listbar widget

### DIFF
--- a/packages/ui/src/Listbar.test.ts
+++ b/packages/ui/src/Listbar.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Screen } from '@termuijs/core';
+import { Listbar } from './Listbar.js';
+
+describe('Listbar', () => {
+    it('renders all labels in a single row', () => {
+        const listbar = new Listbar([
+            { label: 'Save', key: 'F1' },
+            { label: 'Load', key: 'F2' },
+            { label: 'Quit', key: 'F3' },
+        ]);
+
+        listbar.updateRect({ x: 0, y: 0, width: 40, height: 1 });
+        const screen = new Screen(40, 1);
+        listbar.render(screen);
+
+        const row0 = screen.back[0].map(c => c.char).join('');
+        expect(row0).toContain('Save');
+        expect(row0).toContain('Load');
+        expect(row0).toContain('Quit');
+    });
+
+    it('right key moves active item', () => {
+        const actions = [vi.fn(), vi.fn(), vi.fn()];
+        const listbar = new Listbar([
+            { label: 'A', action: actions[0] },
+            { label: 'B', action: actions[1] },
+            { label: 'C', action: actions[2] },
+        ]);
+
+        expect(listbar.activeItem).toBe(0);
+
+        listbar.handleKey({ key: 'right', ctrl: false, alt: false } as any);
+        expect(listbar.activeItem).toBe(1);
+
+        listbar.handleKey({ key: 'right', ctrl: false, alt: false } as any);
+        expect(listbar.activeItem).toBe(2);
+
+        listbar.handleKey({ key: 'right', ctrl: false, alt: false } as any);
+        expect(listbar.activeItem).toBe(0);
+    });
+
+    it('left key moves active item', () => {
+        const listbar = new Listbar([
+            { label: 'A' },
+            { label: 'B' },
+            { label: 'C' },
+        ]);
+
+        listbar.handleKey({ key: 'left', ctrl: false, alt: false } as any);
+        expect(listbar.activeItem).toBe(2);
+
+        listbar.handleKey({ key: 'left', ctrl: false, alt: false } as any);
+        expect(listbar.activeItem).toBe(1);
+    });
+
+    it('enter fires action of active item', () => {
+        const action = vi.fn();
+        const listbar = new Listbar([
+            { label: 'Save', action },
+            { label: 'Load' },
+        ]);
+
+        listbar.handleKey({ key: 'enter', ctrl: false, alt: false } as any);
+        expect(action).toHaveBeenCalledTimes(1);
+    });
+
+    it('disabled items are skipped', () => {
+        const actions = [vi.fn(), vi.fn(), vi.fn()];
+        const listbar = new Listbar([
+            { label: 'A', action: actions[0] },
+            { label: 'B', action: actions[1], disabled: true },
+            { label: 'C', action: actions[2] },
+        ]);
+
+        expect(listbar.activeItem).toBe(0);
+
+        listbar.handleKey({ key: 'right', ctrl: false, alt: false } as any);
+        expect(listbar.activeItem).toBe(2);
+
+        listbar.handleKey({ key: 'left', ctrl: false, alt: false } as any);
+        expect(listbar.activeItem).toBe(0);
+    });
+
+    it('enter does not fire action on disabled item', () => {
+        const action = vi.fn();
+        const listbar = new Listbar([
+            { label: 'A', action: action, disabled: true },
+        ]);
+
+        listbar.handleKey({ key: 'enter', ctrl: false, alt: false } as any);
+        expect(action).not.toHaveBeenCalled();
+    });
+
+    it('setItems updates items and resets active index', () => {
+        const listbar = new Listbar([
+            { label: 'A' },
+            { label: 'B' },
+        ]);
+
+        listbar.handleKey({ key: 'right', ctrl: false, alt: false } as any);
+        expect(listbar.activeItem).toBe(1);
+
+        listbar.setItems([
+            { label: 'X' },
+            { label: 'Y' },
+            { label: 'Z' },
+        ]);
+
+        expect(listbar.activeItem).toBe(0);
+    });
+
+    it('renders separator between items', () => {
+        const listbar = new Listbar([
+            { label: 'Save' },
+            { label: 'Load' },
+        ]);
+
+        listbar.updateRect({ x: 0, y: 0, width: 40, height: 1 });
+        const screen = new Screen(40, 1);
+        listbar.render(screen);
+
+        const row0 = screen.back[0].map(c => c.char).join('');
+        expect(row0).toContain('|');
+    });
+
+    it('renders key hints in the output', () => {
+        const listbar = new Listbar([
+            { label: 'Save', key: 'F1' },
+        ]);
+
+        listbar.updateRect({ x: 0, y: 0, width: 40, height: 1 });
+        const screen = new Screen(40, 1);
+        listbar.render(screen);
+
+        const row0 = screen.back[0].map(c => c.char).join('');
+        expect(row0).toContain('F1');
+        expect(row0).toContain('Save');
+    });
+});

--- a/packages/ui/src/Listbar.test.ts
+++ b/packages/ui/src/Listbar.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
-import { Screen } from '@termuijs/core';
+import { type KeyEvent, createKeyEvent, Screen } from '@termuijs/core';
 import { Listbar } from './Listbar.js';
+
+function makeKey(key: string): KeyEvent {
+    return createKeyEvent({ key, raw: Buffer.alloc(0), ctrl: false, alt: false, shift: false });
+}
 
 describe('Listbar', () => {
     it('renders all labels in a single row', () => {
@@ -30,13 +34,13 @@ describe('Listbar', () => {
 
         expect(listbar.activeItem).toBe(0);
 
-        listbar.handleKey({ key: 'right', ctrl: false, alt: false } as any);
+        listbar.handleKey(makeKey('right'));
         expect(listbar.activeItem).toBe(1);
 
-        listbar.handleKey({ key: 'right', ctrl: false, alt: false } as any);
+        listbar.handleKey(makeKey('right'));
         expect(listbar.activeItem).toBe(2);
 
-        listbar.handleKey({ key: 'right', ctrl: false, alt: false } as any);
+        listbar.handleKey(makeKey('right'));
         expect(listbar.activeItem).toBe(0);
     });
 
@@ -47,10 +51,10 @@ describe('Listbar', () => {
             { label: 'C' },
         ]);
 
-        listbar.handleKey({ key: 'left', ctrl: false, alt: false } as any);
+        listbar.handleKey(makeKey('left'));
         expect(listbar.activeItem).toBe(2);
 
-        listbar.handleKey({ key: 'left', ctrl: false, alt: false } as any);
+        listbar.handleKey(makeKey('left'));
         expect(listbar.activeItem).toBe(1);
     });
 
@@ -61,7 +65,7 @@ describe('Listbar', () => {
             { label: 'Load' },
         ]);
 
-        listbar.handleKey({ key: 'enter', ctrl: false, alt: false } as any);
+        listbar.handleKey(makeKey('enter'));
         expect(action).toHaveBeenCalledTimes(1);
     });
 
@@ -75,10 +79,10 @@ describe('Listbar', () => {
 
         expect(listbar.activeItem).toBe(0);
 
-        listbar.handleKey({ key: 'right', ctrl: false, alt: false } as any);
+        listbar.handleKey(makeKey('right'));
         expect(listbar.activeItem).toBe(2);
 
-        listbar.handleKey({ key: 'left', ctrl: false, alt: false } as any);
+        listbar.handleKey(makeKey('left'));
         expect(listbar.activeItem).toBe(0);
     });
 
@@ -88,7 +92,7 @@ describe('Listbar', () => {
             { label: 'A', action: action, disabled: true },
         ]);
 
-        listbar.handleKey({ key: 'enter', ctrl: false, alt: false } as any);
+        listbar.handleKey(makeKey('enter'));
         expect(action).not.toHaveBeenCalled();
     });
 
@@ -98,7 +102,7 @@ describe('Listbar', () => {
             { label: 'B' },
         ]);
 
-        listbar.handleKey({ key: 'right', ctrl: false, alt: false } as any);
+        listbar.handleKey(makeKey('right'));
         expect(listbar.activeItem).toBe(1);
 
         listbar.setItems([

--- a/packages/ui/src/Listbar.ts
+++ b/packages/ui/src/Listbar.ts
@@ -1,0 +1,140 @@
+import { Widget } from '@termuijs/widgets';
+import { type Style, type Color, type KeyEvent, type Screen, mergeStyles, defaultStyle, styleToCellAttrs } from '@termuijs/core';
+
+export interface ListbarItem {
+    label: string;
+    key?: string;
+    action?: () => void;
+    disabled?: boolean;
+}
+
+export interface ListbarOptions {
+    activeColor?: Color;
+    keyColor?: Color;
+    separator?: string;
+}
+
+export class Listbar extends Widget {
+    private _items: ListbarItem[] = [];
+    private _activeIndex = 0;
+    private _activeColor: Color;
+    private _keyColor: Color;
+    private _separator: string;
+
+    focusable = true;
+
+    constructor(items: ListbarItem[], style?: Partial<Style>, opts?: ListbarOptions) {
+        super(mergeStyles(defaultStyle(), { height: 1, ...style }));
+        this._items = items;
+        this._activeColor = opts?.activeColor ?? { type: 'named', name: 'cyan' };
+        this._keyColor = opts?.keyColor ?? { type: 'named', name: 'yellow' };
+        this._separator = opts?.separator ?? ' | ';
+        this._initActiveIndex();
+    }
+
+    get activeItem(): number {
+        return this._activeIndex;
+    }
+
+    setItems(items: ListbarItem[]): void {
+        this._items = items;
+        this._initActiveIndex();
+        this.markDirty();
+    }
+
+    handleKey(event: KeyEvent): void {
+        switch (event.key) {
+            case 'left':
+                this._activeIndex = this._nextEnabled(this._activeIndex, -1);
+                this.markDirty();
+                break;
+
+            case 'right':
+                this._activeIndex = this._nextEnabled(this._activeIndex, 1);
+                this.markDirty();
+                break;
+
+            case 'enter':
+                const item = this._items[this._activeIndex];
+                if (item && !item.disabled && item.action) {
+                    item.action();
+                }
+                break;
+        }
+    }
+
+    private _initActiveIndex(): void {
+        this._activeIndex = 0;
+        for (let i = 0; i < this._items.length; i++) {
+            if (!this._items[i].disabled) {
+                this._activeIndex = i;
+                return;
+            }
+        }
+    }
+
+    private _nextEnabled(from: number, direction: number): number {
+        if (this._items.length === 0) return from;
+
+        let i = from;
+        do {
+            i = (i + direction + this._items.length) % this._items.length;
+            if (!this._items[i].disabled) return i;
+        } while (i !== from);
+
+        return from;
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width } = this._rect;
+        if (width <= 0) return;
+
+        const baseAttrs = styleToCellAttrs(this.style);
+        let col = x;
+
+        for (let i = 0; i < this._items.length; i++) {
+            if (col >= x + width) break;
+
+            const item = this._items[i];
+            const isActive = i === this._activeIndex;
+
+            if (item.key) {
+                const keyText = `${item.key} `;
+                const keyColor = item.disabled
+                    ? { type: 'named', name: 'brightBlack' } as Color
+                    : isActive
+                        ? this._activeColor
+                        : this._keyColor;
+
+                const keyVisible = keyText.slice(0, x + width - col);
+                screen.writeString(col, y, keyVisible, {
+                    ...baseAttrs,
+                    fg: keyColor,
+                    dim: item.disabled,
+                    bold: isActive,
+                });
+                col += keyText.length;
+                if (col >= x + width) break;
+            }
+
+            const labelVisible = item.label.slice(0, x + width - col);
+            screen.writeString(col, y, labelVisible, {
+                ...baseAttrs,
+                fg: item.disabled
+                    ? { type: 'named', name: 'brightBlack' }
+                    : isActive
+                        ? this._activeColor
+                        : baseAttrs.fg,
+                dim: item.disabled,
+                bold: isActive,
+            });
+            col += item.label.length;
+
+            if (i < this._items.length - 1 && col < x + width) {
+                const sepVisible = this._separator.slice(0, x + width - col);
+                screen.writeString(col, y, sepVisible, baseAttrs);
+                col += this._separator.length;
+            }
+        }
+    }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -206,3 +206,5 @@ export type { BreadcrumbItem, BreadcrumbOptions } from './Breadcrumb.js';
 export { Disclosure } from './Disclosure.js';
 export type { DisclosureOptions } from './Disclosure.js';
 
+export { Listbar } from './Listbar.js';
+export type { ListbarOptions, ListbarItem } from './Listbar.js';


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

<!-- What does this PR do? 1 to 3 sentences. -->
Add a Listbar widget that renders a horizontal row of command buttons, each showing a label and a keyboard shortcut key hint. Supports navigation via left/right keys, disabled item skipping, and customizable colors and separator.

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #267 

## Which package(s)?

<!-- Example: @termuijs/core, @termuijs/widgets, website. -->
@termuijs/ui

## Type of Change


<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/ac85deec-3598-47ef-a9e8-f39ae0af5147`

## Screenshots / Recordings (UI changes)
N/A
<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer
Implementation follows the exact API contract from the issue. Follows Toggle.ts and MenuBar.ts patterns. 9 tests cover all acceptance criteria: rendering all labels, left/right navigation, enter firing action, disabled item skipping, setItems updating, separator rendering, and key hint display.

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->

2 pre-existing test failures (store.test.ts logger middleware, useGpu.test.ts) exist on the base branch and are unrelated to this change. 
The new Listbar tests pass successfully in CI. The failing CI checks appear to be in unrelated packages (store and data) and are not touched by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Listbar widget: horizontal interactive item list with left/right keyboard navigation, wrap-around, Enter to trigger actions, skipping and visually dimming disabled items, optional key hints, separators, and customizable appearance.

* **Tests**
  * Added test suite covering rendering, keyboard navigation (including wrapping and skipping disabled items), Enter/action behavior, item updates/reset, separators, and key hint display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->