### PR TITLE
fix: consume Tab events in Drawer focus trap

### DIFF
--- a/packages/ui/src/Drawer.test.ts
+++ b/packages/ui/src/Drawer.test.ts
@@ -141,6 +141,31 @@ describe('Drawer', () => {
         expect(childB.isFocused).toBe(false);
     });
 
+    it('consumes Tab events so Drawer focus trapping does not fall through', () => {
+        const onClose = vi.fn();
+        const drawer = new Drawer({ position: 'left', width: 20, onClose });
+        drawer.open();
+
+        const childA = new Box();
+        childA.focusable = true;
+        drawer.addChild(childA);
+
+        const event = {
+            key: 'tab',
+            ctrl: false,
+            alt: false,
+            shift: false,
+            preventDefault: vi.fn(),
+            stopPropagation: vi.fn(),
+        } as any;
+
+        drawer.handleKey(event);
+
+        expect(childA.isFocused).toBe(true);
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(event.stopPropagation).toHaveBeenCalled();
+    });
+
     it('cycles focus backwards on Shift+Tab', () => {
         const onClose = vi.fn();
         const drawer = new Drawer({ position: 'left', width: 20, onClose });

--- a/packages/ui/src/Drawer.test.ts
+++ b/packages/ui/src/Drawer.test.ts
@@ -3,7 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi } from 'vitest';
-import { Screen } from '@termuijs/core';
+import { Screen, createKeyEvent } from '@termuijs/core';
 import { Box } from '@termuijs/widgets';
 import { Drawer } from './Drawer.js';
 
@@ -150,14 +150,15 @@ describe('Drawer', () => {
         childA.focusable = true;
         drawer.addChild(childA);
 
-        const event = {
+        const event = createKeyEvent({
             key: 'tab',
+            raw: Buffer.alloc(0),
             ctrl: false,
             alt: false,
             shift: false,
-            preventDefault: vi.fn(),
-            stopPropagation: vi.fn(),
-        } as any;
+        });
+        vi.spyOn(event, 'preventDefault');
+        vi.spyOn(event, 'stopPropagation');
 
         drawer.handleKey(event);
 

--- a/packages/ui/src/Drawer.ts
+++ b/packages/ui/src/Drawer.ts
@@ -149,6 +149,8 @@ export class Drawer extends Widget {
                 } else {
                     this._focusNext();
                 }
+                event.preventDefault?.();
+                event.stopPropagation?.();
                 break;
         }
     }


### PR DESCRIPTION
## Description

This PR fixes a focus-trapping issue in `Drawer`.

`Drawer` handles `Tab` and `Shift+Tab` internally to move focus between focusable children, but the key event was not being consumed after handling. This allowed App-level Tab navigation to process the same event, causing focus to escape the Drawer. The fix consumes the event after internal focus movement and adds a regression test covering the behavior.

## Related Issue

Closes #1190

## Which package(s)?

@termuijs/ui

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)
* [x] 🧪 Tests (`type:testing`)
* [x] ♿ Accessibility (`type:accessibility`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

### Validation

Focused test run:

```bash
bun vitest run packages/ui/src/Drawer.test.ts
```

Result: all Drawer tests passed, including the new regression test.

### Changes

* Consume `Tab` events after Drawer internal focus handling
* Consume `Shift+Tab` events after Drawer internal focus handling
* Add regression test verifying the event is consumed during focus-trap navigation

The change is intentionally minimal and does not modify App-level focus management or focus traversal behavior outside the Drawer component.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced keyboard focus handling in the Drawer so Tab and Shift+Tab are contained while open; default key behavior is suppressed and events are stopped to keep focus within the drawer for improved accessibility.

* **Tests**
  * Added unit tests verifying Tab and Shift+Tab keyboard behavior is consumed and focus moves to the appropriate focusable element within the drawer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->