### PR TITLE
fix: modal uses proper Widget lifecycle for content

### DIFF
--- a/packages/ui/src/Modal.ts
+++ b/packages/ui/src/Modal.ts
@@ -68,8 +68,8 @@ export class Modal extends Widget {
         // Content
         if (this._content) {
             const cr = { x: mx + 2, y: my + 1, width: mw - 4, height: mh - 2 };
-            (this._content as any)._rect = cr;
-            (this._content as any)._renderSelf(screen);
+            this._content.updateRect(cr);
+            this._content.render(screen);
         }
     }
 }


### PR DESCRIPTION
## Description

Modal now calls `updateRect()` + `render()` on its content widget instead of writing `_rect` and `_renderSelf()` directly, preserving the full Widget lifecycle.

## Related Issue

Closes #1297

## Which package(s)?

@termuijs/ui

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

N/A — no visual change.

## Notes for the Reviewer

This is a 2-line change in `packages/ui/src/Modal.ts`. The old code cast to `any` and bypassed `updateRect()` (style computation, onRect hooks, dirty marking) and `render()` (dirty-rect tracking, beforeRender/afterRender hooks).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed modal content rendering so it displays correctly while the modal is visible, using the proper widget update mechanism for layout/rect updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->