### PR TITLE
feat(widgets): add Watermark widget

### DIFF
--- a/packages/widgets/src/display/Watermark.test.ts
+++ b/packages/widgets/src/display/Watermark.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { Screen } from '@termuijs/core';
+import type { Style } from '@termuijs/core';
+import { Watermark, type WatermarkOptions } from './Watermark.js';
+
+function renderWatermark(
+    text: string,
+    style: Partial<Style> = {},
+    opts: WatermarkOptions = {},
+    width = 8,
+    height = 3,
+) {
+    const watermark = new Watermark(text, style, opts);
+    const screen = new Screen(width, height);
+    watermark.updateRect({ x: 0, y: 0, width, height });
+    watermark.render(screen);
+    return { watermark, screen };
+}
+
+function rowText(screen: Screen, row: number): string {
+    return screen.back[row].map(cell => cell.char).join('');
+}
+
+describe('Watermark', () => {
+    it('renders text on row 0', () => {
+        const { screen } = renderWatermark('AB');
+
+        expect(rowText(screen, 0)).toBe('ABABABAB');
+    });
+
+    it('wraps text and continues on row 1', () => {
+        const { screen } = renderWatermark('ABC', {}, {}, 5, 2);
+
+        expect(rowText(screen, 0)).toBe('ABCAB');
+        expect(rowText(screen, 1)).toBe('CABCA');
+    });
+
+    it('angle 45 shifts row 1 by one character relative to row 0', () => {
+        const { screen } = renderWatermark('ABC', {}, { angle: 45 }, 6, 2);
+
+        expect(rowText(screen, 0)).toBe('ABCABC');
+        expect(rowText(screen, 1)).toBe('BCABCA');
+    });
+
+    it('setText updates rendered text and marks dirty', () => {
+        const watermark = new Watermark('AA');
+        const screen = new Screen(6, 2);
+
+        watermark.clearDirty();
+        watermark.setText('XY');
+        expect(watermark.isDirty).toBe(true);
+
+        watermark.updateRect({ x: 0, y: 0, width: 6, height: 2 });
+        watermark.render(screen);
+
+        expect(rowText(screen, 0)).toBe('XYXYXY');
+    });
+});

--- a/packages/widgets/src/display/Watermark.ts
+++ b/packages/widgets/src/display/Watermark.ts
@@ -1,0 +1,52 @@
+// -----------------------------------------------------------------------------
+// @termuijs/widgets - Watermark widget
+// -----------------------------------------------------------------------------
+
+import { type Screen, type Style, type Color, styleToCellAttrs } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export interface WatermarkOptions {
+    /** Color of the repeated text. Default: brightBlack */
+    color?: Color;
+    /** Diagonal tilt angle in characters. 0 = horizontal rows. Default: 0 */
+    angle?: 0 | 45;
+}
+
+/**
+ * Watermark - fills its area with faint repeating text.
+ */
+export class Watermark extends Widget {
+    private _text: string;
+    private _color: Color;
+    private _angle: 0 | 45;
+
+    constructor(text: string, style: Partial<Style> = {}, opts: WatermarkOptions = {}) {
+        super(style);
+        this._text = text;
+        this._color = opts.color ?? { type: 'named', name: 'brightBlack' };
+        this._angle = opts.angle ?? 0;
+    }
+
+    setText(text: string): void {
+        this._text = text;
+        this.markDirty();
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width, height } = this._getContentRect();
+        if (width <= 0 || height <= 0 || this._text.length === 0) return;
+
+        const attrs = { ...styleToCellAttrs(this._style), fg: this._color };
+        const rowOffsetStep = this._angle === 45 ? 1 : 0;
+
+        for (let row = 0; row < height; row++) {
+            for (let col = 0; col < width; col++) {
+                const index = (row * width + col + row * rowOffsetStep) % this._text.length;
+                screen.setCell(x + col, y + row, {
+                    char: this._text[index],
+                    ...attrs,
+                });
+            }
+        }
+    }
+}

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -170,6 +170,8 @@ export { Tag } from './display/Tag.js';
 export type { TagOptions, TagVariant } from './display/Tag.js';
 export { Placeholder } from './display/Placeholder.js';
 export type { PlaceholderOptions } from './display/Placeholder.js';
+export { Watermark } from './display/Watermark.js';
+export type { WatermarkOptions } from './display/Watermark.js';
 export { NotificationBadge } from './display/NotificationBadge.js';
 export type { NotificationBadgeOptions, BadgePosition } from './display/NotificationBadge.js';
 


### PR DESCRIPTION
## Summary\n- Adds a Watermark display widget that fills its area with repeated text.\n- Supports horizontal and 45-degree diagonal row offsets.\n- Exports Watermark and WatermarkOptions from @termuijs/widgets.\n- Adds tests for row rendering, wrapping, diagonal offset, and setText dirty state.\n\nCloses #274\n\n## Validation\n- bun vitest run packages/widgets/src/display/Watermark.test.ts\n- bun vitest run packages/widgets\n- bun run typecheck\n- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Watermark widget for displaying faint, repeated text patterns
  * Configurable text color (defaults to muted black)
  * Optional 45° diagonal tilt for watermark styling
  * Dynamic text updates with real-time rendering

* **Tests**
  * Added unit tests validating repetition, wrapping, diagonal offset behavior, and live text updates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->