### PR TITLE
fix(core): log swallowed exceptions in EventEmitter and recover Renderer flush failures

### DIFF
--- a/packages/core/src/events/EventEmitter.ts
+++ b/packages/core/src/events/EventEmitter.ts
@@ -53,7 +53,9 @@ export class EventEmitter<TEventMap extends Record<string, any>> {
         const handlers = this._handlers.get(event);
         if (handlers) {
             for (const handler of handlers) {
-                try { handler(data); } catch { /* prevent one handler from breaking others */ }
+                try { handler(data); } catch (err) {
+                    console.warn(`[EventEmitter] Handler error for '${String(event)}':`, err);
+                }
             }
         }
 
@@ -61,7 +63,9 @@ export class EventEmitter<TEventMap extends Record<string, any>> {
         const onceHandlers = this._onceHandlers.get(event);
         if (onceHandlers) {
             for (const handler of onceHandlers) {
-                try { handler(data); } catch { /* prevent one handler from breaking others */ }
+                try { handler(data); } catch (err) {
+                    console.warn(`[EventEmitter] Once-handler error for '${String(event)}':`, err);
+                }
             }
             onceHandlers.clear();
         }

--- a/packages/core/src/terminal/Renderer.ts
+++ b/packages/core/src/terminal/Renderer.ts
@@ -172,6 +172,10 @@ export class Renderer {
             this._screen.swap();
         } catch (err) {
             console.error('[TermUI] Renderer flush error:', err);
+            // Re-request render so the next frame tick retries.
+            this._renderRequested = true;
+            // Reset style fingerprint to prevent color bleed on retry.
+            this._lastStyleFingerprint = null;
         }
     }
 


### PR DESCRIPTION
## Description

Replaces empty `catch {}` blocks in EventEmitter with `console.warn` so handler exceptions are visible, and makes Renderer flush failures recoverable by re-requesting the next frame and resetting the style fingerprint to prevent terminal state corruption.

## Related Issue

Closes #1180

## Which package(s)?

@termuijs/core

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/<your-profile>`

## Notes for the Reviewer

Two files changed: EventEmitter.emit() — both regular and once-handler catch blocks now log with `console.warn` including the event name. Renderer._flush() — on exception, `_renderRequested` is set back to `true` so the next frame retries, and `_lastStyleFingerprint` is reset to null to prevent color bleed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added console warnings when event handlers throw, improving visibility into runtime errors for easier debugging and triage.
  * Introduced automatic retry behavior after rendering failures and ensured styles are reapplied on retry, improving recovery from transient render errors and reducing visual glitches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->