### PR TITLE
feat(tss): add Rosé Pine built-in theme

### DIFF
--- a/packages/tss/README.md
+++ b/packages/tss/README.md
@@ -12,13 +12,13 @@ Requires `@termuijs/core` and `@termuijs/widgets`.
 
 ## Built-in themes
 
-Eleven themes ship ready to use: Default, Cyberpunk, Nord, Dracula, Gruvbox, Catppuccin, Solarized, Solarized Light, Tokyo Night, High Contrast, and Everforest.
+Twelve themes ship ready to use: Default, Cyberpunk, Nord, Dracula, Gruvbox, Catppuccin, Solarized, Solarized Light, Tokyo Night, High Contrast, Everforest, and Rosé Pine.
 
 ```typescript
 import { getBuiltinThemeNames, getBuiltinTheme, TSSEngine } from '@termuijs/tss'
 
 getBuiltinThemeNames()
-// ['default', 'cyberpunk', 'nord', 'dracula', 'gruvbox', 'catppuccin', 'solarized', 'solarizedLight', 'tokyo-night', 'highContrast', 'everforest']
+// ['default', 'cyberpunk', 'nord', 'dracula', 'gruvbox', 'catppuccin', 'solarized', 'solarizedLight', 'tokyo-night', 'highContrast', 'everforest', 'rose-pine']
 
 const engine = new TSSEngine()
 engine.load(getBuiltinTheme('nord'))
@@ -102,7 +102,7 @@ const primaryColor = nordTheme['--primary']
 const bgColor = draculaTheme['--bg']
 ```
 
-Available token exports: `draculaTheme`, `nordTheme`, `gruvboxTheme`, `catppuccinTheme`, `monokaiTheme`, `solarizedTheme`, `solarizedLightTheme`, `tokyoNightTheme`, `oneDarkTheme`, `highContrastTheme`, `everforestTheme`.
+Available token exports: `draculaTheme`, `nordTheme`, `gruvboxTheme`, `catppuccinTheme`, `monokaiTheme`, `solarizedTheme`, `solarizedLightTheme`, `tokyoNightTheme`, `oneDarkTheme`, `highContrastTheme`, `everforestTheme`, `rosePineTheme`.
 
 ## tokensToTSS
 

--- a/packages/tss/package.json
+++ b/packages/tss/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/Karanjot786/TermUI"
   },
   "version": "0.1.5",
-  "description": "Terminal Style Sheets for TermUI: variables, selectors, and eleven built-in themes",
+  "description": "Terminal Style Sheets for TermUI: variables, selectors, and twelve built-in themes",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/tss/src/named-themes.ts
+++ b/packages/tss/src/named-themes.ts
@@ -1,4 +1,4 @@
-// Named ThemeTokens — 10 curated color schemes
+// Named ThemeTokens — 11 curated color schemes
 // ─────────────────────────────────────────────────────
 
 import type { ThemeTokens } from './tokens.js';
@@ -121,6 +121,19 @@ export const gruvboxTheme: ThemeTokens = {
   highlight: '#3c3836',
 };
 
+export const rosePineTheme: ThemeTokens = {
+  bg: '#191724',
+  fg: '#e0def4',
+  primary: '#c4a7e7',
+  secondary: '#ebbcba',
+  success: '#9ccfd8',
+  warning: '#f6c177',
+  error: '#eb6f92',
+  muted: '#6e6a86',
+  border: '#6e6a86',
+  highlight: '#26233a',
+};
+
 export const highContrastTheme: ThemeTokens = {
   bg: '#000000',
   fg: '#ffffff',
@@ -160,6 +173,7 @@ export const NAMED_THEMES: Record<string, ThemeTokens> = {
   gruvbox: gruvboxTheme,
   highContrast: highContrastTheme,
   everforest: everforestTheme,
+  "rose-pine": rosePineTheme,
 };
 
 /** Get a named theme by string key, falling back to defaultDark if not found. */

--- a/packages/tss/src/themes.test.ts
+++ b/packages/tss/src/themes.test.ts
@@ -19,7 +19,8 @@ describe('Built-in Themes', () => {
         expect(names).toContain('gruvbox');
         expect(names).toContain('tokyo-night');
         expect(names).toContain('everforest');
-        expect(names).toHaveLength(11);
+        expect(names).toContain('rose-pine');
+        expect(names).toHaveLength(12);
     });
 
     it('tokyo-night theme contains expected palette values', () => {
@@ -102,5 +103,14 @@ describe('Built-in Themes', () => {
         expect(src).toContain('#a7c080');
         expect(src).toContain('#2d353b');
         expect(src).toContain('#e67e80');
+    });
+
+    it('rose-pine theme exposes correct Rosé Pine base hex colors', () => {
+        const src = getBuiltinTheme('rose-pine');
+        expect(src).toBeDefined();
+        expect(src).toContain('@theme rose-pine');
+        expect(src).toContain('#c4a7e7');
+        expect(src).toContain('#191724');
+        expect(src).toContain('#eb6f92');
     });
 });

--- a/packages/tss/src/themes.ts
+++ b/packages/tss/src/themes.ts
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────
-// Built-in Themes — 10 curated terminal color palettes
+// Built-in Themes — 12 curated terminal color palettes
 // ─────────────────────────────────────────────────────
 
 export const BUILTIN_THEMES: Record<string, string> = {
@@ -300,6 +300,33 @@ Gauge {
 Table {
     border: var(--border);
     header-color: var(--primary);
+}
+`,
+
+    "rose-pine": `
+@theme rose-pine {
+    --primary: #c4a7e7;
+    --secondary: #ebbcba;
+    --bg: #191724;
+    --surface: #26233a;
+    --text: #e0def4;
+    --text-muted: #6e6a86;
+    --accent: #9ccfd8;
+    --error: #eb6f92;
+    --warning: #f6c177;
+    --success: #9ccfd8;
+    --border: round;
+    --border-color: #6e6a86;
+    --border-focus: #c4a7e7;
+}
+
+Gauge {
+    color: var(--primary);
+}
+
+Table {
+    border: var(--border);
+    header-color: var(--secondary);
 }
 `,
 };


### PR DESCRIPTION
Closes #534 (proposed by @Karanjot786   )

Adds Rosé Pine (main variant) as a new built-in theme in `@termuijs/tss`, following the existing pattern for named and built-in theme registries.

## Changes

- `src/named-themes.ts` — new `rosePineTheme` token export + `"rose-pine"` entry in `NAMED_THEMES`
- `src/themes.ts` — new `@theme rose-pine { ... }` block in `BUILTIN_THEMES`
- `src/themes.test.ts` — rose-pine palette assertions + length bumped 11 → 12
- `package.json` — description updated to "twelve built-in themes"
- `README.md` — count, theme list, example output, and token exports updated

All 12 theme tests pass.

## Summary by CodeRabbit
* **New Features**
  * Added Rosé Pine theme as a new built-in option, expanding the library to 12 available themes with complete color palette and styling configuration.
* **Documentation**
  * Updated README and package information to reflect the expanded theme collection.
* **Tests**
  * Added test coverage for the new theme to ensure proper functionality.