### PR TITLE
feat(widgets): add Histogram widget (#246)

### DIFF
--- a/packages/widgets/src/data/Histogram.test.ts
+++ b/packages/widgets/src/data/Histogram.test.ts
@@ -1,0 +1,67 @@
+import { caps, Screen } from "@termuijs/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Histogram } from "./Histogram.js";
+
+function renderHistogram(histogram: Histogram, cols = 20, rows = 10): string[] {
+    const screen = new Screen(cols, rows);
+
+    histogram.updateRect({
+        x: 0,
+        y: 0,
+        width: cols,
+        height: rows,
+    });
+
+    histogram.render(screen);
+
+    return screen.back.map((row) => row.map((cell) => cell.char).join(""));
+}
+
+function nonSpaceCells(rows: string[]): number {
+    return [...rows.join("")].filter((char) => char !== " ").length;
+}
+
+describe("Histogram", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("renders without error for a 5-value dataset", () => {
+        const histogram = new Histogram({}, { bins: 4 });
+
+        histogram.setData([1, 2, 2, 3, 4]);
+
+        expect(() => renderHistogram(histogram)).not.toThrow();
+        expect(nonSpaceCells(renderHistogram(histogram))).toBeGreaterThan(0);
+    });
+
+    it("empty data renders empty widget", () => {
+        const histogram = new Histogram();
+
+        histogram.setData([]);
+
+        expect(() => renderHistogram(histogram)).not.toThrow();
+        expect(nonSpaceCells(renderHistogram(histogram))).toBe(0);
+    });
+
+    it("setData triggers markDirty", () => {
+        const histogram = new Histogram();
+        const markDirtySpy = vi.spyOn(histogram, "markDirty");
+
+        histogram.setData([1, 2, 3]);
+
+        expect(markDirtySpy).toHaveBeenCalled();
+    });
+
+    it("uses ASCII fallback when caps.unicode is false", () => {
+        vi.spyOn(caps, "unicode", "get").mockReturnValue(false);
+
+        const histogram = new Histogram({}, { bins: 3 });
+
+        histogram.setData([1, 2, 2, 3, 4]);
+
+        const rows = renderHistogram(histogram);
+
+        expect(rows.join("")).toContain("|");
+    });
+});

--- a/packages/widgets/src/data/Histogram.ts
+++ b/packages/widgets/src/data/Histogram.ts
@@ -1,4 +1,4 @@
-import { type Screen, type Style, type Color, caps } from "@termuijs/core";
+import { type Screen, type Style, type Color, caps, truncate } from "@termuijs/core";
 import { Widget } from "../base/Widget.js";
 
 export interface HistogramOptions {
@@ -79,7 +79,7 @@ export class Histogram extends Widget {
             screen.writeString(
                 x,
                 y + height - 1,
-                this._xLabel.slice(0, width),
+                truncate(this._xLabel, width),
                 {},
             );
         }

--- a/packages/widgets/src/data/Histogram.ts
+++ b/packages/widgets/src/data/Histogram.ts
@@ -1,0 +1,117 @@
+import { type Screen, type Style, type Color, caps } from "@termuijs/core";
+import { Widget } from "../base/Widget.js";
+
+export interface HistogramOptions {
+    bins?: number;
+    barColor?: Color;
+    xLabel?: string;
+}
+
+export class Histogram extends Widget {
+    private _values: number[] = [];
+    private _bins: number;
+    private _barColor: Color;
+    private _xLabel?: string;
+
+    constructor(style: Partial<Style> = {}, opts: HistogramOptions = {}) {
+        super(style);
+
+        this._bins = opts.bins ?? 10;
+        this._barColor = opts.barColor ?? { type: "named", name: "cyan" };
+        this._xLabel = opts.xLabel;
+    }
+
+    setData(values: number[]): void {
+        this._values = values;
+        this.markDirty();
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const rect = this._getContentRect();
+        const { x, y, width, height } = rect;
+
+        if (width <= 0 || height <= 0 || this._values.length === 0) {
+            return;
+        }
+
+        const counts = this._computeBins();
+        const maxCount = Math.max(...counts);
+
+        if (maxCount === 0) {
+            return;
+        }
+
+        const labelRows = this._xLabel ? 1 : 0;
+        const barAreaHeight = height - labelRows;
+
+        if (barAreaHeight <= 0) {
+            return;
+        }
+
+        const barWidth = Math.max(1, Math.floor(width / counts.length));
+
+        for (let i = 0; i < counts.length; i++) {
+            const count = counts[i];
+
+            if (count === undefined) {
+                continue;
+            }
+
+            const scaledHeight = Math.round((count / maxCount) * barAreaHeight);
+
+            for (let row = 0; row < scaledHeight; row++) {
+                for (let col = 0; col < barWidth; col++) {
+                    const cellX = x + i * barWidth + col;
+
+                    if (cellX >= x + width) {
+                        continue;
+                    }
+
+                    screen.setCell(cellX, y + barAreaHeight - 1 - row, {
+                        char: caps.unicode ? "█" : "|",
+                        fg: this._barColor,
+                    });
+                }
+            }
+        }
+
+        if (this._xLabel) {
+            screen.writeString(
+                x,
+                y + height - 1,
+                this._xLabel.slice(0, width),
+                {},
+            );
+        }
+    }
+
+    private _computeBins(): number[] {
+        const counts = Array(this._bins).fill(0);
+
+        if (this._values.length === 0) {
+            return counts;
+        }
+
+        const min = Math.min(...this._values);
+        const max = Math.max(...this._values);
+
+        if (min === max) {
+            counts[0] = this._values.length;
+            return counts;
+        }
+
+        const bucketSize = (max - min) / this._bins;
+
+        for (const value of this._values) {
+            let index = Math.floor((value - min) / bucketSize);
+
+            if (index >= this._bins) {
+                index = this._bins - 1;
+            }
+
+            counts[index]++;
+        }
+
+        return counts;
+    }
+}

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -70,6 +70,10 @@ export { StatusIndicator } from './data/StatusIndicator.js';
 export type { StatusIndicatorOptions } from './data/StatusIndicator.js';
 export { BarChart } from './data/BarChart.js';
 export type { Bar, BarGroup, BarChartDirection, BarChartOptions } from './data/BarChart.js';
+
+export { Histogram } from './data/Histogram.js';
+export type { HistogramOptions } from './data/Histogram.js';
+
 export { GanttChart } from './data/GanttChart.js';
 export type { GanttChartOptions, GanttTask } from './data/GanttChart.js';
 


### PR DESCRIPTION
## Description

Fixes #246

## Summary

Added a new `Histogram` widget to `@termuijs/widgets` for rendering numeric datasets as configurable histogram bins.

### Changes Made

* Added `Histogram` widget implementation
* Added `HistogramOptions` type
* Added support for configurable bin counts
* Added raw numeric data bucketing using min/max ranges
* Added empty dataset handling without throwing
* Added Unicode bar rendering with ASCII fallback when `caps.unicode` is disabled
* Ensured `setData()` triggers `markDirty()`
* Exported `Histogram` from the widgets package entrypoint

### Tests Added

* Renders without error for a 5-value dataset
* Empty data renders an empty widget
* `setData()` triggers `markDirty()`
* ASCII fallback works when Unicode support is disabled

### Validation

* `bun vitest run packages/widgets` ✅
* `bun run typecheck` ✅

## Checklist

* [x] Read `AGENTS.md` and `packages/widgets/AGENTS.md`
* [x] Work confined to `packages/widgets`
* [x] No changes to `bun.lock`
* [x] Tests added and passing
* [x] Typecheck passing
* [x] Exported widget from package entrypoint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Histogram widget for terminal histograms with configurable bins, bar color, and optional x-axis label; supports dynamic data updates, proper handling of empty or degenerate datasets, scaled bar heights, and Unicode/ASCII fallback rendering.

* **Tests**
  * Added comprehensive tests covering rendering, empty-data behavior, data updates triggering redraw, Unicode fallback, and cleanup of mocks after each test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->