### PR TITLE
perf: optimize Placeholder label updates

### DIFF
--- a/packages/widgets/src/display/Placeholder.test.ts
+++ b/packages/widgets/src/display/Placeholder.test.ts
@@ -72,4 +72,25 @@ describe('Placeholder', () => {
         expect(screen.back[0][1].char).toBe('-');
         expect(screen.back[1][0].char).toBe('|');
     });
+
+    it('does not mark dirty when setLabel receives the same value', () => {
+        const placeholder = new Placeholder('Loading');
+    
+        placeholder.clearDirty();
+    
+        placeholder.setLabel('Loading');
+    
+        expect(placeholder.isDirty).toBe(false);
+    });
+    
+    it('marks dirty when setLabel receives a different value', () => {
+        const placeholder = new Placeholder('Loading');
+    
+        placeholder.clearDirty();
+    
+        placeholder.setLabel('Ready');
+    
+        expect(placeholder.isDirty).toBe(true);
+    });
+
 });

--- a/packages/widgets/src/display/Placeholder.ts
+++ b/packages/widgets/src/display/Placeholder.ts
@@ -30,6 +30,7 @@ export class Placeholder extends Widget {
     }
 
     setLabel(label: string): void {
+        if (this._label === label) return;
         this._label = label;
         this.markDirty();
     }


### PR DESCRIPTION
## Description

Optimizes `Placeholder` updates by avoiding unnecessary dirty-state changes when `setLabel()` receives the same value.

Adds tests to verify that identical labels do not mark the widget dirty, while changed labels continue to trigger re-renders correctly.

## Related Issue

Closes #1255 

## Which package(s)?

@termuijs/widgets

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [x] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

This change adds an equality check in `setLabel()` before calling `markDirty()`. The optimization prevents unnecessary re-renders when the label remains unchanged while preserving existing behavior when the label changes.