### PR TITLE
perf(input): avoid redundant TextInput cursor updates

### DIFF
--- a/packages/widgets/src/input/TextInput.test.ts
+++ b/packages/widgets/src/input/TextInput.test.ts
@@ -210,6 +210,7 @@ describe('TextInput', () => {
         const input = new TextInput();
         input.value = 'abc';
 
+        input.moveCursorEnd();
         input.clearDirty();
         input.moveCursorLeft();
         expect(input.isDirty).toBe(true);
@@ -225,5 +226,53 @@ describe('TextInput', () => {
         input.clearDirty();
         input.moveCursorEnd();
         expect(input.isDirty).toBe(true);
+    });
+});
+
+describe('Performance optimizations', () => {
+    it('does not mark dirty when moveCursorLeft is called at the start', () => {
+        const input = new TextInput();
+
+        input.moveCursorHome();
+        input.clearDirty();
+
+        input.moveCursorLeft();
+
+        expect(input.isDirty).toBe(false);
+    });
+
+    it('does not mark dirty when moveCursorRight is called at the end', () => {
+        const input = new TextInput();
+        input.value = 'abc';
+        input.moveCursorEnd();
+
+        input.clearDirty();
+
+        input.moveCursorRight();
+
+        expect(input.isDirty).toBe(false);
+    });
+
+    it('does not mark dirty when moveCursorHome is called at home position', () => {
+        const input = new TextInput();
+
+        input.moveCursorHome();
+        input.clearDirty();
+
+        input.moveCursorHome();
+
+        expect(input.isDirty).toBe(false);
+    });
+
+    it('does not mark dirty when moveCursorEnd is called at end position', () => {
+        const input = new TextInput();
+        input.value = 'abc';
+        input.moveCursorEnd();
+
+        input.clearDirty();
+
+        input.moveCursorEnd();
+
+        expect(input.isDirty).toBe(false);
     });
 });

--- a/packages/widgets/src/input/TextInput.ts
+++ b/packages/widgets/src/input/TextInput.ts
@@ -91,18 +91,43 @@ export class TextInput extends Widget {
         }
     }
 
-    moveCursorLeft(): void { this._cursorPos = Math.max(0, this._cursorPos - 1); 
+    moveCursorLeft(): void {
+        const next = Math.max(0, this._cursorPos - 1);
+    
+        if (next === this._cursorPos) {
+            return;
+        }
+    
+        this._cursorPos = next;
         this.markDirty();
     }
-    moveCursorRight(): void { this._cursorPos = Math.min(this._value.length, this._cursorPos + 1); 
+    moveCursorRight(): void {
+        const next = Math.min(this._value.length, this._cursorPos + 1);
+    
+        if (next === this._cursorPos) {
+            return;
+        }
+    
+        this._cursorPos = next;
         this.markDirty();
     }
-    moveCursorHome(): void { this._cursorPos = 0; 
+    moveCursorHome(): void {
+        if (this._cursorPos === 0) {
+            return;
+        }
+    
+        this._cursorPos = 0;
         this.markDirty();
     }
-    moveCursorEnd(): void { this._cursorPos = this._value.length;
+    moveCursorEnd(): void {
+        if (this._cursorPos === this._value.length) {
+            return;
+        }
+    
+        this._cursorPos = this._value.length;
         this.markDirty();
-     }
+    }
+
     submit(): void { this._onSubmit?.(this._value); }
     clear(): void { this._value = ''; this._cursorPos = 0; this._onChange?.(''); 
         this.markDirty();


### PR DESCRIPTION
## Description

This PR optimizes TextInput cursor navigation by preventing unnecessary dirty-state updates when cursor movement methods are called while already at their target positions.

It also adds regression tests to verify that dirty state is only triggered when the cursor position actually changes.

## Related Issue

Closes #1394 

## Which package(s)?

`@termuijs/widgets`

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [x] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest packages/widgets/src/input/TextInput.test.ts --run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

Cursor movement methods (`moveCursorLeft`, `moveCursorRight`, `moveCursorHome`, and `moveCursorEnd`) now return early when the cursor position would remain unchanged, avoiding unnecessary widget invalidation and re-rendering.

Added regression tests covering both optimized no-op cursor movements and normal cursor movements that should still mark the widget dirty.

Widget-specific tests pass locally. Repository-wide build/typecheck failures appear to originate from unrelated upstream issues in other packages (`@termuijs/adapters` and `example-snake-game`) and are not caused by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Text input fields no longer unnecessarily mark as modified when cursor movement occurs at boundary positions (start, end, or home).

* **Tests**
  * Added test coverage for cursor movement behavior at boundary positions in text input fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->