### PR TITLE
refactor: improve type safety in MultiProgress tests

### DIFF
--- a/packages/widgets/src/feedback/MultiProgress.test.ts
+++ b/packages/widgets/src/feedback/MultiProgress.test.ts
@@ -19,13 +19,13 @@ describe('MultiProgress', () => {
 
     it('renders correct number of rows (one per item)', () => {
         const mp = new MultiProgress({ items });
-        const height = (mp as any)._style.height;
+        const height = mp.getHeightForTest();
         expect(height).toBe(3);
     });
 
     it('setItems() replaces all items and marks dirty', () => {
         const mp = new MultiProgress({ items });
-        (mp as any)._dirty = false;
+        mp.setDirtyForTest(false);
 
         const newItems: ProgressItem[] = [
             { label: 'Task1', value: 0.5 },
@@ -34,15 +34,15 @@ describe('MultiProgress', () => {
         mp.setItems(newItems);
 
         expect(mp.isDirty).toBe(true);
-        expect((mp as any)._items.length).toBe(2);
+        expect(mp.getItemsForTest().length).toBe(2);
     });
 
     it('updateItem(index, value) changes a single item value', () => {
         const mp = new MultiProgress({ items });
-        (mp as any)._dirty = false;
+        mp.setDirtyForTest(false);
 
         mp.updateItem(0, 0.8);
-        expect((mp as any)._items[0].value).toBe(0.8);
+        expect(mp.getItemsForTest()[0].value).toBe(0.8);
         expect(mp.isDirty).toBe(true);
     });
 
@@ -50,10 +50,10 @@ describe('MultiProgress', () => {
         const mp = new MultiProgress({ items });
 
         mp.updateItem(0, 1.5);
-        expect((mp as any)._items[0].value).toBe(1);
+        expect(mp.getItemsForTest()[0].value).toBe(1);
 
         mp.updateItem(0, -0.5);
-        expect((mp as any)._items[0].value).toBe(0);
+        expect(mp.getItemsForTest()[0].value).toBe(0);
     });
 
     it('updateItem() ignores invalid indices silently', () => {
@@ -64,22 +64,22 @@ describe('MultiProgress', () => {
 
     it('initializes with default labelWidth=12', () => {
         const mp = new MultiProgress({ items });
-        expect((mp as any)._labelWidth).toBe(12);
+        expect(mp.getLabelWidthForTest()).toBe(12);
     });
 
     it('respects custom labelWidth', () => {
         const mp = new MultiProgress({ items, labelWidth: 20 });
-        expect((mp as any)._labelWidth).toBe(20);
+        expect(mp.getLabelWidthForTest()).toBe(20);
     });
 
     it('initializes with showValues=true by default', () => {
         const mp = new MultiProgress({ items });
-        expect((mp as any)._showValues).toBe(true);
+        expect(mp.getShowValuesForTest()).toBe(true);
     });
 
     it('respects showValues=false option', () => {
         const mp = new MultiProgress({ items, showValues: false });
-        expect((mp as any)._showValues).toBe(false);
+        expect(mp.getShowValuesForTest()).toBe(false);
     });
 
     it('clamps item values during initialization', () => {
@@ -88,8 +88,8 @@ describe('MultiProgress', () => {
             { label: 'B', value: -0.5 },
         ];
         const mp = new MultiProgress({ items: itemsWithBadValues });
-        expect((mp as any)._items[0].value).toBe(1);
-        expect((mp as any)._items[1].value).toBe(0);
+        expect(mp.getItemsForTest()[0].value).toBe(1);
+        expect(mp.getItemsForTest()[1].value).toBe(0);
     });
 
     it('preserves custom colors on items', () => {
@@ -98,8 +98,8 @@ describe('MultiProgress', () => {
             { label: 'Tests', value: 0.8 },
         ];
         const mp = new MultiProgress({ items: itemsWithColors });
-        expect((mp as any)._items[0].color).toEqual({ type: 'named', name: 'red' });
-        expect((mp as any)._items[1].color).toBeUndefined();
+        expect(mp.getItemsForTest()[0].color).toEqual({ type: 'named', name: 'red' });
+        expect(mp.getItemsForTest()[1].color).toBeUndefined();
     });
 });
 
@@ -143,12 +143,12 @@ describe('MultiProgress — ASCII fallback', () => {
 describe('MultiProgress — edge cases', () => {
     it('handles empty items array', () => {
         const mp = new MultiProgress({ items: [] });
-        expect((mp as any)._items.length).toBe(0);
+        expect(mp.getItemsForTest().length).toBe(0);
     });
 
     it('handles single item', () => {
         const mp = new MultiProgress({ items: [{ label: 'Single', value: 0.5 }] });
-        expect((mp as any)._items.length).toBe(1);
+        expect(mp.getItemsForTest().length).toBe(1);
     });
 
     it('handles very long labels', () => {
@@ -166,7 +166,7 @@ describe('MultiProgress — edge cases', () => {
             { label: 'C', value: -1 },
         ];
         mp.setItems(newItems);
-        expect((mp as any)._items[0].value).toBe(1);
-        expect((mp as any)._items[1].value).toBe(0);
+        expect(mp.getItemsForTest()[0].value).toBe(1);
+        expect(mp.getItemsForTest()[1].value).toBe(0);
     });
 });

--- a/packages/widgets/src/feedback/MultiProgress.ts
+++ b/packages/widgets/src/feedback/MultiProgress.ts
@@ -100,7 +100,8 @@ export class MultiProgress extends Widget {
      * @internal
      */
     getHeightForTest(): number {
-        return this._style.height;
+        // Height is always set in constructor, but handle undefined for type safety
+        return this._style.height ?? 0;
     }
 
     /**
@@ -108,6 +109,8 @@ export class MultiProgress extends Widget {
      * @internal
      */
     setDirtyForTest(value: boolean): void {
+        // Access private _dirty from Widget base class for testing
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (this as any)._dirty = value;
     }
 

--- a/packages/widgets/src/feedback/MultiProgress.ts
+++ b/packages/widgets/src/feedback/MultiProgress.ts
@@ -71,6 +71,46 @@ export class MultiProgress extends Widget {
         }
     }
 
+    /**
+     * Test-only getter for items array
+     * @internal
+     */
+    getItemsForTest(): ProgressItem[] {
+        return this._items;
+    }
+
+    /**
+     * Test-only getter for labelWidth
+     * @internal
+     */
+    getLabelWidthForTest(): number {
+        return this._labelWidth;
+    }
+
+    /**
+     * Test-only getter for showValues
+     * @internal
+     */
+    getShowValuesForTest(): boolean {
+        return this._showValues;
+    }
+
+    /**
+     * Test-only getter for style height
+     * @internal
+     */
+    getHeightForTest(): number {
+        return this._style.height;
+    }
+
+    /**
+     * Test-only setter for dirty state
+     * @internal
+     */
+    setDirtyForTest(value: boolean): void {
+        (this as any)._dirty = value;
+    }
+
     protected _renderSelf(screen: Screen): void {
         const rect = this._getContentRect();
         const { x, y, width } = rect;

--- a/packages/widgets/src/feedback/MultiProgress.ts
+++ b/packages/widgets/src/feedback/MultiProgress.ts
@@ -100,8 +100,9 @@ export class MultiProgress extends Widget {
      * @internal
      */
     getHeightForTest(): number {
-        // Height is always set in constructor, but handle undefined for type safety
-        return this._style.height ?? 0;
+        // Height is always set as number in constructor (options.items.length)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return this._style.height as number;
     }
 
     /**

--- a/packages/widgets/src/feedback/MultiProgress.ts
+++ b/packages/widgets/src/feedback/MultiProgress.ts
@@ -110,9 +110,8 @@ export class MultiProgress extends Widget {
      * @internal
      */
     setDirtyForTest(value: boolean): void {
-        // Access private _dirty from Widget base class for testing
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (this as any)._dirty = value;
+        // _dirty is protected in Widget base class; accessible directly from subclass
+        this._dirty = value;
     }
 
     protected _renderSelf(screen: Screen): void {


### PR DESCRIPTION
## Description

This PR improves type safety in the MultiProgress widget tests by removing all usages of `(mp as any)` for accessing private properties.

To maintain encapsulation while allowing tests to verify internal state, test-only helper methods were added to `MultiProgress`. The tests were then updated to use these methods instead of bypassing TypeScript with `any` casts.

## Related Issue

#1267

## Which package(s)?

@termuijs/widgets

## Type of Change

* [x] 🧪 Tests (`type:testing`)
* [x] ♻️ Refactor (`type:refactor`)


## Testing

* Existing MultiProgress tests continue to pass
* No functional changes to widget behavior
* Only test-access patterns were refactored
## GSSoC contributor?

* [x] Yes. I contribute under GSSoC 2026.

## Notes for the Reviewer

This change focuses solely on improving test maintainability and type safety. No runtime behavior or public API was modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved MultiProgress test coverage by introducing test-only helpers to verify behavior without relying on internals. Tests now assert item counts and values (including clamping), preservation of custom colors, default and custom display/configuration, and edge cases (empty/single items), enabling more robust, maintainable verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->