### PR TITLE
perf(feedback): avoid redundant Alert invalidation on unchanged content

### DIFF
--- a/packages/widgets/src/feedback/Alert.test.ts
+++ b/packages/widgets/src/feedback/Alert.test.ts
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────
-// @termuijs/widgets — Tests for Alert widget
+// @termuijs/widgets — Tests for Alert widge
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
@@ -125,47 +125,47 @@ describe('Alert — Setters and Getters', () => {
 
     it('does not mark dirty when setMessage receives the same value', () => {
         const alert = new Alert({ message: 'Build complete' });
-    
+
         alert.clearDirty();
-    
+
         alert.setMessage('Build complete');
-    
+
         expect(alert.isDirty).toBe(false);
     });
-    
+
     it('marks dirty when setMessage receives a different value', () => {
         const alert = new Alert({ message: 'Build complete' });
-    
+
         alert.clearDirty();
-    
+
         alert.setMessage('Build failed');
-    
+
         expect(alert.isDirty).toBe(true);
     });
-    
+
     it('does not mark dirty when setVariant receives the same value', () => {
         const alert = new Alert({
             message: 'Test',
             variant: 'success',
         });
-    
+
         alert.clearDirty();
-    
+
         alert.setVariant('success');
-    
+
         expect(alert.isDirty).toBe(false);
     });
-    
+
     it('marks dirty when setVariant receives a different value', () => {
         const alert = new Alert({
             message: 'Test',
             variant: 'info',
         });
-    
+
         alert.clearDirty();
-    
+
         alert.setVariant('error');
-    
+
         expect(alert.isDirty).toBe(true);
     });
 

--- a/packages/widgets/src/feedback/Alert.test.ts
+++ b/packages/widgets/src/feedback/Alert.test.ts
@@ -122,4 +122,51 @@ describe('Alert — Setters and Getters', () => {
         expect(alert.getVariant()).toBe('success');
         expect(alert.isDirty).toBe(true);
     });
+
+    it('does not mark dirty when setMessage receives the same value', () => {
+        const alert = new Alert({ message: 'Build complete' });
+    
+        alert.clearDirty();
+    
+        alert.setMessage('Build complete');
+    
+        expect(alert.isDirty).toBe(false);
+    });
+    
+    it('marks dirty when setMessage receives a different value', () => {
+        const alert = new Alert({ message: 'Build complete' });
+    
+        alert.clearDirty();
+    
+        alert.setMessage('Build failed');
+    
+        expect(alert.isDirty).toBe(true);
+    });
+    
+    it('does not mark dirty when setVariant receives the same value', () => {
+        const alert = new Alert({
+            message: 'Test',
+            variant: 'success',
+        });
+    
+        alert.clearDirty();
+    
+        alert.setVariant('success');
+    
+        expect(alert.isDirty).toBe(false);
+    });
+    
+    it('marks dirty when setVariant receives a different value', () => {
+        const alert = new Alert({
+            message: 'Test',
+            variant: 'info',
+        });
+    
+        alert.clearDirty();
+    
+        alert.setVariant('error');
+    
+        expect(alert.isDirty).toBe(true);
+    });
+
 });

--- a/packages/widgets/src/feedback/Alert.ts
+++ b/packages/widgets/src/feedback/Alert.ts
@@ -58,6 +58,9 @@ export class Alert extends Widget {
 
     /** Set the alert message */
     setMessage(message: string): void {
+        if (message === this._message) {
+            return;
+        }
         this._message = message;
         this.markDirty();
     }
@@ -69,6 +72,9 @@ export class Alert extends Widget {
 
     /** Set the alert variant */
     setVariant(variant: StatusVariant): void {
+        if (variant === this._variant) {
+            return;
+        }
         this._variant = variant;
         this.markDirty();
     }


### PR DESCRIPTION
## Description

This PR optimizes the `Alert` widget by avoiding redundant invalidation when `setMessage()` or `setVariant()` receives the same value as the current state. It also adds regression tests to verify that dirty-state updates occur only when content actually changes.

## Related Issue

Closes #1402 

## Which package(s)?

`@termuijs/widgets`

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [x] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

Added equality guards to `setMessage()` and `setVariant()` to skip unnecessary invalidation when the incoming value matches the existing state. Added regression tests covering both unchanged and changed values to ensure dirty-state behavior remains correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test coverage for Alert's setter methods to verify dirty-state behavior with both unchanged and changed values.

* **Performance**
  * Optimized Alert's `setMessage` and `setVariant` methods to eliminate redundant state updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->