### PR TITLE
test(widgets): improve type safety in Calendar test by replacing KeyE…

### DIFF
--- a/packages/widgets/src/data/Calendar.test.ts
+++ b/packages/widgets/src/data/Calendar.test.ts
@@ -3,8 +3,12 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi } from 'vitest';
-import { Screen, caps, type KeyEvent } from '@termuijs/core';
+import { Screen, caps, createKeyEvent } from '@termuijs/core';
 import { Calendar } from './Calendar.js';
+
+// Helper to create KeyEvent objects for testing
+const key = (name: string) =>
+    createKeyEvent({ key: name, raw: Buffer.alloc(0), ctrl: false, alt: false, shift: false });
 
 describe('Calendar', () => {
     it('initializes with default date (today) and options', () => {
@@ -64,11 +68,11 @@ describe('Calendar', () => {
         const cal = new Calendar({ width: 30, height: 10 }, { date: new Date(2026, 5, 2) });
 
         // Move left: -1 day -> June 1, 2026
-        cal.handleKey({ key: 'left' } as KeyEvent);
+        cal.handleKey(key('left'));
         expect(cal.getSelectedDate().getDate()).toBe(1);
 
         // Move right: +1 day -> June 2, 2026
-        cal.handleKey({ key: 'right' } as KeyEvent);
+        cal.handleKey(key('right'));
         expect(cal.getSelectedDate().getDate()).toBe(2);
     });
 
@@ -76,11 +80,11 @@ describe('Calendar', () => {
         const cal = new Calendar({ width: 30, height: 10 }, { date: new Date(2026, 5, 10) });
 
         // Move up: -7 days -> June 3, 2026
-        cal.handleKey({ key: 'up' } as KeyEvent);
+        cal.handleKey(key('up'));
         expect(cal.getSelectedDate().getDate()).toBe(3);
 
         // Move down: +7 days -> June 10, 2026
-        cal.handleKey({ key: 'down' } as KeyEvent);
+        cal.handleKey(key('down'));
         expect(cal.getSelectedDate().getDate()).toBe(10);
     });
 
@@ -88,14 +92,14 @@ describe('Calendar', () => {
         const cal = new Calendar({ width: 30, height: 10 }, { date: new Date(2026, 5, 1) }); // June 1, 2026
 
         // Move left: -1 day -> May 31, 2026
-        cal.handleKey({ key: 'left' } as KeyEvent);
+        cal.handleKey(key('left'));
         const date = cal.getSelectedDate();
         expect(date.getFullYear()).toBe(2026);
         expect(date.getMonth()).toBe(4); // May is 4
         expect(date.getDate()).toBe(31);
 
         // Move right: +1 day -> June 1, 2026
-        cal.handleKey({ key: 'right' } as KeyEvent);
+        cal.handleKey(key('right'));
         expect(cal.getSelectedDate().getMonth()).toBe(5); // June is 5
         expect(cal.getSelectedDate().getDate()).toBe(1);
     });
@@ -105,11 +109,11 @@ describe('Calendar', () => {
         const cal = new Calendar({ width: 30, height: 10 }, { date: new Date(2024, 1, 28) });
 
         // Move right: +1 day -> Feb 29, 2024
-        cal.handleKey({ key: 'right' } as KeyEvent);
+        cal.handleKey(key('right'));
         expect(cal.getSelectedDate().getDate()).toBe(29);
 
         // Move right: +1 day -> Mar 1, 2024
-        cal.handleKey({ key: 'right' } as KeyEvent);
+        cal.handleKey(key('right'));
         expect(cal.getSelectedDate().getMonth()).toBe(2); // March is 2
         expect(cal.getSelectedDate().getDate()).toBe(1);
     });
@@ -119,7 +123,7 @@ describe('Calendar', () => {
         const date = new Date(2026, 5, 2);
         const cal = new Calendar({ width: 30, height: 10 }, { date, onSelect });
 
-        cal.handleKey({ key: 'enter' } as KeyEvent);
+        cal.handleKey(key('enter'));
         expect(onSelect).toHaveBeenCalled();
         expect(onSelect.mock.calls[0][0].getDate()).toBe(2);
     });
@@ -193,7 +197,7 @@ describe('Calendar', () => {
         cal.clearDirty();
         expect(cal.isDirty).toBe(false);
 
-        cal.handleKey({ key: 'left' } as KeyEvent);
+        cal.handleKey(key('left'));
         expect(cal.isDirty).toBe(true);
 
         cal.clearDirty();

--- a/packages/widgets/src/data/Calendar.test.ts
+++ b/packages/widgets/src/data/Calendar.test.ts
@@ -3,7 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi } from 'vitest';
-import { Screen, caps } from '@termuijs/core';
+import { Screen, caps, type KeyEvent } from '@termuijs/core';
 import { Calendar } from './Calendar.js';
 
 describe('Calendar', () => {
@@ -64,11 +64,11 @@ describe('Calendar', () => {
         const cal = new Calendar({ width: 30, height: 10 }, { date: new Date(2026, 5, 2) });
 
         // Move left: -1 day -> June 1, 2026
-        cal.handleKey({ key: 'left' } as any);
+        cal.handleKey({ key: 'left' } as KeyEvent);
         expect(cal.getSelectedDate().getDate()).toBe(1);
 
         // Move right: +1 day -> June 2, 2026
-        cal.handleKey({ key: 'right' } as any);
+        cal.handleKey({ key: 'right' } as KeyEvent);
         expect(cal.getSelectedDate().getDate()).toBe(2);
     });
 
@@ -76,11 +76,11 @@ describe('Calendar', () => {
         const cal = new Calendar({ width: 30, height: 10 }, { date: new Date(2026, 5, 10) });
 
         // Move up: -7 days -> June 3, 2026
-        cal.handleKey({ key: 'up' } as any);
+        cal.handleKey({ key: 'up' } as KeyEvent);
         expect(cal.getSelectedDate().getDate()).toBe(3);
 
         // Move down: +7 days -> June 10, 2026
-        cal.handleKey({ key: 'down' } as any);
+        cal.handleKey({ key: 'down' } as KeyEvent);
         expect(cal.getSelectedDate().getDate()).toBe(10);
     });
 
@@ -88,14 +88,14 @@ describe('Calendar', () => {
         const cal = new Calendar({ width: 30, height: 10 }, { date: new Date(2026, 5, 1) }); // June 1, 2026
 
         // Move left: -1 day -> May 31, 2026
-        cal.handleKey({ key: 'left' } as any);
+        cal.handleKey({ key: 'left' } as KeyEvent);
         const date = cal.getSelectedDate();
         expect(date.getFullYear()).toBe(2026);
         expect(date.getMonth()).toBe(4); // May is 4
         expect(date.getDate()).toBe(31);
 
         // Move right: +1 day -> June 1, 2026
-        cal.handleKey({ key: 'right' } as any);
+        cal.handleKey({ key: 'right' } as KeyEvent);
         expect(cal.getSelectedDate().getMonth()).toBe(5); // June is 5
         expect(cal.getSelectedDate().getDate()).toBe(1);
     });
@@ -105,11 +105,11 @@ describe('Calendar', () => {
         const cal = new Calendar({ width: 30, height: 10 }, { date: new Date(2024, 1, 28) });
 
         // Move right: +1 day -> Feb 29, 2024
-        cal.handleKey({ key: 'right' } as any);
+        cal.handleKey({ key: 'right' } as KeyEvent);
         expect(cal.getSelectedDate().getDate()).toBe(29);
 
         // Move right: +1 day -> Mar 1, 2024
-        cal.handleKey({ key: 'right' } as any);
+        cal.handleKey({ key: 'right' } as KeyEvent);
         expect(cal.getSelectedDate().getMonth()).toBe(2); // March is 2
         expect(cal.getSelectedDate().getDate()).toBe(1);
     });
@@ -119,7 +119,7 @@ describe('Calendar', () => {
         const date = new Date(2026, 5, 2);
         const cal = new Calendar({ width: 30, height: 10 }, { date, onSelect });
 
-        cal.handleKey({ key: 'enter' } as any);
+        cal.handleKey({ key: 'enter' } as KeyEvent);
         expect(onSelect).toHaveBeenCalled();
         expect(onSelect.mock.calls[0][0].getDate()).toBe(2);
     });
@@ -193,7 +193,7 @@ describe('Calendar', () => {
         cal.clearDirty();
         expect(cal.isDirty).toBe(false);
 
-        cal.handleKey({ key: 'left' } as any);
+        cal.handleKey({ key: 'left' } as KeyEvent);
         expect(cal.isDirty).toBe(true);
 
         cal.clearDirty();


### PR DESCRIPTION
## Description

Improves type safety in Calendar widget tests by replacing `KeyEvent` `as any` assertions with proper `KeyEvent` typing. No functional changes were made.

## Related Issue

#1161

## Which package(s)?

@termuijs/widgets

## Type of Change

- [x] 🧪 Tests (`type:testing`)
- [x] ♻️ Refactor (`type:refactor`)

## Notes for the Reviewer

- Imported `KeyEvent` from `@termuijs/core`
- Replaced `as any` assertions with proper `KeyEvent` typing in Calendar tests
- No runtime or behavior changes
- Existing tests continue to pass



## GSSoC 2026 Participation

- [x]  GSSoC 2026 contributor.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved calendar keyboard navigation tests to more reliably validate left/right/up/down day and week movement, month-boundary wrapping, leap-year behavior, selection via Enter, and state updates after navigation—helping ensure consistent keyboard interactions in the calendar widget.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->