### PR TITLE
perf(feedback): avoid redundant ProgressCircle updates

### DIFF
--- a/packages/widgets/src/feedback/ProgressCircle.test.ts
+++ b/packages/widgets/src/feedback/ProgressCircle.test.ts
@@ -52,7 +52,29 @@ describe('ProgressCircle — value handling', () => {
     it('setValue marks the widget dirty', () => {
         const c = new ProgressCircle();
         (c as unknown as { _dirty: boolean })._dirty = false;
+
         c.setValue(0.5);
+
+        expect(c.isDirty).toBe(true);
+    });
+
+    it('does not mark dirty when setValue receives the same value', () => {
+        const c = new ProgressCircle({}, { value: 0.5 });
+
+        c.clearDirty();
+
+        c.setValue(0.5);
+
+        expect(c.isDirty).toBe(false);
+    });
+
+    it('marks dirty when setValue receives a different value', () => {
+        const c = new ProgressCircle({}, { value: 0.5 });
+
+        c.clearDirty();
+
+        c.setValue(0.75);
+
         expect(c.isDirty).toBe(true);
     });
 });
@@ -144,4 +166,5 @@ describe('ProgressCircle — unicode rendering', () => {
         const rendered = row(screen, 0);
         expect(rendered).toBe('⣿⣿⣿⣿⣿⣿');
     });
+
 });

--- a/packages/widgets/src/feedback/ProgressCircle.ts
+++ b/packages/widgets/src/feedback/ProgressCircle.ts
@@ -45,6 +45,10 @@ export class ProgressCircle extends Widget {
 
     /** Update the current progress. Out-of-range values are clamped to [0, 1]. */
     setValue(value: number): void {
+        const nextValue = clamp01(value);
+            if (this._value === nextValue) {
+            return;
+        }
         this._value = clamp01(value);
         this.markDirty();
     }


### PR DESCRIPTION
## Description

This PR optimizes `ProgressCircle` updates by preventing unnecessary dirty-state changes when `setValue()` is called with the same value. It also adds regression tests to verify that the widget only marks itself dirty when the progress value actually changes.

## Related Issue

Closes #1200

## Which package(s)?

@termuijs/widgets

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [x] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

Added performance-focused regression tests for `setValue()` and updated the widget to skip redundant updates when the incoming value matches the current value. This reduces unnecessary re-renders while preserving existing behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced value clamping and state management to avoid redundant rendering when values don't change.

* **Tests**
  * Added comprehensive test coverage for value updates and state tracking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->