### PR TITLE
feat(data): add Docker monitoring provider and useDocker hook

### DIFF
--- a/packages/data/src/docker.test.ts
+++ b/packages/data/src/docker.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockExecFileSync = vi.fn();
+
+vi.mock('node:child_process', () => ({
+    execFileSync: (...args: unknown[]) => mockExecFileSync(...args),
+}));
+
+const { docker } = await import('./docker.js');
+
+const MOCK_PS_JSON = [
+    JSON.stringify({
+        ID: 'abc123def456ghi789jkl',
+        Names: '/api-server',
+        Image: 'node:20',
+        Status: 'Up 2 hours',
+        State: 'running',
+        Ports: '0.0.0.0:3000->3000/tcp',
+        CreatedAt: '2026-06-10 08:00:00',
+        RunningFor: '2 hours ago',
+    }),
+    JSON.stringify({
+        ID: 'xyz789abc123def456ghi',
+        Names: '/redis-cache',
+        Image: 'redis:7',
+        Status: 'Exited (0) 5 hours ago',
+        State: 'exited',
+        Ports: '',
+        CreatedAt: '2026-06-09 10:00:00',
+        RunningFor: '5 hours ago',
+    }),
+].join('\n');
+
+const MOCK_STATS_JSON = JSON.stringify({
+    CPU: '2.10%',
+    CPUPerc: '2.10%',
+    MemUsage: '120MiB / 512MiB',
+    MemPerc: '24.57%',
+    NetIO: '1.02kB / 512B',
+    BlockIO: '0B / 0B',
+    PIDs: '12',
+    Name: 'api-server',
+    ID: 'abc123def456ghi789jkl',
+    Container: 'abc123def456',
+});
+
+describe('docker provider', () => {
+    beforeEach(() => {
+        mockExecFileSync.mockReset();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('returns empty array when docker CLI is unavailable', () => {
+        mockExecFileSync.mockImplementation(() => { throw new Error('docker not found'); });
+
+        const result = docker.list();
+        expect(result).toEqual([]);
+    });
+
+    it('parses docker ps output for all containers', () => {
+        mockExecFileSync.mockReturnValue(MOCK_PS_JSON);
+
+        const result = docker.list();
+
+        expect(result).toHaveLength(2);
+        expect(result[0].id).toBe('abc123def456');
+        expect(result[0].name).toBe('api-server');
+        expect(result[0].image).toBe('node:20');
+        expect(result[0].state).toBe('running');
+        expect(result[1].name).toBe('redis-cache');
+        expect(result[1].state).toBe('exited');
+    });
+
+    it('enriches running containers with stats', () => {
+        mockExecFileSync
+            .mockImplementationOnce(() => MOCK_PS_JSON)
+            .mockImplementationOnce(() => MOCK_STATS_JSON);
+
+        const result = docker.list();
+
+        const api = result.find(c => c.name === 'api-server')!;
+        expect(api).toBeDefined();
+        expect(api.cpu).toBe(2.1);
+        expect(api.memPercent).toBe(24.57);
+        expect(api.memUsed).toBe(125829120); // 120 MiB
+        expect(api.memLimit).toBe(536870912); // 512 MiB
+        expect(api.netRx).toBe(1020); // 1.02 kB
+        expect(api.netTx).toBe(512);
+        expect(api.pids).toBe(12);
+    });
+
+    it('returns stats for a specific container', () => {
+        mockExecFileSync.mockReturnValue(MOCK_STATS_JSON);
+
+        const result = docker.stats('abc123def456');
+
+        expect(result).not.toBeNull();
+        expect(result!.cpu).toBe(2.1);
+        expect(result!.mem.used).toBe(125829120); // 120 MiB
+        expect(result!.mem.limit).toBe(536870912); // 512 MiB
+        expect(result!.mem.percent).toBe(24.57);
+        expect(result!.net.rx).toBe(1020);
+        expect(result!.net.tx).toBe(512);
+        expect(result!.pids).toBe(12);
+    });
+
+    it('returns null for stats when docker fails', () => {
+        mockExecFileSync.mockImplementation(() => { throw new Error('container not found'); });
+
+        const result = docker.stats('nonexistent');
+        expect(result).toBeNull();
+    });
+
+    it('stops at ps when stats command fails', () => {
+        mockExecFileSync
+            .mockImplementationOnce(() => MOCK_PS_JSON)
+            .mockImplementationOnce(() => { throw new Error('stats failed'); });
+
+        const result = docker.list();
+
+        expect(result).toHaveLength(2);
+        const api = result.find(c => c.name === 'api-server')!;
+        expect(api.cpu).toBe(0);
+        expect(api.state).toBe('running');
+    });
+});

--- a/packages/data/src/docker.ts
+++ b/packages/data/src/docker.ts
@@ -1,0 +1,206 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/data — Docker container monitoring
+// ─────────────────────────────────────────────────────
+
+import { execFileSync } from 'node:child_process';
+
+export interface DockerContainer {
+    id: string;
+    name: string;
+    image: string;
+    status: string;
+    state: string;
+    cpu: number;
+    memPercent: number;
+    memUsed: number;
+    memLimit: number;
+    netRx: number;
+    netTx: number;
+    pids: number;
+}
+
+export interface DockerContainerStats {
+    cpu: number;
+    mem: {
+        used: number;
+        limit: number;
+        percent: number;
+    };
+    net: {
+        rx: number;
+        tx: number;
+    };
+    pids: number;
+}
+
+function parseBytes(value: string): number {
+    const trimmed = value.trim();
+    const match = trimmed.match(/^([\d.]+)\s*([kKMGTPE]i?B|B)$/);
+    if (!match) return 0;
+    const num = parseFloat(match[1]) || 0;
+    const unit = match[2];
+    const units: Record<string, number> = {
+        B: 1, KiB: 1024, MiB: 1024 ** 2, GiB: 1024 ** 3,
+        TiB: 1024 ** 4, kB: 1000, KB: 1000, MB: 1000 ** 2, GB: 1000 ** 3,
+    };
+    return Math.round(num * (units[unit] ?? 1));
+}
+
+function parsePerc(value: string): number {
+    return parseFloat(value.replace('%', '')) || 0;
+}
+
+function parseNetIO(value: string): { rx: number; tx: number } {
+    // Docker format: "1.02kB / 512B" or "0B / 0B"
+    const parts = value.split('/').map(s => s.trim());
+    return {
+        rx: parseBytes(parts[0] ?? '0B'),
+        tx: parseBytes(parts[1] ?? '0B'),
+    };
+}
+
+interface DockerPsRow {
+    ID: string;
+    Names: string;
+    Image: string;
+    Status: string;
+    State: string;
+    Ports: string;
+    CreatedAt: string;
+    RunningFor: string;
+}
+
+interface DockerStatsRow {
+    CPU?: string;
+    CPUPerc?: string;
+    MemUsage: string;
+    MemPerc: string;
+    NetIO: string;
+    BlockIO: string;
+    PIDs: string;
+    Name: string;
+    ID: string;
+    Container: string;
+}
+
+function runDockerPs(): DockerContainer[] {
+    try {
+        const output = execFileSync('docker', [
+            'ps', '--all', '--no-trunc',
+            '--format', '{{json .}}',
+        ], { encoding: 'utf-8', timeout: 5000 });
+
+        const lines = output.trim().split('\n').filter(Boolean);
+        return lines.map(line => {
+            try {
+                const raw: DockerPsRow = JSON.parse(line);
+                const state = (raw.State ?? '').toLowerCase();
+                const running = state === 'running';
+
+                return {
+                    id: raw.ID.slice(0, 12),
+                    name: raw.Names?.replace(/^\//, '') ?? 'unknown',
+                    image: raw.Image ?? 'unknown',
+                    status: raw.Status ?? 'unknown',
+                    state,
+                    cpu: 0,
+                    memPercent: 0,
+                    memUsed: 0,
+                    memLimit: 0,
+                    netRx: 0,
+                    netTx: 0,
+                    pids: running ? 1 : 0,
+                };
+            } catch {
+                return null;
+            }
+        }).filter((c): c is DockerContainer => c !== null);
+    } catch {
+        return [];
+    }
+}
+
+function enrichWithStats(containers: DockerContainer[]): DockerContainer[] {
+    if (containers.length === 0) return containers;
+
+    const running = containers.filter(c => c.state === 'running');
+    if (running.length === 0) return containers;
+
+    try {
+        const output = execFileSync('docker', [
+            'stats', '--no-stream', '--no-trunc',
+            '--format', '{{json .}}',
+            ...running.map(c => c.id),
+        ], { encoding: 'utf-8', timeout: 10000 });
+
+        const lines = output.trim().split('\n').filter(Boolean);
+        const statsMap = new Map<string, DockerStatsRow>();
+
+        for (const line of lines) {
+            try {
+                const stat: DockerStatsRow = JSON.parse(line);
+                // Match by short container ID (12 chars) from the Container field
+                statsMap.set(stat.Container, stat);
+            } catch {
+                // skip malformed lines
+            }
+        }
+
+        return containers.map(c => {
+            const stat = statsMap.get(c.id);
+            if (!stat) return c;
+
+            const cpu = stat.CPUPerc ? parsePerc(stat.CPUPerc) : 0;
+            const memPerc = parsePerc(stat.MemPerc);
+            const memParts = stat.MemUsage.split('/').map(s => s.trim());
+            const memUsed = parseBytes(memParts[0] ?? '0B');
+            const memLimit = parseBytes(memParts[1] ?? '0B');
+            const net = parseNetIO(stat.NetIO);
+            const pids = parseInt(stat.PIDs, 10) || 0;
+
+            return { ...c, cpu, memPercent: memPerc, memUsed, memLimit, netRx: net.rx, netTx: net.tx, pids };
+        });
+    } catch {
+        return containers;
+    }
+}
+
+/** Docker container monitoring data provider */
+export const docker = {
+    /**
+     * List all containers with basic info.
+     * Enriches running containers with live CPU/mem/net stats.
+     */
+    list(): DockerContainer[] {
+        const containers = runDockerPs();
+        return enrichWithStats(containers);
+    },
+
+    /**
+     * Get detailed live stats for a specific container by ID or name.
+     */
+    stats(id: string): DockerContainerStats | null {
+        try {
+            const output = execFileSync('docker', [
+                'stats', '--no-stream', '--no-trunc',
+                '--format', '{{json .}}', id,
+            ], { encoding: 'utf-8', timeout: 5000 });
+
+            const line = output.trim().split('\n').filter(Boolean)[0];
+            if (!line) return null;
+
+            const stat: DockerStatsRow = JSON.parse(line);
+            const cpu = stat.CPUPerc ? parsePerc(stat.CPUPerc) : 0;
+            const memPerc = parsePerc(stat.MemPerc);
+            const memParts = stat.MemUsage.split('/').map(s => s.trim());
+            const memUsed = parseBytes(memParts[0] ?? '0B');
+            const memLimit = parseBytes(memParts[1] ?? '0B');
+            const net = parseNetIO(stat.NetIO);
+            const pids = parseInt(stat.PIDs, 10) || 0;
+
+            return { cpu, mem: { used: memUsed, limit: memLimit, percent: memPerc }, net, pids };
+        } catch {
+            return null;
+        }
+    },
+};

--- a/packages/data/src/hooks/useDocker.test.ts
+++ b/packages/data/src/hooks/useDocker.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+let stateValues: any[] = [];
+let stateCallCount = 0;
+let effectCb: (() => (() => void) | void) | null = null;
+
+vi.mock('@termuijs/jsx', () => ({
+    useState: (initial: any) => {
+        const id = stateCallCount++;
+        if (stateValues[id] === undefined) {
+            stateValues[id] = typeof initial === 'function' ? initial() : initial;
+        }
+        const setter = vi.fn((newVal: any) => {
+            stateValues[id] = typeof newVal === 'function' ? newVal(stateValues[id]) : newVal;
+        });
+        return [stateValues[id], setter];
+    },
+    useEffect: (cb: () => (() => void) | void) => {
+        effectCb = cb;
+    },
+    useInterval: vi.fn(),
+}));
+
+const mockDockerList = vi.fn();
+
+vi.mock('../docker.js', () => ({
+    docker: {
+        list: (...args: any[]) => mockDockerList(...args),
+    },
+}));
+
+const { useDocker } = await import('./useDocker.js');
+
+const MOCK_CONTAINERS = [
+    { id: 'abc123', name: 'api', image: 'node:20', status: 'Up 2 hours', state: 'running', cpu: 2.1, memPercent: 24.5, memUsed: 125829120, memLimit: 536870912, netRx: 1024, netTx: 512, pids: 12 },
+    { id: 'def456', name: 'redis', image: 'redis:7', status: 'Exited (0)', state: 'exited', cpu: 0, memPercent: 0, memUsed: 0, memLimit: 0, netRx: 0, netTx: 0, pids: 0 },
+];
+
+describe('useDocker', () => {
+    beforeEach(() => {
+        stateValues = [];
+        stateCallCount = 0;
+        effectCb = null;
+        vi.useFakeTimers();
+        mockDockerList.mockReset();
+        mockDockerList.mockReturnValue(MOCK_CONTAINERS);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    it('returns data from docker.list after effect runs', () => {
+        useDocker(5000);
+
+        if (effectCb) {
+            effectCb();
+        }
+
+        expect(stateValues[0]).toHaveLength(2);
+        expect(stateValues[0][0].name).toBe('api');
+        expect(stateValues[0][0].cpu).toBe(2.1);
+        expect(stateValues[1]).toBeNull();
+        expect(stateValues[2]).toBe(false);
+    });
+
+    it('polls and updates data via setInterval', () => {
+        useDocker(5000);
+
+        if (effectCb) {
+            effectCb();
+        }
+
+        const updatedData = [
+            { id: 'abc123', name: 'api', image: 'node:20', status: 'Up 3 hours', state: 'running', cpu: 3.2, memPercent: 30.1, memUsed: 150000000, memLimit: 536870912, netRx: 2048, netTx: 1024, pids: 14 },
+        ];
+        mockDockerList.mockReturnValue(updatedData);
+
+        vi.advanceTimersByTime(5000);
+
+        // Called once from effect + once from interval = 2 total
+        expect(mockDockerList).toHaveBeenCalledTimes(2);
+    });
+
+    it('cleans up interval on unmount', () => {
+        useDocker(5000);
+
+        const cleanup = effectCb ? effectCb() : undefined;
+
+        expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+        if (typeof cleanup === 'function') {
+            cleanup();
+        }
+
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('sets error when docker.list throws', () => {
+        mockDockerList.mockImplementation(() => { throw new Error('Docker not available'); });
+
+        const { data, loading, error: initialError } = useDocker(5000);
+
+        // Initial state is empty, loading, no error
+        expect(data).toEqual([]);
+        expect(loading).toBe(true);
+        expect(initialError).toBeNull();
+
+        // Trigger the effect which calls update() and catches the error
+        if (effectCb) {
+            effectCb();
+        }
+
+        expect(stateValues[1]).toBeInstanceOf(Error);
+        expect((stateValues[1] as Error).message).toContain('Docker not available');
+    });
+});

--- a/packages/data/src/hooks/useDocker.ts
+++ b/packages/data/src/hooks/useDocker.ts
@@ -1,0 +1,56 @@
+import { useState, useEffect } from '@termuijs/jsx';
+import { docker } from '../docker.js';
+import type { DockerContainer } from '../docker.js';
+
+export interface UseDockerResult {
+    data: DockerContainer[];
+    error: Error | null;
+    loading: boolean;
+}
+
+/**
+ * useDocker — reactive Docker container monitoring hook.
+ *
+ * Polls `docker.list()` on the given interval and exposes
+ * the result reactively. Cleans up timers on unmount.
+ *
+ * @param intervalMs - Poll interval in milliseconds (default 5000).
+ */
+export function useDocker(intervalMs = 5000): UseDockerResult {
+    const [data, setData] = useState<DockerContainer[]>([]);
+    const [error, setError] = useState<Error | null>(null);
+    const [loading, setLoading] = useState<boolean>(true);
+
+    useEffect(() => {
+        let isMounted = true;
+        let timer: ReturnType<typeof setInterval> | null = null;
+
+        const update = () => {
+            try {
+                const result = docker.list();
+                if (isMounted) {
+                    setData(result);
+                    setError(null);
+                    setLoading(false);
+                }
+            } catch (err) {
+                if (isMounted) {
+                    setError(err instanceof Error ? err : new Error(String(err)));
+                    setLoading(false);
+                }
+            }
+        };
+
+        update();
+        timer = setInterval(update, intervalMs);
+
+        return () => {
+            isMounted = false;
+            if (timer !== null) {
+                clearInterval(timer);
+            }
+        };
+    }, [intervalMs]);
+
+    return { data, error, loading };
+}

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -74,3 +74,7 @@ export { database } from './database.js';
 export type { DatabaseConfig, DatabaseHealth } from './database.js';
 export { useDatabaseHealth } from './hooks/useDatabaseHealth.js';
 export type { UseDatabaseHealthResult } from './hooks/useDatabaseHealth.js';
+export { docker } from './docker.js';
+export type { DockerContainer, DockerContainerStats } from './docker.js';
+export { useDocker } from './hooks/useDocker.js';
+export type { UseDockerResult } from './hooks/useDocker.js';


### PR DESCRIPTION
## Description

Adds Docker container monitoring to `@termuijs/data` with a sync provider (`docker.list()`, `docker.stats()`) and a reactive polling hook (`useDocker`).

## Related Issue

Closes #1309

## Which package(s)?

@termuijs/data

## Type of Change

- [x] ✨ Feature (`type:feature`)

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Notes for the Reviewer

Provider uses `execFileSync` calls to `docker ps --format json` and `docker stats --no-stream --format json`. No external dependencies. `parseBytes()` handles both lowercase `k` and uppercase `K` unit suffixes from Docker CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Docker container monitoring that lists containers and enriches them with CPU, memory, network, and PID metrics.
  * Added a UI hook for reactive container monitoring with configurable polling intervals and built-in loading/error states.
  * Handles unavailable/unparsable Docker outputs gracefully by returning safe defaults.
* **Tests**
  * Introduced unit tests covering container listing, stats parsing, failure modes, and the hook’s polling, cleanup, and error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->