### PR TITLE
fix: add space key handler in TextInput to prevent word concatenation

### DIFF
--- a/examples/chat-app/src/index.tsx
+++ b/examples/chat-app/src/index.tsx
@@ -219,6 +219,9 @@ class ChatExampleApp extends Widget {
             case 'end':
                 this.textInput.moveCursorEnd();
                 break;
+            case 'space':
+                this.textInput.insertChar(' ');
+                break;
             case 'enter':
             case 'return':
                 this.textInput.submit();


### PR DESCRIPTION
# fix: add space key handler in TextInput to prevent word concatenation

## Description
The `TextInput` component in the `chat-app` example was silently dropping spacebar presses, causing all typed words to concatenate together. Added an explicit `case 'space'` handler in `handleTextInputKey()` that correctly inserts a space character when the spacebar is pressed.

## Related Issue
Closes #1134 

## Which package(s)?
`@termuijs/widgets` — `TextInput` (reproduced via `examples/chat-app`)

## Type of Change
- [x] 🐛 Bug fix (`type:bug`)

## Checklist
- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`[CONTRIBUTING.md]
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation
- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/944accbd-2283-4364-9c90-43bdbee0ecbf`

## Root Cause
TermUI's key event system delivers the spacebar as the string `'space'`, not as a single `' '` character. The existing `default` branch in `handleTextInputKey()` only catches keys where `key.length === 1`. Since `'space'.length === 6`, it silently fell through and the space was never inserted.

**Before (broken):**
```typescript
default:
    if (key && key.length === 1 && !event.ctrl && !event.alt) {
        this.textInput.insertChar(key); // 'space' never reaches here
    }
```

**After (fixed):**
```typescript
case 'space':
    this.textInput.insertChar(' ');
    break;
```

## Screenshots / Recordings (UI changes)
<img width="612" height="375" alt="image" src="https://github.com/user-attachments/assets/24f7ff5d-ea12-41c7-bf0d-85763f7af5a6" />

**Before fix:** Typing "what is term ui ? " appeared as "whatistermui?"  
**After fix:** Typing "what is term ui ?" appears as "what is term ui ?" ✅

## Notes for the Reviewer
Simple one-line fix. The `handleTextInputKey()` method handles all other special keys (`backspace`, `delete`, `enter`, etc.) explicitly via a switch statement — space should have been included from the start. No side effects, no rendering changes needed since `insertChar()` already calls the necessary update internally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed space-key handling in the chat input so pressing space reliably inserts a space character while composing messages.
* **Chores**
  * Minor non-functional formatting adjustment to the chat startup script (no user-facing behavior change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->