### PR TITLE
test(core): add resize redraw regression coverage

### DIFF
--- a/packages/core/src/terminal/resize-style-regression.test.ts
+++ b/packages/core/src/terminal/resize-style-regression.test.ts
@@ -3,13 +3,33 @@ import { Terminal } from './Terminal.js';
 import { Screen } from './Screen.js';
 import { Renderer } from './Renderer.js';
 
+interface FakeStdout {
+    writes: string;
+    columns: number;
+    rows: number;
+    isTTY: boolean;
+    write(data: string): void;
+    on(event: string, listener: (...args: unknown[]) => void): void;
+    once(event: string, listener: (...args: unknown[]) => void): void;
+    off(event: string, listener: (...args: unknown[]) => void): void;
+}
+
+interface FakeStdin {
+    isTTY: boolean;
+    setRawMode(mode: boolean): void;
+    resume(): void;
+    pause(): void;
+    on(event: string, listener: (...args: unknown[]) => void): void;
+    off(event: string, listener: (...args: unknown[]) => void): void;
+}
+
 // Regression: ensure a resize does not leave stale style fingerprints
 // that would make the renderer skip redrawing rows after a resize.
 
 describe('Renderer — resize does not suppress redraw via stale style fingerprints', () => {
     it('renders after resize (no stale-style suppression)', () => {
         // fake stdout to capture writes
-        const fakeStdout: any = {
+        const fakeStdout: FakeStdout = {
             writes: '',
             columns: 80,
             rows: 24,
@@ -19,7 +39,14 @@ describe('Renderer — resize does not suppress redraw via stale style fingerpri
             once() {},
             off() {},
         };
-        const fakeStdin: any = { isTTY: true, setRawMode() {}, resume() {}, pause() {}, on() {}, off() {} };
+        const fakeStdin: FakeStdin = {
+            isTTY: true,
+            setRawMode() {},
+            resume() {},
+            pause() {},
+            on() {},
+            off() {},
+        };
 
         const terminal = new Terminal({ stdout: fakeStdout, stdin: fakeStdin });
         const screen = new Screen(40, 5);
@@ -38,9 +65,9 @@ describe('Renderer — resize does not suppress redraw via stale style fingerpri
         // 3) Write new content and render again
         screen.writeString(0, 0, 'After');
         renderer.renderNow();
-        const afterWrites = fakeStdout.writes.length - beforeWrites;
+        const afterOutput = fakeStdout.writes.slice(beforeWrites);
 
-        // Expect at least some output was written after resize (i.e. no suppression)
-        expect(afterWrites).toBeGreaterThan(0);
+        // Expect the second render to include the new text, not just wrapper output.
+        expect(afterOutput).toContain('After');
     });
 });

--- a/packages/core/src/terminal/resize-style-regression.test.ts
+++ b/packages/core/src/terminal/resize-style-regression.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { Terminal } from './Terminal.js';
+import { Screen } from './Screen.js';
+import { Renderer } from './Renderer.js';
+
+// Regression: ensure a resize does not leave stale style fingerprints
+// that would make the renderer skip redrawing rows after a resize.
+
+describe('Renderer — resize does not suppress redraw via stale style fingerprints', () => {
+    it('renders after resize (no stale-style suppression)', () => {
+        // fake stdout to capture writes
+        const fakeStdout: any = {
+            writes: '',
+            columns: 80,
+            rows: 24,
+            isTTY: true,
+            write(s: string) { this.writes += s; },
+            on() {},
+            once() {},
+            off() {},
+        };
+        const fakeStdin: any = { isTTY: true, setRawMode() {}, resume() {}, pause() {}, on() {}, off() {} };
+
+        const terminal = new Terminal({ stdout: fakeStdout, stdin: fakeStdin });
+        const screen = new Screen(40, 5);
+
+        // Use non-diff renderer to exercise the getPreviousLine/getPreviousStyleLine path
+        const renderer = new Renderer(terminal, screen, 60, false);
+
+        // 1) Write a line and render — establish an initial state
+        screen.writeString(0, 0, 'Saved');
+        renderer.renderNow();
+        const beforeWrites = fakeStdout.writes.length;
+
+        // 2) Resize the screen (this clears previousLines but not previousStyleLines)
+        screen.resize(40, 5);
+
+        // 3) Write new content and render again
+        screen.writeString(0, 0, 'After');
+        renderer.renderNow();
+        const afterWrites = fakeStdout.writes.length - beforeWrites;
+
+        // Expect at least some output was written after resize (i.e. no suppression)
+        expect(afterWrites).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
## Description

Add a regression test covering renderer redraw behavior after screen resize in `@termuijs/core`.

The test verifies that a resize does not suppress subsequent rendering because of historical style state and ensures redraw output is still emitted after a resize operation. No production code changes are included.

## Related Issue

Closes #1313

## Which package(s)?

@termuijs/core

## Type of Change

* [x] 🧪 Tests (`type:testing`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

* Test-only change; no production code modifications.
* Verifies that rendering still occurs after a screen resize.
* The test was validated by temporarily introducing a renderer suppression condition, which caused the test to fail, and then restoring the original implementation, which caused the test to pass again.
* Scope is intentionally limited to regression coverage for resize-related redraw behavior.
* Repository-wide build/typecheck failures, if present, are unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a regression test that verifies the terminal renderer correctly redraws updated content after a screen resize, ensuring style-related cached state does not prevent new text from appearing (covers non-diff rendering behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->