### PR TITLE
feat: RTL and Internationalization (i18n) Support (fixes #1246)

### DIFF
--- a/packages/core/src/style/Style.ts
+++ b/packages/core/src/style/Style.ts
@@ -81,9 +81,6 @@ export interface Style {
 
     // ── Visibility ──────────
     visible?: boolean;
-
-    // ── RTL / I18N ──────────
-    direction?: 'ltr' | 'rtl';
 }
 
 /**
@@ -144,7 +141,7 @@ export const LAYOUT_PROPS: ReadonlySet<keyof Style> = new Set<keyof Style>([
     'width', 'height', 'minWidth', 'minHeight', 'maxWidth', 'maxHeight',
     'padding', 'margin', 'border',
     'flexDirection', 'justifyContent', 'alignItems', 'flexGrow', 'flexShrink', 'flexWrap', 'gap',
-    'overflow', 'visible', 'direction',
+    'overflow', 'visible',
 ]);
 
 /**

--- a/packages/core/src/style/Style.ts
+++ b/packages/core/src/style/Style.ts
@@ -81,6 +81,9 @@ export interface Style {
 
     // ── Visibility ──────────
     visible?: boolean;
+
+    // ── RTL / I18N ──────────
+    direction?: 'ltr' | 'rtl';
 }
 
 /**
@@ -141,7 +144,7 @@ export const LAYOUT_PROPS: ReadonlySet<keyof Style> = new Set<keyof Style>([
     'width', 'height', 'minWidth', 'minHeight', 'maxWidth', 'maxHeight',
     'padding', 'margin', 'border',
     'flexDirection', 'justifyContent', 'alignItems', 'flexGrow', 'flexShrink', 'flexWrap', 'gap',
-    'overflow', 'visible',
+    'overflow', 'visible', 'direction',
 ]);
 
 /**

--- a/packages/jsx/src/i18n.test.ts
+++ b/packages/jsx/src/i18n.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { useI18n, I18nContext, I18nProvider } from './i18n.js';
+import { useI18n, I18nProvider } from './i18n.js';
 import { createFiber, setCurrentFiber, clearCurrentFiber, type Fiber } from './hooks.js';
+import { Screen } from '@termuijs/core';
+import { reconcile, unmountAll } from './reconciler.js';
+import { createElement as h } from './createElement.js';
 
 describe('i18n hooks', () => {
     let fiber: Fiber;
@@ -12,12 +15,12 @@ describe('i18n hooks', () => {
 
     afterEach(() => {
         clearCurrentFiber();
+        unmountAll();
     });
 
     it('returns default values when used outside a provider', () => {
         const result = useI18n();
         
-        expect(result).toBeDefined();
         expect(result.locale).toBe('en');
         expect(result.direction).toBe('ltr');
         expect(result.t('hello.world')).toBe('hello.world');
@@ -30,15 +33,25 @@ describe('i18n hooks', () => {
             t: (key: string) => key === 'hello.world' ? 'مرحبا بالعالم' : key,
         };
 
-        // Simulate what the Provider does when rendered
-        I18nContext.Provider({ value: customI18n, children: undefined as any });
+        let result: ReturnType<typeof useI18n> | undefined;
+
+        function Child() {
+            result = useI18n();
+            return h('text', {}, 'test');
+        }
+
+        clearCurrentFiber();
+
+        const screen = new Screen(10, 10);
+        const node = h(I18nProvider, { value: customI18n }, h(Child, {}));
+        const widget = reconcile(node);
         
-        const result = useI18n();
+        widget.updateRect({ x: 0, y: 0, width: 10, height: 10 });
+        widget.render(screen);
         
-        expect(result).toBeDefined();
-        expect(result.locale).toBe('ar');
-        expect(result.direction).toBe('rtl');
-        expect(result.t('hello.world')).toBe('مرحبا بالعالم');
-        expect(result.t('other.key')).toBe('other.key');
+        expect(result!.locale).toBe('ar');
+        expect(result!.direction).toBe('rtl');
+        expect(result!.t('hello.world')).toBe('مرحبا بالعالم');
+        expect(result!.t('other.key')).toBe('other.key');
     });
 });

--- a/packages/jsx/src/i18n.test.ts
+++ b/packages/jsx/src/i18n.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { useI18n, I18nContext, I18nProvider } from './i18n.js';
+import { createFiber, setCurrentFiber, clearCurrentFiber, type Fiber } from './hooks.js';
+
+describe('i18n hooks', () => {
+    let fiber: Fiber;
+
+    beforeEach(() => {
+        fiber = createFiber();
+        setCurrentFiber(fiber);
+    });
+
+    afterEach(() => {
+        clearCurrentFiber();
+    });
+
+    it('returns default values when used outside a provider', () => {
+        const result = useI18n();
+        
+        expect(result).toBeDefined();
+        expect(result.locale).toBe('en');
+        expect(result.direction).toBe('ltr');
+        expect(result.t('hello.world')).toBe('hello.world');
+    });
+
+    it('supplies the provided locale, direction, and translation function', () => {
+        const customI18n = {
+            locale: 'ar',
+            direction: 'rtl' as const,
+            t: (key: string) => key === 'hello.world' ? 'مرحبا بالعالم' : key,
+        };
+
+        // Simulate what the Provider does when rendered
+        I18nContext.Provider({ value: customI18n, children: undefined as any });
+        
+        const result = useI18n();
+        
+        expect(result).toBeDefined();
+        expect(result.locale).toBe('ar');
+        expect(result.direction).toBe('rtl');
+        expect(result.t('hello.world')).toBe('مرحبا بالعالم');
+        expect(result.t('other.key')).toBe('other.key');
+    });
+});

--- a/packages/jsx/src/i18n.ts
+++ b/packages/jsx/src/i18n.ts
@@ -22,7 +22,8 @@ export interface I18nProviderProps {
 }
 
 export function I18nProvider({ value, children }: I18nProviderProps) {
-    return createElement(I18nContext.Provider, { value, children });
+    const childArr = Array.isArray(children) ? children : (children ? [children] : []);
+    return createElement(I18nContext.Provider, { value }, ...childArr);
 }
 
 export function useI18n(): I18nContextValue {

--- a/packages/jsx/src/i18n.ts
+++ b/packages/jsx/src/i18n.ts
@@ -1,0 +1,30 @@
+import { createContext, useContext } from './context.js';
+import { createElement } from './createElement.js';
+import type { VNode } from './vnode.js';
+
+export interface I18nContextValue {
+    locale: string;
+    direction: 'ltr' | 'rtl';
+    t: (key: string, params?: Record<string, any>) => string;
+}
+
+const defaultI18n: I18nContextValue = {
+    locale: 'en',
+    direction: 'ltr',
+    t: (key: string) => key,
+};
+
+export const I18nContext = createContext<I18nContextValue>(defaultI18n);
+
+export interface I18nProviderProps {
+    value: I18nContextValue;
+    children?: VNode | VNode[];
+}
+
+export function I18nProvider({ value, children }: I18nProviderProps) {
+    return createElement(I18nContext.Provider, { value, children });
+}
+
+export function useI18n(): I18nContextValue {
+    return useContext(I18nContext);
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -115,3 +115,4 @@ export { useTransition } from './hooks/useTransition.js';
 export { useStopwatch } from './hooks/useStopwatch.js';
 export type { UseStopwatchOptions, UseStopwatchControls } from './hooks/useStopwatch.js';
 export { useBell } from './hooks/useBell.js';
+

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -96,13 +96,16 @@ export { setRequestRender, getRequestRender, setInsertBefore, collectInputHandle
 /** h() — shorthand for createElement */
 export { createElement as h } from './createElement.js';
 export { useMount } from './hooks/useMount.js';
-export { usePrevious } from './hooks/usePrevious.js';
-export { useLatest } from './hooks/useLatest.js';
+export { useTimeout } from './hooks/useTimeout.js';
+export { I18nContext, I18nProvider, useI18n } from './i18n.js';
+export type { I18nContextValue, I18nProviderProps } from './i18n.js';
 export { useFirstRender } from './hooks/useFirstRender.js';
 export { useSyncExternalStore } from './hooks/useSyncExternalStore.js';
 export { useHover } from './hooks/useHover.js';
 export { useElementSize } from './hooks/useElementSize.js';
 export type { ElementSize } from './hooks/useElementSize.js';
+export { usePrevious } from './hooks/usePrevious.js';
+export { useLatest } from './hooks/useLatest.js';
 export { useDebounce } from './hooks/useDebounce.js';
 export { useTerminalSize } from './hooks/useTerminalSize.js';
 export type { TerminalSize } from './hooks/useTerminalSize.js';
@@ -111,4 +114,3 @@ export { useUnmount } from './hooks/useUnmount.js';
 export { useTransition } from './hooks/useTransition.js';
 export { useStopwatch } from './hooks/useStopwatch.js';
 export type { UseStopwatchOptions, UseStopwatchControls } from './hooks/useStopwatch.js';
-export { useTimeout } from './hooks/useTimeout.js';


### PR DESCRIPTION
### Description
Adds the I18nProvider context and useI18n hook to @termuijs/jsx, and adds the RTL text direction property to the style definition in @termuijs/core.

Fixes #1246

GSSoC '26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Internationalization support: locale, text direction, and translation function
  * Added I18nProvider to configure i18n and useI18n hook for components
  * Exposed a useTimeout hook in the public API

* **Tests**
  * Added tests verifying default i18n behavior and provider-overridden values
<!-- end of auto-generated comment: release notes by coderabbit.ai -->