### PR TITLE
feat(motion): add animated layout transitions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -457,6 +457,7 @@
         "@termuijs/core": "workspace:*",
       },
       "devDependencies": {
+        "@termuijs/widgets": "workspace:*",
         "tsup": "^8.0.0",
         "typescript": "^5.3.0",
       },

--- a/packages/motion/src/index.ts
+++ b/packages/motion/src/index.ts
@@ -36,3 +36,7 @@ export type { VirtualClock } from './virtual-clock.js'
 export { mapRange, interpolate } from './interpolate.js';
 export type { InterpolateOptions } from './interpolate.js';
 
+// Layout transitions
+export { animateRect } from './layout-transition.js';
+export type { LayoutTransitionOptions } from './layout-transition.js';
+

--- a/packages/motion/src/layout-transition.test.ts
+++ b/packages/motion/src/layout-transition.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Rect } from '@termuijs/core';
+
+async function advanceSpring(ms: number) {
+    const steps = Math.ceil(ms / 16);
+    for (let i = 0; i < steps; i++) {
+        vi.advanceTimersByTime(16);
+        await Promise.resolve();
+    }
+}
+
+describe('animateRect', () => {
+    let animateRect: typeof import('./layout-transition.js').animateRect;
+
+    beforeEach(async () => {
+        vi.useFakeTimers();
+        vi.unstubAllEnvs();
+        vi.stubEnv('NO_MOTION', '');
+        vi.stubEnv('CI', '');
+        vi.resetModules();
+        const mod = await import('./layout-transition.js');
+        animateRect = mod.animateRect;
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllEnvs();
+    });
+
+    it('calls onFrame with interpolated rects', async () => {
+        const from: Rect = { x: 0, y: 0, width: 10, height: 10 };
+        const to: Rect = { x: 100, y: 100, width: 50, height: 50 };
+        const frames: Rect[] = [];
+
+        animateRect(from, to, {
+            onFrame: (rect) => frames.push(rect)
+        });
+
+        await advanceSpring(100);
+        
+        expect(frames.length).toBeGreaterThan(0);
+        const midFrame = frames[frames.length - 1];
+        expect(midFrame.x).toBeGreaterThan(0);
+        expect(midFrame.x).toBeLessThan(100);
+    });
+
+    it('calls onComplete when all 4 springs settle', async () => {
+        const from: Rect = { x: 0, y: 0, width: 10, height: 10 };
+        const to: Rect = { x: 10, y: 10, width: 20, height: 20 };
+        
+        let completed = false;
+        animateRect(from, to, {
+            onFrame: () => {},
+            onComplete: () => { completed = true; }
+        });
+
+        await advanceSpring(5000);
+        expect(completed).toBe(true);
+    });
+
+    it('the returned cancel function stops further onFrame calls', async () => {
+        const from: Rect = { x: 0, y: 0, width: 10, height: 10 };
+        const to: Rect = { x: 100, y: 100, width: 50, height: 50 };
+        const frames: Rect[] = [];
+
+        const cancel = animateRect(from, to, {
+            onFrame: (rect) => frames.push(rect)
+        });
+
+        await advanceSpring(64);
+        const framesSoFar = frames.length;
+
+        cancel();
+
+        await advanceSpring(5000);
+        expect(frames.length).toBe(framesSoFar);
+    });
+});
+
+describe('Widget.layoutTransition', () => {
+    let Widget: typeof import('@termuijs/widgets').Widget;
+
+    beforeEach(async () => {
+        vi.useFakeTimers();
+        vi.unstubAllEnvs();
+        vi.stubEnv('NO_MOTION', '');
+        vi.stubEnv('CI', '');
+        vi.resetModules();
+        
+        const widgetsMod = await import('@termuijs/widgets');
+        Widget = widgetsMod.Widget;
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllEnvs();
+    });
+
+    it('Widget.layoutTransition = true causes updateRect to animate rather than snap', async () => {
+        class TestWidget extends Widget {
+            protected _renderSelf(): void {}
+        }
+        
+        const widget = new TestWidget({ id: 'test' });
+        
+        widget.updateRect({ x: 0, y: 0, width: 10, height: 10 });
+        expect(widget.rect).toEqual({ x: 0, y: 0, width: 10, height: 10 });
+
+        widget.layoutTransition = true;
+        
+        widget.updateRect({ x: 100, y: 100, width: 100, height: 100 });
+        
+        await advanceSpring(64);
+        
+        const rect = widget.rect;
+        expect(rect.x).toBeGreaterThan(0);
+        expect(rect.x).toBeLessThan(100);
+        expect(rect.width).toBeGreaterThan(10);
+        expect(rect.width).toBeLessThan(100);
+        
+        await advanceSpring(5000);
+        expect(widget.rect).toEqual({ x: 100, y: 100, width: 100, height: 100 });
+    });
+});

--- a/packages/motion/src/layout-transition.test.ts
+++ b/packages/motion/src/layout-transition.test.ts
@@ -77,48 +77,4 @@ describe('animateRect', () => {
     });
 });
 
-describe('Widget.layoutTransition', () => {
-    let Widget: typeof import('@termuijs/widgets').Widget;
 
-    beforeEach(async () => {
-        vi.useFakeTimers();
-        vi.unstubAllEnvs();
-        vi.stubEnv('NO_MOTION', '');
-        vi.stubEnv('CI', '');
-        vi.resetModules();
-        
-        const widgetsMod = await import('@termuijs/widgets');
-        Widget = widgetsMod.Widget;
-    });
-
-    afterEach(() => {
-        vi.restoreAllMocks();
-        vi.unstubAllEnvs();
-    });
-
-    it('Widget.layoutTransition = true causes updateRect to animate rather than snap', async () => {
-        class TestWidget extends Widget {
-            protected _renderSelf(): void {}
-        }
-        
-        const widget = new TestWidget({ id: 'test' });
-        
-        widget.updateRect({ x: 0, y: 0, width: 10, height: 10 });
-        expect(widget.rect).toEqual({ x: 0, y: 0, width: 10, height: 10 });
-
-        widget.layoutTransition = true;
-        
-        widget.updateRect({ x: 100, y: 100, width: 100, height: 100 });
-        
-        await advanceSpring(64);
-        
-        const rect = widget.rect;
-        expect(rect.x).toBeGreaterThan(0);
-        expect(rect.x).toBeLessThan(100);
-        expect(rect.width).toBeGreaterThan(10);
-        expect(rect.width).toBeLessThan(100);
-        
-        await advanceSpring(5000);
-        expect(widget.rect).toEqual({ x: 100, y: 100, width: 100, height: 100 });
-    });
-});

--- a/packages/motion/src/layout-transition.ts
+++ b/packages/motion/src/layout-transition.ts
@@ -1,0 +1,70 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/motion — Layout Transitions
+// ─────────────────────────────────────────────────────
+
+import type { Rect } from '@termuijs/core';
+import { animateSpring, type SpringPresetName, type SpringConfig } from './spring.js';
+
+export interface LayoutTransitionOptions {
+    config?: Partial<SpringConfig> | SpringPresetName;
+    onFrame: (rect: Rect) => void;
+    onComplete?: () => void;
+}
+
+/**
+ * Animates between two rectangles using spring physics.
+ * Returns a cancellation function.
+ */
+export function animateRect(
+    from: Rect,
+    to: Rect,
+    options: LayoutTransitionOptions
+): () => void {
+    const currentRect = { ...from };
+    let active = 4;
+    
+    const checkDone = () => {
+        active--;
+        if (active <= 0 && options.onComplete) {
+            options.onComplete();
+        }
+    };
+    
+    let frameRequested = false;
+    const batchFrame = () => {
+        if (!frameRequested) {
+            frameRequested = true;
+            queueMicrotask(() => {
+                frameRequested = false;
+                options.onFrame({ ...currentRect });
+            });
+        }
+    };
+    
+    const cfg = options.config ?? 'default';
+    
+    const unsubs = [
+        animateSpring(from.x, to.x, cfg, (v) => {
+            currentRect.x = Math.round(v);
+            batchFrame();
+        }, checkDone),
+        animateSpring(from.y, to.y, cfg, (v) => {
+            currentRect.y = Math.round(v);
+            batchFrame();
+        }, checkDone),
+        animateSpring(from.width, to.width, cfg, (v) => {
+            currentRect.width = Math.round(v);
+            batchFrame();
+        }, checkDone),
+        animateSpring(from.height, to.height, cfg, (v) => {
+            currentRect.height = Math.round(v);
+            batchFrame();
+        }, checkDone)
+    ];
+    
+    return () => {
+        for (let i = 0; i < unsubs.length; i++) {
+            unsubs[i]();
+        }
+    };
+}

--- a/packages/widgets/src/base/Widget.test.ts
+++ b/packages/widgets/src/base/Widget.test.ts
@@ -3,6 +3,14 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@termuijs/core', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@termuijs/core')>();
+    return {
+        ...actual,
+        prefersReducedMotion: () => false,
+    };
+});
 import { Widget } from './Widget.js';
 import { Screen, computeLayout } from '@termuijs/core';
 
@@ -168,3 +176,52 @@ describe('Widget', () => {
         });
     });
 });
+
+async function advanceSpring(ms: number) {
+    const steps = Math.ceil(ms / 16);
+    for (let i = 0; i < steps; i++) {
+        vi.advanceTimersByTime(16);
+        await Promise.resolve();
+    }
+}
+
+describe('Widget.layoutTransition', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.unstubAllEnvs();
+        vi.stubEnv('NO_MOTION', '');
+        vi.stubEnv('CI', '');
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllEnvs();
+    });
+
+    it('Widget.layoutTransition = true causes updateRect to animate rather than snap', async () => {
+        class TransitionTestWidget extends Widget {
+            protected _renderSelf(): void {}
+        }
+        
+        const widget = new TransitionTestWidget({ id: 'test' });
+        
+        widget.updateRect({ x: 0, y: 0, width: 10, height: 10 });
+        expect(widget.rect).toEqual({ x: 0, y: 0, width: 10, height: 10 });
+
+        widget.layoutTransition = true;
+        
+        widget.updateRect({ x: 100, y: 100, width: 100, height: 100 });
+        
+        await advanceSpring(64);
+        
+        const rect = widget.rect;
+        expect(rect.x).toBeGreaterThan(0);
+        expect(rect.x).toBeLessThan(100);
+        expect(rect.width).toBeGreaterThan(10);
+        expect(rect.width).toBeLessThan(100);
+        
+        await advanceSpring(5000);
+        expect(widget.rect).toEqual({ x: 100, y: 100, width: 100, height: 100 });
+    });
+});
+

--- a/packages/widgets/src/base/Widget.ts
+++ b/packages/widgets/src/base/Widget.ts
@@ -19,6 +19,7 @@ import {
     containsPoint,
     caps,
 } from '@termuijs/core';
+import { animateRect, type SpringConfig, type SpringPresetName } from '@termuijs/motion';
 
 /**
  * Event map for widgets.
@@ -105,6 +106,11 @@ export abstract class Widget {
      */
     protected _dirty = true;
 
+    /** Enable animated layout transitions for size/position changes */
+    public layoutTransition: Partial<SpringConfig> | SpringPresetName | boolean = false;
+    private _layoutCancel: (() => void) | null = null;
+    private _targetRect: Rect | null = null;
+
     constructor(style: Partial<Style> = {}) {
         this.id = `widget_${++_widgetIdCounter}`;
         this._style = mergeStyles(defaultStyle(), style);
@@ -178,7 +184,7 @@ export abstract class Widget {
      */
     syncLayout(): void {
         if (this._layoutNode) {
-            this._rect = { ...this._layoutNode.computed };
+            this._applyRect({ ...this._layoutNode.computed });
         }
 
         // Sync children (match visible children to layout node children)
@@ -247,7 +253,63 @@ export abstract class Widget {
      * Update the computed rect from layout results.
      */
     updateRect(rect: Rect): void {
-        this._rect = rect;
+        this._applyRect(rect);
+    }
+
+    private _applyRect(newRect: Rect): void {
+        if (this._rect.width === 0 && this._rect.height === 0) {
+            // First render, do not animate
+            this._rect = newRect;
+            return;
+        }
+
+        if (!this.layoutTransition) {
+            if (this._layoutCancel) {
+                this._layoutCancel();
+                this._layoutCancel = null;
+                this._targetRect = null;
+            }
+            this._rect = newRect;
+            return;
+        }
+        
+        // If target is same, ignore
+        if (this._targetRect && 
+            this._targetRect.x === newRect.x && 
+            this._targetRect.y === newRect.y && 
+            this._targetRect.width === newRect.width && 
+            this._targetRect.height === newRect.height) {
+            return;
+        }
+        
+        if (this._rect.x === newRect.x && 
+            this._rect.y === newRect.y && 
+            this._rect.width === newRect.width && 
+            this._rect.height === newRect.height) {
+            return;
+        }
+        
+        if (this._layoutCancel) {
+            this._layoutCancel();
+        }
+        
+        this._targetRect = { ...newRect };
+        
+        const config = typeof this.layoutTransition === 'boolean' 
+            ? 'default' 
+            : this.layoutTransition;
+            
+        this._layoutCancel = animateRect(this._rect, newRect, {
+            config,
+            onFrame: (rect) => {
+                this._rect = rect;
+                this.markDirty();
+            },
+            onComplete: () => {
+                this._layoutCancel = null;
+                this._targetRect = null;
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
## Description
Implemented animated layout transitions.

Closes #1244

## Testing
Tested manually. Layout correctly uses spring animations for transitions. All checks pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smooth spring-based layout animations for widgets when position/size change; widgets now expose a configurable layout-transition option with presets.
  * Motion package now exposes layout-transition helpers for integrations to drive animated rect updates.

* **Tests**
  * Added deterministic tests covering animated frames, completion, cancellation, and widget transition behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->