### PR TITLE
fix(core): re-layout grandchildren when non-dirty node dimensions change

### DIFF
--- a/packages/core/src/layout/LayoutEngine.ts
+++ b/packages/core/src/layout/LayoutEngine.ts
@@ -28,6 +28,10 @@ export interface LayoutNode {
     /** Last container dimensions used — separate from computed so manual computed edits don't confuse sizeChanged detection */
     _lastContainerWidth: number;
     _lastContainerHeight: number;
+    /** Last computed dimensions — used to detect size changes in non-dirty nodes
+     *  so grandchildren are re-laid out when a parent recomputes this node's rect. */
+    _lastComputedWidth: number;
+    _lastComputedHeight: number;
 }
 
 /**
@@ -42,6 +46,8 @@ export function createLayoutNode(id: string, style: Style, children: LayoutNode[
         _dirty: true,
         _lastContainerWidth: 0,
         _lastContainerHeight: 0,
+        _lastComputedWidth: 0,
+        _lastComputedHeight: 0,
     };
 }
 
@@ -85,7 +91,11 @@ function hasDirtyChild(node: LayoutNode): boolean {
     return false;
 }
 function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, precomputed = false): void {
-    if (!node._dirty) return;
+    if (!node._dirty &&
+        node._lastComputedWidth === node.computed.width &&
+        node._lastComputedHeight === node.computed.height) {
+        return;
+    }
 
     const style = node.style;
     const padding = normalizeEdges(style.padding);
@@ -114,6 +124,8 @@ function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, p
 
     if (node.children.length === 0) {
         node._dirty = false;
+        node._lastComputedWidth = node.computed.width;
+        node._lastComputedHeight = node.computed.height;
         return;
     }
 
@@ -170,6 +182,8 @@ function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, p
             visibleIndex++;
         }
         node._dirty = false;
+        node._lastComputedWidth = node.computed.width;
+        node._lastComputedHeight = node.computed.height;
         return;
     }
 
@@ -369,6 +383,8 @@ function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, p
 
     // Mark this node clean after layout is complete (used by future caching logic)
     node._dirty = false;
+    node._lastComputedWidth = node.computed.width;
+    node._lastComputedHeight = node.computed.height;
 }
 
 /**

--- a/packages/core/src/layout/LayoutEngine.ts
+++ b/packages/core/src/layout/LayoutEngine.ts
@@ -91,6 +91,9 @@ function hasDirtyChild(node: LayoutNode): boolean {
     return false;
 }
 function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, precomputed = false): void {
+    // Skip only if not dirty AND dimensions are unchanged since last layout pass.
+    // Note: node.computed.width/height are written by the parent before this call,
+    // so comparing against them detects non-dirty nodes whose allocated size changed.
     if (!node._dirty &&
         node._lastComputedWidth === node.computed.width &&
         node._lastComputedHeight === node.computed.height) {


### PR DESCRIPTION
## Description

Fixes the layout cache skipping re-layout of grandchildren when a non-dirty node's dimensions change. Previously, `layoutNode()` returned early if `_dirty` was false, even when a parent had just recomputed this node's rect. Added `_lastComputedWidth` / `_lastComputedHeight` tracking so the early return also checks whether dimensions actually changed.

## Related Issue

Closes #1167

## Which package(s)?

@termuijs/core

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (not applicable — core package).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Notes for the Reviewer

This is Option A from the issue (track previous computed rect). The `_lastComputedWidth` / `_lastComputedHeight` fields are persisted at every `_dirty = false` point — three locations in `layoutNode()`. All 336 core tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Layout engine now caches recent element sizes to avoid unnecessary re-layouts. This reduces redundant calculations during rendering and resizing, yielding faster updates, improved responsiveness, and smoother UI performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->