### PR TITLE
feat(widgets): add Canvas 2D drawing widget

### DIFF
--- a/packages/widgets/src/display/Canvas.test.ts
+++ b/packages/widgets/src/display/Canvas.test.ts
@@ -1,0 +1,112 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for Canvas widget
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import { Canvas } from './Canvas.js';
+import { Screen, BRAILLE_OFFSET, BRAILLE_DOTS } from '@termuijs/core';
+
+describe('Canvas', () => {
+    it('creates an empty canvas without errors', () => {
+        expect(() => new Canvas()).not.toThrow();
+    });
+
+    it('renders empty canvas with spaces', () => {
+        const canvas = new Canvas({ width: 5, height: 3 });
+        const screen = new Screen(10, 5);
+        canvas.updateRect({ x: 0, y: 0, width: 5, height: 3 });
+        canvas.render(screen);
+        expect(screen.back[0][0].char).toBe(' ');
+        expect(screen.back[2][4].char).toBe(' ');
+    });
+
+    it('renders Braille characters for set pixels', () => {
+        const canvas = new Canvas({ width: 5, height: 3 });
+        const screen = new Screen(10, 5);
+        
+        // Ensure size initializes
+        canvas.updateRect({ x: 0, y: 0, width: 5, height: 3 });
+        canvas.render(screen);
+        
+        canvas.setPixel(0, 0, true);
+        canvas.setPixel(1, 0, true);
+        
+        canvas.render(screen);
+        
+        const expectedCharCode = BRAILLE_OFFSET | BRAILLE_DOTS[0][0] | BRAILLE_DOTS[0][1];
+        expect(screen.back[0][0].char).toBe(String.fromCharCode(expectedCharCode));
+    });
+
+    it('fillRect correctly fills a region', () => {
+        const canvas = new Canvas({ width: 5, height: 3 });
+        const screen = new Screen(10, 5);
+        
+        canvas.updateRect({ x: 0, y: 0, width: 5, height: 3 });
+        canvas.render(screen);
+        
+        // Fill a 2x4 pixel block which corresponds to exactly 1 full Braille cell (1 column, 1 row)
+        canvas.fillRect(0, 0, 2, 4);
+        canvas.render(screen);
+        
+        const fullBraille = String.fromCharCode(BRAILLE_OFFSET | 0xFF);
+        expect(screen.back[0][0].char).toBe(fullBraille);
+        // Next cell should be empty
+        expect(screen.back[0][1].char).toBe(' ');
+    });
+
+    it('clear removes all pixels', () => {
+        const canvas = new Canvas({ width: 5, height: 3 });
+        const screen = new Screen(10, 5);
+        
+        canvas.updateRect({ x: 0, y: 0, width: 5, height: 3 });
+        canvas.render(screen);
+        
+        canvas.fillRect(0, 0, 10, 10);
+        canvas.render(screen);
+        
+        canvas.clear();
+        canvas.render(screen);
+        
+        expect(screen.back[0][0].char).toBe(' ');
+    });
+
+    it('lineTo draws a line', () => {
+        const canvas = new Canvas({ width: 5, height: 5 });
+        const screen = new Screen(10, 10);
+        
+        canvas.updateRect({ x: 0, y: 0, width: 5, height: 5 });
+        canvas.render(screen);
+        
+        canvas.lineTo(0, 0, 2, 0); // 3 pixels horizontally
+        canvas.render(screen);
+        
+        // It spans across 2 cells (col 0, col 1) since each cell is 2px wide.
+        const firstCellBraille = String.fromCharCode(BRAILLE_OFFSET | BRAILLE_DOTS[0][0] | BRAILLE_DOTS[0][1]);
+        const secondCellBraille = String.fromCharCode(BRAILLE_OFFSET | BRAILLE_DOTS[0][0]);
+        
+        expect(screen.back[0][0].char).toBe(firstCellBraille);
+        expect(screen.back[0][1].char).toBe(secondCellBraille);
+    });
+
+    it('drawCircle creates a circle without throwing', () => {
+        const canvas = new Canvas({ width: 10, height: 10 });
+        const screen = new Screen(10, 10);
+        
+        canvas.updateRect({ x: 0, y: 0, width: 10, height: 10 });
+        canvas.render(screen);
+        
+        canvas.drawCircle(5, 5, 4);
+        canvas.render(screen);
+        
+        // Assert that at least something was drawn (not empty)
+        let hasContent = false;
+        for (let r = 0; r < 10; r++) {
+            for (let c = 0; c < 10; c++) {
+                if (screen.back[r][c].char !== ' ') {
+                    hasContent = true;
+                }
+            }
+        }
+        expect(hasContent).toBe(true);
+    });
+});

--- a/packages/widgets/src/display/Canvas.ts
+++ b/packages/widgets/src/display/Canvas.ts
@@ -1,0 +1,203 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Canvas widget
+// ─────────────────────────────────────────────────────
+
+import type { Screen, Style, Color } from '@termuijs/core';
+import { styleToCellAttrs, BRAILLE_OFFSET, BRAILLE_DOTS } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+/**
+ * A raw Canvas widget providing a HTML5-like 2D drawing context for custom rendering.
+ * Mapped to Braille characters for 2x4 sub-cell pixel resolution.
+ */
+export class Canvas extends Widget {
+    private _pixels: Uint8Array;
+    private _canvasWidth: number = 0;
+    private _canvasHeight: number = 0;
+    private _color: Color | undefined;
+
+    constructor(style: Partial<Style> = {}) {
+        super(style);
+        this._pixels = new Uint8Array(0);
+    }
+
+    /**
+     * Sets the active drawing color. If not set, the foreground color from style is used.
+     */
+    public setColor(color: Color): void {
+        this._color = color;
+    }
+
+    /**
+     * Clears the entire canvas.
+     */
+    public clear(): void {
+        if (this._pixels.length > 0) {
+            this._pixels.fill(0);
+            this.markDirty();
+        }
+    }
+
+    /**
+     * Sets a single sub-cell pixel.
+     */
+    public setPixel(x: number, y: number, value: boolean = true): void {
+        x = Math.floor(x);
+        y = Math.floor(y);
+        if (x < 0 || x >= this._canvasWidth || y < 0 || y >= this._canvasHeight) return;
+        
+        const idx = y * this._canvasWidth + x;
+        const current = this._pixels[idx];
+        const next = value ? 1 : 0;
+        
+        if (current !== next) {
+            this._pixels[idx] = next;
+            this.markDirty();
+        }
+    }
+
+    /**
+     * Fills a rectangle with the current drawing state.
+     */
+    public fillRect(x: number, y: number, w: number, h: number): void {
+        x = Math.floor(x);
+        y = Math.floor(y);
+        w = Math.floor(w);
+        h = Math.floor(h);
+
+        let dirty = false;
+        for (let r = Math.max(0, y); r < Math.min(this._canvasHeight, y + h); r++) {
+            for (let c = Math.max(0, x); c < Math.min(this._canvasWidth, x + w); c++) {
+                const idx = r * this._canvasWidth + c;
+                if (this._pixels[idx] !== 1) {
+                    this._pixels[idx] = 1;
+                    dirty = true;
+                }
+            }
+        }
+        if (dirty) {
+            this.markDirty();
+        }
+    }
+
+    /**
+     * Draws an unfilled circle.
+     */
+    public drawCircle(cx: number, cy: number, r: number): void {
+        cx = Math.floor(cx);
+        cy = Math.floor(cy);
+        r = Math.floor(r);
+
+        // Bresenham's circle algorithm
+        let x = 0;
+        let y = r;
+        let d = 3 - 2 * r;
+        
+        const drawCirclePixels = (xc: number, yc: number, x: number, y: number) => {
+            this.setPixel(xc + x, yc + y);
+            this.setPixel(xc - x, yc + y);
+            this.setPixel(xc + x, yc - y);
+            this.setPixel(xc - x, yc - y);
+            this.setPixel(xc + y, yc + x);
+            this.setPixel(xc - y, yc + x);
+            this.setPixel(xc + y, yc - x);
+            this.setPixel(xc - y, yc - x);
+        };
+
+        drawCirclePixels(cx, cy, x, y);
+        while (y >= x) {
+            x++;
+            if (d > 0) {
+                y--;
+                d = d + 4 * (x - y) + 10;
+            } else {
+                d = d + 4 * x + 6;
+            }
+            drawCirclePixels(cx, cy, x, y);
+        }
+    }
+
+    /**
+     * Draws a line from (x0, y0) to (x1, y1).
+     */
+    public lineTo(x0: number, y0: number, x1: number, y1: number): void {
+        x0 = Math.floor(x0);
+        y0 = Math.floor(y0);
+        x1 = Math.floor(x1);
+        y1 = Math.floor(y1);
+
+        const dx = Math.abs(x1 - x0);
+        const dy = -Math.abs(y1 - y0);
+        const sx = x0 < x1 ? 1 : -1;
+        const sy = y0 < y1 ? 1 : -1;
+        let err = dx + dy;
+
+        while (true) {
+            this.setPixel(x0, y0);
+            if (x0 === x1 && y0 === y1) break;
+            const e2 = 2 * err;
+            if (e2 >= dy) {
+                err += dy;
+                x0 += sx;
+            }
+            if (e2 <= dx) {
+                err += dx;
+                y0 += sy;
+            }
+        }
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width, height } = this._rect;
+        const border = this._style.border && this._style.border !== 'none' ? 1 : 0;
+        
+        const innerWidth = width - border * 2;
+        const innerHeight = height - border * 2;
+
+        if (innerWidth <= 0 || innerHeight <= 0) {
+            return;
+        }
+
+        const pxWidth = innerWidth * 2;
+        const pxHeight = innerHeight * 4;
+
+        if (this._canvasWidth !== pxWidth || this._canvasHeight !== pxHeight) {
+            const newPixels = new Uint8Array(pxWidth * pxHeight);
+            
+            // Optionally preserve old pixels if resizing
+            for (let r = 0; r < Math.min(this._canvasHeight, pxHeight); r++) {
+                for (let c = 0; c < Math.min(this._canvasWidth, pxWidth); c++) {
+                    newPixels[r * pxWidth + c] = this._pixels[r * this._canvasWidth + c];
+                }
+            }
+
+            this._pixels = newPixels;
+            this._canvasWidth = pxWidth;
+            this._canvasHeight = pxHeight;
+        }
+
+        const { bg, fg } = styleToCellAttrs(this._style);
+        const finalFg = this._color ? this._color : fg;
+
+        for (let r = 0; r < innerHeight; r++) {
+            for (let c = 0; c < innerWidth; c++) {
+                let charCode = BRAILLE_OFFSET;
+                let hasPixels = false;
+                
+                for (let br = 0; br < 4; br++) {
+                    for (let bc = 0; bc < 2; bc++) {
+                        const px = c * 2 + bc;
+                        const py = r * 4 + br;
+                        if (this._pixels[py * this._canvasWidth + px]) {
+                            charCode |= BRAILLE_DOTS[br][bc];
+                            hasPixels = true;
+                        }
+                    }
+                }
+                
+                const char = hasPixels ? String.fromCharCode(charCode) : ' ';
+                screen.setCell(x + border + c, y + border + r, { char, bg, fg: finalFg });
+            }
+        }
+    }
+}

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -27,7 +27,7 @@ export type { ChatMessageOptions, MessageRole } from './display/ChatMessage.js';
 export { ToolCall, ToolApproval } from './display/ToolCall.js';
 export type { ToolCallOptions, ToolApprovalOptions, ToolCallStatus } from './display/ToolCall.js';
 export { Canvas } from './display/Canvas.js';
-export type { CanvasOptions } from './display/Canvas.js';
+
 
 
 

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -28,9 +28,6 @@ export { ToolCall, ToolApproval } from './display/ToolCall.js';
 export type { ToolCallOptions, ToolApprovalOptions, ToolCallStatus } from './display/ToolCall.js';
 export { Canvas } from './display/Canvas.js';
 
-
-
-
 // ── Virtual Scroll Helpers ────────────────────────────
 export { computeRange, computeVariableRange } from './input/virtual-scroll.js';
 export type { ScrollRange } from './input/virtual-scroll.js';

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -26,6 +26,10 @@ export { ChatMessage } from './display/ChatMessage.js';
 export type { ChatMessageOptions, MessageRole } from './display/ChatMessage.js';
 export { ToolCall, ToolApproval } from './display/ToolCall.js';
 export type { ToolCallOptions, ToolApprovalOptions, ToolCallStatus } from './display/ToolCall.js';
+export { Canvas } from './display/Canvas.js';
+export type { CanvasOptions } from './display/Canvas.js';
+
+
 
 // ── Virtual Scroll Helpers ────────────────────────────
 export { computeRange, computeVariableRange } from './input/virtual-scroll.js';


### PR DESCRIPTION
## Description
Implemented Canvas 2D drawing widget.

Closes #1241

## Testing
Tested using vitest suite packages/widgets/src/display/Canvas.test.ts. All checks pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a Canvas widget for terminal 2D drawing using Unicode Braille, with automatic sizing and rendering.
  * New drawing APIs: set individual pixels, clear canvas, fill rectangles, draw circles, and draw lines.
  * Supports an optional drawing color override and preserves drawn content when resized.

* **Tests**
  * Added test suite validating Canvas creation, rendering behavior, pixel output, and all drawing primitives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->