### PR TITLE
perf(feedback): avoid redundant Progress invalidation on unchanged tasks

### DIFF
--- a/packages/widgets/src/feedback/Progress.test.ts
+++ b/packages/widgets/src/feedback/Progress.test.ts
@@ -46,4 +46,39 @@ describe("Progress", () => {
         
         expect(screen.back[0].map(c => c.char).join('')).toContain('100%')
     })
+
+    it("does not mark dirty when setTasks receives the same array reference", () => {
+        const tasks = [
+            { label: 'Downloading', value: 0.5 }
+        ];
+    
+        const widget = new Progress({
+            tasks,
+            columns: [TextColumn(), PercentageColumn()]
+        });
+    
+        widget.clearDirty();
+    
+        widget.setTasks(tasks);
+    
+        expect(widget.isDirty).toBe(false);
+    });
+    
+    it("marks dirty when setTasks receives a different array", () => {
+        const widget = new Progress({
+            tasks: [
+                { label: 'Downloading', value: 0.5 }
+            ],
+            columns: [TextColumn(), PercentageColumn()]
+        });
+    
+        widget.clearDirty();
+    
+        widget.setTasks([
+            { label: 'Downloading', value: 0.75 }
+        ]);
+    
+        expect(widget.isDirty).toBe(true);
+    });
+
 })

--- a/packages/widgets/src/feedback/Progress.ts
+++ b/packages/widgets/src/feedback/Progress.ts
@@ -108,6 +108,9 @@ this._columns =
     }
 
     public setTasks(tasks: ProgressTask[]): void {
+        if (tasks === this._tasks) {
+            return;
+        }
     this._tasks = tasks;
     this.markDirty();
 }


### PR DESCRIPTION
## Description

This PR optimizes the `Progress` widget by avoiding unnecessary invalidation when `setTasks()` receives the same task array reference. It also adds regression tests to verify dirty-state behavior for both unchanged and updated task lists.

## Related Issue

Closes #1396

## Which package(s)?

`@termuijs/widgets`

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [x] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

`setTasks()` now returns early when the incoming task array is the same reference as the current one, preventing unnecessary dirty-state updates and re-renders. Regression tests have been added to verify correct behavior for both unchanged and updated task lists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized the Progress widget to prevent redundant state updates when the same task array is reapplied, improving overall performance and ensuring accurate dirty-state tracking during task management workflows.

* **Tests**
  * Added comprehensive test cases for Progress widget dirty-state behavior to verify proper handling when tasks are updated with the same or different array references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->