### PR TITLE
fix(store): support asynchronous batch functions and fix early rendering

### DIFF
--- a/packages/store/src/batch.test.ts
+++ b/packages/store/src/batch.test.ts
@@ -1,0 +1,32 @@
+import { test, expect, vi } from 'vitest';
+import { createStore, batch } from './store';
+
+test('nested async batch test', async () => {
+    const useAppStore = createStore((set) => ({
+        count: 0,
+        status: 'idle',
+        increment: () => set((s) => ({ count: s.count + 1 })),
+        setStatus: (status: string) => set({ status })
+    }));
+
+    const listener = vi.fn();
+    useAppStore.subscribe(listener);
+
+    await batch(async () => {
+        useAppStore.getState().setStatus('loading');
+        
+        await Promise.resolve(); // Simulate async gap
+        
+        batch(() => {
+            useAppStore.getState().increment();
+            useAppStore.getState().increment();
+        });
+        
+        useAppStore.getState().setStatus('done');
+    });
+
+    // Wait for microtasks
+    await Promise.resolve();
+    
+    expect(listener).toHaveBeenCalledTimes(1);
+});

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -57,35 +57,61 @@ const _batchStores = new Map<Set<any>, BatchEntry<any>>();
  * });
  * ```
  */
-export function batch(fn: () => void): void {
+export function batch<T>(fn: () => T): T {
     _batchDepth++;
     let threw = false;
+    let res: any;
     try {
-        fn();
+        res = fn();
     } catch (err) {
         threw = true;
-        throw err;
-    } finally {
         _batchDepth--;
         if (_batchDepth === 0) {
-            if (threw) {
-                for (const [, { prevState, rollback }] of _batchStores) {
-                    rollback(prevState);
-                }
-                _batchStores.clear(); // Don't notify listeners with partial state
-            } else {
-                queueMicrotask(() => {
-                    const stores = Array.from(_batchStores.entries());
-                    _batchStores.clear();
-                    for (const [listeners, { prevState, nextState ,commit }] of stores) {
-                        commit();
-                        for (const listener of listeners) {
-                            listener(nextState, prevState);
-                        }
-                    }
-                });
-            }
+            flushBatch(threw);
         }
+        throw err;
+    }
+
+    if (res && typeof res.then === 'function') {
+        return (res as Promise<any>).then(
+            (val) => {
+                _batchDepth--;
+                if (_batchDepth === 0) flushBatch(false);
+                return val;
+            },
+            (err) => {
+                _batchDepth--;
+                if (_batchDepth === 0) flushBatch(true);
+                throw err;
+            }
+        ) as T;
+    } else {
+        _batchDepth--;
+        if (_batchDepth === 0) {
+            flushBatch(false);
+        }
+        return res;
+    }
+}
+
+function flushBatch(threw: boolean) {
+    if (threw) {
+        for (const [, { prevState, rollback }] of _batchStores) {
+            rollback(prevState);
+        }
+        _batchStores.clear(); // Don't notify listeners with partial state
+    } else {
+        if (_batchStores.size === 0) return;
+        queueMicrotask(() => {
+            const stores = Array.from(_batchStores.entries());
+            _batchStores.clear();
+            for (const [listeners, { prevState, nextState ,commit }] of stores) {
+                commit();
+                for (const listener of listeners) {
+                    listener(nextState, prevState);
+                }
+            }
+        });
     }
 }
 


### PR DESCRIPTION
## Description

This PR fixes a bug in `@termuijs/store` where asynchronous functions executed within `batch()` would prematurely trigger a render flush. 

Previously, `batch()` only expected synchronous execution, so its `finally` block decremented `_batchDepth` to `0` instantly. This allowed inner nested batches to reset the depth and flush partial UI states before outer `await` blocks completed, leading to UI tearing. The `batch()` function now detects if a `Promise` is returned, deferring depth decrements and UI rendering until after all interleaved asynchronous microtasks resolve. A nested async integration test has also been added.

## Related Issue

Fixes #1292

## Which package(s)?

- `@termuijs/store`

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `batch` function to return values from callbacks instead of void
  * `batch` now supports asynchronous callbacks, properly handling promise-based operations
  * Improved batching logic for nested operations with better state management

* **Tests**
  * Added test coverage for nested `batch` calls with asynchronous operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->