### PR TITLE
feat(tss): add lighten, darken, and alpha color functions (closes #158)

### DIFF
--- a/packages/tss/src/color-functions.test.ts
+++ b/packages/tss/src/color-functions.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { lighten, darken, alpha, evalColorFunction } from './color-functions.js';
+
+describe('lighten', () => {
+    it('lightens a hex color by percentage', () => {
+        const result = lighten('#336699', '20%');
+        expect(result).toMatch(/^#[0-9a-f]{6}$/);
+        // lightened color has higher RGB values than original
+        const r = parseInt(result.slice(1, 3), 16);
+        expect(r).toBeGreaterThan(0x33);
+    });
+
+    it('lightens a hex color by decimal amount', () => {
+        const result = lighten('#000000', 0.5);
+        expect(result).toBe('#808080');
+    });
+
+    it('returns original color for invalid hex', () => {
+        expect(lighten('notacolor', '10%')).toBe('notacolor');
+    });
+});
+
+describe('darken', () => {
+    it('darkens a hex color by percentage', () => {
+        const result = darken('#336699', '20%');
+        expect(result).toMatch(/^#[0-9a-f]{6}$/);
+        const r = parseInt(result.slice(1, 3), 16);
+        expect(r).toBeLessThan(0x33);
+    });
+
+    it('darkens a hex color by decimal amount', () => {
+        const result = darken('#ffffff', 1);
+        expect(result).toBe('#000000');
+    });
+
+    it('returns original color for invalid hex', () => {
+        expect(darken('notacolor', '10%')).toBe('notacolor');
+    });
+});
+
+describe('alpha', () => {
+    it('sets alpha on a hex color', () => {
+        const result = alpha('#000000', 0.5);
+        expect(result).toBe('rgba(0, 0, 0, 0.5)');
+    });
+
+    it('accepts percentage string for alpha', () => {
+        const result = alpha('#ffffff', '50%');
+        expect(result).toBe('rgba(255, 255, 255, 0.5)');
+    });
+
+    it('returns original color for invalid hex', () => {
+        expect(alpha('notacolor', 0.5)).toBe('notacolor');
+    });
+});
+
+describe('evalColorFunction', () => {
+    it('evaluates lighten() function call', () => {
+        const result = evalColorFunction('lighten(#336699, 20%)');
+        expect(result).toMatch(/^#[0-9a-f]{6}$/);
+    });
+
+    it('evaluates darken() function call', () => {
+        const result = evalColorFunction('darken(#336699, 20%)');
+        expect(result).toMatch(/^#[0-9a-f]{6}$/);
+    });
+
+    it('evaluates alpha() function call', () => {
+        const result = evalColorFunction('alpha(#000000, 0.5)');
+        expect(result).toBe('rgba(0, 0, 0, 0.5)');
+    });
+
+    it('returns value unchanged if not a color function', () => {
+        expect(evalColorFunction('#336699')).toBe('#336699');
+        expect(evalColorFunction('cyan')).toBe('cyan');
+    });
+});

--- a/packages/tss/src/color-functions.ts
+++ b/packages/tss/src/color-functions.ts
@@ -1,0 +1,95 @@
+function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
+    const clean = hex.replace('#', '');
+    if (clean.length === 3) {
+        return {
+            r: parseInt(clean[0] + clean[0], 16),
+            g: parseInt(clean[1] + clean[1], 16),
+            b: parseInt(clean[2] + clean[2], 16),
+        };
+    }
+    if (clean.length === 6) {
+        return {
+            r: parseInt(clean.slice(0, 2), 16),
+            g: parseInt(clean.slice(2, 4), 16),
+            b: parseInt(clean.slice(4, 6), 16),
+        };
+    }
+    return null;
+}
+
+/** Clamp a number between 0 and 255 */
+function clamp(n: number): number {
+    return Math.max(0, Math.min(255, Math.round(n)));
+}
+
+/** Convert r,g,b back to hex string */
+function rgbToHex(r: number, g: number, b: number): string {
+    return '#' + [r, g, b].map(v => clamp(v).toString(16).padStart(2, '0')).join('');
+}
+
+/** Parse an amount — supports percentage string ("20%") or plain number (0.2) */
+function parseAmount(amount: string | number): number {
+    if (typeof amount === 'string' && amount.endsWith('%')) {
+        return parseFloat(amount) / 100;
+    }
+    return typeof amount === 'string' ? parseFloat(amount) : amount;
+}
+
+/**
+ * Lighten a hex color by a given amount (0–1 or "0%"–"100%").
+ * Shifts each RGB channel toward 255.
+ */
+export function lighten(color: string, amount: string | number): string {
+    const rgb = hexToRgb(color);
+    if (!rgb) return color;
+    const a = parseAmount(amount);
+    return rgbToHex(
+        rgb.r + (255 - rgb.r) * a,
+        rgb.g + (255 - rgb.g) * a,
+        rgb.b + (255 - rgb.b) * a,
+    );
+}
+
+/**
+ * Darken a hex color by a given amount (0–1 or "0%"–"100%").
+ * Shifts each RGB channel toward 0.
+ */
+export function darken(color: string, amount: string | number): string {
+    const rgb = hexToRgb(color);
+    if (!rgb) return color;
+    const a = parseAmount(amount);
+    return rgbToHex(
+        rgb.r * (1 - a),
+        rgb.g * (1 - a),
+        rgb.b * (1 - a),
+    );
+}
+
+/**
+ * Set the alpha/transparency of a hex color.
+ * Returns rgba(r, g, b, alpha) string.
+ */
+export function alpha(color: string, amount: string | number): string {
+    const rgb = hexToRgb(color);
+    if (!rgb) return color;
+    const a = parseAmount(amount);
+    return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${a})`;
+}
+
+/**
+ * Evaluate a color function call string like:
+ *   lighten(#336699, 20%)
+ *   darken(#336699, 0.2)
+ *   alpha(#000000, 0.5)
+ *
+ * Returns the resolved color string, or the original value if not matched.
+ */
+export function evalColorFunction(value: string): string {
+    const match = value.match(/^(lighten|darken|alpha)\(\s*(#[0-9a-fA-F]{3,6})\s*,\s*([^)]+)\s*\)$/);
+    if (!match) return value;
+    const [, fn, color, amount] = match;
+    if (fn === 'lighten') return lighten(color, amount.trim());
+    if (fn === 'darken') return darken(color, amount.trim());
+    if (fn === 'alpha') return alpha(color, amount.trim());
+    return value;
+}

--- a/packages/tss/src/color-functions.ts
+++ b/packages/tss/src/color-functions.ts
@@ -85,7 +85,7 @@ export function alpha(color: string, amount: string | number): string {
  * Returns the resolved color string, or the original value if not matched.
  */
 export function evalColorFunction(value: string): string {
-    const match = value.match(/^(lighten|darken|alpha)\(\s*(#[0-9a-fA-F]{3,6})\s*,\s*([^)]+)\s*\)$/);
+    const match = value.match(/^(lighten|darken|alpha)\(\s*(#(?:[0-9a-fA-F]{6}|[0-9a-fA-F]{3}))\s*,\s*([^)]+)\s*\)$/);
     if (!match) return value;
     const [, fn, color, amount] = match;
     if (fn === 'lighten') return lighten(color, amount.trim());

--- a/packages/tss/src/index.ts
+++ b/packages/tss/src/index.ts
@@ -39,3 +39,4 @@ export { AutoThemeProvider, ThemeContext, useTheme } from './AutoThemeProvider.j
 export type { AutoThemeProviderProps } from './AutoThemeProvider.js';
 export * from './media.js';
 export * from './importer.js';
+export { lighten, darken, alpha, evalColorFunction } from './color-functions.js';


### PR DESCRIPTION
Closes #158

## Changes
- Added `color-functions.ts` with `lighten()`, `darken()`, and `alpha()` functions
- `evalColorFunction()` evaluates function call strings like `lighten(#336699, 20%)`
- Exported from `src/index.ts`
- Added `color-functions.test.ts` with 13 tests covering all functions

## Tests
All 13 tests passing ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added color utilities to lighten/darken hex colors and adjust transparency using percentage or decimal amounts.
  * Support for function-call syntax to evaluate color transformations directly within color definitions.
  * Graceful handling of invalid inputs by returning the original value unchanged.

* **Tests**
  * Added test coverage validating lighten, darken, alpha, and the function-call evaluator across valid and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->