### PR TITLE
feat(widgets): add Placeholder widget

### DIFF
--- a/packages/widgets/src/display/Placeholder.test.ts
+++ b/packages/widgets/src/display/Placeholder.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Screen, caps } from '@termuijs/core';
+import type { Style } from '@termuijs/core';
+import { Placeholder, type PlaceholderOptions } from './Placeholder.js';
+
+function renderPlaceholder(
+    label: string,
+    style: Partial<Style> = {},
+    opts: PlaceholderOptions = {},
+    width = 16,
+    height = 5,
+) {
+    const placeholder = new Placeholder(label, style, opts);
+    const screen = new Screen(width, height);
+    placeholder.updateRect({ x: 0, y: 0, width, height });
+    placeholder.render(screen);
+    return { placeholder, screen };
+}
+
+function rowText(screen: Screen, row: number): string {
+    return screen.back[row].map(cell => cell.char).join('');
+}
+
+describe('Placeholder', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('renders the label centered in the widget area', () => {
+        const { screen } = renderPlaceholder('Preview');
+
+        expect(rowText(screen, 2)).toContain('Preview');
+    });
+
+    it('fills the background with the fill character', () => {
+        const { screen } = renderPlaceholder('Box', {}, { fillChar: '*' });
+
+        expect(screen.back[1][1].char).toBe('*');
+        expect(screen.back[3][14].char).toBe('*');
+    });
+
+    it('renders a border around the widget', () => {
+        const { screen } = renderPlaceholder('Box');
+
+        expect(screen.back[0][0].char).toBe('\u250c');
+        expect(screen.back[0][15].char).toBe('\u2510');
+        expect(screen.back[4][0].char).toBe('\u2514');
+        expect(screen.back[4][15].char).toBe('\u2518');
+    });
+
+    it('setLabel updates the rendered label and marks dirty', () => {
+        const placeholder = new Placeholder('Old');
+        const screen = new Screen(16, 5);
+
+        placeholder.clearDirty();
+        placeholder.setLabel('New');
+        expect(placeholder.isDirty).toBe(true);
+
+        placeholder.updateRect({ x: 0, y: 0, width: 16, height: 5 });
+        placeholder.render(screen);
+
+        expect(rowText(screen, 2)).toContain('New');
+    });
+
+    it('uses ASCII fallback for fill and border characters', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+
+        const { screen } = renderPlaceholder('Box');
+
+        expect(screen.back[1][1].char).toBe('.');
+        expect(screen.back[0][0].char).toBe('+');
+        expect(screen.back[0][1].char).toBe('-');
+        expect(screen.back[1][0].char).toBe('|');
+    });
+});

--- a/packages/widgets/src/display/Placeholder.ts
+++ b/packages/widgets/src/display/Placeholder.ts
@@ -1,0 +1,85 @@
+// -----------------------------------------------------------------------------
+// @termuijs/widgets - Placeholder widget
+// -----------------------------------------------------------------------------
+
+import { type Screen, type Style, type Color, caps, stringWidth, styleToCellAttrs } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export interface PlaceholderOptions {
+    /** Fill character. Default: '░' with ASCII fallback '.' */
+    fillChar?: string;
+    borderColor?: Color;
+    labelColor?: Color;
+}
+
+/**
+ * Placeholder - a labeled stand-in box for prototyping terminal layouts.
+ */
+export class Placeholder extends Widget {
+    private _label: string;
+    private _fillChar?: string;
+    private _borderColor?: Color;
+    private _labelColor?: Color;
+
+    constructor(label: string, style: Partial<Style> = {}, opts: PlaceholderOptions = {}) {
+        super(style);
+        this._label = label;
+        this._fillChar = opts.fillChar;
+        this._borderColor = opts.borderColor;
+        this._labelColor = opts.labelColor;
+    }
+
+    setLabel(label: string): void {
+        this._label = label;
+        this.markDirty();
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width, height } = this._getContentRect();
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this._style);
+        const fillAttrs = { ...attrs };
+        const borderAttrs = { ...attrs, fg: this._borderColor };
+        const labelAttrs = { ...attrs, fg: this._labelColor };
+
+        const fillChar = this._fillChar ?? (caps.unicode ? '\u2591' : '.');
+        const tl = caps.unicode ? '\u250c' : '+';
+        const tr = caps.unicode ? '\u2510' : '+';
+        const bl = caps.unicode ? '\u2514' : '+';
+        const br = caps.unicode ? '\u2518' : '+';
+        const hz = caps.unicode ? '\u2500' : '-';
+        const vt = caps.unicode ? '\u2502' : '|';
+
+        for (let row = 0; row < height; row++) {
+            for (let col = 0; col < width; col++) {
+                screen.setCell(x + col, y + row, { char: fillChar, ...fillAttrs });
+            }
+        }
+
+        for (let col = 0; col < width; col++) {
+            screen.setCell(x + col, y, { char: hz, ...borderAttrs });
+            screen.setCell(x + col, y + height - 1, { char: hz, ...borderAttrs });
+        }
+
+        for (let row = 0; row < height; row++) {
+            screen.setCell(x, y + row, { char: vt, ...borderAttrs });
+            screen.setCell(x + width - 1, y + row, { char: vt, ...borderAttrs });
+        }
+
+        screen.setCell(x, y, { char: tl, ...borderAttrs });
+        screen.setCell(x + width - 1, y, { char: tr, ...borderAttrs });
+        screen.setCell(x, y + height - 1, { char: bl, ...borderAttrs });
+        screen.setCell(x + width - 1, y + height - 1, { char: br, ...borderAttrs });
+
+        if (width <= 2 || height <= 2 || this._label.length === 0) return;
+
+        const innerWidth = width - 2;
+        const visibleLabel = this._label.slice(0, innerWidth);
+        const labelWidth = Math.min(stringWidth(visibleLabel), innerWidth);
+        const labelX = x + 1 + Math.max(0, Math.floor((innerWidth - labelWidth) / 2));
+        const labelY = y + Math.floor(height / 2);
+
+        screen.writeString(labelX, labelY, visibleLabel, labelAttrs);
+    }
+}

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -165,6 +165,8 @@ export { Kbd } from './display/Kbd.js';
 export type { KbdOptions } from './display/Kbd.js';
 export { Tag } from './display/Tag.js';
 export type { TagOptions, TagVariant } from './display/Tag.js';
+export { Placeholder } from './display/Placeholder.js';
+export type { PlaceholderOptions } from './display/Placeholder.js';
 export { NotificationBadge } from './display/NotificationBadge.js';
 export type { NotificationBadgeOptions, BadgePosition } from './display/NotificationBadge.js';
 


### PR DESCRIPTION
## Summary\n- Adds a Placeholder display widget for prototyping terminal layouts.\n- Renders fill, border, and centered label with unicode/ASCII fallback.\n- Exports Placeholder and PlaceholderOptions from @termuijs/widgets.\n- Adds focused tests for label rendering, fill, border, setLabel, and ASCII fallback.\n\nCloses #272\n\n## Validation\n- bun vitest run packages/widgets/src/display/Placeholder.test.ts\n- bun vitest run packages/widgets\n- bun run build\n- bun run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `Placeholder` widget featuring customizable fill characters, border colors, and label colors; automatically adapts between Unicode and ASCII rendering modes.

* **Tests**
  * Added comprehensive test coverage for the new widget functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->