### PR TITLE
test: add snapshot tests for Table widget

### DIFF
--- a/packages/widgets/src/data/Table.snapshot.test.ts
+++ b/packages/widgets/src/data/Table.snapshot.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { Screen } from '@termuijs/core';
+import { Table } from './Table.js';
+
+const screenText = (screen: Screen): string =>
+    screen.back.map(r => r.map(c => c.char).join('')).join('\n');
+
+describe('Table snapshot tests', () => {
+    it('renders 3-column table', () => {
+        const table = new Table(
+            [
+                { key: 'name', header: 'Name', width: 10 },
+                { key: 'age', header: 'Age', width: 5 },
+                { key: 'role', header: 'Role', width: 10 },
+            ],
+            [
+                { name: 'Alice', age: 22, role: 'Dev' },
+            ]
+        );
+
+        table.updateRect({ x: 0, y: 0, width: 40, height: 10 });
+
+        const screen = new Screen(40, 10);
+        table.render(screen);
+
+        expect(screenText(screen)).toMatchSnapshot();
+    });
+
+    it('renders headers only when rows are empty', () => {
+        const table = new Table(
+            [
+                { key: 'name', header: 'Name', width: 10 },
+                { key: 'age', header: 'Age', width: 5 },
+            ],
+            []
+        );
+
+        table.updateRect({ x: 0, y: 0, width: 30, height: 10 });
+
+        const screen = new Screen(30, 10);
+        table.render(screen);
+
+        expect(screenText(screen)).toMatchSnapshot();
+    });
+
+    it('truncates long content', () => {
+        const table = new Table(
+            [
+                { key: 'name', header: 'Name', width: 8 },
+                { key: 'role', header: 'Role', width: 8 },
+            ],
+            [
+                {
+                    name: 'VeryLongNameThatShouldCut',
+                    role: 'VeryLongRoleName',
+                },
+            ]
+        );
+
+        table.updateRect({ x: 0, y: 0, width: 25, height: 10 });
+
+        const screen = new Screen(25, 10);
+        table.render(screen);
+
+        expect(screenText(screen)).toMatchSnapshot();
+    });
+});

--- a/packages/widgets/src/data/__snapshots__/Table.snapshot.test.ts.snap
+++ b/packages/widgets/src/data/__snapshots__/Table.snapshot.test.ts.snap
@@ -1,0 +1,40 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Table snapshot tests > renders 3-column table 1`] = `
+"Name       │ Age   │ Role               
+────────────────────────────────────────
+Alice      │ 22    │ Dev                
+                                        
+                                        
+                                        
+                                        
+                                        
+                                        
+                                        "
+`;
+
+exports[`Table snapshot tests > renders headers only when rows are empty 1`] = `
+"Name       │ Age              
+──────────────────────────────
+                              
+                              
+                              
+                              
+                              
+                              
+                              
+                              "
+`;
+
+exports[`Table snapshot tests > truncates long content 1`] = `
+"Name     │ Role          
+─────────────────────────
+VeryLon… │ VeryLon…      
+                         
+                         
+                         
+                         
+                         
+                         
+                         "
+`;


### PR DESCRIPTION
## Description

Added snapshot tests for the Table widget using `renderToString()` to help detect UI regressions. The tests cover table rendering, header rendering with empty rows, and long content truncation.

## Related Issue

Closes #13

## Which package(s)?

@termuijs/widgets

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read `CONTRIBUTING.md`.
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: https://gssoc.girlscript.org/profile/e28902d6-ac09-4030-a305-38827f21efb0

## Screenshots / Recordings (UI changes)

N/A (test-only change)

## Notes for the Reviewer

Added snapshot coverage for:

* 3-column table rendering
* Empty rows rendering headers only
* Long content truncation

Snapshot files were generated and committed with the tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added snapshot test suite for the Table component, verifying proper rendering across multiple scenarios including basic table display, empty row handling with visible headers, and content truncation within column width constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->