### PR TITLE
feat(widgets): add Pty terminal multiplexer widget

### DIFF
--- a/packages/widgets/src/display/Pty.test.ts
+++ b/packages/widgets/src/display/Pty.test.ts
@@ -1,0 +1,119 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for Pty widget
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Pty } from './Pty.js';
+import { Screen } from '@termuijs/core';
+
+// Mock child_process to avoid actually spawning shells during tests
+vi.mock('node:child_process', () => {
+    return {
+        spawn: vi.fn().mockImplementation(() => {
+            let stdoutCb: any;
+            let stderrCb: any;
+            let closeCb: any;
+            
+            return {
+                stdout: {
+                    on: (event: string, cb: any) => { if (event === 'data') stdoutCb = cb; }
+                },
+                stderr: {
+                    on: (event: string, cb: any) => { if (event === 'data') stderrCb = cb; }
+                },
+                stdin: {
+                    writable: true,
+                    write: vi.fn()
+                },
+                on: (event: string, cb: any) => { if (event === 'close') closeCb = cb; },
+                kill: vi.fn(),
+                
+                // Helper to simulate output in tests
+                _emitStdout: (data: string) => {
+                    if (stdoutCb) stdoutCb(Buffer.from(data));
+                },
+                _emitStderr: (data: string) => {
+                    if (stderrCb) stderrCb(Buffer.from(data));
+                },
+                _emitClose: () => {
+                    if (closeCb) closeCb();
+                }
+            };
+        })
+    };
+});
+
+describe('Pty', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('creates a Pty without throwing', () => {
+        expect(() => new Pty()).not.toThrow();
+    });
+
+    it('renders initial empty lines', () => {
+        const pty = new Pty();
+        const screen = new Screen(20, 5);
+        pty.updateRect({ x: 0, y: 0, width: 20, height: 5 });
+        pty.render(screen);
+        
+        // Empty state
+        expect(screen.back[0][0].char).toBe(' ');
+    });
+
+    it('handles process output and renders it', () => {
+        const pty = new Pty();
+        const screen = new Screen(20, 5);
+        pty.updateRect({ x: 0, y: 0, width: 20, height: 5 });
+        
+        // Grab the mocked process to simulate output
+        const mockProcess = (pty as any)._process;
+        mockProcess._emitStdout('Hello terminal\nSecond line');
+        
+        pty.render(screen);
+        
+        // The first line should be rendered
+        const row0 = screen.back[0].map(c => c.char).join('').trimEnd();
+        expect(row0).toBe('Hello terminal');
+        
+        // The second line should be rendered
+        const row1 = screen.back[1].map(c => c.char).join('').trimEnd();
+        expect(row1).toBe('Second line');
+    });
+
+    it('strips ANSI escape sequences from output', () => {
+        const pty = new Pty();
+        const screen = new Screen(20, 5);
+        pty.updateRect({ x: 0, y: 0, width: 20, height: 5 });
+        
+        const mockProcess = (pty as any)._process;
+        // Output with red text ANSI
+        mockProcess._emitStdout('\x1b[31mColored text\x1b[0m');
+        
+        pty.render(screen);
+        
+        const row0 = screen.back[0].map(c => c.char).join('').trimEnd();
+        expect(row0).toBe('Colored text');
+    });
+
+    it('pipes keys to stdin', () => {
+        const pty = new Pty();
+        const mockProcess = (pty as any)._process;
+        
+        pty.handleKey({ key: 'a', raw: Buffer.from('a'), ctrl: false, alt: false, shift: false } as any);
+        expect(mockProcess.stdin.write).toHaveBeenCalledWith(Buffer.from('a'));
+        
+        pty.handleKey({ key: 'enter', raw: Buffer.from('\n'), ctrl: false, alt: false, shift: false } as any);
+        expect(mockProcess.stdin.write).toHaveBeenCalledWith(Buffer.from('\n'));
+    });
+
+    it('cleans up process on destroy', () => {
+        const pty = new Pty();
+        const mockProcess = (pty as any)._process;
+        
+        pty.destroy();
+        expect(mockProcess.kill).toHaveBeenCalled();
+        expect((pty as any)._process).toBeNull();
+    });
+});

--- a/packages/widgets/src/display/Pty.ts
+++ b/packages/widgets/src/display/Pty.ts
@@ -1,0 +1,111 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Pty widget
+// ─────────────────────────────────────────────────────
+
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import type { Screen, Style, KeyEvent } from '@termuijs/core';
+import { styleToCellAttrs, stripAnsi, truncate } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export interface PtyOptions {
+    /** The command to spawn */
+    command?: string;
+    /** Arguments to the command */
+    args?: string[];
+}
+
+/**
+ * Pty — Terminal Multiplexer widget.
+ * Spawns a child process and renders its output inside the TermUI screen.
+ */
+export class Pty extends Widget {
+    private _process: ChildProcessWithoutNullStreams | null = null;
+    private _lines: string[] = [];
+    private _autoScroll = true;
+
+    constructor(style: Partial<Style> = {}, opts: PtyOptions = {}) {
+        super(style);
+        
+        // Default to a shell if no command is provided
+        const cmd = opts.command ?? (process.platform === 'win32' ? 'cmd.exe' : '/bin/sh');
+        const args = opts.args ?? [];
+        
+        try {
+            this._process = spawn(cmd, args);
+            
+            this._process.stdout.on('data', (data) => {
+                this._handleOutput(data.toString());
+            });
+            
+            this._process.stderr.on('data', (data) => {
+                this._handleOutput(data.toString());
+            });
+            
+            this._process.on('close', () => {
+                this._handleOutput('\n[Process Exited]');
+            });
+        } catch (err) {
+            this._lines.push(`Failed to spawn ${cmd}`);
+        }
+    }
+
+    private _handleOutput(chunk: string): void {
+        const clean = stripAnsi(chunk);
+        // Normalize carriage returns and split into lines
+        const newLines = clean.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
+        
+        if (newLines.length > 0) {
+            if (this._lines.length === 0) {
+                this._lines.push(newLines[0]);
+            } else {
+                this._lines[this._lines.length - 1] += newLines[0];
+            }
+            
+            for (let i = 1; i < newLines.length; i++) {
+                this._lines.push(newLines[i]);
+            }
+        }
+        
+        // Keep a reasonable buffer size
+        if (this._lines.length > 1000) {
+            this._lines = this._lines.slice(this._lines.length - 1000);
+        }
+        
+        this.markDirty();
+    }
+
+    public handleKey(event: KeyEvent): boolean {
+        if (!this._process || !this._process.stdin.writable) return false;
+        
+        this._process.stdin.write(event.raw);
+        return true;
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const rect = this._getContentRect();
+        const { x, y, width, height } = rect;
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this._style);
+        
+        // Render from bottom up or top down depending on scroll
+        const startIdx = Math.max(0, this._lines.length - height);
+        const visibleLines = this._lines.slice(startIdx, startIdx + height);
+        
+        for (let i = 0; i < visibleLines.length; i++) {
+            // Note: truncate from unicode utils properly handles wide characters
+            const line = truncate(visibleLines[i], width);
+            screen.writeString(x, y + i, line, attrs);
+        }
+    }
+    
+    /**
+     * Terminate the spawned process
+     */
+    public destroy(): void {
+        if (this._process) {
+            this._process.kill();
+            this._process = null;
+        }
+    }
+}

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -29,6 +29,8 @@ export type { ToolCallOptions, ToolApprovalOptions, ToolCallStatus } from './dis
 export { Canvas } from './display/Canvas.js';
 export { Rating } from './display/Rating.js';
 export type { RatingOptions } from './display/Rating.js';
+export { Pty } from './display/Pty.js';
+export type { PtyOptions } from './display/Pty.js';
 
 // ── Virtual Scroll Helpers ────────────────────────────
 export { computeRange, computeVariableRange } from './input/virtual-scroll.js';


### PR DESCRIPTION
## Description
Implemented Pty terminal multiplexer widget.

Closes #1242

## Testing
Tested using vitest suite packages/widgets/src/display/Pty.test.ts. All checks pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a `Pty` widget for rendering terminal output from spawned child processes with customizable commands, keyboard input handling, and automatic ANSI escape sequence sanitization.

* **Tests**
  * Added test suite for the `Pty` widget covering process spawning, output rendering, keyboard input forwarding, and resource cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->