### PR TITLE
fix(hooks): re-queue pending fibers when _requestRender is unset during flush

### DIFF
--- a/packages/jsx/src/hooks.ts
+++ b/packages/jsx/src/hooks.ts
@@ -180,8 +180,15 @@ function scheduleRender(fiber?: Fiber): void {
 /** Flush all pending state updates in a single render pass */
 function flushUpdates(): void {
     _flushScheduled = false;
-    _pendingUpdates.clear();
-    _requestRender?.();
+    const pending = _pendingUpdates;
+    _pendingUpdates = new Set<Fiber>();
+    if (!_requestRender) {
+        for (const fiber of pending) {
+            _pendingUpdates.add(fiber);
+        }
+        return;
+    }
+    _requestRender();
 }
 
 // ── Hooks ──


### PR DESCRIPTION
## Description
Fixes the issue where batched state updates drop pending renders after the first batch.

## Related Issue
Fixes #1207

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made
- Captured and cleared pending updates atomically.
- Re-queued dirty fibers if no render callback is registered.

## How Has This Been Tested?
- Verified by observing correct component re-rendering.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new TypeScript errors
- [x] I have added tests that prove my fix is effective (where applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where batched render updates could be lost in certain conditions, ensuring all pending updates are properly queued and processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->