### PR TITLE
perf(feedback): optimize TaskList updates

### DIFF
--- a/packages/widgets/src/feedback/TaskList.test.ts
+++ b/packages/widgets/src/feedback/TaskList.test.ts
@@ -53,4 +53,35 @@ describe("TaskList", () => {
         widget.render(screen)
         expect(screen.back[0].map(c => c.char).join('')).toContain('Task 1 ⠙')
     })
+
+    it("does not mark dirty when setTasks receives the same array reference", () => {
+        const tasks: TaskItem[] = [
+            { id: 1, label: "Task 1", status: "pending" }
+        ];
+    
+        const widget = new TaskList({}, {}, tasks);
+    
+        widget.clearDirty();
+    
+        widget.setTasks(tasks);
+    
+        expect(widget.isDirty).toBe(false);
+    });
+    
+    it("marks dirty when setTasks receives a different array", () => {
+        const widget = new TaskList(
+            {},
+            {},
+            [{ id: 1, label: "Task 1", status: "pending" }]
+        );
+    
+        widget.clearDirty();
+    
+        widget.setTasks([
+            { id: 2, label: "Task 2", status: "done" }
+        ]);
+    
+        expect(widget.isDirty).toBe(true);
+    });
+    
 })

--- a/packages/widgets/src/feedback/TaskList.ts
+++ b/packages/widgets/src/feedback/TaskList.ts
@@ -73,6 +73,9 @@ export class TaskList extends Widget {
 
     /** Replace the task list and schedule a re-render. */
     setTasks(tasks: TaskItem[]): void {
+        if (tasks === this._tasks) {
+            return;
+        }
         this._tasks = tasks;
         this.markDirty();
     }


### PR DESCRIPTION
## Description

Adds an equality guard to `TaskList.setTasks()` to avoid unnecessary calls to `markDirty()` when the same task array reference is provided.

Also adds regression tests to verify that unchanged task arrays do not mark the widget dirty, while updated task arrays continue to trigger re-renders.

## Related Issue

Closes #1260 

## Which package(s)?

@termuijs/widgets

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [x] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

This change follows the same optimization pattern recently applied to other widgets by preventing redundant dirty-state updates when widget state has not changed. The accompanying tests ensure the optimization remains covered by regression testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved TaskList widget performance by preventing unnecessary re-renders when updating tasks.

* **Tests**
  * Added test coverage for TaskList update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->