### PR TITLE
fix: overlay render skip

### DIFF
--- a/packages/core/src/app/App.ts
+++ b/packages/core/src/app/App.ts
@@ -312,8 +312,9 @@ export class App {
         // pick up all dirty state when it eventually runs.
         if (this._isRenderPending) return;
 
-        // Skip full layout pass if widget tree reports nothing has changed.
-        if (this._rootWidget.isDirty === false) {
+        // Skip full render pass if neither the widget tree nor overlay layers
+        // have reported any changes.
+        if (this._rootWidget.isDirty === false && !this.layers.hasDirtyLayers()) {
             return;
         }
 
@@ -349,35 +350,35 @@ export class App {
                         mergeBorders(this.screen);
                     }
 
-                    // Composite overlay layers on top of the base rendering
-                    this.layers.composite(this.screen);
-
-                    // Inline rendering bypasses the differential renderer and writes
-                    // the bottom N rows directly into the main buffer so scrollback is preserved.
-                    if (this._options.screenMode === 'inline') {
-                        for (const item of this._insertBefore) {
-                            this.terminal.write(item.text + '\n');
-                        }
-                        try {
-                            // eslint-disable-next-line @typescript-eslint/no-var-requires
-                            const mod = require('../inline-viewport.js');
-                            const renderInlineToTerminal = mod.renderInlineToTerminal ?? mod.default?.renderInlineToTerminal;
-                            if (typeof renderInlineToTerminal === 'function') {
-                                const writer = (this.terminal && typeof (this.terminal as any).write === 'function')
-                                    ? (this.terminal as any)
-                                    : { write: (s: string) => (this.terminal as any).stdout.write(s) };
-                                renderInlineToTerminal(writer, this.screen as any, this._options.inlineRows ?? 0);
-                            }
-                        } catch (_e) {
-                            // Fallback: write nothing
-                        }
-                    } else {
-                        this.renderer.requestFrame();
-                    }
-
-                    // Clear dirty flags now that rendering is complete — future
-                    // requestRender() calls will skip layout until markDirty() fires again.
+                    // Clear dirty flags on the widget tree
                     this._rootWidget.clearDirty?.();
+                }
+
+                // Composite overlay layers on top of the base rendering.
+                // Runs even when only layers are dirty (root widget is clean).
+                this.layers.composite(this.screen);
+
+                // Inline rendering bypasses the differential renderer and writes
+                // the bottom N rows directly into the main buffer so scrollback is preserved.
+                if (this._options.screenMode === 'inline') {
+                    for (const item of this._insertBefore) {
+                        this.terminal.write(item.text + '\n');
+                    }
+                    try {
+                        // eslint-disable-next-line @typescript-eslint/no-var-requires
+                        const mod = require('../inline-viewport.js');
+                        const renderInlineToTerminal = mod.renderInlineToTerminal ?? mod.default?.renderInlineToTerminal;
+                        if (typeof renderInlineToTerminal === 'function') {
+                            const writer = (this.terminal && typeof (this.terminal as any).write === 'function')
+                                ? (this.terminal as any)
+                                : { write: (s: string) => (this.terminal as any).stdout.write(s) };
+                            renderInlineToTerminal(writer, this.screen as any, this._options.inlineRows ?? 0);
+                        }
+                    } catch (_e) {
+                        // Fallback: write nothing
+                    }
+                } else {
+                    this.renderer.requestFrame();
                 }
             } finally {
                 // Unlock the queue flag so subsequent frames can be scheduled

--- a/packages/core/src/terminal/LayerManager.ts
+++ b/packages/core/src/terminal/LayerManager.ts
@@ -169,6 +169,18 @@ export class LayerManager {
     }
 
     /**
+     * Check whether any visible layer has pending dirty changes.
+     */
+    hasDirtyLayers(): boolean {
+        for (const layer of this._layers.values()) {
+            if (layer.visible && layer.dirtyRegion) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Clear all cells in a specific layer.
      */
     clearLayer(id: string): void {
@@ -180,7 +192,7 @@ export class LayerManager {
                 layer.cells[r][c] = emptyCell();
             }
         }
-        layer.dirtyRegion = null;
+        layer.dirtyRegion = { x: 0, y: 0, width: this._cols, height: this._rows };
     }
 
     /**


### PR DESCRIPTION
## Description

Stops `requestRender()` from skipping the entire render pass when only overlay layers are dirty, so modals, dropdowns, and toasts repaint correctly without a root widget re-render, and `clearLayer()` properly reveals the base layer behind the overlay.

## Related Issue

Closes #1178

## Which package(s)?

@termuijs/core

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/<your-profile>`

## Notes for the Reviewer

Three changes: (1) added `LayerManager.hasDirtyLayers()` to detect pending layer changes, (2) fixed `clearLayer()` to set `dirtyRegion` to full dimensions instead of null so `composite()` properly overwrites cleared areas, (3) extracted `layers.composite()` and `requestFrame()` out of the `isDirty` guard so they execute even when only layers are dirty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Refined the rendering pipeline to more intelligently handle overlay layer updates, reducing unnecessary render cycles
  * Improved layer state tracking to ensure visual changes are applied correctly
  * Reorganized render loop flow for better performance and consistency
  * Enhanced inline rendering behavior for more reliable results
<!-- end of auto-generated comment: release notes by coderabbit.ai -->