### PR TITLE
perf(input): avoid redundant List invalidation on unchanged items

### DIFF
--- a/packages/widgets/src/input/List.test.ts
+++ b/packages/widgets/src/input/List.test.ts
@@ -71,4 +71,33 @@ describe('List', () => {
         list.selectNext();
         expect(list.isDirty).toBe(true);
     });
+
+    it('does not mark dirty when setItems receives the same array reference', () => {
+        const items = [
+            { label: 'Apple', value: 'apple' }
+        ];
+    
+        const list = new List(items);
+    
+        list.clearDirty();
+    
+        list.setItems(items);
+    
+        expect(list.isDirty).toBe(false);
+    });
+    
+    it('marks dirty when setItems receives a different array', () => {
+        const list = new List([
+            { label: 'Apple', value: 'apple' }
+        ]);
+    
+        list.clearDirty();
+    
+        list.setItems([
+            { label: 'Banana', value: 'banana' }
+        ]);
+    
+        expect(list.isDirty).toBe(true);
+    });
+
 });

--- a/packages/widgets/src/input/List.ts
+++ b/packages/widgets/src/input/List.ts
@@ -75,6 +75,9 @@ export class List extends Widget {
     // ── Mutations ─────────────────────────────────────
 
     setItems(items: ListItem[]): void {
+        if (items === this._items) {
+            return;
+        }
         this._items = items;
         if (this._selectedIndex >= items.length) {
             this._selectedIndex = Math.max(0, items.length - 1);


### PR DESCRIPTION
## Description

This PR optimizes `List` updates by avoiding redundant invalidation when `setItems()` receives the same array reference. It also adds regression tests to verify that the widget only marks itself dirty when the items collection actually changes.

## Related Issue

Closes #1400 

## Which package(s)?

`@termuijs/widgets`

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [x] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

Added a reference-equality guard in `setItems()` to skip unnecessary invalidation when the same items array instance is provided. Regression tests cover both unchanged-array and changed-array scenarios to ensure dirty-state behavior remains correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed widget state management to correctly handle identical data updates.

* **Tests**
  * Added test coverage for widget state behavior during item updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->