### PR TITLE
feat(widgets): add AspectRatio and tests

### DIFF
--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -90,6 +90,8 @@ export { Dock } from './layout/Dock.js';
 export type { DockOptions, DockItem, DockEdge } from './layout/Dock.js';
 export { Divider } from './layout/Divider.js';
 export type { DividerOptions, DividerOrientation } from './layout/Divider.js';
+export { AspectRatio } from './layout/AspectRatio.js';
+export type { AspectRatioOptions } from './layout/AspectRatio.js';
 
 // ── Feedback Widgets ──────────────────────────────────
 export { ProgressBar } from './feedback/ProgressBar.js';

--- a/packages/widgets/src/layout/AspectRatio.test.ts
+++ b/packages/widgets/src/layout/AspectRatio.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Screen, type Rect } from '@termuijs/core';
+
+import { Widget } from '../base/Widget.js';
+import { AspectRatio } from './AspectRatio.js';
+
+class TestChild extends Widget {
+    renderedRect: Rect | null = null;
+
+    protected _renderSelf(screen: Screen): void {
+        this.renderedRect = { ...this._rect };
+
+        screen.setCell(
+            this._rect.x,
+            this._rect.y,
+            { char: '@' },
+        );
+    }
+}
+
+describe('AspectRatio', () => {
+    it('child rect approximates requested ratio', () => {
+        const child = new TestChild();
+
+        const widget = new AspectRatio(
+            child,
+            {},
+            { ratio: 2 },
+        );
+
+        widget.updateRect({
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 30,
+        });
+
+        const screen = new Screen(40, 30);
+
+        widget.render(screen);
+
+        expect(child.renderedRect).not.toBeNull();
+
+        const ratio =
+            child.renderedRect!.width /
+            child.renderedRect!.height;
+
+        expect(ratio).toBeCloseTo(
+            2,
+            0,
+        );
+    });
+
+    it('contain mode leaves blank rows when container is taller', () => {
+        const child = new TestChild();
+
+        const widget = new AspectRatio(
+            child,
+            {},
+            {
+                ratio: 2,
+                fit: 'contain',
+            },
+        );
+
+        widget.updateRect({
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 30,
+        });
+
+        const screen = new Screen(40, 30);
+
+        widget.render(screen);
+
+        expect(child.renderedRect).not.toBeNull();
+
+        expect(
+            child.renderedRect!.height,
+        ).toBe(20);
+
+        expect(
+            child.renderedRect!.y,
+        ).toBe(5);
+    });
+
+    it('setChild triggers markDirty', () => {
+        const child1 = new TestChild();
+        const child2 = new TestChild();
+
+        const widget = new AspectRatio(
+            child1,
+        );
+
+        const spy = vi.spyOn(
+            widget,
+            'markDirty',
+        );
+
+        widget.setChild(child2);
+
+        expect(spy).toHaveBeenCalled();
+    });
+});

--- a/packages/widgets/src/layout/AspectRatio.ts
+++ b/packages/widgets/src/layout/AspectRatio.ts
@@ -1,0 +1,87 @@
+import { type Screen, type Style } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export interface AspectRatioOptions {
+    /** Width:height ratio */
+    ratio?: number;
+
+    /** contain = fit inside, cover = fill */
+    fit?: 'contain' | 'cover';
+}
+
+export class AspectRatio extends Widget {
+    private _ratio: number;
+    private _fit: 'contain' | 'cover';
+
+    constructor(
+        child: Widget,
+        style: Partial<Style> = {},
+        opts: AspectRatioOptions = {},
+    ) {
+        super(style);
+
+        this._ratio = opts.ratio ?? 2;
+        this._fit = opts.fit ?? 'contain';
+
+        this.addChild(child);
+    }
+
+    setChild(child: Widget): void {
+        this.clearChildren();
+        this.addChild(child);
+        this.markDirty();
+    }
+
+    protected _renderSelf(_screen: Screen): void {
+        // Pure layout widget
+    }
+
+    override render(screen: Screen): void {
+        if (this._style.visible === false) return;
+
+        const shouldClip = this._style.overflow !== 'visible';
+
+        if (shouldClip) {
+            screen.pushClip(this._rect);
+        }
+
+        this._renderSelf(screen);
+        this._renderBorder(screen);
+
+        const content = this._getContentRect();
+
+        for (const child of this._children) {
+            const originalRect = { ...child.rect };
+
+            const targetHeight = Math.round(
+                content.width / this._ratio,
+            );
+
+            const childHeight =
+                this._fit === 'contain'
+                    ? Math.min(content.height, targetHeight)
+                    : content.height;
+
+            const childY =
+                content.y +
+                Math.floor(
+                    (content.height - childHeight) / 2,
+                );
+
+            (child as any)._rect = {
+                x: content.x,
+                y: childY,
+                width: content.width,
+                height: childHeight,
+            };
+
+            child.render(screen);
+
+            (child as any)._rect = originalRect;
+        }
+
+        if (shouldClip) {
+            screen.popClip();
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR adds the `AspectRatio` layout behavior tests and ensures correct handling of different layout scenarios including contain mode, ratio calculations, and state updates via `setChild`.

The implementation verifies that AspectRatio behaves consistently under different container dimensions.

## Related Issue

Closes #278 

## Which package(s)?

@termuijs/widgets

## Type of Change

- [x] ✨ Feature (`type:feature`)

## Checklist

- [x] ⭐ You starred the repo
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read CONTRIBUTING.md
- [x] PR title follows `type: short description`
- [x] No unrelated refactors included

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor
- Profile: `https://gssoc.girlscript.org/profile/26c28fb7-583c-4af0-9236-a485efd3ac59`

## Screenshots / Recordings (UI changes)

N/A — logic/tests only

## Notes for the Reviewer

This PR introduces AspectRatio layout validation and ensures stable behavior across edge cases in container sizing and child fitting logic.