### PR TITLE
fix: resolve blank screen in kanban-board example

### DIFF
--- a/examples/kanban-board/src/index.tsx
+++ b/examples/kanban-board/src/index.tsx
@@ -1,6 +1,13 @@
 import { App, type KeyEvent } from '@termuijs/core';
 import { Box, Text, Widget } from '@termuijs/widgets';
 
+// Control Command
+// ← → — switch columns
+// ↑ ↓ — move between cards
+// Shift + → — move a card to next column
+// Shift + ← — move a card back
+// q — quit
+
 type Card = { id: string; text: string };
 type ColumnData = { title: string; cards: Card[] };
 
@@ -40,11 +47,11 @@ class KanbanBoard extends Widget {
 
         this.addChild(new Text(' 📋 Kanban Board Example ', { bold: true, fg: { type: 'named', name: 'cyan' } }));
 
-        const boardLayout = new Box({ flexDirection: 'row', width: '100%', flex: 1, gap: 2 });
+       const boardLayout = new Box({ flexDirection: 'row', width: '100%', flexGrow: 1, gap: 2 });
         this.addChild(boardLayout);
 
         for (let i = 0; i < this.columnsData.length; i++) {
-            const colWidget = new Box({ flexDirection: 'column', width: 25, flex: 0, border: 'single', padding: 1, gap: 1 });
+            const colWidget = new Box({ flexDirection: 'column', width: 25, flexGrow: 1, border: 'single', padding: 1, gap: 1 });
             this.columnWidgets.push(colWidget);
             boardLayout.addChild(colWidget);
         }
@@ -71,21 +78,22 @@ class KanbanBoard extends Widget {
             const colWidget = this.columnWidgets[c];
 
             // Column Header
-            const headerColor = this.activeColIdx === c ? { type: 'named', name: 'blue' as const } : { type: 'named', name: 'default' as const };
+            const headerColor = this.activeColIdx === c ? { type: 'named', name: 'blue' as const } : { type: 'named', name: 'white' as const };
             colWidget.setStyle({ borderFg: headerColor });
-            colWidget.addChild(new Text(colData.title.toUpperCase(), { bold: true, fg: headerColor }));
-            colWidget.addChild(new Text('─'.repeat(21), { dim: true }));
+            colWidget.addChild(new Text(colData.title.toUpperCase(), { bold: true, fg: headerColor  , height : 1}));
+            colWidget.addChild(new Text('─'.repeat(21), { dim: true , height:1}));
 
             // Cards
             if (colData.cards.length === 0) {
-                colWidget.addChild(new Text(' (Empty)', { dim: true }));
+                colWidget.addChild(new Text(' (Empty)', { dim: true  , height : 1}));
             } else {
                 for (let r = 0; r < colData.cards.length; r++) {
                     const card = colData.cards[r];
                     const isSelected = this.activeColIdx === c && this.activeCardIdx === r;
                     const cardText = new Text(` ${card.text} `, { 
                         inverse: isSelected, 
-                        fg: isSelected ? { type: 'named', name: 'white' } : { type: 'named', name: 'default' } 
+                        fg: isSelected ? { type: 'named', name: 'white' } : { type: 'named', name: 'white' },
+                        height:1 
                     });
                     this.cardWidgets.set(card.id, cardText);
                     colWidget.addChild(cardText);


### PR DESCRIPTION
## Description
The `kanban-board` example was rendering a completely blank screen due to invalid style properties and missing `height` values on `Text` widgets. This PR fixes all three root causes so the board renders correctly with columns, cards, and keyboard navigation working as expected.
 
## Related Issue
Closes #1331
 
## Which package(s)?
`examples/kanban-board` — `@termuijs/widgets` (`Box`, `Text`)
 
## Type of Change
- [x] 🐛 Bug fix (`type:bug`)
## What was fixed
 
**Fix 1 — Invalid `flex` property on board layout:**
```typescript
// Before
const boardLayout = new Box({ flexDirection: 'row', width: '100%', flex: 1, gap: 2 });
 
// After
const boardLayout = new Box({ flexDirection: 'row', width: '100%', flexGrow: 1, gap: 2 });
```
 
**Fix 2 — Invalid `flex` property on column widgets:**
```typescript
// Before
const colWidget = new Box({ flexDirection: 'column', width: 25, flex: 0, ... });
 
// After
const colWidget = new Box({ flexDirection: 'column', width: 25, flexGrow: 1, ... });
```
`flex` is not a valid TermUI style property and was silently ignored, causing columns to get zero height.
 
**Fix 3 — Missing `height: 1` on all `Text` widgets:**
```typescript
// Before
new Text(colData.title.toUpperCase(), { bold: true, fg: headerColor })
 
// After
new Text(colData.title.toUpperCase(), { bold: true, fg: headerColor, height: 1 })
```
Without explicit `height`, TermUI collapses `Text` widgets to zero height making them invisible. Applied to all Text widgets — column headers, dividers, card labels, and empty state text.
 
## Checklist
- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.
## GSSoC 2026 Participation
- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/944accbd-2283-4364-9c90-43bdbee0ecbf`
## Screenshot
<img width="1000" height="498" alt="image" src="https://github.com/user-attachments/assets/e35809f6-1954-4ae9-9ef5-92222205e25a" />

 
## Notes for the Reviewer
Three separate but related issues all caused by the same pattern — TermUI requires explicit layout values (`flexGrow` instead of `flex`, `height: 1` on Text) that differ from standard CSS/React conventions. No logic changes, purely layout fixes. Navigation and card movement logic was already correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added keyboard control documentation to the Kanban board example to guide users through available interactions.

* **Style**
  * Improved the visual layout and styling of the Kanban board UI with refined column header appearance, enhanced card rendering and sizing, and more consistent text colors and heights across both selected and non-selected card states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->