### PR TITLE
fix: ScrollView no longer mutates children's _rect

### DIFF
--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -133,6 +133,9 @@ export class Screen {
      */
     private _clipStack: Array<{ x: number; y: number; width: number; height: number }> = [];
 
+    private _translateYStack: number[] = [];
+    private _translateY = 0;
+
     constructor(cols: number, rows: number) {
         this._cols = cols;
         this._rows = rows;
@@ -251,6 +254,16 @@ export class Screen {
             : null;
     }
 
+    pushTranslateY(offset: number): void {
+        this._translateYStack.push(offset);
+        this._translateY += offset;
+    }
+
+    popTranslateY(): void {
+        const offset = this._translateYStack.pop() ?? 0;
+        this._translateY -= offset;
+    }
+
     /**
      * Write a cell to the back buffer at position (col, row).
      */
@@ -258,6 +271,8 @@ export class Screen {
         // Floor to integers — layout engine may produce fractional values
         col = Math.floor(col);
         row = Math.floor(row);
+        // Apply Y translation before bounds/clip checks
+        row += this._translateY;
         // Use positive range check (NaN fails >= 0, preventing NaN indices)
         if (!(col >= 0 && col < this._cols && row >= 0 && row < this._rows)) return;
 

--- a/packages/widgets/src/layout/ScrollView.ts
+++ b/packages/widgets/src/layout/ScrollView.ts
@@ -106,26 +106,13 @@ export class ScrollView extends Widget {
         this._renderSelf(screen);
         this._renderBorder(screen);
 
-        // Temporarily shift children's rects upward by scrollOffset
+        // Render children with a Y offset for scrolling
         const rect = this._getContentRect();
+        screen.pushTranslateY(-this._scrollOffset);
         for (const child of this._children) {
-            const origRect = { ...child.rect };
-            // Access protected _rect to temporarily modify for scroll offset rendering
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (child as any)._rect = {
-                x: origRect.x,
-                y: origRect.y - this._scrollOffset,
-                width: origRect.width,
-                height: origRect.height,
-            };
-            try {
-                child.render(screen);
-            } finally {
-                // Restore original rect after rendering
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                (child as any)._rect = origRect;
-            }
+            child.render(screen);
         }
+        screen.popTranslateY();
 
         if (shouldClip) screen.popClip();
 


### PR DESCRIPTION
## Description

ScrollView no longer mutates children's private `_rect` — replaced with `Screen.pushTranslateY()/popTranslateY()` stack applied to `setCell()` row coordinates before clipping.

## Related Issue

Closes #1296

## Which package(s)?

@termuijs/core, @termuijs/widgets

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

N/A — no visual change.

## Notes for the Reviewer

The `Screen` API gains two public methods (`pushTranslateY`, `popTranslateY`) that work like `pushClip`/`popClip`. They nest correctly with clip regions and with nested ScrollViews.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced vertical scrolling support in terminal widgets using a translation-based rendering approach for more efficient and consistent scroll behavior.
  * Writes now support vertical translation while maintaining correct clipping behavior, improving reliability when rendering shifted content.
* **Bug Fixes**
  * Fixed rendering inconsistencies caused by per-child layout adjustments during scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->