### PR TITLE
fix(store): add dispose() to Computed to prevent subscription memory leak

### DIFF
--- a/packages/store/src/computed.test.ts
+++ b/packages/store/src/computed.test.ts
@@ -136,4 +136,39 @@ describe('computed', () => {
         expect(sum.get()).toBe(10);
         expect(spy).toHaveBeenCalledWith(10);
     });
+
+    it('selector is no longer called after dispose()', () => {
+        const selector = vi.fn((s: { count: number }) => s.count * 2);
+        const useStore = createStore((set) => ({
+            count: 0,
+            inc: () => set((s) => ({ count: s.count + 1 })),
+        }));
+        const doubled = useStore.computed(selector);
+
+        // Selector is called once to seed the initial cached value
+        const callsBeforeDispose = selector.mock.calls.length;
+
+        doubled.dispose();
+
+        // setState after dispose — selector must NOT be called again
+        useStore.getState().inc();
+        useStore.getState().inc();
+
+        expect(selector.mock.calls.length).toBe(callsBeforeDispose);
+    });
+
+    it('dispose() clears all computed listeners', () => {
+        const useStore = createStore((set) => ({
+            count: 0,
+            inc: () => set((s) => ({ count: s.count + 1 })),
+        }));
+        const doubled = useStore.computed((s) => s.count * 2);
+        const spy = vi.fn();
+        doubled.subscribe(spy);
+
+        doubled.dispose();
+
+        useStore.getState().inc();
+        expect(spy).not.toHaveBeenCalled();
+    });
 });

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -132,6 +132,8 @@ export interface Computed<U> {
     get(): U;
     /** Subscribe to changes — listener fires only when the derived value changes */
     subscribe(listener: (value: U) => void): () => void;
+    /** Remove the internal store subscription and clear all computed listeners — call when done to prevent memory leaks */
+    dispose(): void;
 }
 
 export interface Store<T> {
@@ -373,7 +375,7 @@ export function createStore<T extends object>(
 
         // Piggyback on the store's own subscribe — recompute on every state change
         // but only notify computed subscribers when the derived value actually changes
-        subscribe((newState) => {
+        const storeUnsub = subscribe((newState) => {
             const newValue = selector(newState);
             if (!Object.is(cachedValue, newValue)) {
                 cachedValue = newValue;
@@ -388,6 +390,10 @@ export function createStore<T extends object>(
             subscribe: (listener) => {
                 computedListeners.add(listener);
                 return () => { computedListeners.delete(listener); };
+            },
+            dispose: () => {
+                storeUnsub();
+                computedListeners.clear();
             },
         };
     };
@@ -422,6 +428,7 @@ export function createStore<T extends object>(
     (useStore as any).subscribe = subscribe;
     (useStore as any).destroy = destroy;
     (useStore as any).computed = computed;
+    // dispose is exposed on each Computed<U> instance returned by computed() — no hook-level attach needed
     (useStore as any).reset = reset;
     (useStore as any).getInitialState = getInitialState;
 


### PR DESCRIPTION
## Description

`computed()` internally called `subscribe()` but discarded the returned unsubscribe function, leaving the selector running forever even after all computed listeners were removed. Added `dispose(): void` to `Computed<U>` that calls `storeUnsub()` and clears `computedListeners`.

## Related Issue

Closes #1150

## Which package(s)?

`@termuijs/store`

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read `CONTRIBUTING.md`.
- [x] Your PR title follows `type: short description`.
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/a8dd8aa7-2131-48b1-b6c3-4383bd6313da`

## Notes for the Reviewer

Fix is exactly as described in issue #1150. The store-level unsubscribe is now captured as `storeUnsub` and exposed via `dispose()` on the returned `Computed<U>` object. Two tests added to `computed.test.ts` verifying the selector stops running and listeners are cleared after `dispose()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `dispose()` method to computed selectors, enabling explicit cleanup and unsubscription from store updates when no longer needed.

* **Tests**
  * Added comprehensive test coverage for `dispose()` functionality, verifying proper cleanup of subscriptions and listener removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->