### PR TITLE
perf(display): avoid redundant DirectoryTree selection updates

### DIFF
--- a/packages/widgets/src/display/DirectoryTree.test.ts
+++ b/packages/widgets/src/display/DirectoryTree.test.ts
@@ -97,4 +97,27 @@ describe('DirectoryTree', () => {
 
         expect(hasASCIIFile || hasASCIIDir).toBe(true);
     });
+
+    it('does not mark dirty when pressing up on the first item', () => {
+        const tree = new DirectoryTree({ tree: sampleTree });
+    
+        tree.clearDirty();
+    
+        tree.handleKey('up');
+    
+        expect(tree.isDirty).toBe(false);
+    });
+    
+    it('does not mark dirty when pressing down on the last item', () => {
+        const tree = new DirectoryTree({ tree: sampleTree });
+    
+        tree.handleKey('down'); // move to last item
+    
+        tree.clearDirty();
+    
+        tree.handleKey('down'); // already at last item
+    
+        expect(tree.isDirty).toBe(false);
+    });
+
 });

--- a/packages/widgets/src/display/DirectoryTree.ts
+++ b/packages/widgets/src/display/DirectoryTree.ts
@@ -87,21 +87,33 @@ handleKey(key: string) {
     if (!current) return;
 
     switch (key) {
-        case 'down':
-            this._selectedIndex = Math.min(
+        case 'down': {
+            const next = Math.min(
                 this._selectedIndex + 1,
                 this._visible.length - 1,
             );
-            this.markDirty();
+        
+            if (next !== this._selectedIndex) {
+                this._selectedIndex = next;
+                this.markDirty();
+            }
+        
             break;
-
-        case 'up':
-            this._selectedIndex = Math.max(
+        }
+        
+        case 'up': {
+            const next = Math.max(
                 this._selectedIndex - 1,
                 0,
             );
-            this.markDirty();
+        
+            if (next !== this._selectedIndex) {
+                this._selectedIndex = next;
+                this.markDirty();
+            }
+        
             break;
+        }
 
         case 'right':
         case 'enter':


### PR DESCRIPTION
## Description

This PR optimizes DirectoryTree navigation by preventing unnecessary dirty-state updates when navigation keys are pressed but the selected item does not change. It also adds regression tests to verify that the widget only marks itself dirty when the selection actually changes.

## Related Issue

Closes #1388 

## Which package(s)?

@termuijs/widgets

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [x] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest packages/widgets/src/display/DirectoryTree.test.ts --run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

DirectoryTree now skips `markDirty()` when navigation keys (`up` / `down`) do not result in a selection change, such as pressing `up` on the first item or `down` on the last item.

Added regression tests to verify that redundant navigation events do not invalidate the widget while normal selection changes continue to behave as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard navigation in the directory tree to prevent the component from being unnecessarily marked as modified when navigating at list boundaries (attempting to move beyond the first or last item).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->