### PR TITLE
feat(data): add database connection pool monitoring provider

### DIFF
--- a/packages/data/src/database.test.ts
+++ b/packages/data/src/database.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockConnect = vi.fn();
+const mockExecFileSync = vi.fn();
+
+vi.mock('node:net', () => ({
+    connect: (...args: unknown[]) => mockConnect(...args),
+}));
+
+vi.mock('node:child_process', () => ({
+    execFileSync: (...args: unknown[]) => mockExecFileSync(...args),
+}));
+
+function makeMockSocket() {
+    const events: Record<string, (args?: unknown) => void> = {};
+    return {
+        destroy: vi.fn(),
+        setTimeout: vi.fn(),
+        on: vi.fn((event: string, cb: (args?: unknown) => void) => {
+            events[event] = cb;
+            return this;
+        }),
+        emit: (event: string, arg?: unknown) => {
+            if (events[event]) events[event](arg);
+        },
+        _events: events,
+    };
+}
+
+const { database } = await import('./database.js');
+
+describe('database provider', () => {
+    beforeEach(() => {
+        mockConnect.mockReset();
+        mockExecFileSync.mockReset();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('returns connected result with latency on successful TCP ping', async () => {
+        const socket = makeMockSocket();
+        mockConnect.mockImplementation((_port: number, _host: string, cb: () => void) => {
+            setTimeout(cb, 0);
+            return socket;
+        });
+
+        const result = await database.ping({
+            type: 'postgres',
+            host: 'localhost',
+            port: 5432,
+        });
+
+        expect(result.connected).toBe(true);
+        expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+        expect(result.activeConnections).toBeNull();
+        expect(result.maxConnections).toBeNull();
+        expect(result.poolPercent).toBeNull();
+    });
+
+    it('returns disconnected result on TCP failure', async () => {
+        const socket = makeMockSocket();
+        mockConnect.mockImplementation((_port: number, _host: string, _cb: () => void) => {
+            setTimeout(() => socket._events.error?.(new Error('Connection refused')), 0);
+            return socket;
+        });
+
+        const result = await database.ping({
+            type: 'postgres',
+            host: 'localhost',
+            port: 5432,
+        });
+
+        expect(result.connected).toBe(false);
+        expect(result.latencyMs).toBe(0);
+    });
+
+    it('tries pg_isready and psql for Postgres metrics', async () => {
+        const socket = makeMockSocket();
+        mockConnect.mockImplementation((_port: number, _host: string, cb: () => void) => {
+            setTimeout(cb, 0);
+            return socket;
+        });
+
+        mockExecFileSync
+            .mockImplementationOnce(() => 'pg_isready: accepting connections')
+            .mockImplementationOnce(() => '100')
+            .mockImplementationOnce(() => '5');
+
+        const result = await database.ping({
+            type: 'postgres',
+            host: 'localhost',
+            port: 5432,
+            username: 'test',
+            database: 'testdb',
+        });
+
+        expect(result.connected).toBe(true);
+        expect(result.maxConnections).toBe(100);
+        expect(result.activeConnections).toBe(5);
+        expect(result.poolPercent).toBe(5);
+    });
+
+    it('tries mysql ping and mysql CLI for MySQL metrics', async () => {
+        const socket = makeMockSocket();
+        mockConnect.mockImplementation((_port: number, _host: string, cb: () => void) => {
+            setTimeout(cb, 0);
+            return socket;
+        });
+
+        mockExecFileSync
+            .mockImplementationOnce(() => 'mysqld is alive')
+            .mockImplementationOnce(() => 'max_connections\t200')
+            .mockImplementationOnce(() => '10');
+
+        const result = await database.ping({
+            type: 'mysql',
+            host: 'localhost',
+            port: 3306,
+        });
+
+        expect(result.connected).toBe(true);
+        expect(result.maxConnections).toBe(200);
+        expect(result.activeConnections).toBe(10);
+        expect(result.poolPercent).toBe(5);
+    });
+
+    it('returns null pool metrics when CLI tools are unavailable', async () => {
+        const socket = makeMockSocket();
+        mockConnect.mockImplementation((_port: number, _host: string, cb: () => void) => {
+            setTimeout(cb, 0);
+            return socket;
+        });
+
+        mockExecFileSync.mockImplementation(() => { throw new Error('command not found'); });
+
+        const result = await database.ping({
+            type: 'postgres',
+            host: 'localhost',
+            port: 5432,
+        });
+
+        expect(result.connected).toBe(true);
+        expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+        expect(result.activeConnections).toBeNull();
+        expect(result.maxConnections).toBeNull();
+        expect(result.poolPercent).toBeNull();
+    });
+
+    it('returns zero pool percent when maxConnections is 0', async () => {
+        const socket = makeMockSocket();
+        mockConnect.mockImplementation((_port: number, _host: string, cb: () => void) => {
+            setTimeout(cb, 0);
+            return socket;
+        });
+
+        mockExecFileSync
+            .mockImplementationOnce(() => 'pg_isready: accepting connections')
+            .mockImplementationOnce(() => '0')
+            .mockImplementationOnce(() => '5');
+
+        const result = await database.ping({
+            type: 'postgres',
+            host: 'localhost',
+            port: 5432,
+        });
+
+        expect(result.poolPercent).toBeNull();
+    });
+});

--- a/packages/data/src/database.ts
+++ b/packages/data/src/database.ts
@@ -1,0 +1,175 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/data — Database connection pool monitoring
+// ─────────────────────────────────────────────────────
+
+import { connect } from 'node:net';
+import { execFileSync } from 'node:child_process';
+
+export interface DatabaseConfig {
+    type: 'postgres' | 'mysql';
+    host: string;
+    port: number;
+    database?: string;
+    username?: string;
+    password?: string;
+}
+
+export interface DatabaseHealth {
+    connected: boolean;
+    latencyMs: number;
+    activeConnections: number | null;
+    maxConnections: number | null;
+    poolPercent: number | null;
+}
+
+function tcpPing(host: string, port: number, timeoutMs: number): Promise<number> {
+    return new Promise((resolve, reject) => {
+        const start = Date.now();
+        const socket = connect(port, host, () => {
+            const latency = Date.now() - start;
+            socket.destroy();
+            resolve(latency);
+        });
+        socket.setTimeout(timeoutMs);
+        socket.on('timeout', () => {
+            socket.destroy();
+            reject(new Error('Connection timed out'));
+        });
+        socket.on('error', (err: Error) => {
+            socket.destroy();
+            reject(err);
+        });
+    });
+}
+
+function getPostgresCliMetrics(config: DatabaseConfig): { activeConnections: number | null; maxConnections: number | null } {
+    try {
+        const baseArgs = ['-h', config.host, '-p', String(config.port), '-t', '-A'];
+        const env: Record<string, string | undefined> = { ...process.env as Record<string, string | undefined> };
+        if (config.username) env.PGUSER = config.username;
+        if (config.database) env.PGDATABASE = config.database;
+
+        const maxOut = execFileSync('psql', [...baseArgs, '-c', 'SHOW max_connections'], {
+            encoding: 'utf-8', timeout: 5000, env,
+        });
+
+        const activeOut = execFileSync('psql', [...baseArgs, '-c', "SELECT count(*) FROM pg_stat_activity"], {
+            encoding: 'utf-8', timeout: 5000, env,
+        });
+
+        const maxConnections = parseInt(maxOut.trim(), 10) || null;
+        const activeConnections = parseInt(activeOut.trim(), 10) || null;
+        return { activeConnections, maxConnections };
+    } catch {
+        return { activeConnections: null, maxConnections: null };
+    }
+}
+
+function getMysqlCliMetrics(config: DatabaseConfig): { activeConnections: number | null; maxConnections: number | null } {
+    try {
+        const baseArgs = ['-h', config.host, '-P', String(config.port), '--batch', '--skip-column-names'];
+        if (config.username) baseArgs.push('-u', config.username);
+        if (config.password) baseArgs.push(`-p${config.password}`);
+
+        const maxOut = execFileSync('mysql', [...baseArgs, '-e', "SHOW VARIABLES LIKE 'max_connections'"], {
+            encoding: 'utf-8', timeout: 5000,
+        });
+
+        const activeOut = execFileSync('mysql', [...baseArgs, '-e', 'SELECT COUNT(*) FROM information_schema.processlist'], {
+            encoding: 'utf-8', timeout: 5000,
+        });
+
+        const maxConnections = parseInt(maxOut.trim().split('\t')[1] ?? '', 10) || null;
+        const activeConnections = parseInt(activeOut.trim(), 10) || null;
+        return { activeConnections, maxConnections };
+    } catch {
+        return { activeConnections: null, maxConnections: null };
+    }
+}
+
+function tryPgIsReady(config: DatabaseConfig): boolean {
+    try {
+        execFileSync('pg_isready', ['-h', config.host, '-p', String(config.port)], {
+            encoding: 'utf-8', timeout: 5000,
+        });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function tryMysqlPing(config: DatabaseConfig): boolean {
+    try {
+        const args = ['ping', '-h', config.host, '-P', String(config.port)];
+        if (config.username) args.push('-u', config.username);
+        if (config.password) args.push(`-p${config.password}`);
+        execFileSync('mysqladmin', args, { encoding: 'utf-8', timeout: 5000 });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/** Database connection pool data provider */
+export const database = {
+    /**
+     * Ping a database and return health status + pool metrics.
+     *
+     * First attempts a TCP socket connection to measure latency.
+     * Then tries CLI tools (psql/pg_isready for Postgres, mysql/mysqladmin
+     * for MySQL) for extended pool metrics. Pool fields are null when
+     * the CLI tools are not available or authentication fails.
+     */
+    async ping(config: DatabaseConfig): Promise<DatabaseHealth> {
+        let latencyMs: number;
+        let connected: boolean;
+
+        try {
+            latencyMs = await tcpPing(config.host, config.port, 5000);
+            connected = true;
+        } catch {
+            return {
+                connected: false,
+                latencyMs: 0,
+                activeConnections: null,
+                maxConnections: null,
+                poolPercent: null,
+            };
+        }
+
+        let activeConnections: number | null = null;
+        let maxConnections: number | null = null;
+
+        try {
+            if (config.type === 'postgres') {
+                const pgReady = tryPgIsReady(config);
+                if (pgReady) {
+                    const metrics = getPostgresCliMetrics(config);
+                    activeConnections = metrics.activeConnections;
+                    maxConnections = metrics.maxConnections;
+                }
+            } else {
+                const mysqlOk = tryMysqlPing(config);
+                if (mysqlOk) {
+                    const metrics = getMysqlCliMetrics(config);
+                    activeConnections = metrics.activeConnections;
+                    maxConnections = metrics.maxConnections;
+                }
+            }
+        } catch {
+            // CLI tools not available — pool metrics stay null
+        }
+
+        const poolPercent = activeConnections !== null && maxConnections !== null && maxConnections > 0
+            ? Math.round((activeConnections / maxConnections) * 100)
+            : null;
+
+        return {
+            connected,
+            latencyMs,
+            activeConnections,
+            maxConnections,
+            poolPercent,
+        };
+    },
+};

--- a/packages/data/src/hooks/useDatabaseHealth.test.ts
+++ b/packages/data/src/hooks/useDatabaseHealth.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+let stateValues: unknown[] = [];
+let stateSetters: Array<ReturnType<typeof vi.fn>> = [];
+let effectCb: (() => (() => void) | void) | null = null;
+let stateCallCount = 0;
+
+vi.mock('@termuijs/jsx', () => ({
+    useState: (initial: unknown) => {
+        const id = stateCallCount++;
+        if (stateValues[id] === undefined) {
+            stateValues[id] = typeof initial === 'function' ? (initial as () => unknown)() : initial;
+        }
+        if (!stateSetters[id]) {
+            stateSetters[id] = vi.fn((newVal: unknown) => {
+                stateValues[id] = typeof newVal === 'function'
+                    ? (newVal as (prev: unknown) => unknown)(stateValues[id])
+                    : newVal;
+            });
+        }
+        return [stateValues[id], stateSetters[id]];
+    },
+    useEffect: (cb: () => (() => void) | void) => {
+        effectCb = cb;
+    },
+    useInterval: vi.fn(),
+}));
+
+const mockDatabasePing = vi.fn();
+
+vi.mock('../database.js', () => ({
+    database: {
+        ping: (...args: unknown[]) => mockDatabasePing(...args),
+    },
+}));
+
+const flushPromises = () => new Promise<void>(resolve => process.nextTick(resolve));
+
+const { useDatabaseHealth } = await import('./useDatabaseHealth.js');
+
+const MOCK_CONFIG = { type: 'postgres' as const, host: 'localhost', port: 5432 };
+
+describe('useDatabaseHealth', () => {
+    beforeEach(() => {
+        stateValues = [];
+        stateSetters = [];
+        stateCallCount = 0;
+        effectCb = null;
+
+        vi.useFakeTimers();
+        mockDatabasePing.mockReset();
+        mockDatabasePing.mockResolvedValue({
+            connected: true,
+            latencyMs: 3,
+            activeConnections: 5,
+            maxConnections: 100,
+            poolPercent: 5,
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    it('initial state is loading', () => {
+        const { data, error, loading } = useDatabaseHealth(MOCK_CONFIG, 5000);
+
+        expect(loading).toBe(true);
+        expect(data).toBeNull();
+        expect(error).toBeNull();
+    });
+
+    it('fetches data and updates state after async resolution', async () => {
+        useDatabaseHealth(MOCK_CONFIG, 5000);
+
+        if (effectCb) {
+            effectCb();
+        }
+
+        await flushPromises();
+
+        expect(stateValues[0]).toEqual({
+            connected: true,
+            latencyMs: 3,
+            activeConnections: 5,
+            maxConnections: 100,
+            poolPercent: 5,
+        });
+        expect(stateValues[1]).toBeNull();
+        expect(stateValues[2]).toBe(false);
+    });
+
+    it('cleans up interval on unmount', () => {
+        useDatabaseHealth(MOCK_CONFIG, 5000);
+
+        const cleanup = effectCb ? effectCb() : undefined;
+
+        expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+        if (typeof cleanup === 'function') {
+            cleanup();
+        }
+
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('sets error when ping fails', async () => {
+        mockDatabasePing.mockRejectedValue(new Error('Connection refused'));
+
+        useDatabaseHealth(MOCK_CONFIG, 5000);
+
+        if (effectCb) {
+            effectCb();
+        }
+
+        await flushPromises();
+
+        expect(stateValues[1]).toBeInstanceOf(Error);
+        expect((stateValues[1] as Error).message).toContain('Connection refused');
+        expect(stateValues[2]).toBe(false);
+    });
+
+    it('polls and updates on interval', async () => {
+        useDatabaseHealth(MOCK_CONFIG, 5000);
+
+        if (effectCb) {
+            effectCb();
+        }
+
+        await flushPromises();
+
+        expect(mockDatabasePing).toHaveBeenCalledTimes(1);
+
+        mockDatabasePing.mockResolvedValue({
+            connected: true,
+            latencyMs: 5,
+            activeConnections: 10,
+            maxConnections: 100,
+            poolPercent: 10,
+        });
+
+        vi.advanceTimersByTime(5000);
+        await flushPromises();
+
+        expect(mockDatabasePing).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/data/src/hooks/useDatabaseHealth.ts
+++ b/packages/data/src/hooks/useDatabaseHealth.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect } from '@termuijs/jsx';
+import { database } from '../database.js';
+import type { DatabaseConfig, DatabaseHealth } from '../database.js';
+
+export interface UseDatabaseHealthResult {
+    data: DatabaseHealth | null;
+    error: Error | null;
+    loading: boolean;
+}
+
+/**
+ * useDatabaseHealth — reactive database connection pool health hook.
+ *
+ * Pings the database via `database.ping(config)` on the given interval
+ * and exposes the result reactively. Cleans up timers on unmount.
+ *
+ * @param config - Database connection configuration.
+ * @param intervalMs - Poll interval in milliseconds (default 5000).
+ */
+export function useDatabaseHealth(config: DatabaseConfig, intervalMs = 5000): UseDatabaseHealthResult {
+    const [data, setData] = useState<DatabaseHealth | null>(null);
+    const [error, setError] = useState<Error | null>(null);
+    const [loading, setLoading] = useState<boolean>(true);
+
+    useEffect(() => {
+        let isMounted = true;
+        let timer: ReturnType<typeof setInterval> | null = null;
+
+        const update = async () => {
+            try {
+                const result = await database.ping(config);
+                if (isMounted) {
+                    setData(result);
+                    setError(null);
+                    setLoading(false);
+                }
+            } catch (err) {
+                if (isMounted) {
+                    setError(err instanceof Error ? err : new Error(String(err)));
+                    setLoading(false);
+                }
+            }
+        };
+
+        update();
+        timer = setInterval(update, intervalMs);
+
+        return () => {
+            isMounted = false;
+            if (timer !== null) {
+                clearInterval(timer);
+            }
+        };
+    }, [intervalMs, config.host, config.port, config.type, config.database, config.username]);
+
+    return { data, error, loading };
+}

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -70,3 +70,7 @@ export { services } from './services.js';
 export type { ServiceInfo } from './services.js';
 export { useServiceHealth } from './hooks/useServiceHealth.js';
 export type { UseServiceHealthResult } from './hooks/useServiceHealth.js';
+export { database } from './database.js';
+export type { DatabaseConfig, DatabaseHealth } from './database.js';
+export { useDatabaseHealth } from './hooks/useDatabaseHealth.js';
+export type { UseDatabaseHealthResult } from './hooks/useDatabaseHealth.js';


### PR DESCRIPTION
## Description

Add a `database` data provider and `useDatabaseHealth` reactive hook for monitoring database connection pool health in terminal dashboards. Uses TCP socket ping for connectivity/latency and optional CLI tools for pool metrics.

## Related Issue

Closes #1310

## Which package(s)

@termuijs/data

## Type of Change

- [x] ✨ Feature (`type:feature`)
- [x] 🧪 Tests (`type:testing`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/<your-profile-id>`

## Screenshots / Recordings (UI changes)

N/A — backend data provider with no visual component.

## Notes for the Reviewer

The provider tries three approaches: TCP socket ping, then CLI tools (`pg_isready` + `psql` for Postgres, `mysqladmin ping` + `mysql` for MySQL), falling back to null metrics when tools are unavailable. Zero external dependencies — uses only `node:net` and `node:child_process`. Tests mock both at module level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added database connectivity health monitoring, including TCP latency and connection status (connected/disconnected).
  * Added PostgreSQL and MySQL pool metrics (active/max connections and pool utilization).
  * Introduced a `useDatabaseHealth` hook to poll database health on a configurable interval.
  * Extended the package public API to expose the new health types and hook.

* **Tests**
  * Added Vitest coverage for database health checks and the polling hook behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->