### PR TITLE
Feat/use local storage adapter

### DIFF
--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -39,4 +39,5 @@ export type { RAGChatOptions } from './ai/RAGChat.js'
 
 export { useDotenv } from './dotenv/index.js'
 export type { DotenvValues, UseDotenvResult } from './dotenv/index.js'
-
+export { useLocalStorage } from './localStorage/index.js'
+export type { LocalStorageAdapter } from './localStorage/index.js'

--- a/packages/adapters/src/localStorage/index.test.ts
+++ b/packages/adapters/src/localStorage/index.test.ts
@@ -1,0 +1,38 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+
+const previousHome = process.env.HOME
+const previousUserProfile = process.env.USERPROFILE
+
+const tempHomeDir = mkdtempSync(join(tmpdir(), 'termui-test-'))
+process.env.HOME = tempHomeDir
+process.env.USERPROFILE = tempHomeDir
+
+import { useLocalStorage } from './index'
+
+describe('useLocalStorage', () => {
+  const store = useLocalStorage('test-svc')
+
+  beforeEach(() => store.clear())
+
+  afterAll(() => {
+    process.env.HOME = previousHome
+    process.env.USERPROFILE = previousUserProfile
+    rmSync(tempHomeDir, { recursive: true, force: true })
+  })
+
+  it('returns null for missing key', () => expect(store.get('x')).toBeNull())
+  it('sets and gets string',  () => { store.set('k', 'v'); expect(store.get('k')).toBe('v') })
+  it('sets and gets number',  () => { store.set('n', 42);  expect(store.get('n')).toBe(42)  })
+  it('sets and gets object',  () => {
+    store.set('o', { a: 1 })
+    expect(store.get<{ a: number }>('o')).toEqual({ a: 1 })
+  })
+  it('removes a key',  () => { store.set('r', 'v'); store.remove('r'); expect(store.get('r')).toBeNull() })
+  it('clears all keys', () => {
+    store.set('a', 1); store.set('b', 2); store.clear()
+    expect(store.get('a')).toBeNull(); expect(store.get('b')).toBeNull()
+  })
+})

--- a/packages/adapters/src/localStorage/index.ts
+++ b/packages/adapters/src/localStorage/index.ts
@@ -1,0 +1,48 @@
+import * as fs   from 'node:fs'
+import * as path from 'node:path'
+import * as os   from 'node:os'
+
+export interface LocalStorageAdapter {
+  get<T>(key: string): T | null
+  set<T>(key: string, value: T): void
+  remove(key: string): void
+  clear(): void
+}
+
+function resolveStorePath(service: string): string {
+  const dir = path.join(os.homedir(), '.config', 'termui')
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
+  return path.join(dir, `${service}.json`)
+}
+
+function readStore(filePath: string): Record<string, unknown> {
+  try {
+    if (!fs.existsSync(filePath)) return {}
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Record<string, unknown>
+  } catch { return {} }
+}
+
+function writeStore(filePath: string, data: Record<string, unknown>): void {
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf-8')
+}
+
+export function useLocalStorage(service: string): LocalStorageAdapter {
+  const storePath = resolveStorePath(service)
+  return {
+    get<T>(key: string): T | null {
+      const s = readStore(storePath)
+      return key in s ? (s[key] as T) : null
+    },
+    set<T>(key: string, value: T): void {
+      const s = readStore(storePath)
+      s[key] = value
+      writeStore(storePath, s)
+    },
+    remove(key: string): void {
+      const s = readStore(storePath)
+      delete s[key]
+      writeStore(storePath, s)
+    },
+    clear(): void { writeStore(storePath, {}) },
+  }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` -->

## Description

Introduces a new `useLocalStorage` adapter for persistent local storage in terminal applications. Data is stored in service-specific JSON files under the TermUI configuration directory and supports typed get/set/remove/clear operations.

## Related Issue

Closes #1113 

## Which package(s)?

@termuijs/adapters

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [x] ✨ Feature (`type:feature`)
* [x] 🧪 Tests (`type:testing`)
* [ ] 📝 Docs (`type:docs`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md](https://chatgpt.com/c/CONTRIBUTING.md)`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/84e87b15-54d6-40b1-949b-a09fec98075a`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

Implemented synchronous JSON-backed storage with generic typing support. Added tests using temporary directories and exported the adapter through the package entrypoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local storage adapter for persisting application data locally.

* **Tests**
  * Added comprehensive test coverage for the local storage adapter, including data retrieval, storage, deletion, and clearing operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->