### PR TITLE
perf(display): avoid redundant OrderedList updates

### DIFF
--- a/packages/widgets/src/display/OrderedList.test.ts
+++ b/packages/widgets/src/display/OrderedList.test.ts
@@ -122,4 +122,34 @@ describe('OrderedList', () => {
         });
     });
 
+    describe('Performance optimizations', () => {
+        it('does not mark dirty when setItems receives the same array reference', () => {
+            const items: OrderedListItem[] = [
+                { text: 'Item 1' },
+            ];
+    
+            const list = makeList(items);
+    
+            list.clearDirty();
+    
+            list.setItems(items);
+    
+            expect(list.isDirty).toBe(false);
+        });
+    
+        it('marks dirty when setItems receives a different array', () => {
+            const list = makeList([
+                { text: 'Item 1' },
+            ]);
+    
+            list.clearDirty();
+    
+            list.setItems([
+                { text: 'Item 2' },
+            ]);
+    
+            expect(list.isDirty).toBe(true);
+        });
+    });
+
 });

--- a/packages/widgets/src/display/OrderedList.ts
+++ b/packages/widgets/src/display/OrderedList.ts
@@ -99,6 +99,9 @@ export class OrderedList extends Widget {
     }
 
     setItems(items: OrderedListItem[]): void {
+        if (items === this._items) {
+            return;
+        }
         this._items = items;
         this.markDirty();
     }


### PR DESCRIPTION
## Description

This PR optimizes OrderedList updates by preventing unnecessary dirty-state changes when `setItems()` is called with the same array reference. It also adds regression tests to verify that the widget only marks itself dirty when the item list actually changes.

## Related Issue

Closes #1273 

## Which package(s)?

@termuijs/widgets

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [x] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

`setItems()` now returns early when the incoming array reference matches the current list. This prevents unnecessary dirty-state updates and redundant re-renders while preserving existing behavior.

Added regression tests to verify correct dirty-state handling for both unchanged and updated item collections.

**Note:** Repository-wide `build` and `typecheck` currently report unrelated upstream failures in other packages. The OrderedList widget tests pass successfully and the changes are isolated to `@termuijs/widgets`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized list display widget performance by preventing unnecessary updates when identical collection references are reapplied.

* **Tests**
  * Added comprehensive test suite verifying reference-equality semantics in list collection operations, ensuring proper efficiency during data refresh cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->