### PR TITLE
feat: add Slider and RangeInput widget

### DIFF
--- a/packages/ui/src/Slider.test.ts
+++ b/packages/ui/src/Slider.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Screen, createKeyEvent, caps } from '@termuijs/core';
+import { Slider, RangeInput } from './Slider.js';
+
+function key(name: string) {
+    return createKeyEvent({
+        key: name,
+        raw: Buffer.from(''),
+        ctrl: false,
+        alt: false,
+        shift: false,
+    });
+}
+
+function renderSlider() {
+    const slider = new Slider({}, {
+        min: 0,
+        max: 100,
+        step: 5,
+        value: 20,
+    });
+
+    const screen = new Screen(20, 1);
+
+    slider.updateRect({
+        x: 0,
+        y: 0,
+        width: 20,
+        height: 1,
+    });
+
+    slider.render(screen);
+
+    return { slider, screen };
+}
+
+describe('Slider', () => {
+    it('right key increments value', () => {
+        const { slider } = renderSlider();
+
+        slider.handleKey(key('right'));
+
+        expect(slider.getValue()).toBe(25);
+    });
+
+    it('left key decrements value', () => {
+        const { slider } = renderSlider();
+
+        slider.handleKey(key('left'));
+
+        expect(slider.getValue()).toBe(15);
+    });
+
+    it('clamps at max', () => {
+        const slider = new Slider({}, {
+            min: 0,
+            max: 100,
+            step: 5,
+            value: 100,
+        });
+
+        slider.handleKey(key('right'));
+
+        expect(slider.getValue()).toBe(100);
+    });
+
+    it('fires onChange callback', () => {
+        const onChange = vi.fn();
+
+        const slider = new Slider({}, {
+            min: 0,
+            max: 100,
+            step: 5,
+            value: 20,
+            onChange,
+        });
+
+        slider.handleKey(key('right'));
+
+        expect(onChange).toHaveBeenCalledWith(25);
+    });
+
+    it('renders ASCII fallback', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+
+        const slider = new Slider({}, {
+            min: 0,
+            max: 100,
+            value: 50,
+        });
+
+        const screen = new Screen(10, 1);
+
+        slider.updateRect({
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 1,
+        });
+
+        slider.render(screen);
+
+        const rendered = screen.back[0]
+            .map((c: { char: string }) => c.char)
+            .join('');
+
+        expect(rendered).toContain('O');
+    });
+
+    it('stores low and high values', () => {
+        const range = new RangeInput({}, {
+            min: 0,
+            max: 100,
+            low: 20,
+            high: 80,
+        });
+
+        expect(range.getLow()).toBe(20);
+        expect(range.getHigh()).toBe(80);
+    });
+
+    it('renders two handles', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+
+        const range = new RangeInput({}, {
+            min: 0,
+            max: 100,
+            low: 20,
+            high: 80,
+        });
+
+        const screen = new Screen(20, 1);
+
+        range.updateRect({
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 1,
+        });
+
+        range.render(screen);
+
+        const rendered = screen.back[0]
+            .map((c: { char: string }) => c.char)
+            .join('');
+
+        const handles = rendered
+            .split('')
+            .filter((ch) => ch === 'O')
+            .length;
+
+        expect(handles).toBe(2);
+    });
+});

--- a/packages/ui/src/Slider.ts
+++ b/packages/ui/src/Slider.ts
@@ -148,10 +148,15 @@ export class RangeInput extends Widget {
         this._max = opts.max;
         this._step = opts.step ?? 1;
 
-        this._low = opts.low ?? opts.min;
-        this._high = opts.high ?? opts.max;
-
         this.onChange = opts.onChange;
+
+this._low = this._min;
+this._high = this._max;
+
+this.setRange(
+    opts.low ?? this._min,
+    opts.high ?? this._max,
+);
     }
 
     getLow(): number {
@@ -163,15 +168,39 @@ export class RangeInput extends Widget {
     }
 
     setRange(low: number, high: number): void {
-        const nextLow = Math.max(this._min, Math.min(low, high));
-        const nextHigh = Math.min(this._max, Math.max(high, nextLow));
+    const nextLow = Math.max(
+        this._min,
+        Math.min(this._max, low),
+    );
 
-        this._low = nextLow;
-        this._high = nextHigh;
+    const nextHigh = Math.max(
+        this._min,
+        Math.min(this._max, high),
+    );
 
-        this.onChange?.(this._low, this._high);
-        this.markDirty();
+    const normalizedLow = Math.min(
+        nextLow,
+        nextHigh,
+    );
+
+    const normalizedHigh = Math.max(
+        nextLow,
+        nextHigh,
+    );
+
+    if (
+        normalizedLow === this._low &&
+        normalizedHigh === this._high
+    ) {
+        return;
     }
+
+    this._low = normalizedLow;
+    this._high = normalizedHigh;
+
+    this.onChange?.(this._low, this._high);
+    this.markDirty();
+}
 
     protected _renderSelf(screen: Screen): void {
         const { x, y, width } = this._rect;

--- a/packages/ui/src/Slider.ts
+++ b/packages/ui/src/Slider.ts
@@ -1,0 +1,213 @@
+import { Widget } from '@termuijs/widgets';
+import {
+    type Screen,
+    type Style,
+    type KeyEvent,
+    mergeStyles,
+    defaultStyle,
+    styleToCellAttrs,
+    caps,
+} from '@termuijs/core';
+
+export interface SliderOptions {
+    min: number;
+    max: number;
+    step?: number;
+    value?: number;
+    onChange?: (value: number) => void;
+}
+
+export interface RangeInputOptions {
+    min: number;
+    max: number;
+    step?: number;
+    low?: number;
+    high?: number;
+    onChange?: (low: number, high: number) => void;
+}
+
+export class Slider extends Widget {
+    private _value: number;
+    private _min: number;
+    private _max: number;
+    private _step: number;
+
+    onChange?: (value: number) => void;
+
+    focusable = true;
+
+    constructor(
+        style: Partial<Style> = {},
+        opts: SliderOptions,
+    ) {
+        super(
+            mergeStyles(
+                defaultStyle(),
+                { height: 1, ...style },
+            ),
+        );
+
+        this._min = opts.min;
+        this._max = opts.max;
+        this._step = opts.step ?? 1;
+        this._value = this._clamp(opts.value ?? opts.min);
+        this.onChange = opts.onChange;
+    }
+
+    private _clamp(value: number): number {
+        return Math.min(
+            this._max,
+            Math.max(this._min, value),
+        );
+    }
+
+    getValue(): number {
+        return this._value;
+    }
+
+    setValue(value: number): void {
+        const clamped = this._clamp(value);
+
+        if (clamped === this._value) return;
+
+        this._value = clamped;
+        this.onChange?.(this._value);
+        this.markDirty();
+    }
+
+    increment(): void {
+        this.setValue(this._value + this._step);
+    }
+
+    decrement(): void {
+        this.setValue(this._value - this._step);
+    }
+
+    handleKey(event: KeyEvent): void {
+        switch (event.key) {
+            case 'right':
+                this.increment();
+                break;
+
+            case 'left':
+                this.decrement();
+                break;
+        }
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width } = this._rect;
+
+        if (width <= 0) return;
+
+        const attrs = styleToCellAttrs(this.style);
+
+        const trackChar = caps.unicode ? '\u2500' : '-';
+const handleChar = caps.unicode ? '\u25CF' : 'O';
+        const ratio =
+            (this._value - this._min) /
+            (this._max - this._min || 1);
+
+        const handlePos =
+            Math.round(ratio * (width - 1));
+
+        let track = trackChar.repeat(width);
+
+        track =
+            track.slice(0, handlePos) +
+            handleChar +
+            track.slice(handlePos + 1);
+
+        screen.writeString(x, y, track, attrs);
+    }
+}
+
+export class RangeInput extends Widget {
+    private _low: number;
+    private _high: number;
+    private _min: number;
+    private _max: number;
+    private _step: number;
+
+    onChange?: (low: number, high: number) => void;
+
+    focusable = true;
+
+    constructor(
+        style: Partial<Style> = {},
+        opts: RangeInputOptions,
+    ) {
+        super(
+            mergeStyles(
+                defaultStyle(),
+                { height: 1, ...style },
+            ),
+        );
+
+        this._min = opts.min;
+        this._max = opts.max;
+        this._step = opts.step ?? 1;
+
+        this._low = opts.low ?? opts.min;
+        this._high = opts.high ?? opts.max;
+
+        this.onChange = opts.onChange;
+    }
+
+    getLow(): number {
+        return this._low;
+    }
+
+    getHigh(): number {
+        return this._high;
+    }
+
+    setRange(low: number, high: number): void {
+        const nextLow = Math.max(this._min, Math.min(low, high));
+        const nextHigh = Math.min(this._max, Math.max(high, nextLow));
+
+        this._low = nextLow;
+        this._high = nextHigh;
+
+        this.onChange?.(this._low, this._high);
+        this.markDirty();
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width } = this._rect;
+
+        if (width <= 0) return;
+
+        const attrs = styleToCellAttrs(this.style);
+
+        const trackChar = caps.unicode ? '\u2500' : '-';
+        const handleChar = caps.unicode ? '\u25CF' : 'O';
+
+        const range = this._max - this._min || 1;
+
+        const lowPos = Math.round(
+            ((this._low - this._min) / range) * (width - 1),
+        );
+
+        const highPos = Math.round(
+            ((this._high - this._min) / range) * (width - 1),
+        );
+
+        const chars = trackChar.repeat(width).split('');
+
+        if (lowPos >= 0 && lowPos < chars.length) {
+            chars[lowPos] = handleChar;
+        }
+
+        if (highPos >= 0 && highPos < chars.length) {
+            chars[highPos] = handleChar;
+        }
+
+        screen.writeString(
+            x,
+            y,
+            chars.join(''),
+            attrs,
+        );
+    }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -29,6 +29,7 @@ export {
 } from '@termuijs/widgets';
 
 // ── New components ──
+import { Slider, RangeInput } from './Slider.js';
 export { Divider } from './Divider.js';
 export type { DividerOptions } from './Divider.js';
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -29,7 +29,7 @@ export {
 } from '@termuijs/widgets';
 
 // ── New components ──
-import { Slider, RangeInput } from './Slider.js';
+export { Slider, RangeInput } from './Slider.js';
 export { Divider } from './Divider.js';
 export type { DividerOptions } from './Divider.js';
 


### PR DESCRIPTION
## Description

Adds a new `Slider` widget and `RangeInput` variant to `@termuijs/ui`.

The Slider renders a horizontal track with a movable handle, supports left/right arrow keyboard navigation, step-based value updates, min/max clamping, Unicode/ASCII fallbacks, and `onChange` callbacks. The RangeInput variant supports selecting a low/high range with two handles. Test coverage has been added for both widgets.

## Related Issue

Closes #144

## Which package(s)?

@termuijs/ui

## Type of Change

* [x] ✨ Feature (`type:feature`)
* [x] 🧪 Tests (`type:testing`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md](https://chatgpt.com/c/CONTRIBUTING.md)`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/YOUR_PROFILE_ID`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

### Features Implemented

* Slider widget with horizontal track and movable handle
* Left/right arrow keyboard controls
* Step-based value adjustment
* Min/max clamping
* `onChange(value)` callback support
* Unicode rendering with ASCII fallback
* RangeInput variant with two handles
* `markDirty()` on rendering state changes

### Tests Added

* Increment value with right arrow
* Decrement value with left arrow
* Clamp value at max
* Verify `onChange` callback
* ASCII fallback rendering
* RangeInput low/high value storage
* RangeInput two-handle rendering

### Additional Notes

Full monorepo typecheck currently reports existing errors in `@termuijs/adapters` unrelated to this PR. Slider and RangeInput tests pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Slider for single-value selection and a RangeInput for dual-handle ranges. Both support configurable min/max/step, keyboard interaction, change callbacks, and Unicode/ASCII handle rendering.

* **Tests**
  * Added test coverage for keyboard interaction, value clamping, change callbacks, and fallback (ASCII) rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->