### PR TITLE
perf(feedback): avoid redundant ProgressBar invalidation

### DIFF
--- a/packages/widgets/src/feedback/ProgressBar.test.ts
+++ b/packages/widgets/src/feedback/ProgressBar.test.ts
@@ -171,3 +171,25 @@ describe('ProgressBar — ASCII fallback', () => {
         expect(fillChar).toBe('=');
     });
 });
+
+describe('Performance optimizations', () => {
+    it('does not mark dirty when setValue receives the same value', () => {
+        const pb = new ProgressBar({}, { value: 0.5 });
+
+        pb.clearDirty();
+
+        pb.setValue(0.5);
+
+        expect(pb.isDirty).toBe(false);
+    });
+
+    it('marks dirty when setValue receives a different value', () => {
+        const pb = new ProgressBar({}, { value: 0.5 });
+
+        pb.clearDirty();
+
+        pb.setValue(0.75);
+
+        expect(pb.isDirty).toBe(true);
+    });
+});

--- a/packages/widgets/src/feedback/ProgressBar.ts
+++ b/packages/widgets/src/feedback/ProgressBar.ts
@@ -53,7 +53,13 @@ export class ProgressBar extends Widget {
 
     /** Set progress value (0–1) */
     setValue(value: number): void {
-        this._value = Math.max(0, Math.min(1, value));
+        const normalized = Math.max(0, Math.min(1, value));
+    
+        if (this._value === normalized) {
+            return;
+        }
+    
+        this._value = normalized;
         this.markDirty();
     }
 


### PR DESCRIPTION
## Description

This PR optimizes `ProgressBar` updates by avoiding unnecessary dirty-state invalidation when `setValue()` receives the same normalized value. It also adds regression tests to verify that the widget only marks itself dirty when the progress value actually changes.

## Related Issue

Closes #1398 

## Which package(s)?

`@termuijs/widgets`

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [x] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

Added an early-return guard in `setValue()` to skip redundant invalidation when the normalized incoming value matches the current state. Regression tests cover both unchanged-value and changed-value scenarios to ensure dirty-state behavior remains correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * ProgressBar now skips unnecessary updates when the value remains unchanged, improving performance and reducing redundant processing.

* **Tests**
  * Added test coverage to verify ProgressBar's optimized update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->