### PR TITLE
perf(ui): avoid redundant Combobox invalidation

### DIFF
--- a/packages/ui/src/Combobox.test.ts
+++ b/packages/ui/src/Combobox.test.ts
@@ -182,3 +182,43 @@ describe('Combobox', () => {
         expect(cb.filtered.length).toBe(1);
     });
 });
+
+describe('Performance optimizations', () => {
+    it('does not mark dirty when escape is pressed while already closed', () => {
+        const cb = new Combobox([
+            { label: 'Apple', value: 'a' }
+        ]);
+
+        cb.clearDirty();
+
+        cb.handleKey(makeKey('escape'));
+
+        expect(cb.isDirty).toBe(false);
+    });
+
+    it('does not mark dirty when backspace is pressed on empty input', () => {
+        const cb = new Combobox([
+            { label: 'Apple', value: 'a' }
+        ]);
+
+        cb.clearDirty();
+
+        cb.handleKey(makeKey('backspace'));
+
+        expect(cb.isDirty).toBe(false);
+    });
+
+    it('marks dirty when backspace removes a character', () => {
+        const cb = new Combobox([
+            { label: 'Apple', value: 'a' }
+        ]);
+
+        cb.handleKey(makeKey('a'));
+
+        cb.clearDirty();
+
+        cb.handleKey(makeKey('backspace'));
+
+        expect(cb.isDirty).toBe(true);
+    });
+});

--- a/packages/ui/src/Combobox.ts
+++ b/packages/ui/src/Combobox.ts
@@ -81,6 +81,10 @@ export class Combobox extends Widget {
         }
 
         if (key === 'escape') {
+            if (!this._isOpen && this._selectedIndex === -1) {
+                return;
+            }
+        
             this._isOpen = false;
             this._selectedIndex = -1;
             this.markDirty();
@@ -104,11 +108,13 @@ export class Combobox extends Widget {
         }
 
         if (key === 'backspace') {
-            if (this._inputValue.length > 0) {
-                this._inputValue = this._inputValue.slice(0, -1);
-                this._isOpen = true;
-                this._selectedIndex = -1;
+            if (this._inputValue.length === 0) {
+                return;
             }
+        
+            this._inputValue = this._inputValue.slice(0, -1);
+            this._isOpen = true;
+            this._selectedIndex = -1;
             this.markDirty();
             return;
         }


### PR DESCRIPTION
## Description

This PR optimizes Combobox rendering by avoiding unnecessary dirty-state updates when users press `Escape` while the dropdown is already closed or `Backspace` when the input is already empty.

Regression tests have been added to verify that redundant key actions do not trigger widget invalidation, while valid input changes continue to mark the widget dirty as expected.

## Related Issue

Closes #1392 

## Which package(s)?

@termuijs/ui

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [ ] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [x] ⚡ Performance (`type:performance`)
* [x] 🧪 Tests (`type:testing`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

The optimization introduces early-return guards for two no-op user interactions:

* Pressing `Escape` when the dropdown is already closed.
* Pressing `Backspace` when the input field is empty.

These actions previously triggered unnecessary invalidation despite producing no visible state change. Added regression tests cover both no-op paths and confirm that valid input modifications still mark the widget dirty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced Combobox component performance by preventing unnecessary state updates when pressing escape on already-closed dropdowns or backspace with empty input fields.

* **Tests**
  * Added comprehensive tests validating Combobox keyboard interaction behavior during edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->