### PR TITLE
perf(display): avoid redundant Breadcrumbs updates

### DIFF
--- a/packages/widgets/src/display/Breadcrumbs.test.ts
+++ b/packages/widgets/src/display/Breadcrumbs.test.ts
@@ -92,4 +92,25 @@ describe('Breadcrumbs', () => {
         const row = rowText(screen, 0);
         expect(row).toContain('A / B');
     });
+
+    it('does not mark dirty when setSegments receives identical segments', () => {
+        const bc = new Breadcrumbs(['Home', 'Docs', 'API']);
+    
+        bc.clearDirty();
+    
+        bc.setSegments(['Home', 'Docs', 'API']);
+    
+        expect(bc.isDirty).toBe(false);
+    });
+    
+    it('marks dirty when setSegments receives different segments', () => {
+        const bc = new Breadcrumbs(['Home', 'Docs', 'API']);
+    
+        bc.clearDirty();
+    
+        bc.setSegments(['Home', 'Guides', 'API']);
+    
+        expect(bc.isDirty).toBe(true);
+    });
+
 });

--- a/packages/widgets/src/display/Breadcrumbs.ts
+++ b/packages/widgets/src/display/Breadcrumbs.ts
@@ -32,6 +32,12 @@ export class Breadcrumbs extends Widget {
 
     /** Update the trail of segments. */
     setSegments(segments: string[]): void {
+        if (
+            this._segments.length === segments.length &&
+            this._segments.every((segment, index) => segment === segments[index])
+        ) {
+            return;
+        }
         this._segments = segments;
         this.markDirty();
     }


### PR DESCRIPTION
## Description

Optimize `Breadcrumbs` widget updates by avoiding unnecessary `markDirty()` calls when `setSegments()` receives the same segment list.

Added regression tests to verify dirty-state behavior for both unchanged and updated breadcrumb segments.

## Related Issue

Closes #1198

## Which package(s)?

@termuijs/widgets

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [x] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

`setSegments()` now performs a lightweight equality check before updating state. If the incoming breadcrumb segments are identical to the current segments, the widget skips `markDirty()` and avoids unnecessary re-renders.

Regression tests have been added to verify correct dirty-state behavior for both unchanged and modified segment lists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Breadcrumbs no longer triggers unnecessary state updates or redraws when the segment list is unchanged, reducing wasted work and improving UI responsiveness.

* **Tests**
  * Added tests to verify Breadcrumbs preserves clean/dirty state when given identical segments and flips dirty state when segments change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->