### PR TITLE
feat(data): add systemd service and process supervisor monitoring pro…

### DIFF
--- a/packages/data/src/hooks/useServiceHealth.test.ts
+++ b/packages/data/src/hooks/useServiceHealth.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+let stateValues: any[] = [];
+let stateCallCount = 0;
+let effectCb: (() => (() => void) | void) | null = null;
+
+vi.mock('@termuijs/jsx', () => ({
+    useState: (initial: any) => {
+        const id = stateCallCount++;
+        if (stateValues[id] === undefined) {
+            stateValues[id] = typeof initial === 'function' ? initial() : initial;
+        }
+        const setter = vi.fn((newVal: any) => {
+            stateValues[id] = typeof newVal === 'function' ? newVal(stateValues[id]) : newVal;
+        });
+        return [stateValues[id], setter];
+    },
+    useEffect: (cb: () => (() => void) | void) => {
+        effectCb = cb;
+    },
+    useInterval: vi.fn(),
+}));
+
+const mockServicesList = vi.fn();
+
+vi.mock('../services.js', () => ({
+    services: {
+        list: (...args: any[]) => mockServicesList(...args),
+    },
+}));
+
+const { useServiceHealth } = await import('./useServiceHealth.js');
+
+describe('useServiceHealth', () => {
+    beforeEach(() => {
+        stateValues = [];
+        stateCallCount = 0;
+        effectCb = null;
+        vi.useFakeTimers();
+        mockServicesList.mockReturnValue([
+            { name: 'nginx', active: true, status: 'running', uptime: '3d', uptimeSeconds: 259200, restarts: 0, cpu: 2.5, mem: 3.1, pid: 1234, description: 'nginx web server' },
+        ]);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    it('returns data from services.list on mount', () => {
+        const { data, error, loading } = useServiceHealth(['nginx'], 5000);
+
+        expect(data).toHaveLength(1);
+        expect(data[0].name).toBe('nginx');
+        expect(data[0].active).toBe(true);
+        expect(error).toBeNull();
+        expect(loading).toBe(false);
+    });
+
+    it('polls and updates data via setInterval', () => {
+        useServiceHealth(['nginx'], 5000);
+
+        // Execute the effect to start the interval
+        if (effectCb) {
+            effectCb();
+        }
+
+        // Change return value to simulate updated service status
+        const updatedData = [
+            { name: 'nginx', active: false, status: 'stopped', uptime: '0s', uptimeSeconds: 0, restarts: 1, cpu: 0, mem: 0, pid: 0, description: 'nginx web server' },
+        ];
+        mockServicesList.mockReturnValue(updatedData);
+
+        // Advance time to trigger the interval
+        vi.advanceTimersByTime(5000);
+
+        // The data should have been updated from the polling
+        expect(mockServicesList).toHaveBeenCalledWith(['nginx']);
+    });
+
+    it('cleans up interval on unmount', () => {
+        useServiceHealth(['nginx'], 5000);
+
+        const cleanup = effectCb ? effectCb() : undefined;
+
+        expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+        if (typeof cleanup === 'function') {
+            cleanup();
+        }
+
+        expect(vi.getTimerCount()).toBe(0);
+    });
+});

--- a/packages/data/src/hooks/useServiceHealth.ts
+++ b/packages/data/src/hooks/useServiceHealth.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect } from '@termuijs/jsx';
+import { services } from '../services.js';
+import type { ServiceInfo } from '../services.js';
+
+export interface UseServiceHealthResult {
+    data: ServiceInfo[];
+    error: Error | null;
+    loading: boolean;
+}
+
+/**
+ * useServiceHealth — reactive service/supervisor health hook.
+ *
+ * Polls `services.list(names)` on the given interval and exposes
+ * the result reactively. Cleans up timers on unmount.
+ *
+ * @param names - Array of service names to monitor.
+ * @param intervalMs - Poll interval in milliseconds (default 5000).
+ */
+export function useServiceHealth(names: string[], intervalMs = 5000): UseServiceHealthResult {
+    const [data, setData] = useState<ServiceInfo[]>(() => services.list(names));
+    const [error, setError] = useState<Error | null>(null);
+    const [loading, setLoading] = useState<boolean>(false);
+
+    useEffect(() => {
+        let isMounted = true;
+        let timer: ReturnType<typeof setInterval> | null = null;
+
+        const update = async () => {
+            try {
+                const result = services.list(names);
+                if (isMounted) {
+                    setData(result);
+                    setError(null);
+                    setLoading(false);
+                }
+            } catch (err) {
+                if (isMounted) {
+                    setError(err instanceof Error ? err : new Error(String(err)));
+                    setLoading(false);
+                }
+            }
+        };
+
+        update();
+        timer = setInterval(update, intervalMs);
+
+        return () => {
+            isMounted = false;
+            if (timer !== null) {
+                clearInterval(timer);
+            }
+        };
+    }, [intervalMs, ...names]);
+
+    return { data, error, loading };
+}

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -65,3 +65,8 @@ export type { TemperatureData, UseTemperatureResult } from './hooks/useTemperatu
 
 export { useFileWatch } from './hooks/useFileWatch.js'
 export type { FileWatchData, UseFileWatchResult, UseFileWatchOptions } from './hooks/useFileWatch.js'
+
+export { services } from './services.js';
+export type { ServiceInfo } from './services.js';
+export { useServiceHealth } from './hooks/useServiceHealth.js';
+export type { UseServiceHealthResult } from './hooks/useServiceHealth.js';

--- a/packages/data/src/services.test.ts
+++ b/packages/data/src/services.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockExecFileSync = vi.fn();
+
+vi.mock('node:child_process', () => ({
+    execFileSync: (...args: any[]) => {
+        return mockExecFileSync(...args);
+    },
+}));
+
+vi.mock('node:os', () => ({
+    platform: vi.fn(() => 'linux'),
+}));
+
+const { services } = await import('./services.js');
+
+const MOCK_SYSTEMCTL_SHOW_NGINX = [
+    'Type=notify',
+    'Restart=always',
+    'ActiveState=active',
+    'SubState=running',
+    'MainPID=1234',
+    'NRestarts=2',
+    'ActiveEnterTimestamp=Mon 2026-06-01 08:00:00 UTC',
+    'Description=nginx web server',
+    '',
+].join('\n');
+
+const MOCK_SYSTEMCTL_SHOW_POSTGRES = [
+    'Type=simple',
+    'Restart=on-failure',
+    'ActiveState=inactive',
+    'SubState=dead',
+    'MainPID=0',
+    'NRestarts=0',
+    'ActiveEnterTimestamp=n/a',
+    'Description=PostgreSQL database server',
+    '',
+].join('\n');
+
+const MOCK_PS_OUTPUT = '  2.5  3.1\n';
+
+const MOCK_PM2_JLIST = JSON.stringify([
+    {
+        name: 'api-server',
+        pid: 5678,
+        pm2_env: { status: 'online', restart_time: 1, pm_uptime: Date.now() - 86400000 },
+        monit: { cpu: 10, memory: 256 * 1024 * 1024 },
+    },
+]);
+
+const { platform } = await import('node:os');
+
+describe('services provider', () => {
+    beforeEach(() => {
+        mockExecFileSync.mockReset();
+        (platform as unknown as ReturnType<typeof vi.fn>).mockReturnValue('linux');
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('returns empty array for empty names list', () => {
+        const result = services.list([]);
+        expect(result).toEqual([]);
+    });
+
+    it('parses systemd output for active services', () => {
+        mockExecFileSync
+            .mockImplementationOnce(() => 'systemd 252')
+            .mockImplementationOnce(() => MOCK_SYSTEMCTL_SHOW_NGINX)
+            .mockImplementationOnce(() => MOCK_PS_OUTPUT);
+
+        const result = services.list(['nginx']);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe('nginx');
+        expect(result[0].active).toBe(true);
+        expect(result[0].status).toBe('running');
+        expect(result[0].pid).toBe(1234);
+        expect(result[0].restarts).toBe(2);
+        expect(result[0].description).toBe('nginx web server');
+        expect(result[0].cpu).toBe(2.5);
+        expect(result[0].mem).toBe(3.1);
+    });
+
+    it('parses systemd output for inactive services', () => {
+        mockExecFileSync
+            .mockImplementationOnce(() => 'systemd 252')
+            .mockImplementationOnce(() => MOCK_SYSTEMCTL_SHOW_POSTGRES);
+
+        const result = services.list(['postgresql']);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe('postgresql');
+        expect(result[0].active).toBe(false);
+        expect(result[0].status).toBe('dead');
+        expect(result[0].pid).toBe(0);
+        expect(result[0].cpu).toBe(0);
+        expect(result[0].mem).toBe(0);
+        expect(result[0].uptime).toBe('0s');
+    });
+
+    it('falls back to PM2 when systemctl is unavailable', () => {
+        mockExecFileSync
+            .mockImplementationOnce(() => { throw new Error('systemctl not found'); })
+            .mockImplementationOnce(() => MOCK_PM2_JLIST);
+
+        const result = services.list(['api-server']);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe('api-server');
+        expect(result[0].active).toBe(true);
+        expect(result[0].pid).toBe(5678);
+        expect(result[0].cpu).toBe(10);
+        expect(result[0].mem).toBe(256);
+    });
+
+    it('falls back to process matching for unknown services', () => {
+        const MOCK_PS_AUX = [
+            'USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND',
+            'root      1234  2.5  3.1 123456 78900 ?        Ss   Jun01   0:10 /usr/sbin/nginx',
+            'root      5678  1.2  0.5 654321 12345 ?        Ss   Jun01   0:05 /usr/bin/redis-server',
+        ].join('\n');
+
+        mockExecFileSync
+            .mockImplementationOnce(() => { throw new Error('systemctl not found'); })
+            .mockImplementationOnce(() => { throw new Error('pm2 not found'); })
+            .mockImplementationOnce(() => MOCK_PS_AUX);
+
+        const result = services.list(['nginx']);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe('nginx');
+        expect(result[0].active).toBe(true);
+        expect(result[0].pid).toBe(1234);
+        expect(result[0].cpu).toBe(2.5);
+    });
+
+    it('returns inactive entry when process is not found', () => {
+        mockExecFileSync
+            .mockImplementationOnce(() => { throw new Error('systemctl not found'); })
+            .mockImplementationOnce(() => { throw new Error('pm2 not found'); })
+            .mockImplementationOnce(() => 'USER PID %CPU %MEM COMMAND\n');
+
+        const result = services.list(['nonexistent-service']);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe('nonexistent-service');
+        expect(result[0].active).toBe(false);
+        expect(result[0].status).toBe('stopped');
+    });
+});

--- a/packages/data/src/services.ts
+++ b/packages/data/src/services.ts
@@ -1,0 +1,260 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/data — Service / process supervisor monitoring
+// ─────────────────────────────────────────────────────
+
+import { execFileSync } from 'node:child_process';
+import * as os from 'node:os';
+
+export interface ServiceInfo {
+    name: string;
+    active: boolean;
+    status: string;
+    uptime: string;
+    uptimeSeconds: number;
+    restarts: number;
+    cpu: number;
+    mem: number;
+    pid: number;
+    description: string;
+}
+
+function formatUptime(seconds: number): string {
+    if (seconds <= 0) return '0s';
+    const days = Math.floor(seconds / 86400);
+    const hours = Math.floor((seconds % 86400) / 3600);
+    const mins = Math.floor((seconds % 3600) / 60);
+    const secs = Math.floor(seconds % 60);
+    if (days > 0) return `${days}d ${hours}h`;
+    if (hours > 0) return `${hours}h ${mins}m`;
+    if (mins > 0) return `${mins}m ${secs}s`;
+    return `${secs}s`;
+}
+
+interface ParsedSystemdService {
+    name: string;
+    description: string;
+    activeState: string;
+    subState: string;
+    pid: number;
+    nRestarts: number;
+    activeEnterTimestamp: number;
+}
+
+function parseSystemdShow(output: string, serviceName: string): ParsedSystemdService | null {
+    const lines = output.split('\n');
+    const props: Record<string, string> = {};
+    for (const line of lines) {
+        const idx = line.indexOf('=');
+        if (idx === -1) continue;
+        props[line.slice(0, idx)] = line.slice(idx + 1);
+    }
+
+    const activeState = props['ActiveState'] ?? 'unknown';
+    const description = props['Description'] ?? serviceName;
+    const pid = parseInt(props['MainPID'] ?? '0', 10) || 0;
+    const nRestarts = parseInt(props['NRestarts'] ?? '0', 10) || 0;
+
+    // Parse ActiveEnterTimestamp (format: "Mon YYYY-DD-DD HH:MM:SS TZ")
+    const timestampStr = props['ActiveEnterTimestamp'] ?? '';
+    const activeEnterTimestamp = timestampStr && timestampStr !== 'n/a'
+        ? new Date(timestampStr).getTime()
+        : 0;
+
+    const subState = props['SubState'] ?? 'unknown';
+    return { name: serviceName, description, activeState, subState, pid, nRestarts, activeEnterTimestamp };
+}
+
+function getSystemdServices(serviceNames: string[]): ServiceInfo[] {
+    const results: ServiceInfo[] = [];
+    for (const name of serviceNames) {
+        try {
+            const output = execFileSync('systemctl', ['show', name], {
+                encoding: 'utf-8',
+                timeout: 3000,
+            });
+            const parsed = parseSystemdShow(output, name);
+            if (!parsed) continue;
+
+            const active = parsed.activeState === 'active';
+            const uptimeSeconds = active && parsed.activeEnterTimestamp > 0
+                ? Math.floor((Date.now() - parsed.activeEnterTimestamp) / 1000)
+                : 0;
+
+            let cpu = 0;
+            let mem = 0;
+            if (parsed.pid > 0) {
+                try {
+                    const psOut = execFileSync('ps', ['-p', String(parsed.pid), '-o', '%cpu,%mem', '--no-headers'], {
+                        encoding: 'utf-8',
+                        timeout: 2000,
+                    });
+                    const parts = psOut.trim().split(/\s+/);
+                    cpu = parseFloat(parts[0] ?? '0') || 0;
+                    mem = parseFloat(parts[1] ?? '0') || 0;
+                } catch {
+                    // ps failed — cpu/mem stay 0
+                }
+            }
+
+            results.push({
+                name: parsed.name,
+                active,
+                status: parsed.subState,
+                uptime: formatUptime(uptimeSeconds),
+                uptimeSeconds,
+                restarts: parsed.nRestarts,
+                cpu,
+                mem,
+                pid: parsed.pid,
+                description: parsed.description,
+            });
+        } catch {
+            // systemctl not available or service not found — try fallback
+        }
+    }
+    return results;
+}
+
+interface Pm2Process {
+    name: string;
+    pid: number;
+    pm2_env?: {
+        status: string;
+        restart_time: number;
+        pm_uptime: number;
+    };
+    monit?: {
+        cpu: number;
+        memory: number;
+    };
+}
+
+function getPm2Services(serviceNames: string[]): ServiceInfo[] {
+    try {
+        const output = execFileSync('pm2', ['jlist'], {
+            encoding: 'utf-8',
+            timeout: 5000,
+        });
+        const allProcesses: Pm2Process[] = JSON.parse(output);
+        const nameSet = new Set(serviceNames);
+        return allProcesses
+            .filter(p => nameSet.has(p.name))
+            .map(p => {
+                const active = p.pm2_env?.status === 'online';
+                const uptimeSeconds = p.pm2_env?.pm_uptime
+                    ? Math.floor((Date.now() - p.pm2_env.pm_uptime) / 1000)
+                    : 0;
+                return {
+                    name: p.name,
+                    active,
+                    status: p.pm2_env?.status ?? 'unknown',
+                    uptime: formatUptime(uptimeSeconds),
+                    uptimeSeconds,
+                    restarts: p.pm2_env?.restart_time ?? 0,
+                    cpu: p.monit?.cpu ?? 0,
+                    mem: p.monit ? Math.round(p.monit.memory / (1024 * 1024)) : 0,
+                    pid: p.pid,
+                    description: p.name,
+                };
+            });
+    } catch {
+        return [];
+    }
+}
+
+function getProcessFallback(serviceNames: string[]): ServiceInfo[] {
+    try {
+        const output = execFileSync('ps', ['aux'], {
+            encoding: 'utf-8',
+            timeout: 3000,
+        });
+        const lines = output.trim().split('\n').slice(1);
+        const results: ServiceInfo[] = [];
+
+        for (const name of serviceNames) {
+            const matchingLines = lines.filter(line => {
+                const parts = line.trim().split(/\s+/);
+                const procName = parts.slice(10).join(' ').split('/').pop() ?? '';
+                return procName.includes(name);
+            });
+
+            if (matchingLines.length === 0) {
+                results.push({
+                    name,
+                    active: false,
+                    status: 'stopped',
+                    uptime: '0s',
+                    uptimeSeconds: 0,
+                    restarts: 0,
+                    cpu: 0,
+                    mem: 0,
+                    pid: 0,
+                    description: name,
+                });
+                continue;
+            }
+
+            // Aggregate CPU and mem across matching processes
+            let totalCpu = 0;
+            let totalMem = 0;
+            const pids: number[] = [];
+            for (const line of matchingLines) {
+                const parts = line.trim().split(/\s+/);
+                totalCpu += parseFloat(parts[2]) || 0;
+                totalMem += parseFloat(parts[3]) || 0;
+                pids.push(parseInt(parts[1], 10) || 0);
+            }
+
+            results.push({
+                name,
+                active: true,
+                status: 'running',
+                uptime: '-',
+                uptimeSeconds: 0,
+                restarts: 0,
+                cpu: Math.round(totalCpu * 10) / 10,
+                mem: Math.round(totalMem * 10) / 10,
+                pid: pids[0] ?? 0,
+                description: name,
+            });
+        }
+        return results;
+    } catch {
+        return [];
+    }
+}
+
+/** Service / process supervisor data provider */
+export const services = {
+    /**
+     * List service status for the given service names.
+     * Tries systemd first, falls back to PM2, then to process name matching.
+     */
+    list(serviceNames: string[]): ServiceInfo[] {
+        if (serviceNames.length === 0) return [];
+
+        // Try systemd on Linux
+        if (os.platform() === 'linux') {
+            try {
+                execFileSync('systemctl', ['--version'], { encoding: 'utf-8', timeout: 1000 });
+                const svcs = getSystemdServices(serviceNames);
+                if (svcs.length > 0) return svcs;
+            } catch {
+                // systemctl not available — continue to PM2
+            }
+        }
+
+        // Try PM2
+        const pm2Svcs = getPm2Services(serviceNames);
+        const pm2Names = new Set(pm2Svcs.map(s => s.name));
+        const missing = serviceNames.filter(n => !pm2Names.has(n));
+        const results = [...pm2Svcs];
+
+        // Fall back to process name matching for services PM2 didn't cover
+        if (missing.length > 0) {
+            results.push(...getProcessFallback(missing));
+        }
+
+        return results;
+    },
+};


### PR DESCRIPTION
## Description

Add a `services` data provider and `useServiceHealth` reactive hook for monitoring systemd services, PM2 processes, and fallback process name matching in terminal dashboards.

## Related Issue

Closes #1311

## Which package(s)?

@termuijs/data

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [ ] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/<your-profile-id>`

## Screenshots / Recordings (UI changes)

N/A — backend data provider with no visual component.

## Notes for the Reviewer

The provider tries three backends in order: systemd (Linux), PM2, then process name matching via `ps` as cross-platform fallback. Tests mock `execFileSync` and `os.platform` to cover all paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced service health monitoring with configurable polling intervals (default: 5 seconds).
  * Multi-backend service detection: systemd (Linux), PM2, and process-level fallback.
  * Returns service information including active state, uptime, CPU/memory usage, and restart counts.

* **Tests**
  * Added comprehensive test coverage for service monitoring and health polling functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->