### PR TITLE
feat: Support CSS grid layout engine inside @termuijs/core (Closes #1351)

### DIFF
--- a/packages/core/src/layout/LayoutEngine.ts
+++ b/packages/core/src/layout/LayoutEngine.ts
@@ -209,10 +209,12 @@ function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, p
             const colInfo = getSpan(s.gridColumnStart, s.gridColumnEnd);
             const rowInfo = getSpan(s.gridRowStart, s.gridRowEnd);
 
+            const clampedColSpan = Math.max(1, Math.min(colInfo.span, numCols));
+
             while (true) {
                 let available = true;
                 for (let r = currentAutoRow; r < currentAutoRow + rowInfo.span; r++) {
-                    for (let c = currentAutoCol; c < currentAutoCol + colInfo.span; c++) {
+                    for (let c = currentAutoCol; c < currentAutoCol + clampedColSpan; c++) {
                         if (c >= numCols) {
                             available = false;
                             break;
@@ -231,16 +233,16 @@ function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, p
                         row: currentAutoRow,
                         col: currentAutoCol,
                         rowSpan: rowInfo.span,
-                        colSpan: colInfo.span
+                        colSpan: clampedColSpan
                     });
 
                     for (let r = currentAutoRow; r < currentAutoRow + rowInfo.span; r++) {
-                        for (let c = currentAutoCol; c < currentAutoCol + colInfo.span; c++) {
+                        for (let c = currentAutoCol; c < currentAutoCol + clampedColSpan; c++) {
                             setOccupied(r, c, true);
                         }
                     }
 
-                    currentAutoCol += colInfo.span;
+                    currentAutoCol += clampedColSpan;
                     if (currentAutoCol >= numCols) {
                         currentAutoCol = 0;
                         currentAutoRow++;
@@ -610,6 +612,8 @@ function getSpan(start: number | string | undefined, end: number | string | unde
         if (startIdx !== null) {
             span = Math.max(1, end - 1 - startIdx);
         } else {
+            // Note: When start is undefined, the numeric end value is interpreted as
+            // a span count rather than a grid line number.
             span = end;
         }
     } else if (typeof end === 'string') {

--- a/packages/core/src/layout/LayoutEngine.ts
+++ b/packages/core/src/layout/LayoutEngine.ts
@@ -145,6 +145,179 @@ function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, p
     const isRow = direction === 'row';
     const gap = style.gap ?? 0;
 
+    // ── Phase 0.0: CSS Grid Layout Solver ──
+    if (style.display === 'grid') {
+        const colGap = style.gridGap ?? style.gap ?? 0;
+        const rowGap = style.gridGap ?? style.gap ?? 0;
+
+        const colWidths = resolveTracks(style.gridTemplateColumns, innerWidth, colGap, 1);
+        const numCols = colWidths.length;
+
+        const occupied: boolean[][] = [];
+        const getOccupied = (r: number, c: number): boolean => {
+            if (!occupied[r]) return false;
+            return !!occupied[r][c];
+        };
+        const setOccupied = (r: number, c: number, val: boolean) => {
+            if (!occupied[r]) occupied[r] = [];
+            occupied[r][c] = val;
+        };
+
+        const placements: Array<{
+            child: LayoutNode;
+            row: number;
+            col: number;
+            rowSpan: number;
+            colSpan: number;
+        }> = [];
+
+        const autoChildren: LayoutNode[] = [];
+        for (const child of node.children) {
+            if (child.style.visible === false) continue;
+            const s = child.style;
+
+            const colInfo = getSpan(s.gridColumnStart, s.gridColumnEnd);
+            const rowInfo = getSpan(s.gridRowStart, s.gridRowEnd);
+
+            if (colInfo.start !== null || rowInfo.start !== null) {
+                const cStart = colInfo.start ?? 0;
+                const rStart = rowInfo.start ?? 0;
+
+                placements.push({
+                    child,
+                    row: rStart,
+                    col: cStart,
+                    rowSpan: rowInfo.span,
+                    colSpan: colInfo.span
+                });
+
+                for (let r = rStart; r < rStart + rowInfo.span; r++) {
+                    for (let c = cStart; c < cStart + colInfo.span; c++) {
+                        setOccupied(r, c, true);
+                    }
+                }
+            } else {
+                autoChildren.push(child);
+            }
+        }
+
+        let currentAutoRow = 0;
+        let currentAutoCol = 0;
+
+        for (const child of autoChildren) {
+            const s = child.style;
+            const colInfo = getSpan(s.gridColumnStart, s.gridColumnEnd);
+            const rowInfo = getSpan(s.gridRowStart, s.gridRowEnd);
+
+            while (true) {
+                let available = true;
+                for (let r = currentAutoRow; r < currentAutoRow + rowInfo.span; r++) {
+                    for (let c = currentAutoCol; c < currentAutoCol + colInfo.span; c++) {
+                        if (c >= numCols) {
+                            available = false;
+                            break;
+                        }
+                        if (getOccupied(r, c)) {
+                            available = false;
+                            break;
+                        }
+                    }
+                    if (!available) break;
+                }
+
+                if (available) {
+                    placements.push({
+                        child,
+                        row: currentAutoRow,
+                        col: currentAutoCol,
+                        rowSpan: rowInfo.span,
+                        colSpan: colInfo.span
+                    });
+
+                    for (let r = currentAutoRow; r < currentAutoRow + rowInfo.span; r++) {
+                        for (let c = currentAutoCol; c < currentAutoCol + colInfo.span; c++) {
+                            setOccupied(r, c, true);
+                        }
+                    }
+
+                    currentAutoCol += colInfo.span;
+                    if (currentAutoCol >= numCols) {
+                        currentAutoCol = 0;
+                        currentAutoRow++;
+                    }
+                    break;
+                } else {
+                    currentAutoCol++;
+                    if (currentAutoCol >= numCols) {
+                        currentAutoCol = 0;
+                        currentAutoRow++;
+                    }
+                }
+            }
+        }
+
+        let maxRowIndex = 0;
+        for (const p of placements) {
+            maxRowIndex = Math.max(maxRowIndex, p.row + p.rowSpan - 1);
+        }
+
+        const numRows = maxRowIndex + 1;
+        const rowHeights = resolveTracks(style.gridTemplateRows, innerHeight, rowGap, numRows);
+
+        const colOffsets: number[] = [];
+        let cOffset = 0;
+        for (let c = 0; c < colWidths.length; c++) {
+            colOffsets.push(cOffset);
+            cOffset += colWidths[c] + colGap;
+        }
+
+        const rowOffsets: number[] = [];
+        let rOffset = 0;
+        for (let r = 0; r < rowHeights.length; r++) {
+            rowOffsets.push(rOffset);
+            rOffset += rowHeights[r] + rowGap;
+        }
+
+        for (const p of placements) {
+            const child = p.child;
+
+            let itemWidth = 0;
+            for (let c = p.col; c < p.col + p.colSpan; c++) {
+                if (c < colWidths.length) itemWidth += colWidths[c];
+            }
+            if (p.colSpan > 1) {
+                itemWidth += (p.colSpan - 1) * colGap;
+            }
+
+            let itemHeight = 0;
+            for (let r = p.row; r < p.row + p.rowSpan; r++) {
+                if (r < rowHeights.length) itemHeight += rowHeights[r];
+            }
+            if (p.rowSpan > 1) {
+                itemHeight += (p.rowSpan - 1) * rowGap;
+            }
+
+            const xStart = colOffsets[p.col] ?? 0;
+            const yStart = rowOffsets[p.row] ?? 0;
+
+            const childMargin = normalizeEdges(child.style.margin);
+
+            child.computed = {
+                x: Math.floor(node.computed.x + innerX + xStart + childMargin.left),
+                y: Math.floor(node.computed.y + innerY + yStart + childMargin.top),
+                width: Math.round(Math.max(0, itemWidth - childMargin.left - childMargin.right)),
+                height: Math.round(Math.max(0, itemHeight - childMargin.top - childMargin.bottom))
+            };
+
+            layoutNode(child, child.computed.width, child.computed.height, true);
+        }
+
+        node._dirty = false;
+        node._lastComputedWidth = node.computed.width;
+        node._lastComputedHeight = node.computed.height;
+        return;
+    }
+
     // ── Phase 0.1: 1D Layout Constraints (Overrides Flexbox) ──
     if (style.constraints && style.constraints.length > 0) {
         const mainAvail = isRow ? innerWidth : innerHeight;
@@ -417,3 +590,89 @@ function clampSize(value: number, min?: number, max?: number): number {
     if (max !== undefined) result = Math.min(result, max);
     return result;
 }
+
+function getSpan(start: number | string | undefined, end: number | string | undefined): { start: number | null, span: number } {
+    let startIdx: number | null = null;
+    let span = 1;
+
+    if (typeof start === 'number') {
+        startIdx = start - 1;
+    } else if (typeof start === 'string') {
+        if (start.startsWith('span ')) {
+            span = parseInt(start.substring(5)) || 1;
+        } else {
+            const val = parseInt(start);
+            if (!isNaN(val)) startIdx = val - 1;
+        }
+    }
+
+    if (typeof end === 'number') {
+        if (startIdx !== null) {
+            span = Math.max(1, end - 1 - startIdx);
+        } else {
+            span = end;
+        }
+    } else if (typeof end === 'string') {
+        if (end.startsWith('span ')) {
+            span = parseInt(end.substring(5)) || 1;
+        } else {
+            const val = parseInt(end);
+            if (startIdx !== null && !isNaN(val)) {
+                span = Math.max(1, val - 1 - startIdx);
+            }
+        }
+    }
+    return { start: startIdx, span };
+}
+
+function resolveTracks(template: string | undefined, totalSize: number, gap: number, fallbackCount: number): number[] {
+    let parts: string[] = [];
+    if (template) {
+        parts = template.trim().split(/\s+/);
+    }
+    while (parts.length < fallbackCount) {
+        parts.push('1fr');
+    }
+    const count = parts.length;
+    const totalGaps = Math.max(0, count - 1) * gap;
+    const sizeForTracks = Math.max(0, totalSize - totalGaps);
+
+    let fixedSum = 0;
+    let frSum = 0;
+    const parsed = parts.map(part => {
+        if (part.endsWith('px')) {
+            const val = parseFloat(part);
+            fixedSum += val;
+            return { type: 'px', value: val };
+        } else if (part.endsWith('fr')) {
+            const val = parseFloat(part);
+            frSum += val;
+            return { type: 'fr', value: val };
+        } else if (part.endsWith('%')) {
+            const val = (parseFloat(part) / 100) * sizeForTracks;
+            fixedSum += val;
+            return { type: 'px', value: val };
+        } else if (part === 'auto') {
+            frSum += 1;
+            return { type: 'fr', value: 1 };
+        } else {
+            const val = parseFloat(part);
+            if (!isNaN(val)) {
+                fixedSum += val;
+                return { type: 'px', value: val };
+            }
+            frSum += 1;
+            return { type: 'fr', value: 1 };
+        }
+    });
+
+    const remaining = Math.max(0, sizeForTracks - fixedSum);
+    const frUnitValue = frSum > 0 ? remaining / frSum : 0;
+
+    return parsed.map(track => {
+        if (track.type === 'px') return track.value;
+        if (track.type === 'fr') return track.value * frUnitValue;
+        return 0;
+    });
+}
+

--- a/packages/core/src/style/Style.ts
+++ b/packages/core/src/style/Style.ts
@@ -66,6 +66,16 @@ export interface Style {
     flexWrap?: 'nowrap' | 'wrap';
     gap?: number;
 
+    // ── Grid Layout ─────────
+    display?: 'flex' | 'grid';
+    gridTemplateColumns?: string;
+    gridTemplateRows?: string;
+    gridColumnStart?: number | string;
+    gridColumnEnd?: number | string;
+    gridRowStart?: number | string;
+    gridRowEnd?: number | string;
+    gridGap?: number;
+
     // ── Overflow ────────────
     overflow?: 'visible' | 'hidden' | 'scroll';
 
@@ -141,6 +151,7 @@ export const LAYOUT_PROPS: ReadonlySet<keyof Style> = new Set<keyof Style>([
     'width', 'height', 'minWidth', 'minHeight', 'maxWidth', 'maxHeight',
     'padding', 'margin', 'border',
     'flexDirection', 'justifyContent', 'alignItems', 'flexGrow', 'flexShrink', 'flexWrap', 'gap',
+    'display', 'gridTemplateColumns', 'gridTemplateRows', 'gridColumnStart', 'gridColumnEnd', 'gridRowStart', 'gridRowEnd', 'gridGap',
     'overflow', 'visible',
 ]);
 

--- a/packages/jsx/src/reconciler.ts
+++ b/packages/jsx/src/reconciler.ts
@@ -129,8 +129,7 @@ function createIntrinsicWidget(tag: string, props: Record<string, any>, children
             return new Grid({ ...style }, {
                 columns: props.columns ?? 12,
                 gap: props.gap,
-                rowGap: props.rowGap,
-                colGap: props.colGap,
+                rows: props.rows,
             });
         }
 

--- a/packages/quick/src/widgets.ts
+++ b/packages/quick/src/widgets.ts
@@ -276,8 +276,6 @@ export function skeleton(opts: QuickSkeletonOptions = {}): Widget {
 
 export interface QuickGridOptions {
     gap?: number;
-    rowGap?: number;
-    colGap?: number;
 }
 
 /**
@@ -288,8 +286,6 @@ export function gridWidget(columns: number, items: Widget[], opts: QuickGridOpti
     const gridOpts: GridOptions = {
         columns,
         gap: opts.gap,
-        rowGap: opts.rowGap,
-        colGap: opts.colGap,
     };
     const g = new GridWidget({ flexGrow: 1 }, gridOpts);
     for (const item of items) {

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -86,8 +86,8 @@ export { GanttChart } from './data/GanttChart.js';
 export type { GanttChartOptions, GanttTask } from './data/GanttChart.js';
 
 // ── Layout Widgets ────────────────────────────────────
-export { Grid } from './layout/Grid.js';
-export type { GridOptions } from './layout/Grid.js';
+export { Grid, GridItem } from './layout/Grid.js';
+export type { GridOptions, GridItemOptions } from './layout/Grid.js';
 export { ScrollView } from './layout/ScrollView.js';
 export type { ScrollViewOptions } from './layout/ScrollView.js';
 export { Center } from './layout/Center.js';

--- a/packages/widgets/src/layout/Grid.test.ts
+++ b/packages/widgets/src/layout/Grid.test.ts
@@ -1,44 +1,14 @@
 // ─────────────────────────────────────────────────────
-// @termuijs/widgets — Tests for Grid layout
+// @termuijs/widgets — Tests for CSS Grid layout
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect } from 'vitest';
-import { Grid } from './Grid.js';
+import { Grid, GridItem } from './Grid.js';
 import { Box } from '../display/Box.js';
 import { computeLayout } from '@termuijs/core';
 
 describe('Grid layout', () => {
-    it('places children into rows based on column count', () => {
-        const grid = new Grid(
-            { width: 40, height: 20 },
-            { columns: 2, gap: 0 }
-        );
-    
-        const a = new Box();
-        const b = new Box();
-        const c = new Box();
-    
-        grid.addChild(a);
-        grid.addChild(b);
-        grid.addChild(c);
-    
-        const node = grid.getLayoutNode();
-        computeLayout(node, 40, 20);
-        grid.syncLayout();
-
-    
-        expect(grid.children.length).toBe(2);
-
-        expect(a.rect.x).toBe(0);
-        expect(b.rect.x).toBe(20);
-        
-        expect(a.rect.width).toBe(20);
-        expect(b.rect.width).toBe(20);
-
-        // third item starts a new row
-        expect(c.rect.x).toBe(0);
-    });
-    it('creates a new row after reaching column limit', () => {
+    it('places children into columns and rows (auto-placement)', () => {
         const grid = new Grid(
             { width: 40, height: 20 },
             { columns: 2, gap: 0 }
@@ -58,39 +28,160 @@ describe('Grid layout', () => {
         computeLayout(node, 40, 20);
         grid.syncLayout();
 
-        expect(grid.children.length).toBe(2);
+        // 4 children directly under the grid
+        expect(grid.children.length).toBe(4);
 
+        // Row 1 (y = 0), each takes half width (20 cells)
         expect(a.rect.x).toBe(0);
+        expect(a.rect.y).toBe(0);
+        expect(a.rect.width).toBe(20);
+        expect(a.rect.height).toBe(10); // Auto-row height: remaining / 2 rows = 10
+
         expect(b.rect.x).toBe(20);
-        
+        expect(b.rect.y).toBe(0);
+        expect(b.rect.width).toBe(20);
+        expect(b.rect.height).toBe(10);
+
+        // Row 2 (y = 10)
         expect(c.rect.x).toBe(0);
+        expect(c.rect.y).toBe(10);
+        expect(c.rect.width).toBe(20);
+        expect(c.rect.height).toBe(10);
+
         expect(d.rect.x).toBe(20);
+        expect(d.rect.y).toBe(10);
+        expect(d.rect.width).toBe(20);
+        expect(d.rect.height).toBe(10);
     });
 
-    it('addItem behaves the same as addChild', () => {
+    it('applies grid gaps correctly', () => {
+        const grid = new Grid(
+            { width: 41, height: 21 },
+            { columns: 2, gap: 1 }
+        );
+
+        const a = new Box();
+        const b = new Box();
+        const c = new Box();
+        const d = new Box();
+
+        grid.addChild(a);
+        grid.addChild(b);
+        grid.addChild(c);
+        grid.addChild(d);
+
+        const node = grid.getLayoutNode();
+        computeLayout(node, 41, 21);
+        grid.syncLayout();
+
+        // Width 41, gap 1 -> columns get (41 - 1)/2 = 20 width each.
+        // Height 21, gap 1 -> rows get (21 - 1)/2 = 10 height each.
+        expect(a.rect.x).toBe(0);
+        expect(a.rect.width).toBe(20);
+        expect(a.rect.height).toBe(10);
+
+        expect(b.rect.x).toBe(21); // 20 + gap 1
+        expect(b.rect.width).toBe(20);
+
+        expect(c.rect.y).toBe(11); // 10 + gap 1
+        expect(c.rect.height).toBe(10);
+    });
+
+    it('supports track sizing using px, fr, and %', () => {
+        const grid = new Grid(
+            { width: 50, height: 20 },
+            { columns: '10px 2fr 30%', gap: 0 }
+        );
+
+        const a = new Box();
+        const b = new Box();
+        const c = new Box();
+
+        grid.addChild(a);
+        grid.addChild(b);
+        grid.addChild(c);
+
+        const node = grid.getLayoutNode();
+        computeLayout(node, 50, 20);
+        grid.syncLayout();
+
+        // Column 1: 10px -> 10 cells
+        // Column 3: 30% of 50 -> 15 cells
+        // Column 2: 2fr -> takes remaining 25 cells (since total width is 50, 50 - 10 - 15 = 25)
+        expect(a.rect.width).toBe(10);
+        expect(b.rect.width).toBe(25);
+        expect(c.rect.width).toBe(15);
+
+        expect(a.rect.x).toBe(0);
+        expect(b.rect.x).toBe(10);
+        expect(c.rect.x).toBe(35);
+    });
+
+    it('supports column and row spans using GridItem', () => {
+        const grid = new Grid(
+            { width: 40, height: 20 },
+            { columns: '1fr 1fr', gap: 0 }
+        );
+
+        // GridItem spanning 2 columns
+        const a = new GridItem({}, { columnStart: 'span 2' });
+        const b = new Box();
+        const c = new Box();
+
+        grid.addChild(a);
+        grid.addChild(b);
+        grid.addChild(c);
+
+        const node = grid.getLayoutNode();
+        computeLayout(node, 40, 20);
+        grid.syncLayout();
+
+        // a spans 2 columns, so it takes full width of the first row
+        expect(a.rect.x).toBe(0);
+        expect(a.rect.y).toBe(0);
+        expect(a.rect.width).toBe(40);
+
+        // b and c are placed in the second row
+        expect(b.rect.x).toBe(0);
+        expect(b.rect.y).toBe(10);
+        expect(b.rect.width).toBe(20);
+
+        expect(c.rect.x).toBe(20);
+        expect(c.rect.y).toBe(10);
+        expect(c.rect.width).toBe(20);
+    });
+
+    it('respects child margins in layout cells', () => {
+        const grid = new Grid(
+            { width: 40, height: 20 },
+            { columns: 2, gap: 0 }
+        );
+
+        const a = new Box({ margin: 2 });
+        grid.addChild(a);
+
+        const node = grid.getLayoutNode();
+        computeLayout(node, 40, 20);
+        grid.syncLayout();
+
+        // a's grid cell is x: 0..20, y: 0..20. Margin is 2 all around.
+        expect(a.rect.x).toBe(2);
+        expect(a.rect.y).toBe(2);
+        expect(a.rect.width).toBe(16); // 20 - 2 (left) - 2 (right)
+        expect(a.rect.height).toBe(16); // 20 - 2 (top) - 2 (bottom)
+    });
+
+    it('addItem behaves the same as addChild and clearItems clears them', () => {
         const grid = new Grid(
             { width: 40, height: 20 },
             { columns: 2 }
         );
 
         const item = new Box();
-
         grid.addItem(item);
-
         expect(grid.children.length).toBe(1);
-    });
-
-    it('clearItems removes all rows and items', () => {
-        const grid = new Grid(
-            { width: 40, height: 20 },
-            { columns: 2 }
-        );
-
-        grid.addChild(new Box());
-        grid.addChild(new Box());
 
         grid.clearItems();
-
         expect(grid.children.length).toBe(0);
     });
 });

--- a/packages/widgets/src/layout/Grid.ts
+++ b/packages/widgets/src/layout/Grid.ts
@@ -58,6 +58,7 @@ export class Grid extends Widget {
             child.parent = null;
         }
         this._children = [];
+        this.markDirty();
     }
 
     protected _renderSelf(_screen: Screen): void {

--- a/packages/widgets/src/layout/Grid.ts
+++ b/packages/widgets/src/layout/Grid.ts
@@ -1,77 +1,49 @@
 // ─────────────────────────────────────────────────────
-// @termuijs/widgets — Grid layout widget
+// @termuijs/widgets — CSS Grid Layout Widgets
 // ─────────────────────────────────────────────────────
 
 import type { Screen, Style } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
-import { Box } from '../display/Box.js';
 
 export interface GridOptions {
-    /** Number of equal-width columns */
-    columns: number;
-    /** Gap between items in both directions (default: 1) */
+    /** CSS grid-template-columns track definitions, e.g. "1fr 2fr", "10 20" or number of columns */
+    columns?: number | string;
+    /** CSS grid-template-rows track definitions, e.g. "1fr 1fr", "auto" or number of rows */
+    rows?: number | string;
+    /** Grid gap in characters/cells */
     gap?: number;
-    /** Row gap override (overrides gap for rows) */
-    rowGap?: number;
-    /** Column gap override (overrides gap for columns) */
-    colGap?: number;
+}
+
+export interface GridItemOptions {
+    /** grid-column-start index (1-indexed) or "span N" */
+    columnStart?: number | string;
+    /** grid-column-end index (1-indexed) or "span N" */
+    columnEnd?: number | string;
+    /** grid-row-start index (1-indexed) or "span N" */
+    rowStart?: number | string;
+    /** grid-row-end index (1-indexed) or "span N" */
+    rowEnd?: number | string;
 }
 
 /**
- * Grid — a CSS-Grid-like layout widget.
- *
- * Items fill left-to-right, wrapping to a new row every `columns` items.
- * Internally creates a column-flex Box per row, each with equal-flex-grow items.
- *
- * The `addChild()` override means the reconciler's generic child-adding
- * loop works without any special casing.
+ * Grid — a true CSS-Grid-like layout container.
  */
 export class Grid extends Widget {
-    private _columns: number;
-    private _colGap: number;
-    private _rowGap: number;
-    private _rows: Box[] = [];
-    private _itemCount: number = 0;
+    constructor(style: Partial<Style> = {}, options: GridOptions = {}) {
+        const columns = typeof options.columns === 'number'
+            ? Array(Math.max(1, options.columns)).fill('1fr').join(' ')
+            : options.columns;
+        const rows = typeof options.rows === 'number'
+            ? Array(Math.max(1, options.rows)).fill('1fr').join(' ')
+            : options.rows;
 
-    constructor(style: Partial<Style>, options: GridOptions) {
-        super({ flexDirection: 'column', ...style });
-        this._columns = Math.max(1, options.columns);
-        const gap = options.gap ?? 1;
-        this._colGap = options.colGap ?? gap;
-        this._rowGap = options.rowGap ?? gap;
-    }
-
-    protected _renderSelf(_screen: Screen): void {
-        // Grid is a pure layout container — no self-rendering needed.
-    }
-
-    /**
-     * Add a widget to the grid. Items fill left-to-right,
-     * wrapping to a new row automatically every `columns` items.
-     * Overrides Widget.addChild so the reconciler generic loop works unchanged.
-     */
-    override addChild(widget: Widget): void {
-        const rowIndex = Math.floor(this._itemCount / this._columns);
-
-        // Create a new row Box if needed
-        if (rowIndex >= this._rows.length) {
-            const rowStyle: Partial<Style> = { flexDirection: 'row' };
-            if (this._colGap > 0) rowStyle.gap = this._colGap;
-            // Add row gap as margin-top on rows after the first
-            if (this._rows.length > 0 && this._rowGap > 0) {
-                rowStyle.margin = this._rowGap;
-            }
-            const row = new Box(rowStyle);
-            this._rows.push(row);
-            // Register the row as a child of this widget
-            super.addChild(row);
-        }
-
-        // Add item to the current row with equal flex growth
-        const currentRow = this._rows[rowIndex];
-        widget.setStyle({ flexGrow: 1 });
-        currentRow.addChild(widget);
-        this._itemCount++;
+        super({
+            display: 'grid',
+            gridTemplateColumns: columns,
+            gridTemplateRows: rows,
+            gridGap: options.gap,
+            ...style
+        });
     }
 
     /** Add an item explicitly (alias for addChild) */
@@ -81,13 +53,33 @@ export class Grid extends Widget {
 
     /** Remove all items and reset the grid */
     clearItems(): void {
-        // Unmount and detach every row
-        for (const row of this._rows) {
-            row.unmount();
-            row.parent = null;
+        for (const child of this._children) {
+            child.unmount();
+            child.parent = null;
         }
         this._children = [];
-        this._rows = [];
-        this._itemCount = 0;
+    }
+
+    protected _renderSelf(_screen: Screen): void {
+        // Grid is a pure layout container — no self-rendering needed.
+    }
+}
+
+/**
+ * GridItem — a child container that can define grid column/row spans or starts.
+ */
+export class GridItem extends Widget {
+    constructor(style: Partial<Style> = {}, options: GridItemOptions = {}) {
+        super({
+            gridColumnStart: options.columnStart,
+            gridColumnEnd: options.columnEnd,
+            gridRowStart: options.rowStart,
+            gridRowEnd: options.rowEnd,
+            ...style
+        });
+    }
+
+    protected _renderSelf(_screen: Screen): void {
+        // Pure layout container — no self-rendering needed.
     }
 }


### PR DESCRIPTION

## What problem does this solve?
This Pull Request Closes #1351. It implements core layout/rendering capabilities inside TermUI packages.

## Proposed solution
Created Grid.tsx widget and integrated track parsing calculations in core layout managers.

## Which package would this belong in?
- packages/widgets/src/Grid.tsx

## GSSoC contributor?
- [x] Yes. You contribute under GSSoC 2026 and want to work on this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CSS Grid layout support with auto-placement and `span` handling for explicit and spanning track placement.
  * Introduced `GridItem` for setting grid cell coordinates (`columnStart/End`, `rowStart/End`).
  * Simplified grid spacing via a single `gap` option and unified grid template configuration.
* **Tests**
  * Expanded `Grid` test coverage for auto-placement, track sizing (`px`, `fr`, `%`), gap behavior, margins within cells, and `GridItem` spanning.
* **Changes**
  * Updated style/layout handling to treat grid-related properties as layout-affecting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->