### PR TITLE
feat(data): add PATCH support, reset(), and mutationCount to useMutation

### DIFF
--- a/packages/data/src/hooks/useMutation.ts
+++ b/packages/data/src/hooks/useMutation.ts
@@ -2,13 +2,15 @@
 
 import { useCallback, useState } from "@termuijs/jsx";
 
-export type HttpMethod = 'POST' | 'PUT' | 'DELETE'
+export type HttpMethod = 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 
 export interface UseMutationReturn<T> {
-    mutate: (payload: any) => Promise<T>;
+    mutate: (payload: unknown) => Promise<T>;
+    reset: ()  => void;
     data: T | null;
     error: Error | null;
     loading: boolean;
+    mutationCount: number;
 }
 
 /**
@@ -19,14 +21,15 @@ export interface UseMutationReturn<T> {
  * `loading`, `data`, and `error` state.
  *
  * @param url - The endpoint URL to mutate.
- * @param method - HTTP method: 'POST' (default), 'PUT', or 'DELETE'.
+ * @param method - HTTP method: 'POST' (default), 'PUT', 'PATCH', or 'DELETE'.
  */
-export function useMutation<T = any>(url: string, method: HttpMethod = 'POST'): UseMutationReturn<T> {
+export function useMutation<T = unknown>(url: string, method: HttpMethod = 'POST'): UseMutationReturn<T> {
     const [loading, setLoading] = useState<boolean>(false)
     const [error, setError] = useState<Error | null>(null)
     const [data, setData] = useState<T | null>(null)
+    const [mutationCount, setMutationCount] = useState<number>(0)
 
-    const mutate = useCallback(async (payload: any): Promise<T> => {
+    const mutate = useCallback(async (payload: unknown): Promise<T> => {
         setLoading(true)
         setError(null)
 
@@ -45,6 +48,7 @@ export function useMutation<T = any>(url: string, method: HttpMethod = 'POST'): 
 
             const result = (await response.json()) as T
             setData(result)
+            setMutationCount((c)=> c+1)
             return result;
 
         } catch (err) {
@@ -57,5 +61,11 @@ export function useMutation<T = any>(url: string, method: HttpMethod = 'POST'): 
 
     }, [url, method])
 
-    return { mutate, data, error, loading };
+    const reset = useCallback(() => {
+    setData(null)
+    setError(null)
+    setLoading(false)
+}, [])
+
+    return { mutate,reset, data, error, loading,mutationCount };
 }


### PR DESCRIPTION


## Description
Three additive improvements to `useMutation` in `@termuijs/data`:
1. Added `'PATCH'` to `HttpMethod` — passing `'PATCH'` previously caused a
   TypeScript error. PATCH is standard for partial resource updates.
2. Added `reset()` — clears `data`, `error`, and `loading` back to initial
   values. Terminal forms that submit multiple times had no way to clear
   stale results between submissions.
3. Added `mutationCount` — increments on every successful `mutate()` call.
   Allows components to react to each new submission without comparing
   `data` values, which breaks when the API returns the same payload twice.


#768 


## Which package(s)?
`@termuijs/data`

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [X] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [X] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [X] Tests pass locally: `bun vitest run`
- [X] Build passes: `bun run build`
- [X] Typecheck passes: `bun run typecheck`
- [X] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [X] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [X] No new `any` types without an inline comment explaining why.
- [X] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [X] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Notes for the Reviewer
## Description
Three additive improvements to `useMutation` in `@termuijs/data`:
1. Added `'PATCH'` to `HttpMethod` — passing `'PATCH'` previously caused a
   TypeScript error. PATCH is standard for partial resource updates.
2. Added `reset()` — clears `data`, `error`, and `loading` back to initial
   values. Terminal forms that submit multiple times had no way to clear
   stale results between submissions.
3. Added `mutationCount` — increments on every successful `mutate()` call.
   Allows components to react to each new submission without comparing
   `data` values, which breaks when the API returns the same payload twice.
All changes are additive. Existing `{ mutate, data, error, loading }`
destructuring continues to work unchanged.

## Related Issue
Closes #

## Which package(s)?
`@termuijs/data`

## Type of Change
- [x] ✨ Feature (`type:feature`)

## Checklist
- [ ] ⭐ You starred the repo.
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] No new `any` types (replaced `any` with `unknown` on payload and generic default).
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation
- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/048e6a97-baaf-4a03-b6e5-bdfc6c38e173`

## Notes for the Reviewer
`mutationCount` increments inside the `try` block after `setData(result)`,
so it only counts successful mutations. `reset()` does not reset
`mutationCount` — this is intentional so components can track the
lifetime total of successful submissions independently of the form state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for PATCH HTTP requests in mutations, in addition to existing methods.
  * New reset action to clear mutation results and error/loading state.
  * Mutation counter added to track how many mutations have been performed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->