### PR TITLE
perf(display): avoid redundant ChatMessage updates

### DIFF
--- a/packages/widgets/src/display/ChatMessage.test.ts
+++ b/packages/widgets/src/display/ChatMessage.test.ts
@@ -247,3 +247,45 @@ describe('ChatMessage', () => {
         });
     });
 });
+
+describe('9. Performance optimizations', () => {
+    it('does not mark dirty when setContent receives the same value', () => {
+        const widget = makeChat('user', 'Hello');
+
+        widget.clearDirty();
+
+        widget.setContent('Hello');
+
+        expect(widget.isDirty).toBe(false);
+    });
+
+    it('marks dirty when setContent receives a different value', () => {
+        const widget = makeChat('user', 'Hello');
+
+        widget.clearDirty();
+
+        widget.setContent('Updated');
+
+        expect(widget.isDirty).toBe(true);
+    });
+
+    it('does not mark dirty when setRole receives the same role', () => {
+        const widget = makeChat('assistant', 'Hello');
+
+        widget.clearDirty();
+
+        widget.setRole('assistant');
+
+        expect(widget.isDirty).toBe(false);
+    });
+
+    it('marks dirty when setRole receives a different role', () => {
+        const widget = makeChat('assistant', 'Hello');
+
+        widget.clearDirty();
+
+        widget.setRole('system');
+
+        expect(widget.isDirty).toBe(true);
+    });
+});

--- a/packages/widgets/src/display/ChatMessage.ts
+++ b/packages/widgets/src/display/ChatMessage.ts
@@ -55,12 +55,14 @@ export class ChatMessage extends Widget {
 
     /** Update the message content and mark dirty. */
     setContent(content: string): void {
+        if (this._content === content) return; 
         this._content = content;
         this.markDirty();
     }
 
     /** Update the message role and mark dirty. */
     setRole(role: MessageRole): void {
+        if (this._role === role) return;
         this._role = role;
         this.markDirty();
     }


### PR DESCRIPTION

## Description

Avoid unnecessary rerenders in ChatMessage by skipping `markDirty()` when the new content or role is identical to the current value.

Also adds regression tests covering both unchanged and changed update paths.

## Related Issue

Closes #1195

## Which package(s)?

@termuijs/widgets

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [x] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Notes for the Reviewer

This change prevents redundant dirty-state updates when `setContent()` or `setRole()` receives the current value. Existing behavior remains unchanged while avoiding unnecessary rerenders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unnecessary re-renders in chat messages when updating content or role with unchanged values.

* **Tests**
  * Added test cases to verify chat message update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->