### PR TITLE
fix(jsx): render portal children in correct fiber context during render phase

### DIFF
--- a/packages/jsx/src/createPortal.ts
+++ b/packages/jsx/src/createPortal.ts
@@ -5,7 +5,7 @@
 import type { Widget } from '@termuijs/widgets';
 import type { VNode } from './vnode.js';
 import { createElement as h } from './createElement.js';
-import { useLayoutEffect } from './hooks.js';
+import { useLayoutEffect, currentFiber } from './hooks.js';
 import { reconcile } from './reconciler.js';
 
 interface PortalProps {
@@ -14,19 +14,25 @@ interface PortalProps {
 }
 
 function PortalComponent({ target, children }: PortalProps): VNode {
-    // We must call reconcile() inside the effect so we don't break the active Fiber stack 
-    // during the render phase. When the layout effect runs, the Fiber context is correctly
-    // restored, so Context and Hooks inside the portal children will work flawlessly!
-    useLayoutEffect(() => {
-        const childArray = Array.isArray(children) ? children : (children != null ? [children] : []);
-        const childWidgets = childArray.map((child: VNode) => reconcile(child, target));
+    const fiber = currentFiber();
+    const childArray = Array.isArray(children) ? children : (children != null ? [children] : []);
 
+    // Reconcile portal children during the render phase while the fiber context
+    // (_currentFiber / _parentFiber) is still active. This ensures correct fiber
+    // parent references, context propagation, and proper cleanup registration.
+    const childWidgets = childArray.map((child: VNode) => reconcile(child, target));
+
+    // Register portal children on the fiber so destroyFiber can clean them up
+    fiber.portalChildren = [{ widgets: childWidgets, target }];
+
+    // Use useLayoutEffect only for DOM-like side effects (adding/removing from target).
+    // The cleanup function from the previous render cycle removes old widgets before
+    // the new effect adds the new ones, matching React's effect lifecycle semantics.
+    useLayoutEffect(() => {
         for (const widget of childWidgets) {
             target.addChild(widget);
         }
 
-        // Cleanup: remove ONLY this portal's widgets from the target
-        // when the portal unmounts or re-renders.
         return () => {
             for (const widget of childWidgets) {
                 target.removeChild(widget);

--- a/packages/jsx/src/hooks.ts
+++ b/packages/jsx/src/hooks.ts
@@ -9,6 +9,7 @@
 import type { KeyEvent } from '@termuijs/core';
 import { caps } from '@termuijs/core';
 import { timerPoolSubscribe } from '@termuijs/motion';
+import type { Widget } from '@termuijs/widgets';
 import type { FC } from './vnode.js';
 
 // ── Fiber — per-component-instance state ──
@@ -44,6 +45,9 @@ export interface Fiber {
     _prevChildFibers?: Map<string, ChildFiberEntry>;
     /** Next child render index, reset by setCurrentFiber each render pass */
     _nextChildIdx?: number;
+    // ── Portal tracking ──
+    /** Widgets created via createPortal and their target, for proper teardown */
+    portalChildren?: Array<{ widgets: Widget[]; target: Widget }>;
 }
 
 interface HookState {
@@ -601,6 +605,15 @@ export function destroyFiber(fiber: Fiber): void {
         for (const entry of fiber._prevChildFibers.values()) {
             destroyFiber(entry.fiber);
         }
+    }
+    // Clean up portal children — remove portal widgets from their targets
+    if (fiber.portalChildren) {
+        for (const entry of fiber.portalChildren) {
+            for (const widget of entry.widgets) {
+                entry.target.removeChild(widget);
+            }
+        }
+        fiber.portalChildren = undefined;
     }
     // Clean up global _instanceMap entries pointing to this fiber
     const termuiInstances: Map<any, any> | undefined = (globalThis as any).__termuijs_instances;


### PR DESCRIPTION
## Fixes #1137

### Problem
`createPortal` deferred `reconcile()` to a `useLayoutEffect`, which ran outside React's
reconciliation phase. The created fibers had no `_parentFiber`, breaking hooks and context.

### Changes
- Moved `reconcile()` from `useLayoutEffect` into the `PortalComponent` render body,
  so portal children are reconciled during the normal render phase with proper fiber context
- Added `portalChildren` array to the `Fiber` type for `destroyFiber` cleanup traversal
- DOM operations remain in effects (only reconciliation moved to render)

### Verification
- `npx vitest run packages/jsx` — all 236 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved portal cleanup issues to prevent memory leaks by improving how portal-based widgets are tracked and removed throughout the component lifecycle.
  * Enhanced portal child management for more reliable resource teardown when components are destroyed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->