### PR TITLE
feat(tss): add Rosé Pine built-in theme 

### DIFF
--- a/packages/tss/README.md
+++ b/packages/tss/README.md
@@ -12,13 +12,13 @@ Requires `@termuijs/core` and `@termuijs/widgets`.
 
 ## Built-in themes
 
-Eleven themes ship ready to use: Default, Cyberpunk, Nord, Dracula, Gruvbox, Catppuccin, Solarized, Solarized Light, Tokyo Night, High Contrast, and Everforest.
+Twelve themes ship ready to use: Default, Cyberpunk, Nord, Dracula, Gruvbox, Catppuccin, Solarized, Solarized Light, Tokyo Night, High Contrast, Everforest, and Rosé Pine.
 
 ```typescript
 import { getBuiltinThemeNames, getBuiltinTheme, TSSEngine } from '@termuijs/tss'
 
 getBuiltinThemeNames()
-// ['default', 'cyberpunk', 'nord', 'dracula', 'gruvbox', 'catppuccin', 'solarized', 'solarizedLight', 'tokyo-night', 'highContrast', 'everforest']
+// ['default', 'cyberpunk', 'nord', 'dracula', 'gruvbox', 'catppuccin', 'solarized', 'solarizedLight', 'tokyo-night', 'highContrast', 'everforest', 'rose-pine']
 
 const engine = new TSSEngine()
 engine.load(getBuiltinTheme('nord'))
@@ -102,7 +102,7 @@ const primaryColor = nordTheme['--primary']
 const bgColor = draculaTheme['--bg']
 ```
 
-Available token exports: `draculaTheme`, `nordTheme`, `gruvboxTheme`, `catppuccinTheme`, `monokaiTheme`, `solarizedTheme`, `solarizedLightTheme`, `tokyoNightTheme`, `oneDarkTheme`, `highContrastTheme`, `everforestTheme`.
+Available token exports: `draculaTheme`, `nordTheme`, `gruvboxTheme`, `catppuccinTheme`, `monokaiTheme`, `solarizedTheme`, `solarizedLightTheme`, `tokyoNightTheme`, `oneDarkTheme`, `highContrastTheme`, `everforestTheme`, `rosePineTheme`.
 
 ## tokensToTSS
 

--- a/packages/tss/package.json
+++ b/packages/tss/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/Karanjot786/TermUI"
   },
   "version": "0.1.5",
-  "description": "Terminal Style Sheets for TermUI: variables, selectors, and eleven built-in themes",
+  "description": "Terminal Style Sheets for TermUI: variables, selectors, and twelve built-in themes",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/tss/src/index.ts
+++ b/packages/tss/src/index.ts
@@ -31,6 +31,7 @@ export { adaptive, type AdaptiveColor } from './adaptive.js';
 export {
   draculaTheme, nordTheme, catppuccinTheme, monokaiTheme,
   solarizedTheme, solarizedLightTheme, tokyoNightTheme, oneDarkTheme, highContrastTheme,
+  rosePineTheme,
   NAMED_THEMES, getNamedTheme,
 } from './named-themes.js';
 

--- a/packages/tss/src/named-themes.ts
+++ b/packages/tss/src/named-themes.ts
@@ -1,4 +1,4 @@
-// Named ThemeTokens — 10 curated color schemes
+// Named ThemeTokens — 11 curated color schemes
 // ─────────────────────────────────────────────────────
 
 import type { ThemeTokens } from './tokens.js';
@@ -121,6 +121,19 @@ export const gruvboxTheme: ThemeTokens = {
   highlight: '#3c3836',
 };
 
+export const rosePineTheme: ThemeTokens = {
+  bg: '#191724',
+  fg: '#e0def4',
+  primary: '#c4a7e7',
+  secondary: '#ebbcba',
+  success: '#9ccfd8',
+  warning: '#f6c177',
+  error: '#eb6f92',
+  muted: '#6e6a86',
+  border: '#6e6a86',
+  highlight: '#26233a',
+};
+
 export const highContrastTheme: ThemeTokens = {
   bg: '#000000',
   fg: '#ffffff',
@@ -160,6 +173,7 @@ export const NAMED_THEMES: Record<string, ThemeTokens> = {
   gruvbox: gruvboxTheme,
   highContrast: highContrastTheme,
   everforest: everforestTheme,
+  "rose-pine": rosePineTheme,
 };
 
 /** Get a named theme by string key, falling back to defaultDark if not found. */

--- a/packages/tss/src/themes.test.ts
+++ b/packages/tss/src/themes.test.ts
@@ -19,7 +19,8 @@ describe('Built-in Themes', () => {
         expect(names).toContain('gruvbox');
         expect(names).toContain('tokyo-night');
         expect(names).toContain('everforest');
-        expect(names).toHaveLength(11);
+        expect(names).toContain('rose-pine');
+        expect(names).toHaveLength(12);
     });
 
     it('tokyo-night theme contains expected palette values', () => {
@@ -102,5 +103,14 @@ describe('Built-in Themes', () => {
         expect(src).toContain('#a7c080');
         expect(src).toContain('#2d353b');
         expect(src).toContain('#e67e80');
+    });
+
+    it('rose-pine theme exposes correct Rosé Pine base hex colors', () => {
+        const src = getBuiltinTheme('rose-pine');
+        expect(src).toBeDefined();
+        expect(src).toContain('@theme rose-pine');
+        expect(src).toContain('#c4a7e7');
+        expect(src).toContain('#191724');
+        expect(src).toContain('#eb6f92');
     });
 });

--- a/packages/tss/src/themes.ts
+++ b/packages/tss/src/themes.ts
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────
-// Built-in Themes — 10 curated terminal color palettes
+// Built-in Themes — 12 curated terminal color palettes
 // ─────────────────────────────────────────────────────
 
 export const BUILTIN_THEMES: Record<string, string> = {
@@ -300,6 +300,33 @@ Gauge {
 Table {
     border: var(--border);
     header-color: var(--primary);
+}
+`,
+
+    "rose-pine": `
+@theme rose-pine {
+    --primary: #c4a7e7;
+    --secondary: #ebbcba;
+    --bg: #191724;
+    --surface: #26233a;
+    --text: #e0def4;
+    --text-muted: #6e6a86;
+    --accent: #9ccfd8;
+    --error: #eb6f92;
+    --warning: #f6c177;
+    --success: #9ccfd8;
+    --border: round;
+    --border-color: #6e6a86;
+    --border-focus: #c4a7e7;
+}
+
+Gauge {
+    color: var(--primary);
+}
+
+Table {
+    border: var(--border);
+    header-color: var(--secondary);
 }
 `,
 };

--- a/packages/tss/src/themes.ts
+++ b/packages/tss/src/themes.ts
@@ -315,7 +315,7 @@ Table {
     --error: #eb6f92;
     --warning: #f6c177;
     --success: #9ccfd8;
-    --border: round;
+    --border: #6e6a86;
     --border-color: #6e6a86;
     --border-focus: #c4a7e7;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

<!-- What does this PR do? 1 to 3 sentences. -->

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #

## Which package(s)?

<!-- Example: @termuijs/core, @termuijs/widgets, website. -->

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Rosé Pine theme to the built-in theme library, increasing curated themes to twelve.

* **Documentation**
  * Updated docs and package description to reflect the new theme and updated theme count.

* **Tests**
  * Added/updated tests to verify the Rosé Pine theme is present and its palette is correct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->