### PR TITLE
refactor: improve Progress widget type safety

### DIFF
--- a/packages/widgets/src/feedback/Progress.ts
+++ b/packages/widgets/src/feedback/Progress.ts
@@ -11,7 +11,7 @@ import {
     SpeedColumn,
     PercentageColumn,
 } from './ProgressColumn.js';
-import type { Screen } from '@termuijs/core';
+import type { Screen, Style } from '@termuijs/core';
 export interface ProgressTask {
     label?: string;
     value?: number;
@@ -75,9 +75,9 @@ export class Progress extends Widget {
 
     constructor(
         props: ProgressProps = {},
-        style: Record<string, unknown> = {},
+        style: Partial<Style> = {},
     ) {
-        super(style as any);
+        super(style);
 
         this._tasks = props.tasks ?? [];
         


### PR DESCRIPTION
## Description

This PR improves type safety in the Progress widget by removing an unnecessary `any` type assertion from the constructor.

The `style` parameter is now properly typed using the shared `Style` interface, allowing it to be passed directly to the parent `Widget` constructor without bypassing TypeScript's type checking.

## Related Issue

#1271

## Which package(s)?

@termuijs/widgets

## Type of Change

* [x] ♻️ Refactor (`type:refactor`)

## Changes Made

* Imported the `Style` type from `@termuijs/core`
* Updated the constructor parameter type from:

```ts
Record<string, unknown>
```

to:

```ts
Partial<Style>
```

* Removed the unsafe type assertion:

```ts
super(style as any);
```

and replaced it with:

```ts
super(style);
```

## Testing

* Build passes successfully
* No functional changes to widget behavior
* Type safety improved without affecting existing functionality

## Notes for the Reviewer

This is a type-safety refactor only. The change removes an unnecessary `any` cast and aligns the Progress widget with the project's TypeScript standards while preserving existing behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type definitions for the Progress component's styling configuration, providing better TypeScript support and IDE autocomplete for style properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->