### PR TITLE
feat(quick): add modifier-aware keybindings

### DIFF
--- a/packages/quick/src/app.ts
+++ b/packages/quick/src/app.ts
@@ -293,8 +293,18 @@ export class AppBuilder {
                 return;
             }
 
-            // 2. Check app-level key bindings
-            const action = this._keyMap[event.key];
+            // 2. Check app-level key bindings (support modifier-aware tokens)
+            // Build normalized token: prefixed modifiers (ctrl, alt, shift) in that order
+            const modParts: string[] = [];
+            if (event.ctrl) modParts.push('ctrl');
+            if (event.alt) modParts.push('alt');
+            if (event.shift) modParts.push('shift');
+            const baseKey = String(event.key).toLowerCase();
+            const modToken = modParts.length > 0 ? `${modParts.join('+')}+${baseKey}` : baseKey;
+
+            // Lookup order: modifier-specific token first, then exact plain key,
+            // then lowercase plain-key fallback for backward compatibility.
+            const action = this._keyMap[modToken] ?? this._keyMap[event.key] ?? this._keyMap[baseKey];
             if (action) {
                 if (action === 'quit') {
                     appInstance.exit();

--- a/packages/quick/src/keys.test.ts
+++ b/packages/quick/src/keys.test.ts
@@ -3,10 +3,25 @@ import { app } from './index.js';
 import { App } from '@termuijs/core';
 
 // Helper to run builder without mounting terminal
+// Notes:
+// - `builder: any` used to avoid importing private types from the runtime.
+// - Tests intentionally call internal helpers: `_buildRoot()`, `_runWithRoot()`, and
+//   access `_app` to observe the live `App` instance without performing a real
+//   terminal mount. These are private by design but required for this focused test.
 async function runBuilder(builder: any) {
+    // Build the internal root widget tree (private API used for testing)
     const root = builder._buildRoot();
+
+    // Avoid performing a real terminal mount in tests — mock it so mount()
+    // resolves immediately and doesn't touch the TTY.
     vi.spyOn(App.prototype, 'mount').mockResolvedValue(0);
+
+    // Run the builder lifecycle up to the point where the App instance exists.
+    // `_runWithRoot` is a private helper that wires widgets and events; we
+    // invoke it here to keep the test deterministic.
     await (builder as any)._runWithRoot(root);
+
+    // Read the internal App instance so we can emit key events directly.
     const appInstance = (builder as any)._app;
     return { builder, root, appInstance };
 }

--- a/packages/quick/src/keys.test.ts
+++ b/packages/quick/src/keys.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { app } from './index.js';
+import { App } from '@termuijs/core';
+
+// Helper to run builder without mounting terminal
+async function runBuilder(builder: any) {
+    const root = builder._buildRoot();
+    vi.spyOn(App.prototype, 'mount').mockResolvedValue(0);
+    await (builder as any)._runWithRoot(root);
+    const appInstance = (builder as any)._app;
+    return { builder, root, appInstance };
+}
+
+describe('quick – modifier-aware key bindings', () => {
+    afterEach(() => vi.restoreAllMocks());
+
+    it('simple binding q -> quit still works', async () => {
+        const builder = app('keys');
+        builder.keys({ q: 'quit' });
+        const { appInstance } = await runBuilder(builder);
+        const exitSpy = vi.spyOn(appInstance, 'exit');
+
+        appInstance.events.emit('key', { key: 'q', raw: Buffer.alloc(0), ctrl: false, alt: false, shift: false });
+        expect(exitSpy).toHaveBeenCalled();
+    });
+
+    it('ctrl+q binding triggers quit', async () => {
+        const builder = app('keys');
+        builder.keys({ 'ctrl+q': 'quit' });
+        const { appInstance } = await runBuilder(builder);
+        const exitSpy = vi.spyOn(appInstance, 'exit');
+
+        appInstance.events.emit('key', { key: 'q', raw: Buffer.alloc(0), ctrl: true, alt: false, shift: false });
+        expect(exitSpy).toHaveBeenCalled();
+    });
+
+    it('alt+x binding calls function', async () => {
+        const fn = vi.fn();
+        const builder = app('keys');
+        builder.keys({ 'alt+x': fn });
+        const { appInstance } = await runBuilder(builder);
+
+        appInstance.events.emit('key', { key: 'x', raw: Buffer.alloc(0), ctrl: false, alt: true, shift: false });
+        expect(fn).toHaveBeenCalled();
+    });
+
+    it('ctrl+shift+p calls function', async () => {
+        const fn = vi.fn();
+        const builder = app('keys');
+        builder.keys({ 'ctrl+shift+p': fn });
+        const { appInstance } = await runBuilder(builder);
+
+        appInstance.events.emit('key', { key: 'p', raw: Buffer.alloc(0), ctrl: true, alt: false, shift: true });
+        expect(fn).toHaveBeenCalled();
+    });
+
+    it('fallback coexistence: q and ctrl+q differ', async () => {
+        const fn1 = vi.fn();
+        const fn2 = vi.fn();
+        const builder = app('keys');
+        builder.keys({ q: fn1, 'ctrl+q': fn2 });
+        const { appInstance } = await runBuilder(builder);
+
+        appInstance.events.emit('key', { key: 'q', raw: Buffer.alloc(0), ctrl: false, alt: false, shift: false });
+        expect(fn1).toHaveBeenCalled();
+
+        appInstance.events.emit('key', { key: 'q', raw: Buffer.alloc(0), ctrl: true, alt: false, shift: false });
+        expect(fn2).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Description

Add modifier-aware keybinding support to `@termuijs/quick`.

This change allows quick apps to register shortcuts such as `ctrl+q`, `alt+x`, and `ctrl+shift+p` through `.keys()` while preserving existing keybinding behavior. Modifier-specific bindings are checked first, with fallback to plain key bindings for backward compatibility.

## Related Issue

Closes #1308

## Which package(s)?

@termuijs/quick

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [x] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

* Modifier information (`ctrl`, `alt`, `shift`) already exists in `KeyEvent`; this change only extends quick's keybinding lookup logic.
* Lookup order is:

  1. Modifier-aware token (`ctrl+q`, `alt+x`, etc.)
  2. Plain key fallback (`q`, `x`, etc.)
* Existing bindings remain fully backward compatible.
* Added tests covering:

  * Plain key bindings
  * `ctrl+q`
  * `alt+x`
  * `ctrl+shift+p`
  * Coexistence of `q` and `ctrl+q`
* New tests were verified to fail without the implementation and pass with the implementation.

### Build / Typecheck Status

`bun vitest run packages/quick` passes locally.

Repository-wide `bun run build` and `bun run typecheck` currently fail on the latest branch in unrelated areas of the repository and are not caused by this change. This PR only modifies `@termuijs/quick`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced keyboard shortcuts with modifier key support—use Ctrl, Alt, and Shift combinations (e.g., Ctrl+Q, Alt+X, Ctrl+Shift+P).
  * Maintains backward compatibility with existing single-key bindings.

* **Tests**
  * Added automated tests verifying modifier-aware keybinding behavior and coexistence with single-key shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->