### PR TITLE
bug: Resolve input parser crash on rare/multibyte emoji sequences (Closes #1354)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,7 @@ export { InputParser } from './input/InputParser.js';
 export { ESCAPE_SEQUENCES, CTRL_KEYS, SPECIAL_KEYS, normalizeNavigationKey } from './input/KeyMap.js';
 export { parseMouseEvent, isMouseSequence } from './input/MouseParser.js';
 export { MouseGestures } from './input/MouseGestures.js';
+export { splitGraphemes } from './input/grapheme.js';
 export type { MouseGesturesOptions } from './input/MouseGestures.js';
 export { ChordMatcher } from './input/ChordMatcher.js';
 export type { ChordMatcherOptions, Chord } from './input/ChordMatcher.js';

--- a/packages/core/src/input/InputParser.test.ts
+++ b/packages/core/src/input/InputParser.test.ts
@@ -2,9 +2,15 @@
 // @termuijs/core — Tests for InputParser
 // ─────────────────────────────────────────────────────
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { InputParser } from './InputParser.js';
-import { createMockStdin, sendKey } from '../../../../tests/helpers/mock-stdin.js';
+import { createMockStdin, sendKey as originalSendKey } from '../../../../tests/helpers/mock-stdin.js';
+
+function sendKey(stdin: any, key: any) {
+    originalSendKey(stdin, key);
+    vi.advanceTimersByTime(10);
+}
 
 function createParser() {
     const stdin = createMockStdin();
@@ -16,6 +22,10 @@ function createParser() {
 }
 
 describe('InputParser', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
     afterEach(() => {
         vi.restoreAllMocks();
         vi.useRealTimers();
@@ -237,14 +247,25 @@ describe('InputParser', () => {
         expect(handler).toHaveBeenCalledWith(expect.objectContaining({ key: 'a' }));
     });
 
-    it('processes rapid multi-byte input correctly', () => {
+    it('parses split multibyte emoji sequences arriving in chunks', () => {
         const { stdin, handler } = createParser();
-        sendKey(stdin, 'abc');
-        expect(handler).toHaveBeenCalledTimes(3);
-        expect(handler).toHaveBeenCalledWith(expect.objectContaining({ key: 'a' }));
-        expect(handler).toHaveBeenCalledWith(expect.objectContaining({ key: 'b' }));
-        expect(handler).toHaveBeenCalledWith(expect.objectContaining({ key: 'c' }));
+
+        // Wave emoji with medium skin tone: 👋🏽 (\u{1F44B}\u{1F3FD})
+        // Encoded in UTF-8 as: [0xf0, 0x9f, 0x91, 0x8b, 0xf0, 0x9f, 0x8f, 0xbd]
+        const chunk1 = Buffer.from([0xf0, 0x9f, 0x91, 0x8b]);
+        const chunk2 = Buffer.from([0xf0, 0x9f, 0x8f, 0xbd]);
+
+        originalSendKey(stdin, chunk1);
+        // Should not emit yet as it is incomplete
+        expect(handler).not.toHaveBeenCalled();
+
+        originalSendKey(stdin, chunk2);
+        // Now it is complete
+        vi.advanceTimersByTime(10);
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(handler).toHaveBeenCalledWith(expect.objectContaining({ key: '👋🏽' }));
     });
+
     it('emits paste event for bracketed paste', () => {
         const stdin = createMockStdin();
         const parser = new InputParser(stdin);

--- a/packages/core/src/input/InputParser.ts
+++ b/packages/core/src/input/InputParser.ts
@@ -3,6 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { Buffer } from 'node:buffer';
+import { StringDecoder } from 'node:string_decoder';
 import type { KeyEvent, MouseEvent } from '../events/types.js';
 import { createKeyEvent } from '../events/types.js';
 import { ESCAPE_SEQUENCES, CTRL_KEYS, SPECIAL_KEYS } from './KeyMap.js';
@@ -29,6 +30,9 @@ interface InputEvents {
 export class InputParser {
     private _events = new EventEmitter<InputEvents>();
     private _stdin: NodeJS.ReadStream;
+    private _decoder = new StringDecoder('utf8');
+    private _graphemeBuffer = '';
+    private _graphemeTimeout: ReturnType<typeof setTimeout> | null = null;
     private _handler: ((data: Buffer) => void) | null = null;
     private _escapeTimeout: ReturnType<typeof setTimeout> | null = null;
     private _escapeBuffer: Buffer = Buffer.alloc(0);
@@ -98,7 +102,13 @@ export class InputParser {
             clearTimeout(this._escapeTimeout);
             this._escapeTimeout = null;
         }
+        if (this._graphemeTimeout) {
+            clearTimeout(this._graphemeTimeout);
+            this._graphemeTimeout = null;
+        }
         this._escapeBuffer = Buffer.alloc(0);
+        this._graphemeBuffer = '';
+        this._decoder.end();
         for (const req of this._cursorRequests) {
             clearTimeout(req.timeout);
             req.reject(new Error('InputParser stopped'));
@@ -110,6 +120,17 @@ export class InputParser {
      * Process a chunk of raw input bytes.
      */
     private _processInput(data: Buffer): void {
+        // If we are currently collecting an escape sequence, continue collecting it
+        if (this._escapeBuffer.length > 0) {
+            this._escapeBuffer = Buffer.concat([this._escapeBuffer, data]);
+            if (this._escapeTimeout) {
+                clearTimeout(this._escapeTimeout);
+                this._escapeTimeout = null;
+            }
+            this._tryParseEscape();
+            return;
+        }
+
         const str = data.toString('utf8');
         const PASTE_START = '\x1b[200~';
         const PASTE_END = '\x1b[201~';
@@ -120,16 +141,6 @@ export class InputParser {
                 .replace(PASTE_END, '');
 
             this._events.emit('paste', pastedText);
-            return;
-        }
-        // If we're collecting an escape sequence
-        if (this._escapeBuffer.length > 0) {
-            this._escapeBuffer = Buffer.concat([this._escapeBuffer, data]);
-            if (this._escapeTimeout) {
-                clearTimeout(this._escapeTimeout);
-                this._escapeTimeout = null;
-            }
-            this._tryParseEscape();
             return;
         }
 
@@ -158,8 +169,37 @@ export class InputParser {
             return;
         }
 
-        // Process each grapheme for non-escape input
-        for (const ch of splitGraphemes(str)) {
+        // Decode input and append to grapheme buffer
+        const decoded = this._decoder.write(data);
+        this._graphemeBuffer += decoded;
+
+        if (this._graphemeTimeout) {
+            clearTimeout(this._graphemeTimeout);
+            this._graphemeTimeout = null;
+        }
+
+        // Process after a short 10ms delay to merge split chunks (like modifiers or ZWJ sequences)
+        this._graphemeTimeout = setTimeout(() => {
+            this._processGraphemeBuffer();
+            this._graphemeTimeout = null;
+        }, 10);
+    }
+
+    private _processGraphemeBuffer(): void {
+        if (!this._graphemeBuffer) return;
+
+        const graphemes = splitGraphemes(this._graphemeBuffer);
+        if (graphemes.length === 0) return;
+
+        let processCount = graphemes.length;
+        // Check if the last grapheme is potentially incomplete
+        const lastGrapheme = graphemes[graphemes.length - 1];
+        if (this._isPossiblyIncompleteGrapheme(lastGrapheme)) {
+            processCount = graphemes.length - 1;
+        }
+
+        for (let i = 0; i < processCount; i++) {
+            const ch = graphemes[i];
             const code = ch.codePointAt(0)!;
             const raw = Buffer.from(ch, 'utf8');
 
@@ -200,6 +240,38 @@ export class InputParser {
                 }));
             }
         }
+
+        // Update the remaining buffer
+        this._graphemeBuffer = graphemes.slice(processCount).join('');
+    }
+
+    private _isPossiblyIncompleteGrapheme(ch: string): boolean {
+        if (!ch) return false;
+        // ZWJ sequence continuation check
+        if (ch.endsWith('\u200D')) return true;
+        // Surrogate pair incomplete check (last char is high surrogate)
+        const lastCharCode = ch.charCodeAt(ch.length - 1);
+        if (lastCharCode >= 0xD800 && lastCharCode <= 0xDBFF) return true;
+        
+        // Regional Indicator Symbols (flags: U+1F1E6 to U+1F1FF)
+        // Check if there's an odd number of regional indicator symbols in this grapheme
+        const codePoints = Array.from(ch);
+        const lastCpVal = codePoints[codePoints.length - 1].codePointAt(0)!;
+        if (lastCpVal >= 0x1F1E6 && lastCpVal <= 0x1F1FF) {
+            let riCount = 0;
+            for (let i = codePoints.length - 1; i >= 0; i--) {
+                const cp = codePoints[i].codePointAt(0)!;
+                if (cp >= 0x1F1E6 && cp <= 0x1F1FF) {
+                    riCount++;
+                } else {
+                    break;
+                }
+            }
+            if (riCount % 2 !== 0) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/packages/core/src/input/InputParser.ts
+++ b/packages/core/src/input/InputParser.ts
@@ -8,6 +8,7 @@ import { createKeyEvent } from '../events/types.js';
 import { ESCAPE_SEQUENCES, CTRL_KEYS, SPECIAL_KEYS } from './KeyMap.js';
 import { parseMouseEvent, isMouseSequence } from './MouseParser.js';
 import { EventEmitter } from '../events/EventEmitter.js';
+import { splitGraphemes } from './grapheme.js';
 
 export interface CursorPosition {
     row: number;
@@ -157,8 +158,8 @@ export class InputParser {
             return;
         }
 
-        // Process each code point for non-escape input
-        for (const ch of str) {
+        // Process each grapheme for non-escape input
+        for (const ch of splitGraphemes(str)) {
             const code = ch.codePointAt(0)!;
             const raw = Buffer.from(ch, 'utf8');
 

--- a/packages/core/src/input/grapheme.test.ts
+++ b/packages/core/src/input/grapheme.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { splitGraphemes } from './grapheme.js';
+
+describe('splitGraphemes', () => {
+    it('splits plain ASCII strings into characters', () => {
+        expect(splitGraphemes('hello')).toEqual(['h', 'e', 'l', 'l', 'o']);
+    });
+
+    it('splits skin-tone modifier emoji sequences as single graphemes', () => {
+        // Wave emoji with medium skin tone
+        expect(splitGraphemes('👋🏽')).toEqual(['👋🏽']);
+        expect(splitGraphemes('hello👋🏽world')).toEqual(['h', 'e', 'l', 'l', 'o', '👋🏽', 'w', 'o', 'r', 'l', 'd']);
+    });
+
+    it('splits zero-width joiner (ZWJ) family emoji sequences as single graphemes', () => {
+        // Family: Man, Woman, Girl, Boy
+        const familyEmoji = '👨‍👩‍👧‍👦';
+        expect(splitGraphemes(familyEmoji)).toEqual([familyEmoji]);
+    });
+});

--- a/packages/core/src/input/grapheme.ts
+++ b/packages/core/src/input/grapheme.ts
@@ -1,5 +1,6 @@
 // Grapheme splitting helper
+const GRAPHEME_SEGMENTER = new Intl.Segmenter('en', { granularity: 'grapheme' });
+
 export const splitGraphemes = (str: string): string[] => {
-    const segmenter = new Intl.Segmenter('en', { granularity: 'grapheme' });
-    return Array.from(segmenter.segment(str), s => s.segment);
+    return Array.from(GRAPHEME_SEGMENTER.segment(str), s => s.segment);
 };

--- a/packages/core/src/input/grapheme.ts
+++ b/packages/core/src/input/grapheme.ts
@@ -1,0 +1,5 @@
+// Grapheme splitting helper
+export const splitGraphemes = (str: string): string[] => {
+    const segmenter = new Intl.Segmenter('en', { granularity: 'grapheme' });
+    return Array.from(segmenter.segment(str), s => s.segment);
+};


### PR DESCRIPTION

## What problem does this solve?
This Pull Request Closes #1354. It implements core layout/rendering capabilities inside TermUI packages.

## Proposed solution
Added grapheme.ts helper to handle multi-byte skin tone modifiers and prevent parser splits.

## Which package would this belong in?
- packages/core/src/input/grapheme.ts

## GSSoC contributor?
- [x] Yes. You contribute under GSSoC 2026 and want to work on this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added grapheme segmentation functionality for more accurate text processing across diverse character types.

* **Bug Fixes**
  * Enhanced input parsing to correctly handle complex multi-byte characters, including emoji with skin-tone modifiers, zero-width joiner sequences, and surrogate pairs as unified grapheme clusters.

* **Tests**
  * Added comprehensive test coverage for grapheme segmentation and multi-byte character input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->