### PR TITLE
fix(jsx): route Suspense through renderComponent for correct fiber cotext

### DIFF
--- a/packages/jsx/src/reconciler.ts
+++ b/packages/jsx/src/reconciler.ts
@@ -291,23 +291,9 @@ export function reconcile(vnode: VNode, parentWidget?: Widget): Widget {
         else if (t === Sidebar) type = 'sidebar';
         else if (t === Spinner) type = 'spinner';
 
-        // Suspense boundary
+        // Suspense boundary — go through renderComponent so fiber context is set
         if (type === Suspense) {
-            try {
-                const suspenseChild = children.length === 1 ? children[0] : {
-                    type: Fragment,
-                    props: {},
-                    children,
-                } as any;
-
-                return reconcile(suspenseChild);
-            } catch (err) {
-                if (err instanceof Promise) {
-                    return reconcile(props.fallback);
-                }
-
-                throw err;
-            }
+            return renderComponent(SuspenseBoundary as any, props, children);
         }
 
         // Functional component
@@ -355,6 +341,32 @@ function defaultErrorVNode(err: Error): VNode {
             { type: 'text', props: {}, children: [err.message] },
         ],
     } as any;
+}
+
+/**
+ * SuspenseBoundary — a component wrapper that reconciles children and, if a
+ * lazy-loaded component throws a Promise, renders the fallback instead.
+ * Because it goes through renderComponent(), the fiber context
+ * (_currentFiber, _parentFiber) is correctly set, so the fallback subtree
+ * has proper parent references, context propagation, and error boundary
+ * traversal.
+ */
+function SuspenseBoundary(props: Record<string, any>): any {
+    const children = Array.isArray(props.children) ? props.children : [props.children];
+    const child = children.length === 1 ? children[0] : {
+        type: Fragment,
+        props: {},
+        children,
+    } as any;
+
+    try {
+        return reconcile(child);
+    } catch (err) {
+        if (err instanceof Promise) {
+            return props.fallback;
+        }
+        throw err;
+    }
 }
 
 /** Destroy child fibers in _prevChildFibers that were not re-visited this render */


### PR DESCRIPTION
## Fixes #1138

### Problem
Suspense fallback was rendered via an inline special case in the reconciler that bypassed
`renderComponent()`. The fallback fiber had no `_parentFiber`, breaking hooks and context.

### Changes
- Replaced inline Suspense handling with a `SuspenseBoundary` component defined in `reconciler.ts`
- `SuspenseBoundary` goes through `renderComponent()` like any normal component, gaining
  proper fiber context, hooks support, and lifecycle management
- Defined in reconciler.ts (not Suspense.ts) to avoid circular import

### Verification
- `npx vitest run packages/jsx` — all 236 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Suspense boundary rendering to correctly handle fiber context, ensuring suspended components display fallback UI as expected and error handling works properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->