### PR TITLE
perf: optimize Watermark updates

### DIFF
--- a/packages/widgets/src/display/Watermark.test.ts
+++ b/packages/widgets/src/display/Watermark.test.ts
@@ -55,4 +55,25 @@ describe('Watermark', () => {
 
         expect(rowText(screen, 0)).toBe('XYXYXY');
     });
+
+    it('does not mark dirty when setText receives the same value', () => {
+        const watermark = new Watermark('CONFIDENTIAL');
+    
+        watermark.clearDirty();
+    
+        watermark.setText('CONFIDENTIAL');
+    
+        expect(watermark.isDirty).toBe(false);
+    });
+    
+    it('marks dirty when setText receives a different value', () => {
+        const watermark = new Watermark('CONFIDENTIAL');
+    
+        watermark.clearDirty();
+    
+        watermark.setText('INTERNAL');
+    
+        expect(watermark.isDirty).toBe(true);
+    });
+
 });

--- a/packages/widgets/src/display/Watermark.ts
+++ b/packages/widgets/src/display/Watermark.ts
@@ -28,6 +28,7 @@ export class Watermark extends Widget {
     }
 
     setText(text: string): void {
+        if (this._text === text) return;
         this._text = text;
         this.markDirty();
     }


### PR DESCRIPTION
## Description

Optimizes `Watermark` updates by avoiding unnecessary dirty-state changes when `setText()` receives the same value.

Adds tests to verify that identical values do not mark the widget dirty, while changed values continue to trigger re-renders correctly.

## Related Issue

Closes #1253 

## Which package(s)?

@termuijs/widgets

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [x] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

This change adds an equality check in `setText()` before calling `markDirty()`. The optimization prevents unnecessary re-renders when the watermark text remains unchanged while preserving existing behavior when the text changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance by preventing unnecessary state updates when setting identical text values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->