### PR TITLE
fix: prevent tab focus navigation after PathInput completion

### DIFF
--- a/packages/ui/src/PathInput.test.ts
+++ b/packages/ui/src/PathInput.test.ts
@@ -87,4 +87,23 @@ describe('PathInput', () => {
         
         screen.unmount();
     });
+
+    it('prevents default Tab focus navigation when completing', () => {
+        const input = new PathInput({}, { cwd: '/mock/dir' });
+        input.value = 's';
+        const event = {
+            key: 'tab',
+            ctrl: false,
+            shift: false,
+            alt: false,
+            raw: Buffer.from('\t'),
+            preventDefault: vi.fn(),
+            stopPropagation: vi.fn(),
+        } as unknown as import('@termuijs/core').KeyEvent;
+
+        input.handleKey(event);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(event.stopPropagation).toHaveBeenCalled();
+    });
 });

--- a/packages/ui/src/PathInput.test.ts
+++ b/packages/ui/src/PathInput.test.ts
@@ -99,7 +99,7 @@ describe('PathInput', () => {
             raw: Buffer.from('\t'),
             preventDefault: vi.fn(),
             stopPropagation: vi.fn(),
-        } as unknown as import('@termuijs/core').KeyEvent;
+        } as unknown as import('@termuijs/core').KeyEvent; // runtime-only test object with mocked event methods
 
         input.handleKey(event);
 

--- a/packages/ui/src/PathInput.ts
+++ b/packages/ui/src/PathInput.ts
@@ -187,7 +187,11 @@ export class PathInput extends Widget {
      */
     handleKey(event: KeyEvent): void {
         switch (event.key) {
-            case 'tab': this.triggerCompletion(); break;
+            case 'tab':
+                this.triggerCompletion();
+                event.preventDefault();
+                event.stopPropagation();
+                break;
             case 'escape': this._dismissCompletions(); this.markDirty(); break;
             case 'backspace': this.deleteBack(); break;
             case 'delete': this.deleteForward(); break;


### PR DESCRIPTION
## Description

This PR fixes a keyboard handling issue in `PathInput`.

`PathInput` uses the `Tab` key to trigger path completion, but the event was not being consumed after handling. This allowed application-level Tab focus navigation to process the same key event. The fix consumes the event after triggering completion and adds a regression test covering the behavior.

## Related Issue

Closes #1188

## Which package(s)?

@termuijs/ui

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)
* [x] 🧪 Tests (`type:testing`)
* [x] ♿ Accessibility (`type:accessibility`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

### Validation

Focused test run:

```bash
bun vitest run packages/ui/src/PathInput.test.ts
```

Result: 4/4 tests passed.

### Changes

* Call `preventDefault()` when handling `Tab` in `PathInput`
* Call `stopPropagation()` when handling `Tab` in `PathInput`
* Add a regression test verifying the event is consumed after completion is triggered

The change is intentionally minimal and does not modify completion logic itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tab-key completion in the path input now prevents default browser behavior and stops event propagation, ensuring consistent keyboard interactions.

* **Tests**
  * Added a unit test that verifies Tab-key completion prevents default behavior and stops propagation, ensuring the fix remains covered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->