### PR TITLE
test(widgets): add tests for BigText, Gradient, and Banner

### DIFF
--- a/packages/widgets/src/display/BigText.test.ts
+++ b/packages/widgets/src/display/BigText.test.ts
@@ -120,6 +120,44 @@ describe('BigText', () => {
         // Should render 'A'
         expect(screen.back[0][1].char).toBe('█');
     });
+
+    it('applies custom color to rendered cells', () => {
+        const color = { type: 'named' as const, name: 'red' as const };
+        const widget = new BigText('A', {}, { color });
+        const screen = new Screen(10, 10);
+        widget.updateRect({ x: 0, y: 0, width: 10, height: 10 });
+        widget.render(screen);
+
+        // A filled cell should have the custom fg color
+        expect(screen.back[0][1].fg).toEqual(color);
+    });
+
+    it('renders digit glyphs correctly', () => {
+        const widget = new BigText('1');
+        const screen = new Screen(10, 10);
+        widget.updateRect({ x: 0, y: 0, width: 10, height: 10 });
+        widget.render(screen);
+
+        // '1' row 0: " # "
+        expect(screen.back[0][0].char).toBe(' ');
+        expect(screen.back[0][1].char).toBe('█');
+        expect(screen.back[0][2].char).toBe(' ');
+        // '1' row 4: "###"
+        expect(screen.back[4][0].char).toBe('█');
+        expect(screen.back[4][1].char).toBe('█');
+        expect(screen.back[4][2].char).toBe('█');
+    });
+
+    it('clips glyphs when height is smaller than 5', () => {
+        const widget = new BigText('A');
+        const screen = new Screen(10, 3);
+        widget.updateRect({ x: 0, y: 0, width: 10, height: 3 });
+        widget.render(screen);
+
+        // Only first 3 rows should render
+        expect(screen.back[0][1].char).toBe('█'); // row 0 of 'A'
+        expect(screen.back[2][0].char).toBe('█'); // row 2 of 'A' (###)
+    });
 });
 
 describe('BigText – mutation regression tests', () => {

--- a/packages/widgets/src/display/BigText.test.ts
+++ b/packages/widgets/src/display/BigText.test.ts
@@ -122,7 +122,7 @@ describe('BigText', () => {
     });
 
     it('applies custom color to rendered cells', () => {
-        const color = { type: 'named' as const, name: 'red' as const };
+        const color: import('@termuijs/core').Color = { type: 'named', name: 'red' };
         const widget = new BigText('A', {}, { color });
         const screen = new Screen(10, 10);
         widget.updateRect({ x: 0, y: 0, width: 10, height: 10 });

--- a/packages/widgets/src/display/Gradient.test.ts
+++ b/packages/widgets/src/display/Gradient.test.ts
@@ -88,6 +88,45 @@ describe("Gradient Widget — Rendering & Colors", () => {
         // Should fall back to default style's fg color (green)
         expect(screen.back[0][0].fg).toEqual({ type: 'named', name: 'green' });
     });
+
+    it('interpolates midpoint color between start and end', () => {
+        vi.spyOn(caps, 'color', 'get').mockReturnValue(true);
+        const widget = new Gradient('abc', {}, { startColor: '#ff0000', endColor: '#0000ff' });
+        const screen = new Screen(20, 1);
+        widget.updateRect({ x: 0, y: 0, width: 20, height: 1 });
+        widget.render(screen);
+
+        const mid = screen.back[0][1].fg as { type: string; r: number; g: number; b: number };
+        expect(mid.type).toBe('rgb');
+        // Midpoint of red->blue: r should be between 0 and 255, b should be between 0 and 255
+        expect(mid.r).toBeGreaterThan(0);
+        expect(mid.r).toBeLessThan(255);
+        expect(mid.b).toBeGreaterThan(0);
+        expect(mid.b).toBeLessThan(255);
+    });
+
+    it('assigns start color to a single character', () => {
+        vi.spyOn(caps, 'color', 'get').mockReturnValue(true);
+        const widget = new Gradient('X', {}, { startColor: '#ff0000', endColor: '#0000ff' });
+        const screen = new Screen(20, 1);
+        widget.updateRect({ x: 0, y: 0, width: 20, height: 1 });
+        widget.render(screen);
+
+        // Single char: t=0, so color should be startColor
+        expect(screen.back[0][0].fg).toEqual({ type: 'rgb', r: 255, g: 0, b: 0 });
+        expect(screen.back[0][0].char).toBe('X');
+    });
+
+    it('truncates text to available width', () => {
+        vi.spyOn(caps, 'color', 'get').mockReturnValue(true);
+        const widget = new Gradient('abcdef', {}, { startColor: '#ff0000', endColor: '#0000ff' });
+        const screen = new Screen(3, 1);
+        widget.updateRect({ x: 0, y: 0, width: 3, height: 1 });
+        widget.render(screen);
+
+        const row = screen.back[0].map(c => c.char).join('');
+        expect(row).toBe('abc');
+    });
 });
 
 describe("Gradient Widget — Layout & Alignment", () => {

--- a/packages/widgets/src/display/Gradient.test.ts
+++ b/packages/widgets/src/display/Gradient.test.ts
@@ -96,13 +96,16 @@ describe("Gradient Widget — Rendering & Colors", () => {
         widget.updateRect({ x: 0, y: 0, width: 20, height: 1 });
         widget.render(screen);
 
-        const mid = screen.back[0][1].fg as { type: string; r: number; g: number; b: number };
-        expect(mid.type).toBe('rgb');
-        // Midpoint of red->blue: r should be between 0 and 255, b should be between 0 and 255
-        expect(mid.r).toBeGreaterThan(0);
-        expect(mid.r).toBeLessThan(255);
-        expect(mid.b).toBeGreaterThan(0);
-        expect(mid.b).toBeLessThan(255);
+        const mid = screen.back[0][1].fg;
+        expect(mid).toBeDefined();
+        expect(mid?.type).toBe('rgb');
+        if (mid?.type === 'rgb') {
+            // Midpoint of red->blue: r should be between 0 and 255, b should be between 0 and 255
+            expect(mid.r).toBeGreaterThan(0);
+            expect(mid.r).toBeLessThan(255);
+            expect(mid.b).toBeGreaterThan(0);
+            expect(mid.b).toBeLessThan(255);
+        }
     });
 
     it('assigns start color to a single character', () => {

--- a/packages/widgets/src/feedback/Banner.test.ts
+++ b/packages/widgets/src/feedback/Banner.test.ts
@@ -263,4 +263,36 @@ describe('Banner', () => {
     
         expect(banner.isDirty).toBe(false);
     });
+
+    it('does not mark dirty when variant is unchanged', () => {
+        const banner = new Banner({}, { variant: 'error' });
+
+        banner.clearDirty();
+        banner.setVariant('error');
+
+        expect(banner.isDirty).toBe(false);
+    });
+
+    it('renders body without a title', () => {
+        const screen = renderBanner(
+            new Banner({}, { body: 'just body' }),
+            18,
+            6,
+        );
+
+        expect(rowText(screen, 2)).toContain('just body');
+    });
+
+    it('draws horizontal border characters along top and bottom edges', () => {
+        const screen = renderBanner(new Banner(), 10, 4);
+
+        // Top-left and top-right corners are non-space border chars
+        expect(cell(screen, 0, 0).char).not.toBe(' ');
+        expect(cell(screen, 9, 0).char).not.toBe(' ');
+        // Horizontal bar along top
+        expect(cell(screen, 1, 0).char).not.toBe(' ');
+        // Bottom-left and bottom-right corners
+        expect(cell(screen, 0, 3).char).not.toBe(' ');
+        expect(cell(screen, 9, 3).char).not.toBe(' ');
+    });
 });


### PR DESCRIPTION
## Description

Added comprehensive test coverage for the `BigText`, `Gradient`, and `Banner` widgets. This includes testing missing edge cases such as `BigText` custom colors and clipping, `Gradient` interpolation and truncation, and `Banner` border rendering and no-op mutation handling.

## Related Issue

Closes #154 

## Which package(s)?

@termuijs/widgets

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/557492d3-891a-40c7-b174-9d0feaecf81b`

## Screenshots / Recordings (UI changes)

_N/A - Test additions only._

## Notes for the Reviewer

The requested widgets already had test files in their respective subdirectories (`packages/widgets/src/display/` and `packages/widgets/src/feedback/`). Instead of creating new test files as suggested in the issue description, I extended the existing tests to cover missing edge cases and ensure 100% adherence to the acceptance criteria while maintaining the project's directory structure conventions. Tests added:

*   **BigText:** Custom `color` option, digit glyph rendering, height clipping.
*   **Gradient:** Midpoint color interpolation, single-character `t=0` edge case, string truncation.
*   **Banner:** Unchanged `variant` mutation skip, body-only rendering, corner/edge border characters. All checks pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for the BigText widget: verifies custom cell foreground colors, correct digit glyph rendering patterns, and clipping when display height is limited.
  * Expanded coverage for the Gradient widget: verifies midpoint color interpolation, single-character color assignment, and text truncation to available width.
  * Expanded coverage for the Banner widget: verifies variant state handling, body-only rendering, and horizontal border drawing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->