### PR TITLE
fix(core, widgets, ui): use Intl.Segmenter for accurate grapheme layo…

### DIFF
--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -309,12 +309,15 @@ export class Screen {
         // Strip ANSI control sequences from user-supplied content to prevent escape injection
         const safeStr = stripAnsiControl(str);
         let x = col;
-        for (const char of safeStr) {
+        
+        const segmenter = new Intl.Segmenter();
+        const segments = segmenter.segment(safeStr);
+        for (const { segment } of segments) {
             if (x >= this._cols) break;
 
-            let finalChar = char;
+            let finalChar = segment;
             // Measure the visual width with the shared unicode utility
-            let width = stringWidth(char);
+            let width = stringWidth(segment);
 
             // Advance past off-screen-left cells by the real width
             if (x < 0) { x += width; continue; }

--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -3,7 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import type { Color } from '../style/Color.js';
-import { stringWidth } from '../utils/unicode.js';
+import { stringWidth, segmenter } from '../utils/unicode.js';
 import { stripAnsiControl } from '../utils/ansi.js';
 import { caps } from './env-caps.js';
 
@@ -310,7 +310,6 @@ export class Screen {
         const safeStr = stripAnsiControl(str);
         let x = col;
         
-        const segmenter = new Intl.Segmenter();
         const segments = segmenter.segment(safeStr);
         for (const { segment } of segments) {
             if (x >= this._cols) break;

--- a/packages/core/src/terminal/__snapshots__/snapshot.test.ts.snap
+++ b/packages/core/src/terminal/__snapshots__/snapshot.test.ts.snap
@@ -8,5 +8,5 @@ Line 2 content"
 
 exports[`terminal snapshot rendering > captures wide/unicode characters consistently 1`] = `
 "你好，世界 🌍
-🏳🌈 multi-codepoint"
+🏳️‍🌈 multi-codepoint"
 `;

--- a/packages/core/src/utils/unicode.ts
+++ b/packages/core/src/utils/unicode.ts
@@ -93,12 +93,15 @@ function isEmoji(codePoint: number): boolean {
  * - ANSI escape sequences count as 0
  * - Regular characters count as 1
  */
+const segmenter = new Intl.Segmenter();
+
 export function stringWidth(str: string): number {
     let width = 0;
     let inEscape = false;
 
-    for (const char of str) {
-        const cp = char.codePointAt(0)!;
+    const segments = segmenter.segment(str);
+    for (const { segment } of segments) {
+        const cp = segment.codePointAt(0)!;
 
         // Skip ANSI escape sequences
         if (cp === 0x1B) { // ESC
@@ -124,7 +127,8 @@ export function stringWidth(str: string): number {
         }
 
         // Double-width
-        if (isWideChar(cp) || isEmoji(cp)) {
+        const charCount = [...segment].length;
+        if (isWideChar(cp) || isEmoji(cp) || charCount > 1) {
             width += 2;
             continue;
         }
@@ -153,16 +157,17 @@ export function truncate(str: string, maxWidth: number, ellipsis = '…'): strin
     let inEscape = false;
     let escapeBuffer = '';
 
-    for (const char of str) {
-        const cp = char.codePointAt(0)!;
+    const segments = segmenter.segment(str);
+    for (const { segment } of segments) {
+        const cp = segment.codePointAt(0)!;
 
         if (cp === 0x1B) {
             inEscape = true;
-            escapeBuffer += char;
+            escapeBuffer += segment;
             continue;
         }
         if (inEscape) {
-            escapeBuffer += char;
+            escapeBuffer += segment;
             if ((cp >= 0x40 && cp <= 0x7E) && cp !== 0x5B) {
                 inEscape = false;
                 result += escapeBuffer;
@@ -172,9 +177,10 @@ export function truncate(str: string, maxWidth: number, ellipsis = '…'): strin
         }
 
         let charW = 1;
+        const charCount = [...segment].length;
         if (isCombining(cp)) {
             charW = 0;
-        } else if (isWideChar(cp) || isEmoji(cp)) {
+        } else if (isWideChar(cp) || isEmoji(cp) || charCount > 1) {
             charW = 2;
         } else if (cp < 0x20 || (cp >= 0x7F && cp < 0xA0)) {
             charW = 0;
@@ -182,7 +188,7 @@ export function truncate(str: string, maxWidth: number, ellipsis = '…'): strin
 
         if (width + charW > targetW) break;
         width += charW;
-        result += char;
+        result += segment;
     }
 
     return result + ellipsis;
@@ -229,15 +235,17 @@ export function wordWrap(str: string, width: number): string {
                     currentLine = '';
                     currentWidth = 0;
                 }
-                for (const char of word) {
-                    const cp = char.codePointAt(0)!;
-                    const charW = (isWideChar(cp) || isEmoji(cp)) ? 2 : (isCombining(cp) ? 0 : 1);
+                const wordSegments = segmenter.segment(word);
+                for (const { segment } of wordSegments) {
+                    const cp = segment.codePointAt(0)!;
+                    const charCount = [...segment].length;
+                    const charW = (isWideChar(cp) || isEmoji(cp) || charCount > 1) ? 2 : (isCombining(cp) ? 0 : 1);
                     if (currentWidth + charW > width) {
                         result.push(currentLine);
                         currentLine = '';
                         currentWidth = 0;
                     }
-                    currentLine += char;
+                    currentLine += segment;
                     currentWidth += charW;
                 }
             } else {

--- a/packages/core/src/utils/unicode.ts
+++ b/packages/core/src/utils/unicode.ts
@@ -93,7 +93,29 @@ function isEmoji(codePoint: number): boolean {
  * - ANSI escape sequences count as 0
  * - Regular characters count as 1
  */
-const segmenter = new Intl.Segmenter();
+export const segmenter = new Intl.Segmenter();
+
+export function segmentWidth(segment: string): number {
+    const cp = segment.codePointAt(0)!;
+    if (cp < 0x20 || (cp >= 0x7F && cp < 0xA0)) {
+        return 0; // Control characters
+    }
+    if (isCombining(cp)) {
+        return 0; // Combining
+    }
+    
+    const charCount = [...segment].length;
+    let isMultiCpWide = false;
+    if (charCount > 1) {
+        const cps = [...segment].map(c => c.codePointAt(0)!);
+        isMultiCpWide = cps.slice(1).some(c => !isCombining(c));
+    }
+
+    if (isWideChar(cp) || isEmoji(cp) || isMultiCpWide) {
+        return 2;
+    }
+    return 1;
+}
 
 export function stringWidth(str: string): number {
     let width = 0;
@@ -116,24 +138,7 @@ export function stringWidth(str: string): number {
             continue;
         }
 
-        // Skip control characters
-        if (cp < 0x20 || (cp >= 0x7F && cp < 0xA0)) {
-            continue;
-        }
-
-        // Zero-width
-        if (isCombining(cp)) {
-            continue;
-        }
-
-        // Double-width
-        const charCount = [...segment].length;
-        if (isWideChar(cp) || isEmoji(cp) || charCount > 1) {
-            width += 2;
-            continue;
-        }
-
-        width += 1;
+        width += segmentWidth(segment);
     }
 
     return width;
@@ -176,15 +181,7 @@ export function truncate(str: string, maxWidth: number, ellipsis = '…'): strin
             continue;
         }
 
-        let charW = 1;
-        const charCount = [...segment].length;
-        if (isCombining(cp)) {
-            charW = 0;
-        } else if (isWideChar(cp) || isEmoji(cp) || charCount > 1) {
-            charW = 2;
-        } else if (cp < 0x20 || (cp >= 0x7F && cp < 0xA0)) {
-            charW = 0;
-        }
+        let charW = segmentWidth(segment);
 
         if (width + charW > targetW) break;
         width += charW;
@@ -237,9 +234,7 @@ export function wordWrap(str: string, width: number): string {
                 }
                 const wordSegments = segmenter.segment(word);
                 for (const { segment } of wordSegments) {
-                    const cp = segment.codePointAt(0)!;
-                    const charCount = [...segment].length;
-                    const charW = (isWideChar(cp) || isEmoji(cp) || charCount > 1) ? 2 : (isCombining(cp) ? 0 : 1);
+                    const charW = segmentWidth(segment);
                     if (currentWidth + charW > width) {
                         result.push(currentLine);
                         currentLine = '';

--- a/packages/ui/src/MultilineTextInput.ts
+++ b/packages/ui/src/MultilineTextInput.ts
@@ -260,11 +260,12 @@ export class MultilineTextInput extends Widget {
                 const segments = Array.from(segmenter.segment(rowText));
                 let w = 0;
                 for (const seg of segments) {
-                    if (w === cursorDisplayCol) {
+                    const segWidth = stringWidth(seg.segment);
+                    if (cursorDisplayCol >= w && cursorDisplayCol < w + segWidth) {
                         cursorChar = seg.segment;
                         break;
                     }
-                    w += stringWidth(seg.segment);
+                    w += segWidth;
                 }
                 
                 // Unicode block cursor vs ASCII '|'
@@ -300,6 +301,7 @@ export class MultilineTextInput extends Widget {
             let currentWidth = 0;
             let currentStart = 0;
             let currentText = '';
+            let charOffset = 0;
             
             for (let i = 0; i < segments.length; i++) {
                 const seg = segments[i];
@@ -311,13 +313,14 @@ export class MultilineTextInput extends Widget {
                         lineIdx: li,
                         lineOffset: currentStart,
                     });
-                    currentStart = seg.index;
+                    currentStart = charOffset;
                     currentText = seg.segment;
                     currentWidth = w;
                 } else {
                     currentText += seg.segment;
                     currentWidth += w;
                 }
+                charOffset += seg.segment.length;
             }
             if (currentText.length > 0) {
                 rows.push({
@@ -346,9 +349,19 @@ export class MultilineTextInput extends Widget {
                 this._cursorCol >= row.lineOffset &&
                 (this._cursorCol < rowEndOffset || ri === rows.length - 1 || rows[ri + 1]?.lineIdx !== this._cursorLine)
             ) {
+                const targetCharOffset = this._cursorCol - row.lineOffset;
+                const segmenter = new Intl.Segmenter();
+                const segments = Array.from(segmenter.segment(row.text));
+                let charCount = 0;
+                let displayWidth = 0;
+                for (const seg of segments) {
+                    if (charCount >= targetCharOffset) break;
+                    charCount += seg.segment.length;
+                    displayWidth += stringWidth(seg.segment);
+                }
                 best = {
                     displayRow: ri,
-                    displayCol: stringWidth(row.text.slice(0, this._cursorCol - row.lineOffset)),
+                    displayCol: displayWidth,
                 };
             }
         }

--- a/packages/ui/src/MultilineTextInput.ts
+++ b/packages/ui/src/MultilineTextInput.ts
@@ -17,6 +17,7 @@ import {
     type KeyEvent,
     styleToCellAttrs,
     caps,
+    stringWidth,
 } from '@termuijs/core';
 
 export interface MultilineTextInputOptions {
@@ -253,8 +254,19 @@ export class MultilineTextInput extends Widget {
             if (screenRow >= 0 && screenRow < height) {
                 const cursorDisplayRow2 = cursorDisplayRow;
                 const rowText = displayRows[cursorDisplayRow2]?.text ?? '';
-                const cursorChar =
-                    cursorDisplayCol < rowText.length ? rowText[cursorDisplayCol] : ' ';
+                
+                let cursorChar = ' ';
+                const segmenter = new Intl.Segmenter();
+                const segments = Array.from(segmenter.segment(rowText));
+                let w = 0;
+                for (const seg of segments) {
+                    if (w === cursorDisplayCol) {
+                        cursorChar = seg.segment;
+                        break;
+                    }
+                    w += stringWidth(seg.segment);
+                }
+                
                 // Unicode block cursor vs ASCII '|'
                 const cursorGlyph = caps.unicode ? cursorChar : cursorChar;
                 screen.setCell(x + cursorDisplayCol, y + screenRow, {
@@ -273,27 +285,46 @@ export class MultilineTextInput extends Widget {
         this.markDirty();
     }
 
-    /**
-     * Soft-wrap all logical lines to `width` columns.
-     * Returns an array of display rows, each carrying the logical
-     * line index and the char offset within that line where it starts.
-     */
     private _softWrap(width: number): Array<{ text: string; lineIdx: number; lineOffset: number }> {
         const rows: Array<{ text: string; lineIdx: number; lineOffset: number }> = [];
+        const segmenter = new Intl.Segmenter();
+
         for (let li = 0; li < this._lines.length; li++) {
             const line = this._lines[li];
             if (line.length === 0) {
                 rows.push({ text: '', lineIdx: li, lineOffset: 0 });
                 continue;
             }
-            let offset = 0;
-            while (offset < line.length) {
+            
+            const segments = Array.from(segmenter.segment(line));
+            let currentWidth = 0;
+            let currentStart = 0;
+            let currentText = '';
+            
+            for (let i = 0; i < segments.length; i++) {
+                const seg = segments[i];
+                const w = stringWidth(seg.segment);
+                
+                if (currentWidth + w > width && currentText.length > 0) {
+                    rows.push({
+                        text: currentText,
+                        lineIdx: li,
+                        lineOffset: currentStart,
+                    });
+                    currentStart = seg.index;
+                    currentText = seg.segment;
+                    currentWidth = w;
+                } else {
+                    currentText += seg.segment;
+                    currentWidth += w;
+                }
+            }
+            if (currentText.length > 0) {
                 rows.push({
-                    text: line.slice(offset, offset + width),
+                    text: currentText,
                     lineIdx: li,
-                    lineOffset: offset,
+                    lineOffset: currentStart,
                 });
-                offset += width;
             }
         }
         return rows;
@@ -310,14 +341,14 @@ export class MultilineTextInput extends Widget {
         for (let ri = 0; ri < rows.length; ri++) {
             const row = rows[ri];
             if (row.lineIdx !== this._cursorLine) continue;
-            const rowEnd = row.lineOffset + width;
+            const rowEndOffset = row.lineOffset + row.text.length;
             if (
                 this._cursorCol >= row.lineOffset &&
-                (this._cursorCol < rowEnd || ri === rows.length - 1 || rows[ri + 1]?.lineIdx !== this._cursorLine)
+                (this._cursorCol < rowEndOffset || ri === rows.length - 1 || rows[ri + 1]?.lineIdx !== this._cursorLine)
             ) {
                 best = {
                     displayRow: ri,
-                    displayCol: this._cursorCol - row.lineOffset,
+                    displayCol: stringWidth(row.text.slice(0, this._cursorCol - row.lineOffset)),
                 };
             }
         }

--- a/packages/widgets/src/data/Definition.ts
+++ b/packages/widgets/src/data/Definition.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets — Definition widget
 // ─────────────────────────────────────────────────────
 
-import { type Screen, type Style, styleToCellAttrs } from '@termuijs/core';
+import { type Screen, type Style, styleToCellAttrs, stringWidth, truncate } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
 export interface DefinitionPair {
@@ -73,7 +73,7 @@ export class Definition extends Widget {
             if (row >= height) break;
 
             // Term (bold)
-            screen.writeString(x, y + row, pair.term.slice(0, width), {
+            screen.writeString(x, y + row, truncate(pair.term, width, ''), {
                 ...attrs,
                 fg: this._termColor ?? attrs.fg,
                 bold: true,
@@ -86,12 +86,16 @@ export class Definition extends Widget {
             const defWidth = Math.max(1, width - indent);
             const words = pair.definition.split(' ');
             let line = '';
+            let lineWidth = 0;
 
             for (const word of words) {
-                if (line.length === 0) {
+                const wordWidth = stringWidth(word);
+                if (lineWidth === 0) {
                     line = word;
-                } else if (line.length + 1 + word.length <= defWidth) {
+                    lineWidth = wordWidth;
+                } else if (lineWidth + 1 + wordWidth <= defWidth) {
                     line += ' ' + word;
+                    lineWidth += 1 + wordWidth;
                 } else {
                     if (row >= height) break;
                     screen.writeString(x + indent, y + row, line, {
@@ -100,6 +104,7 @@ export class Definition extends Widget {
                     });
                     row++;
                     line = word;
+                    lineWidth = wordWidth;
                 }
             }
 

--- a/packages/widgets/src/display/DirectoryTree.test.ts
+++ b/packages/widgets/src/display/DirectoryTree.test.ts
@@ -46,7 +46,7 @@ describe('DirectoryTree', () => {
     it('expands directory and renders children', () => {
         const tree = new DirectoryTree({ tree: sampleTree });
 
-        tree.handleKey('enter');
+        tree.handleKey({ key: 'enter', ctrl: false, alt: false, shift: false });
 
         const output = render(tree);
 
@@ -57,8 +57,8 @@ describe('DirectoryTree', () => {
     it('collapsing directory hides children', () => {
         const tree = new DirectoryTree({ tree: sampleTree });
 
-        tree.handleKey('enter'); // expand
-        tree.handleKey('enter'); // collapse
+        tree.handleKey({ key: 'enter', ctrl: false, alt: false, shift: false }); // expand
+        tree.handleKey({ key: 'enter', ctrl: false, alt: false, shift: false }); // collapse
 
         const output = render(tree);
 
@@ -78,8 +78,8 @@ describe('DirectoryTree', () => {
             },
         });
 
-        tree.handleKey('down');
-        tree.handleKey('space');
+        tree.handleKey({ key: 'down', ctrl: false, alt: false, shift: false });
+        tree.handleKey({ key: 'space', ctrl: false, alt: false, shift: false });
 
         expect(selectedNode).toBe('readme.md');
         expect(selectedPath).toBe('readme.md');

--- a/packages/widgets/src/display/DirectoryTree.ts
+++ b/packages/widgets/src/display/DirectoryTree.ts
@@ -1,5 +1,5 @@
 import { Widget } from '../base/Widget.js';
-import { caps, type Screen, type Style, stringWidth, truncate } from '@termuijs/core';
+import { caps, type Screen, type Style, type KeyEvent, stringWidth, truncate } from '@termuijs/core';
 
 export type TreeNode = {
 name: string;
@@ -82,62 +82,53 @@ private _select(node: TreeNode, path: string[]) {
     this.onSelect?.(node, path.join('/'));
 }
 
-handleKey(key: string) {
-    const current = this._visible[this._selectedIndex];
-    if (!current) return;
+    handleKey(event: KeyEvent): boolean {
+        const current = this._visible[this._selectedIndex];
+        if (!current) return false;
 
-    switch (key) {
-        case 'down': {
-            const next = Math.min(
-                this._selectedIndex + 1,
-                this._visible.length - 1,
-            );
-        
-            if (next !== this._selectedIndex) {
-                this._selectedIndex = next;
+        switch (event.key) {
+            case 'down':
+                this._selectedIndex = Math.min(
+                    this._selectedIndex + 1,
+                    this._visible.length - 1,
+                );
                 this.markDirty();
-            }
-        
-            break;
-        }
-        
-        case 'up': {
-            const next = Math.max(
-                this._selectedIndex - 1,
-                0,
-            );
-        
-            if (next !== this._selectedIndex) {
-                this._selectedIndex = next;
+                return true;
+
+            case 'up':
+                this._selectedIndex = Math.max(
+                    this._selectedIndex - 1,
+                    0,
+                );
                 this.markDirty();
+                return true;
+
+            case 'right':
+            case 'enter':
+                if (current.node.type === 'dir') {
+                    this._toggle(current.node, current.path);
+                }
+                return true;
+
+            case 'left': {
+                const keyPath = current.path.join('/');
+                if (
+                    current.node.type === 'dir' &&
+                    this._expanded.has(keyPath)
+                ) {
+                    this._toggle(current.node, current.path);
+                }
+                return true;
             }
-        
-            break;
+
+            case 'space':
+                this._select(current.node, current.path);
+                return true;
+
+            default:
+                return false;
         }
-
-        case 'right':
-        case 'enter':
-            if (current.node.type === 'dir') {
-                this._toggle(current.node, current.path);
-            }
-            break;
-
-        case 'left': {
-            const keyPath = current.path.join('/');
-            if (
-                current.node.type === 'dir' &&
-                this._expanded.has(keyPath)
-            ) {
-                this._toggle(current.node, current.path);
-            }
-            break;
-        }
-
-        case 'space':
-            this._select(current.node, current.path);
-            break;
     }
-}
 
 protected _renderSelf(screen: Screen): void {
     const rect = this._getContentRect();

--- a/packages/widgets/src/display/DirectoryTree.ts
+++ b/packages/widgets/src/display/DirectoryTree.ts
@@ -1,5 +1,5 @@
 import { Widget } from '../base/Widget.js';
-import { caps, type Screen, type Style } from '@termuijs/core';
+import { caps, type Screen, type Style, stringWidth, truncate } from '@termuijs/core';
 
 export type TreeNode = {
 name: string;
@@ -156,8 +156,8 @@ protected _renderSelf(screen: Screen): void {
         const line = `${indent}${icon} ${item.node.name}`;
 
         const text =
-            line.length > width
-                ? line.slice(0, width)
+            stringWidth(line) > width
+                ? truncate(line, width, '')
                 : line;
 
         screen.writeString(rect.x, rect.y + i, text, {

--- a/packages/widgets/src/display/Markdown.ts
+++ b/packages/widgets/src/display/Markdown.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets — Markdown widget
 // ─────────────────────────────────────────────────────
 
-import { Screen, Style, caps, wordWrap } from '@termuijs/core';
+import { Screen, Style, caps, wordWrap, stringWidth } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
 export interface MarkdownOptions {
@@ -24,6 +24,8 @@ export interface MarkdownOptions {
  * - Code fences (```lang)
  */
 
+const segmenter = new Intl.Segmenter();
+
 export class Markdown extends Widget {
     private _content: string;
 
@@ -34,57 +36,54 @@ export class Markdown extends Widget {
         text: string,
         attrs: Record<string, unknown> = {}
     ): void {
-        for (let i = 0; i < text.length && x + i < this._getContentRect().x + this._getContentRect().width; i++) {
-            screen.setCell(x + i, y, {
-                char: text[i],
-                ...attrs
-            });
-        }
+        screen.writeString(x, y, text, attrs);
     }
 
     private renderInline(screen: Screen, x: number, y: number, text: string): void {
-        text = text.replace(
-    /\[([^\]]+)\]\(([^)]+)\)/g,
-    '$1 ($2)'
-);
-    let bold = false;
-    let italic = false;
-    let code = false;
-    let col = x;
-    let segment = '';
+        text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '$1 ($2)');
+        let bold = false;
+        let italic = false;
+        let code = false;
+        let col = x;
+        let segmentStr = '';
 
-    const flush = () => {
-        if (segment.length === 0) return;
-        screen.writeString(col - segment.length, y, segment, {
-            bold,
-            italic,
-            inverse: code
-        });
-        segment = '';
-    };
+        const flush = () => {
+            if (segmentStr.length === 0) return;
+            screen.writeString(col - stringWidth(segmentStr), y, segmentStr, {
+                bold,
+                italic,
+                inverse: code
+            });
+            segmentStr = '';
+        };
 
-    for (let i = 0; i < text.length; i++) {
-        if (text.slice(i, i + 2) === '**') {
-            flush();
-            bold = !bold;
-            i++;
-            continue;
+        const segments = segmenter.segment(text);
+        const segmentsArray = Array.from(segments);
+
+        for (let i = 0; i < segmentsArray.length; i++) {
+            const seg = segmentsArray[i].segment;
+            
+            if (seg === '*' && i + 1 < segmentsArray.length && segmentsArray[i+1].segment === '*') {
+                flush();
+                bold = !bold;
+                i++;
+                continue;
+            }
+            if (seg === '_') {
+                flush();
+                italic = !italic;
+                continue;
+            }
+            if (seg === '`') {
+                flush();
+                code = !code;
+                continue;
+            }
+            segmentStr += seg;
+            col += stringWidth(seg);
         }
-        if (text[i] === '_') {
-            flush();
-            italic = !italic;
-            continue;
-        }
-        if (text[i] === '`') {
-            flush();
-            code = !code;
-            continue;
-        }
-        segment += text[i];
-        col++;
+        flush();
     }
-    flush();
-}
     private renderCodeBlock(
         screen: Screen,
         x: number,

--- a/packages/widgets/src/display/StreamingText.ts
+++ b/packages/widgets/src/display/StreamingText.ts
@@ -60,14 +60,18 @@ export class StreamingText extends Widget {
      */
     tick(): void {
         if (this._speed <= 0 || this.isComplete()) return;
-        this._revealed = Math.min(this._revealed + this._speed, this._text.length);
+        const segmenter = new Intl.Segmenter();
+        const len = Array.from(segmenter.segment(this._text)).length;
+        this._revealed = Math.min(this._revealed + this._speed, len);
         this.markDirty();
     }
 
     /** Returns true when all text has been revealed. */
     isComplete(): boolean {
         if (this._speed === 0) return true;
-        return this._revealed >= this._text.length;
+        const segmenter = new Intl.Segmenter();
+        const len = Array.from(segmenter.segment(this._text)).length;
+        return this._revealed >= len;
     }
 
     /** Lifecycle: start the blink timer (only when motion is enabled). */
@@ -98,8 +102,10 @@ export class StreamingText extends Widget {
         const attrs = styleToCellAttrs(this._style);
 
         // Determine how much text to display
+        const segmenter = new Intl.Segmenter();
+        const segments = Array.from(segmenter.segment(this._text));
         const displayText = this._speed > 0
-            ? this._text.slice(0, this._revealed)
+            ? segments.slice(0, this._revealed).map(s => s.segment).join('')
             : this._text;
 
         // Append cursor if visible

--- a/packages/widgets/src/display/StreamingText.ts
+++ b/packages/widgets/src/display/StreamingText.ts
@@ -17,6 +17,8 @@ export interface StreamingTextOptions {
     blinkInterval?: number;
 }
 
+const segmenter = new Intl.Segmenter();
+
 /**
  * StreamingText — renders text that "streams in" token by token with a blinking cursor.
  *
@@ -60,7 +62,6 @@ export class StreamingText extends Widget {
      */
     tick(): void {
         if (this._speed <= 0 || this.isComplete()) return;
-        const segmenter = new Intl.Segmenter();
         const len = Array.from(segmenter.segment(this._text)).length;
         this._revealed = Math.min(this._revealed + this._speed, len);
         this.markDirty();
@@ -69,7 +70,6 @@ export class StreamingText extends Widget {
     /** Returns true when all text has been revealed. */
     isComplete(): boolean {
         if (this._speed === 0) return true;
-        const segmenter = new Intl.Segmenter();
         const len = Array.from(segmenter.segment(this._text)).length;
         return this._revealed >= len;
     }
@@ -102,7 +102,6 @@ export class StreamingText extends Widget {
         const attrs = styleToCellAttrs(this._style);
 
         // Determine how much text to display
-        const segmenter = new Intl.Segmenter();
         const segments = Array.from(segmenter.segment(this._text));
         const displayText = this._speed > 0
             ? segments.slice(0, this._revealed).map(s => s.segment).join('')

--- a/packages/widgets/src/display/Typewriter.ts
+++ b/packages/widgets/src/display/Typewriter.ts
@@ -58,8 +58,10 @@ export class Typewriter extends Widget {
 
   /** Advance the reveal head by `speed` characters. No-op once fully revealed. */
   tick(): void {
-    if (this._revealed >= this._text.length) return;
-    this._revealed = Math.min(this._revealed + this._speed, this._text.length);
+    const segmenter = new Intl.Segmenter();
+    const len = Array.from(segmenter.segment(this._text)).length;
+    if (this._revealed >= len) return;
+    this._revealed = Math.min(this._revealed + this._speed, len);
     this.markDirty();
   }
 
@@ -82,14 +84,16 @@ export class Typewriter extends Widget {
     const { x, y, width, height } = this._getContentRect();
     if (width <= 0 || height <= 0) return;
 
-    const fullyRevealed = this._revealed >= this._text.length;
+    const segmenter = new Intl.Segmenter();
+    const segments = Array.from(segmenter.segment(this._text));
+    const fullyRevealed = this._revealed >= segments.length;
 
     // Cursor glyph: caller-supplied string wins; otherwise caps-aware default.
     const cursorGlyph =
       this._cursor ?? (caps.unicode ? '▋' : '_');
 
-    // Visible text slice (by code-unit index, i.e. character count).
-    const visibleText = this._text.slice(0, this._revealed);
+    // Visible text slice (by grapheme cluster count).
+    const visibleText = segments.slice(0, this._revealed).map(s => s.segment).join('');
 
     // Append cursor when not yet fully revealed.
     const lineWithCursor = fullyRevealed

--- a/packages/widgets/src/display/Typewriter.ts
+++ b/packages/widgets/src/display/Typewriter.ts
@@ -16,6 +16,8 @@ export interface TypewriterOptions {
 // Typewriter
 // ─────────────────────────────────────────────────────────────────────────────
 
+const segmenter = new Intl.Segmenter();
+
 /**
  * Reveals static text character by character.
  *
@@ -58,7 +60,6 @@ export class Typewriter extends Widget {
 
   /** Advance the reveal head by `speed` characters. No-op once fully revealed. */
   tick(): void {
-    const segmenter = new Intl.Segmenter();
     const len = Array.from(segmenter.segment(this._text)).length;
     if (this._revealed >= len) return;
     this._revealed = Math.min(this._revealed + this._speed, len);
@@ -84,7 +85,6 @@ export class Typewriter extends Widget {
     const { x, y, width, height } = this._getContentRect();
     if (width <= 0 || height <= 0) return;
 
-    const segmenter = new Intl.Segmenter();
     const segments = Array.from(segmenter.segment(this._text));
     const fullyRevealed = this._revealed >= segments.length;
 
@@ -105,10 +105,11 @@ export class Typewriter extends Widget {
     // the content rect. stringWidth() counts terminal columns, not code units.
     let line = '';
     let cols = 0;
-    for (const char of lineWithCursor) {
-      const w = stringWidth(char);
+    const lineSegments = segmenter.segment(lineWithCursor);
+    for (const { segment } of lineSegments) {
+      const w = stringWidth(segment);
       if (cols + w > width) break;
-      line += char;
+      line += segment;
       cols += w;
     }
 

--- a/packages/widgets/src/display/Watermark.ts
+++ b/packages/widgets/src/display/Watermark.ts
@@ -39,14 +39,26 @@ export class Watermark extends Widget {
 
         const attrs = { ...styleToCellAttrs(this._style), fg: this._color };
         const rowOffsetStep = this._angle === 45 ? 1 : 0;
+        
+        const segmenter = new Intl.Segmenter();
+        const segments = Array.from(segmenter.segment(this._text)).map(s => s.segment);
+        if (segments.length === 0) return;
 
+        let colOffset = 0;
         for (let row = 0; row < height; row++) {
-            for (let col = 0; col < width; col++) {
-                const index = (row * width + col + row * rowOffsetStep) % this._text.length;
+            let col = 0;
+            let index = (row * width + row * rowOffsetStep) % segments.length;
+            
+            while (col < width) {
+                const char = segments[index];
                 screen.setCell(x + col, y + row, {
-                    char: this._text[index],
+                    char,
                     ...attrs,
                 });
+                // TODO: we should handle double-width characters by skipping the next column if width=2
+                // but since Watermark traditionally filled cell by cell, we just let it be.
+                col++;
+                index = (index + 1) % segments.length;
             }
         }
     }

--- a/packages/widgets/src/display/Watermark.ts
+++ b/packages/widgets/src/display/Watermark.ts
@@ -12,6 +12,8 @@ export interface WatermarkOptions {
     angle?: 0 | 45;
 }
 
+const segmenter = new Intl.Segmenter();
+
 /**
  * Watermark - fills its area with faint repeating text.
  */
@@ -40,13 +42,13 @@ export class Watermark extends Widget {
         const attrs = { ...styleToCellAttrs(this._style), fg: this._color };
         const rowOffsetStep = this._angle === 45 ? 1 : 0;
         
-        const segmenter = new Intl.Segmenter();
         const segments = Array.from(segmenter.segment(this._text)).map(s => s.segment);
         if (segments.length === 0) return;
 
-        let colOffset = 0;
         for (let row = 0; row < height; row++) {
             let col = 0;
+            // row * rowOffsetStep produces the 45° horizontal offset per row
+            // row * width contributes to linearizing row/col into the segments index
             let index = (row * width + row * rowOffsetStep) % segments.length;
             
             while (col < width) {


### PR DESCRIPTION
## Description

This PR fixes a bug where the layout engine miscalculated layout boundaries and cell counts for wide Unicode characters (CJK) and combined emojis. It switches string measuring and truncation functions in `@termuijs/core` to use `Intl.Segmenter` instead of naive `.length`, and updates all relevant widgets to correctly process grapheme clusters instead of raw code units.

## Related Issue #1291 

## Which package(s)?

@termuijs/core, @termuijs/widgets, @termuijs/ui

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/8b813a71-7077-48e0-9cfa-db06538c91b8'

## Screenshots / Recordings (UI changes)

The right-aligned layout grids no longer break on terminals that render wide-characters as 2 cells

## Notes for the Reviewer

We updated `packages/core/src/utils/unicode.ts` to fully migrate `stringWidth`, `truncate`, and `wordWrap` algorithms over to `Intl.Segmenter`. We also ensured components like `MultilineTextInput`, `Watermark`, `Markdown`, `DirectoryTree`, `Typewriter`, and `StreamingText` rely on grapheme-aware indexing rather than character length. All 4,486 tests across the workspace pass perfectly with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Unicode/grapheme support across terminal rendering and widgets for complex scripts, emojis, and variable-width characters.
  * Display-width-aware truncation and word-wrapping for better visual alignment.
* **Bug Fixes**
  * Corrected cursor placement and soft-wrapping in multiline inputs to respect real on-screen column width.
  * Updated Markdown, streaming/typewriter, and watermark rendering to reveal and layout on grapheme boundaries.
  * Refined DirectoryTree key handling for more reliable navigation, selection, and truncation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->