### PR TITLE
fix(ui): guard tab navigation when tabs array is empty

### DIFF
--- a/packages/ui/src/Tabs.test.ts
+++ b/packages/ui/src/Tabs.test.ts
@@ -40,9 +40,12 @@ describe('Tabs', () => {
 
     it('safe with no tabs', () => {
         const tabs = new Tabs([]);
-        expect(() => tabs.selectTab(0)).not.toThrow();
-        expect(() => tabs.nextTab()).not.toThrow();
-        expect(() => tabs.prevTab()).not.toThrow();
+        tabs.selectTab(0);
+        tabs.nextTab();
+        tabs.nextTab();
+        tabs.prevTab();
+        tabs.prevTab();
         expect(tabs.activeIndex).toBe(0);
+        expect(Number.isFinite(tabs.activeIndex)).toBe(true);
     });
 });

--- a/packages/ui/src/Tabs.test.ts
+++ b/packages/ui/src/Tabs.test.ts
@@ -37,4 +37,12 @@ describe('Tabs', () => {
         tabs.prevTab(); // wraps to 2
         expect(tabs.activeIndex).toBe(2);
     });
+
+    it('safe with no tabs', () => {
+        const tabs = new Tabs([]);
+        expect(() => tabs.selectTab(0)).not.toThrow();
+        expect(() => tabs.nextTab()).not.toThrow();
+        expect(() => tabs.prevTab()).not.toThrow();
+        expect(tabs.activeIndex).toBe(0);
+    });
 });

--- a/packages/ui/src/Tabs.ts
+++ b/packages/ui/src/Tabs.ts
@@ -24,9 +24,19 @@ export class Tabs extends Widget {
     }
 
     get activeIndex(): number { return this._activeIndex; }
-    selectTab(i: number): void { if (i >= 0 && i < this._tabs.length) { this._activeIndex = i; this.markDirty(); } }
-    nextTab(): void { this._activeIndex = (this._activeIndex + 1) % this._tabs.length; this.markDirty(); }
-    prevTab(): void { this._activeIndex = (this._activeIndex - 1 + this._tabs.length) % this._tabs.length; this.markDirty(); }
+    selectTab(i: number): void {
+        if (i >= 0 && i < this._tabs.length) { this._activeIndex = i; this.markDirty(); }
+    }
+    nextTab(): void {
+        if (this._tabs.length === 0) return;
+        this._activeIndex = (this._activeIndex + 1) % this._tabs.length;
+        this.markDirty();
+    }
+    prevTab(): void {
+        if (this._tabs.length === 0) return;
+        this._activeIndex = (this._activeIndex - 1 + this._tabs.length) % this._tabs.length;
+        this.markDirty();
+    }
     get activeContent(): Widget | undefined { return this._tabs[this._activeIndex]?.content; }
 
     protected _renderSelf(screen: Screen): void {


### PR DESCRIPTION
## Description

Fixes an edge case in the `Tabs` component where calling `nextTab()` or `prevTab()` with an empty tabs array could result in invalid modulo operations. Added regression tests to ensure navigation methods behave safely when no tabs are present.

## Related Issue

Closes #1127 

## Which package(s)?

@termuijs/ui

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)
* [x] 🧪 Tests (`type:testing`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [ ] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.

* Your GSSoC profile:
  `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

### Root Cause

`nextTab()` and `prevTab()` performed modulo operations using `this._tabs.length`.

When the tabs array is empty (`length === 0`), navigation could result in invalid active index calculations.

### Changes Made

* Added guards in `nextTab()` and `prevTab()` when no tabs exist.
* Added regression tests covering empty tab arrays.
* Preserved existing behavior for non-empty tab arrays.

### Testing

```bash
bun vitest run packages/ui/src/Tabs.test.ts
```

All Tabs tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tabs navigation now safely handles empty tab lists; switching tabs no longer produces invalid indices or unexpected behavior.

* **Tests**
  * Added test coverage verifying Tabs remains stable when constructed with no tabs and during navigation actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->