### PR TITLE
Feat/cli non interactive

### DIFF
--- a/packages/create-termui-app/src/args.test.ts
+++ b/packages/create-termui-app/src/args.test.ts
@@ -107,5 +107,13 @@ describe("CLI args", () => {
     it("isNonInteractive works", () => {
         expect(isNonInteractive(parseArgs(["app", "--yes"]))).toBe(true);
         expect(isNonInteractive(parseArgs(["app"]))).toBe(false);
+        expect(isNonInteractive(parseArgs(["app", "--template", "dashboard", "--theme", "default"]))).toBe(true);
+        expect(isNonInteractive(parseArgs(["app", "--template", "dashboard"]))).toBe(false);
+    });
+
+    it("throws error for invalid template key", () => {
+        expect(() => parseArgs(["app", "--template", "invalid-template"])).toThrow(
+            'Invalid template "invalid-template". Valid: empty, dashboard, interactive-tool, cli-wrapper, cli-tool, file-manager, ai-assistant, form-wizard'
+        );
     });
 });

--- a/packages/create-termui-app/src/args.ts
+++ b/packages/create-termui-app/src/args.ts
@@ -17,6 +17,7 @@ const TEMPLATE_KEYS = [
     "cli-wrapper",
     "cli-tool",
     "file-manager",
+    "ai-assistant",
     "form-wizard",
 ] as const;
 
@@ -97,9 +98,15 @@ export function parseArgs(argv: string[]): CliArgs {
         args.theme = theme;
     }
 
+    if (args.yes) {
+        args.name = args.name ?? "my-termui-app";
+        args.template = args.template ?? "empty";
+        args.theme = args.theme ?? "default";
+    }
+
     return args;
 }
 
 export function isNonInteractive(args: CliArgs): boolean {
-    return args.yes === true;
+    return args.yes === true || (!!args.name && !!args.template && !!args.theme);
 }

--- a/packages/create-termui-app/src/index.test.ts
+++ b/packages/create-termui-app/src/index.test.ts
@@ -68,4 +68,32 @@ describe('CLI integration', () => {
     expect(generateSpy).not.toHaveBeenCalled();
     expect(existsSync(unsafePath)).toBe(false);
   });
+
+  it('scaffolds project in non-interactive mode without calling prompts', async () => {
+    const addSpy = vi.spyOn(addModule, 'runAddCommand').mockResolvedValue(undefined);
+    const textPromptSpy = vi.spyOn(prompts, 'textPrompt');
+    const selectPromptSpy = vi.spyOn(prompts, 'selectPrompt');
+    const multiSelectPromptSpy = vi.spyOn(prompts, 'multiSelectPrompt');
+    const generateSpy = vi.spyOn(templates, 'generateProject').mockReturnValue(createProjectFiles as any);
+
+    const indexModule = await import('./index');
+    await indexModule.runCli(['non-interactive-app', '--yes']);
+
+    expect(textPromptSpy).not.toHaveBeenCalled();
+    expect(selectPromptSpy).not.toHaveBeenCalled();
+    expect(multiSelectPromptSpy).not.toHaveBeenCalled();
+    expect(generateSpy).toHaveBeenCalledWith({
+      name: 'non-interactive-app',
+      template: 'empty',
+      theme: 'default',
+      features: {
+        router: false,
+        dataProviders: false,
+        hotReload: true,
+      },
+    });
+
+    expect(existsSync(join(tempDir, 'non-interactive-app', 'package.json'))).toBe(true);
+    expect(addSpy).not.toHaveBeenCalled();
+  });
 });

--- a/packages/create-termui-app/src/index.ts
+++ b/packages/create-termui-app/src/index.ts
@@ -7,7 +7,7 @@ import { mkdirSync, writeFileSync, existsSync } from 'node:fs';
 import { getBuiltinThemeNames } from '@termuijs/tss';
 import { textPrompt, selectPrompt, multiSelectPrompt } from './prompts.js';
 import { generateProject, type ProjectConfig } from './templates.js';
-import { parseArgs, type CliArgs } from './args.js';
+import { parseArgs, isNonInteractive, type CliArgs } from './args.js';
 import { runAddCommand } from './commands/add.js';
 import { validateProjectName, validateResolvedPath } from "./validate.js";
 
@@ -58,30 +58,50 @@ async function runProjectScaffold(args: CliArgs): Promise<void> {
   console.log('  └──────────────────────────────────┘');
   console.log();
 
+  const nonInteractive = isNonInteractive(args);
+
   // ── Get project name from args or prompt ──
   let projectName = args.name;
   if (!projectName) {
-    projectName = await textPrompt('Project name', 'my-termui-app');
+    if (nonInteractive) {
+      projectName = 'my-termui-app';
+    } else {
+      projectName = await textPrompt('Project name', 'my-termui-app');
+    }
   }
   projectName = validateProjectName(projectName);
   validateResolvedPath(process.cwd(), projectName);
 
   // ── Template selection ──
-  const templateIdx = args.template
-    ? TEMPLATE_KEYS.indexOf(args.template as typeof TEMPLATE_KEYS[number])
-    : await selectPrompt('What kind of app?', TEMPLATES);
-  const template = TEMPLATE_KEYS[templateIdx >= 0 ? templateIdx : 0];
+  let template: typeof TEMPLATE_KEYS[number];
+  if (args.template) {
+    const templateIdx = TEMPLATE_KEYS.indexOf(args.template as typeof TEMPLATE_KEYS[number]);
+    template = TEMPLATE_KEYS[templateIdx >= 0 ? templateIdx : 0];
+  } else if (nonInteractive) {
+    template = 'empty';
+  } else {
+    const templateIdx = await selectPrompt('What kind of app?', TEMPLATES);
+    template = TEMPLATE_KEYS[templateIdx >= 0 ? templateIdx : 0];
+  }
 
   // ── Theme selection ──
   const themes = getBuiltinThemeNames();
-  const themeIdx = args.theme
-    ? themes.indexOf(args.theme)
-    : await selectPrompt('Choose a theme', themes.map(t => t.charAt(0).toUpperCase() + t.slice(1)));
-  const theme = themes[themeIdx >= 0 ? themeIdx : 0];
+  let theme: string;
+  if (args.theme) {
+    const themeIdx = themes.indexOf(args.theme);
+    theme = themes[themeIdx >= 0 ? themeIdx : 0];
+  } else if (nonInteractive) {
+    theme = themes[0] || 'default';
+  } else {
+    const themeIdx = await selectPrompt('Choose a theme', themes.map(t => t.charAt(0).toUpperCase() + t.slice(1)));
+    theme = themes[themeIdx >= 0 ? themeIdx : 0];
+  }
 
   // ── Feature selection ──
   const featureDefaults = [false, template === 'dashboard', true]; // Router off, Data on for dashboard, HotReload on
-  const featureFlags = await multiSelectPrompt('Features to include', FEATURES, featureDefaults);
+  const featureFlags = nonInteractive
+    ? featureDefaults
+    : await multiSelectPrompt('Features to include', FEATURES, featureDefaults);
 
   const config: ProjectConfig = {
     name: projectName,


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

Adds non-interactive flags (`--template`, `--theme`, and `--yes`) to the project scaffolder. When `--yes` or all required configuration options (`name`, `template`, `theme`) are present, interactive prompts are skipped entirely, making the scaffolding tool usable in CI environments.

## Related Issue

Closes #518 

## Which package(s)?

`packages/create-termui-app`

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: https://gssoc.girlscript.org/profile/3dd85fa0-f204-49cf-8bc2-1fd4c8a63c59

## Screenshots / Recordings (UI changes)

*(N/A - Non-interactive CLI additions; behavior covered by test suites)*

## Notes for the Reviewer

- Template keys and theme lookup are aligned with `index.ts` constants and `@termuijs/tss` builtin themes.
- If `--yes` is specified, unspecified arguments automatically fall back to sensible defaults.
- Added comprehensive unit tests in `args.test.ts` for validating command line parsing and `isNonInteractive` mode detection.
- Added an integration test in `index.test.ts` to verify that the CLI scaffolds projects in non-interactive mode without calling prompt functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added non-interactive mode support via `--yes` flag, which skips all prompts and uses sensible defaults.
  * Introduced new "ai-assistant" template option.

* **Tests**
  * Added test coverage for non-interactive mode behavior and template validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->