### PR TITLE
feat(widgets): add StackedBarChart widget (#245)

### DIFF
--- a/packages/widgets/src/data/StackedBarChart.test.ts
+++ b/packages/widgets/src/data/StackedBarChart.test.ts
@@ -1,0 +1,78 @@
+import { caps, Screen } from "@termuijs/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { StackedBarChart } from "./StackedBarChart.js";
+
+function renderChart(chart: StackedBarChart, cols = 20, rows = 10): string[] {
+    const screen = new Screen(cols, rows);
+    chart.updateRect({ x: 0, y: 0, width: cols, height: rows });
+    chart.render(screen);
+    return screen.back.map((row) => row.map((cell) => cell.char).join(""));
+}
+
+function nonSpaceCells(rows: string[]): number {
+    return rows
+        .join("")
+        .split("")
+        .filter((char) => char !== " ").length;
+}
+
+describe("StackedBarChart", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("renders a single series without error", () => {
+        const chart = new StackedBarChart({}, { categories: ["A", "B"] });
+
+        chart.setSeries([{ label: "Series A", data: [1, 2] }]);
+
+        expect(() => renderChart(chart)).not.toThrow();
+        expect(nonSpaceCells(renderChart(chart))).toBeGreaterThan(0);
+    });
+
+    it("two series stack per category", () => {
+        const chart = new StackedBarChart({}, { categories: ["A"] });
+
+        chart.setSeries([
+            { label: "Bottom", data: [1] },
+            { label: "Top", data: [3] },
+        ]);
+
+        expect(() => renderChart(chart, 12, 8)).not.toThrow();
+
+        const rows = renderChart(chart, 12, 8);
+        expect(nonSpaceCells(rows)).toBeGreaterThan(0);
+        expect(rows.at(-1)).toContain("A");
+    });
+
+    it("renders category labels along the x axis", () => {
+        const chart = new StackedBarChart({}, { categories: ["A", "B"] });
+
+        chart.setSeries([{ label: "Series A", data: [1, 2] }]);
+
+        const rows = renderChart(chart, 20, 8);
+
+        expect(rows.at(-1)).toContain("A");
+        expect(rows.at(-1)).toContain("B");
+    });
+
+    it("setSeries triggers markDirty", () => {
+        const chart = new StackedBarChart();
+        const markDirtySpy = vi.spyOn(chart, "markDirty");
+
+        chart.setSeries([{ label: "A", data: [1, 2] }]);
+
+        expect(markDirtySpy).toHaveBeenCalled();
+    });
+
+    it("uses ASCII fallback when caps.unicode is false", () => {
+        vi.spyOn(caps, "unicode", "get").mockReturnValue(false);
+
+        const chart = new StackedBarChart({}, { categories: ["A"] });
+        chart.setSeries([{ label: "A", data: [2] }]);
+
+        const rows = renderChart(chart, 10, 8);
+
+        expect(rows.join("")).toContain("|");
+    });
+});

--- a/packages/widgets/src/data/StackedBarChart.ts
+++ b/packages/widgets/src/data/StackedBarChart.ts
@@ -1,0 +1,211 @@
+import { type Color, type Screen, type Style, caps } from "@termuijs/core";
+import { Widget } from "../base/Widget.js";
+import { BrailleCanvas } from "./BrailleCanvas.js";
+
+export interface StackedSeries {
+    label: string;
+    data: number[];
+    color?: Color;
+}
+
+export interface StackedBarChartOptions {
+    categories?: string[];
+    barWidth?: number;
+}
+
+export class StackedBarChart extends Widget {
+    private _series: StackedSeries[] = [];
+    private _categories: string[];
+    private _barWidth: number;
+
+    constructor(style: Partial<Style> = {}, opts: StackedBarChartOptions = {}) {
+        super(style);
+        this._categories = opts.categories ?? [];
+        this._barWidth = opts.barWidth ?? 2;
+    }
+
+    setSeries(series: StackedSeries[]): void {
+        this._series = series;
+        this.markDirty();
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width, height } = this._getContentRect();
+
+        if (width <= 0 || height <= 0 || this._series.length === 0) {
+            return;
+        }
+
+        if (!caps.unicode) {
+            this._renderAscii(screen, x, y, width, height);
+            return;
+        }
+
+        this._renderBraille(screen, x, y, width, height);
+    }
+
+    private _categoryCount(): number {
+        return Math.max(
+            this._categories.length,
+            ...this._series.map((series) => series.data.length),
+        );
+    }
+
+    private _totals(categoryCount: number): number[] {
+        return Array.from({ length: categoryCount }, (_, index) =>
+            this._series.reduce(
+                (sum, series) => sum + Math.max(0, series.data[index] ?? 0),
+                0,
+            ),
+        );
+    }
+
+    private _renderBraille(
+        screen: Screen,
+        x: number,
+        y: number,
+        width: number,
+        height: number,
+    ): void {
+        const categoryCount = this._categoryCount();
+        if (categoryCount === 0) return;
+
+        const labelRows = this._categories.length > 0 ? 1 : 0;
+        const chartHeight = height - labelRows;
+        if (chartHeight <= 0) return;
+
+        const totals = this._totals(categoryCount);
+        const maxTotal = Math.max(...totals);
+        if (maxTotal <= 0) return;
+
+        const pixelWidth = width * 2;
+        const pixelHeight = chartHeight * 4;
+        const gap = 1;
+        const barWidth = Math.max(1, this._barWidth);
+        const step = barWidth + gap;
+
+        this._series.forEach((series, seriesIndex) => {
+            const canvas = new BrailleCanvas(
+                {
+                    width: pixelWidth,
+                    height: pixelHeight,
+                    color: series.color,
+                },
+                {},
+            );
+
+            for (
+                let categoryIndex = 0;
+                categoryIndex < categoryCount;
+                categoryIndex++
+            ) {
+                const stackBase = this._series
+                    .slice(0, seriesIndex)
+                    .reduce(
+                        (sum, item) =>
+                            sum + Math.max(0, item.data[categoryIndex] ?? 0),
+                        0,
+                    );
+
+                const value = Math.max(0, series.data[categoryIndex] ?? 0);
+                const start = Math.round((stackBase / maxTotal) * pixelHeight);
+                const end = Math.round(
+                    ((stackBase + value) / maxTotal) * pixelHeight,
+                );
+                const startX = categoryIndex * step;
+
+                for (
+                    let px = startX;
+                    px < startX + barWidth && px < pixelWidth;
+                    px++
+                ) {
+                    for (let py = start; py < end; py++) {
+                        canvas.drawPixel(px, pixelHeight - 1 - py);
+                    }
+                }
+            }
+
+            canvas.updateRect({ x, y, width, height: chartHeight });
+            canvas.render(screen);
+        });
+
+        this._renderLabels(screen, x, y + chartHeight, width);
+    }
+
+    private _renderAscii(
+        screen: Screen,
+        x: number,
+        y: number,
+        width: number,
+        height: number,
+    ): void {
+        const categoryCount = this._categoryCount();
+        if (categoryCount === 0) return;
+
+        const labelRows = this._categories.length > 0 ? 1 : 0;
+        const chartHeight = height - labelRows;
+        if (chartHeight <= 0) return;
+
+        const totals = this._totals(categoryCount);
+        const maxTotal = Math.max(...totals);
+        if (maxTotal <= 0) return;
+
+        const gap = 1;
+        const barWidth = Math.max(1, this._barWidth);
+        const step = barWidth + gap;
+
+        for (
+            let categoryIndex = 0;
+            categoryIndex < categoryCount;
+            categoryIndex++
+        ) {
+            let stackBase = 0;
+
+            for (const series of this._series) {
+                const value = Math.max(0, series.data[categoryIndex] ?? 0);
+                const start = Math.round((stackBase / maxTotal) * chartHeight);
+                const end = Math.round(
+                    ((stackBase + value) / maxTotal) * chartHeight,
+                );
+                const startX = x + categoryIndex * step;
+
+                for (let col = 0; col < barWidth; col++) {
+                    const cellX = startX + col;
+                    if (cellX >= x + width) continue;
+
+                    for (let row = start; row < end; row++) {
+                        const cellY = y + chartHeight - 1 - row;
+                        screen.setCell(cellX, cellY, {
+                            char: "|",
+                            fg: series.color,
+                        });
+                    }
+                }
+
+                stackBase += value;
+            }
+        }
+
+        this._renderLabels(screen, x, y + chartHeight, width);
+    }
+
+    private _renderLabels(
+        screen: Screen,
+        x: number,
+        y: number,
+        width: number,
+    ): void {
+        if (this._categories.length === 0) return;
+
+        const gap = 1;
+        const barWidth = Math.max(1, this._barWidth);
+        const step = barWidth + gap;
+
+        this._categories.forEach((category, index) => {
+            const labelX = x + index * step;
+            if (labelX >= x + width) return;
+
+            screen.writeString(labelX, y, category.slice(0, barWidth), {});
+        });
+    }
+}

--- a/packages/widgets/src/data/StackedBarChart.ts
+++ b/packages/widgets/src/data/StackedBarChart.ts
@@ -1,4 +1,4 @@
-import { type Color, type Screen, type Style, caps } from "@termuijs/core";
+import { type Color, type Screen, type Style, caps, truncate } from "@termuijs/core";
 import { Widget } from "../base/Widget.js";
 import { BrailleCanvas } from "./BrailleCanvas.js";
 
@@ -205,7 +205,7 @@ export class StackedBarChart extends Widget {
             const labelX = x + index * step;
             if (labelX >= x + width) return;
 
-            screen.writeString(labelX, y, category.slice(0, barWidth), {});
+            screen.writeString(labelX, y, truncate(category, barWidth), {});
         });
     }
 }

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -74,6 +74,9 @@ export type { Bar, BarGroup, BarChartDirection, BarChartOptions } from './data/B
 export { Histogram } from './data/Histogram.js';
 export type { HistogramOptions } from './data/Histogram.js';
 
+export { StackedBarChart } from './data/StackedBarChart.js';
+export type { StackedBarChartOptions, StackedSeries } from './data/StackedBarChart.js';
+
 export { GanttChart } from './data/GanttChart.js';
 export type { GanttChartOptions, GanttTask } from './data/GanttChart.js';
 


### PR DESCRIPTION
## Description

Fixes #245

## Summary

Added a new `StackedBarChart` widget to `@termuijs/widgets` for rendering stacked data series per category.

### Changes Made

* Added `StackedBarChart` widget implementation
* Added `StackedSeries` and `StackedBarChartOptions` types
* Added support for stacked rendering of multiple series
* Added category label rendering along the x-axis
* Added Unicode rendering support with ASCII fallback when `caps.unicode` is disabled
* Ensured `setSeries()` triggers `markDirty()`
* Exported `StackedBarChart` from the widgets package entrypoint

### Tests Added

* Renders a single series without error
* Verifies stacked series rendering
* Verifies `setSeries()` triggers `markDirty()`
* Verifies ASCII fallback when Unicode support is unavailable

### Validation

* `bun vitest run packages/widgets` ✅
* `bun run typecheck` ✅

## Checklist

* [x] Read AGENTS.md and packages/widgets/AGENTS.md
* [x] Work confined to `packages/widgets`
* [x] No changes to `bun.lock`
* [x] Tests added and passing
* [x] Typecheck passing
* [x] Exported widget from package entrypoint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a StackedBarChart widget with stacked-series display, ASCII and Unicode rendering modes, configurable bar width, and category labels.
* **Tests**
  * Added unit tests covering rendering, stacking across series, category label display, update handling, and the ASCII fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->