### PR TITLE
fix(jsx): reconcile Suspense fallback VNode into Widget

### DIFF
--- a/packages/jsx/src/Suspense.ts
+++ b/packages/jsx/src/Suspense.ts
@@ -5,6 +5,12 @@ export interface SuspenseProps {
     children?: VNode | VNode[];
 }
 
+/**
+ * Suspense boundary — renders children normally during SSR/initial render.
+ * When a child component throws a Promise (lazy loading), the reconciler
+ * intercepts this component and renders `fallback` instead via SuspenseBoundary.
+ * @see reconciler.ts SuspenseBoundary
+ */
 export function Suspense({ children }: SuspenseProps): VNode | VNode[] | undefined {
     return children;
 }

--- a/packages/jsx/src/reconciler.ts
+++ b/packages/jsx/src/reconciler.ts
@@ -363,7 +363,7 @@ function SuspenseBoundary(props: Record<string, any>): any {
         return reconcile(child);
     } catch (err) {
         if (err instanceof Promise) {
-            return props.fallback;
+            return reconcile(props.fallback ?? null);
         }
         throw err;
     }


### PR DESCRIPTION
## Description
Fixes the issue where Suspense fallback causes a crash by returning a raw VNode instead of a Widget.

## Related Issue
Fixes #1210

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made
- Added \econcile()\ wrapper around \props.fallback\ return in SuspenseBoundary.
- Added JSDoc documentation to the Suspense component.

## How Has This Been Tested?
- Verified by lazy loading a component that throws a Promise.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new TypeScript errors
- [x] I have added tests that prove my fix is effective (where applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Suspense boundary to properly render fallback UI when child components suspend.

* **Documentation**
  * Added documentation describing Suspense boundary behavior and fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->