### PR TITLE
feat: Multi-line Rich Text Editor Widget (fixes #1247)

### DIFF
--- a/packages/ui/src/components/TextArea.ts
+++ b/packages/ui/src/components/TextArea.ts
@@ -8,15 +8,105 @@ export interface TextAreaProps {
 }
 
 export function TextArea({ value = '', onChange, width, height }: TextAreaProps) {
+    const [lines, setLines] = useState<string[]>(value.split('\n').length ? value.split('\n') : ['']);
+    const [cursor, setCursor] = useState({ row: 0, col: 0 });
+    const [focused, setFocused] = useState(false);
+
+    const updateLines = (newLines: string[], newCursor: { row: number, col: number }) => {
+        setLines(newLines);
+        setCursor(newCursor);
+        onChange?.(newLines.join('\n'));
+    };
+
+    useInput((key: string, event: KeyEvent) => {
+        const { row, col } = cursor;
+
+        const isEnter = key === 'enter' || key === 'return' || key === '\r' || key === '\n';
+
+        if (isEnter) {
+            const line = lines[row];
+            const before = line.slice(0, col);
+            const after = line.slice(col);
+            const newLines = [...lines];
+            newLines[row] = before;
+            newLines.splice(row + 1, 0, after);
+            updateLines(newLines, { row: row + 1, col: 0 });
+            return;
+        }
+
+        switch (key) {
+            case 'up':
+                if (row > 0) {
+                    setCursor({ row: row - 1, col: Math.min(col, lines[row - 1].length) });
+                }
+                break;
+            case 'down':
+                if (row < lines.length - 1) {
+                    setCursor({ row: row + 1, col: Math.min(col, lines[row + 1].length) });
+                }
+                break;
+            case 'left':
+                if (col > 0) {
+                    setCursor({ row, col: col - 1 });
+                } else if (row > 0) {
+                    setCursor({ row: row - 1, col: lines[row - 1].length });
+                }
+                break;
+            case 'right':
+                if (col < lines[row].length) {
+                    setCursor({ row, col: col + 1 });
+                } else if (row < lines.length - 1) {
+                    setCursor({ row: row + 1, col: 0 });
+                }
+                break;
+            case 'backspace':
+                if (col > 0) {
+                    const newLines = [...lines];
+                    const line = newLines[row];
+                    newLines[row] = line.slice(0, col - 1) + line.slice(col);
+                    updateLines(newLines, { row, col: col - 1 });
+                } else if (row > 0) {
+                    const newLines = [...lines];
+                    const prevLine = newLines[row - 1];
+                    const curLine = newLines[row];
+                    newLines.splice(row, 1);
+                    newLines[row - 1] = prevLine + curLine;
+                    updateLines(newLines, { row: row - 1, col: prevLine.length });
+                }
+                break;
+            case 'space': {
+                const newLines = [...lines];
+                newLines[row] = newLines[row].slice(0, col) + ' ' + newLines[row].slice(col);
+                updateLines(newLines, { row, col: col + 1 });
+                break;
+            }
+            default:
+                if (key.length === 1 && !event.ctrl && !event.alt) {
+                    const newLines = [...lines];
+                    newLines[row] = newLines[row].slice(0, col) + key + newLines[row].slice(col);
+                    updateLines(newLines, { row, col: col + 1 });
+                }
+                break;
+        }
+    });
+
+    // Render logic: we create a single text node containing all lines,
+    // and we insert an inverse-styled character for the cursor.
+    // Wait, termuijs/jsx text element handles newlines and styling if nested?
+    // Actually, maybe we can just map over lines and render each as a text element,
+    // or just render it all as one string, but how do we style the cursor?
+    // A single 'text' element doesn't support nested styled spans natively in TermUI JSX unless we use nested text elements or styled spans.
+    // Let's use nested text elements! `text` can have children.
+    
     return createElement(
         'text',
         {
-            style: {
-                width,
-                height,
-                border: 'single',
-                overflow: 'scroll'
-            }
+            width,
+            height,
+            border: 'single',
+            focusable: true,
+            onFocus: () => setFocused(true),
+            onBlur: () => setFocused(false)
         },
         value
     );

--- a/packages/ui/src/components/TextArea.ts
+++ b/packages/ui/src/components/TextArea.ts
@@ -1,0 +1,23 @@
+import { createElement } from '@termuijs/jsx';
+
+export interface TextAreaProps {
+    value?: string;
+    onChange?: (value: string) => void;
+    width?: number | string;
+    height?: number | string;
+}
+
+export function TextArea({ value = '', onChange, width, height }: TextAreaProps) {
+    return createElement(
+        'text',
+        {
+            style: {
+                width,
+                height,
+                border: 'single',
+                overflow: 'scroll'
+            }
+        },
+        value
+    );
+}

--- a/packages/ui/src/components/TextArea.ts
+++ b/packages/ui/src/components/TextArea.ts
@@ -108,6 +108,17 @@ export function TextArea({ value = '', onChange, width, height }: TextAreaProps)
             onFocus: () => setFocused(true),
             onBlur: () => setFocused(false)
         },
-        value
+        createElement('col', { width: '100%', height: '100%' }, 
+            ...lines.map((lineStr, r) => {
+                if (r === cursor.row) {
+                    const before = lineStr.slice(0, cursor.col);
+                    const char = cursor.col < lineStr.length ? lineStr[cursor.col] : ' ';
+                    const after = cursor.col < lineStr.length ? lineStr.slice(cursor.col + 1) : '';
+                    
+                    return createElement('text', { key: r }, before + '\x1b[7m' + char + '\x1b[27m' + after);
+                }
+                return createElement('row', { key: r, gap: 0, width: '100%', height: 1 }, createElement('text', { width: lineStr.length || 1 }, lineStr || ' '));
+            })
+        )
     );
 }

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -39,7 +39,6 @@ export { List } from './input/List.js';
 export type { ListItem, ListProps } from './input/List.js';
 export { useListState } from './data/ListState.js';
 export type { ListState } from './data/ListState.js';
-export { TextInput } from './input/TextInput.js';
 export { VirtualList } from './input/VirtualList.js';
 export type { VirtualListOptions } from './input/VirtualList.js';
 export { CommandPalette } from './input/CommandPalette.js';
@@ -51,10 +50,12 @@ export { Slider } from "./input/Slider.js";
 export type { SliderOptions } from "./input/Slider.js";
 export { RangeInput } from "./input/RangeInput.js";
 export type { RangeInputOptions } from "./input/RangeInput.js";
-export { PinInput } from "./input/PinInput.js";
-export type { PinInputOptions } from "./input/PinInput.js";
+export { TextInput } from './input/TextInput.js';
+export type { TextInputProps } from './input/TextInput.js';
 export { Knob } from "./input/Knob.js";
 export type { KnobOptions } from "./input/Knob.js";
+export { PinInput } from "./input/PinInput.js";
+export type { PinInputOptions } from "./input/PinInput.js";
 
 // ── Data Widgets ──────────────────────────────────────
 export { Table } from './data/Table.js';
@@ -258,3 +259,4 @@ export type {
     ProgressTask,
 } from './feedback/Progress.js';
 export * from './display/Highlight.js';
+export type { TextInputProps } from './input/TextInput.js';


### PR DESCRIPTION
### Description
Adds the TextArea component to @termuijs/widgets to support multi-line text input.

Fixes #1247

GSSoC '26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * A fully interactive multi-line TextArea with cursor support and live onChange callbacks; configurable width/height and initial value.

* **Bug Fixes**
  * Widget child operations now mark parents for re-render to ensure UI updates.
  * Rendering utilities now ensure containers are marked dirty after updates.
  * Prompt sizing adjusted for consistent height.

* **Chores**
  * Updated public exports to surface the TextArea and its props.

* **Tests**
  * Added test suite validating TextArea editing, cursor movement, and onChange behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->