### PR TITLE
fix(range-input): prevent tab focus navigation when switching handles

### DIFF
--- a/packages/widgets/src/input/RangeInput.test.ts
+++ b/packages/widgets/src/input/RangeInput.test.ts
@@ -70,6 +70,22 @@ describe('RangeInput', () => {
         expect(r.getLow()).toBe(20);  // low unchanged
     });
 
+    it('prevents default tab focus behavior when toggling handles', async () => {
+        const { RangeInput } = await import('./RangeInput.js');
+        const r = new RangeInput('Price');
+        const event = makeKey('tab');
+        const preventDefault = vi.fn();
+        const stopPropagation = vi.fn();
+
+        event.preventDefault = preventDefault;
+        event.stopPropagation = stopPropagation;
+
+        r.handleKey(event);
+
+        expect(preventDefault).toHaveBeenCalled();
+        expect(stopPropagation).toHaveBeenCalled();
+    });
+
     it('arrow keys move low handle by step', async () => {
         const { RangeInput } = await import('./RangeInput.js');
         const r = new RangeInput('Price');

--- a/packages/widgets/src/input/RangeInput.ts
+++ b/packages/widgets/src/input/RangeInput.ts
@@ -90,6 +90,8 @@ export class RangeInput extends Widget {
             this._activeHandle =
                 this._activeHandle === 'low' ? 'high' : 'low';
             this.markDirty();
+            event.preventDefault();
+            event.stopPropagation();
             return;
         }
 


### PR DESCRIPTION
## Description

This PR fixes a keyboard handling issue in `RangeInput`.

`RangeInput` uses the `Tab` key to switch between the low and high handles, but the event was not being consumed after handling. This could allow higher-level focus navigation handlers to process the same `Tab` event. The fix adds `preventDefault()` and `stopPropagation()` when toggling handles and includes a regression test covering the behavior.

## Related Issue

Closes #1182 

## Which package(s)?

@termuijs/widgets

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)
* [x] 🧪 Tests (`type:testing`)
* [x] ♿ Accessibility (`type:accessibility`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

### Validation

```bash
bun vitest run packages/widgets/src/input/RangeInput.test.ts
```

Passed (13/13 tests).

```bash
cd packages/widgets && bun run typecheck
```

Passed.

### Changes

* Consume the `Tab` event after switching the active handle in `RangeInput`
* Added a regression test verifying `preventDefault()` and `stopPropagation()` are called when handling `Tab`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Range Input component now properly handles Tab key interactions by preventing default browser focus behavior, ensuring correct state management while allowing seamless interaction

* **Tests**
  * Added test verification confirming that Tab key actions in Range Input component properly prevent default browser behavior and maintain widget state consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->