### PR TITLE
feat:added animation rules

### DIFF
--- a/packages/tss/src/animations.test.ts
+++ b/packages/tss/src/animations.test.ts
@@ -74,3 +74,13 @@ it('extractKeyframes produces Record<string, Record<string, string>>', () => {
         '100%': { opacity: '1',   color: 'blue' },
     });
 });
+
+it('extractKeyframes merges properties from duplicate offsets', () => {
+    const ast = parse(tokenize(
+        `@keyframes pulse { 0% { opacity: 0; } 0% { scale: 1; } 100% { opacity: 1; } }`
+    ));
+    const decls = extractKeyframes(ast);
+    expect(decls).toHaveLength(1);
+    expect(decls[0].frames['0%']).toEqual({ opacity: '0', scale: '1' });
+    expect(decls[0].frames['100%']).toEqual({ opacity: '1' });
+});

--- a/packages/tss/src/animations.test.ts
+++ b/packages/tss/src/animations.test.ts
@@ -1,0 +1,76 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/tss — Tests for @keyframes support
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import { tokenize } from './tokenizer.js';
+import { TokenType } from './tokenizer.js';
+import { parse } from './parser.js';
+import { extractKeyframes } from './animations.js';
+
+// ── Pre-check: tokenizer handles % correctly ──
+
+it('tokenizer produces Number then Percent for 0%', () => {
+    const tokens = tokenize('0%');
+    const nums = tokens.filter(t => t.type === TokenType.Number);
+    const pcts = tokens.filter(t => t.type === TokenType.Percent);
+    expect(nums).toHaveLength(1);
+    expect(nums[0].value).toBe('0');
+    expect(pcts).toHaveLength(1);
+});
+
+it('tokenizer produces Number then Percent for 100%', () => {
+    const tokens = tokenize('100%');
+    const nums = tokens.filter(t => t.type === TokenType.Number);
+    expect(nums[0].value).toBe('100');
+    expect(tokens.filter(t => t.type === TokenType.Percent)).toHaveLength(1);
+});
+
+// ── Parsing via tokenizer → parser pipeline ──
+
+it('parses @keyframes with two frames', () => {
+    const ast = parse(tokenize(
+        `@keyframes fadeIn { 0% { opacity: 0; } 100% { opacity: 1; } }`
+    ));
+    expect(ast.keyframes).toHaveLength(1);
+    expect(ast.keyframes[0].name).toBe('fadeIn');
+    expect(ast.keyframes[0].frames).toHaveLength(2);
+    expect(ast.keyframes[0].frames[0].offset).toBe('0%');
+    expect(ast.keyframes[0].frames[0].properties[0]).toMatchObject({ name: 'opacity' });
+});
+
+it('parses multiple @keyframes declarations', () => {
+    const ast = parse(tokenize(
+        `@keyframes a { 0% { x: 1; } 100% { x: 2; } }
+         @keyframes b { 0% { y: 1; } 100% { y: 2; } }`
+    ));
+    expect(ast.keyframes).toHaveLength(2);
+    expect(ast.keyframes[0].name).toBe('a');
+    expect(ast.keyframes[1].name).toBe('b');
+});
+
+it('handles empty @keyframes block', () => {
+    const ast = parse(tokenize(`@keyframes empty { }`));
+    expect(ast.keyframes).toHaveLength(1);
+    expect(ast.keyframes[0].frames).toHaveLength(0);
+});
+
+it('throws when keyframe offset lacks % sign', () => {
+    expect(() => parse(tokenize(
+        `@keyframes fade { 0 { opacity: 0; } }`
+    ))).toThrow();
+});
+
+// ── extractKeyframes ──
+
+it('extractKeyframes produces Record<string, Record<string, string>>', () => {
+    const ast = parse(tokenize(
+        `@keyframes fadeIn { 0% { opacity: 0; color: var(--base); } 100% { opacity: 1; color: blue; } }`
+    ));
+    const decls = extractKeyframes(ast);
+    expect(decls).toHaveLength(1);
+    expect(decls[0].frames).toEqual({
+        '0%':   { opacity: '0',   color: 'var(--base)' },
+        '100%': { opacity: '1',   color: 'blue' },
+    });
+});

--- a/packages/tss/src/animations.ts
+++ b/packages/tss/src/animations.ts
@@ -1,0 +1,52 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/tss — @keyframes support
+// ─────────────────────────────────────────────────────
+
+import type { TSSStylesheet } from './parser.js';
+
+// ── Public types ──
+
+/** A single @keyframes declaration in consumer-facing format.
+ *  Matches the issue spec shape: { '0%': { color: 'red' }, '100%': { color: 'blue' } } */
+export interface KeyframesDeclaration {
+    name: string;
+    /** Map of percentage offset → CSS property map */
+    frames: Record<string, Record<string, string>>;
+}
+
+// ── Extract from parsed stylesheet ──
+
+/** Extract KeyframesDeclaration[] from a parsed TSS stylesheet.
+ *  Call after parse(tokenize(source)) to convert internal AST to
+ *  the consumer-friendly Record<string, Record<string, string>> format.
+ *
+ *  @example
+ *  const ast = parse(tokenize(tssSource));
+ *  const anims = extractKeyframes(ast);
+ *  // anims[0].frames → { '0%': { opacity: '0' }, '100%': { opacity: '1' } }
+ */
+export function extractKeyframes(stylesheet: TSSStylesheet): KeyframesDeclaration[] {
+    return stylesheet.keyframes.map(kf => ({
+        name: kf.name,
+        frames: Object.fromEntries(
+            kf.frames.map(frame => [
+                frame.offset,
+                Object.fromEntries(
+                    frame.properties.map(p => [p.name, serializeValue(p.value)]),
+                ),
+            ]),
+        ),
+    }));
+}
+
+// ── Internal ──
+
+/** Convert typed TSSValue to its plain string representation. */
+function serializeValue(v: { kind: string; value?: unknown; name?: string }): string {
+    switch (v.kind) {
+        case 'var':    return `var(${v.name})`;
+        case 'color':  // falls through — both carry a string .value
+        case 'number': return String(v.value ?? '');
+        default:       return String(v.value ?? '');   // 'literal' and future kinds
+    }
+}

--- a/packages/tss/src/animations.ts
+++ b/packages/tss/src/animations.ts
@@ -26,17 +26,17 @@ export interface KeyframesDeclaration {
  *  // anims[0].frames → { '0%': { opacity: '0' }, '100%': { opacity: '1' } }
  */
 export function extractKeyframes(stylesheet: TSSStylesheet): KeyframesDeclaration[] {
-    return stylesheet.keyframes.map(kf => ({
-        name: kf.name,
-        frames: Object.fromEntries(
-            kf.frames.map(frame => [
-                frame.offset,
-                Object.fromEntries(
-                    frame.properties.map(p => [p.name, serializeValue(p.value)]),
-                ),
-            ]),
-        ),
-    }));
+    return stylesheet.keyframes.map(kf => {
+        const frames: Record<string, Record<string, string>> = {};
+        for (const frame of kf.frames) {
+            const props: Record<string, string> = {};
+            for (const p of frame.properties) {
+                props[p.name] = serializeValue(p.value);
+            }
+            frames[frame.offset] = { ...(frames[frame.offset] ?? {}), ...props };
+        }
+        return { name: kf.name, frames };
+    });
 }
 
 // ── Internal ──

--- a/packages/tss/src/engine.test.ts
+++ b/packages/tss/src/engine.test.ts
@@ -4,9 +4,6 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { ThemeEngine } from './engine.js';
-import { tokenize } from './tokenizer.js';
-import { parse } from './parser.js';
-import { extractKeyframes } from './animations.js';
 
 const TSS_SOURCE = `
 @theme default {
@@ -97,17 +94,11 @@ describe('ThemeEngine', () => {
 
     // ── @keyframes pipeline ──
 
-    it('engine.load() preserves @keyframes through the tokenize→parse pipeline', () => {
+    it('engine.load() preserves @keyframes observable via getKeyframes()', () => {
         const engine = new ThemeEngine();
-        const source = `@keyframes fade { 0% { opacity: 0; } 100% { opacity: 1; } }\nBox { bold: true; }`;
-        engine.load(source);
+        engine.load(`@keyframes fade { 0% { opacity: 0; } 100% { opacity: 1; } }\nBox { bold: true; }`);
 
-        // Simulate the exact pipeline that engine.load() runs internally:
-        //   const tokens = tokenize(source);
-        //   this._stylesheet = parse(tokens);
-        const ast = parse(tokenize(source));
-        const decls = extractKeyframes(ast);
-
+        const decls = engine.getKeyframes();
         expect(decls).toHaveLength(1);
         expect(decls[0].name).toBe('fade');
         expect(decls[0].frames).toEqual({
@@ -120,17 +111,14 @@ describe('ThemeEngine', () => {
         expect(style.bold).toBe(true);
     });
 
-    it('loadAll() preserves @keyframes from merged sources', () => {
+    it('loadAll() preserves keyframes from merged sources observable via getKeyframes()', () => {
         const engine = new ThemeEngine();
-        const src1 = '@keyframes fadeIn { 0% { opacity: 0; } 100% { opacity: 1; } }';
-        const src2 = '@keyframes slideUp { 0% { y: 10; } 100% { y: 0; } }';
-        engine.loadAll([src1, src2]);
+        engine.loadAll([
+            '@keyframes fadeIn { 0% { opacity: 0; } 100% { opacity: 1; } }',
+            '@keyframes slideUp { 0% { y: 10; } 100% { y: 0; } }',
+        ]);
 
-        // Simulate the merged pipeline (what loadAll produces internally)
-        const merged = `${src1}\n${src2}`;
-        const ast = parse(tokenize(merged));
-        const decls = extractKeyframes(ast);
-
+        const decls = engine.getKeyframes();
         expect(decls).toHaveLength(2);
         expect(decls.map(d => d.name)).toEqual(['fadeIn', 'slideUp']);
     });

--- a/packages/tss/src/engine.test.ts
+++ b/packages/tss/src/engine.test.ts
@@ -4,6 +4,9 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { ThemeEngine } from './engine.js';
+import { tokenize } from './tokenizer.js';
+import { parse } from './parser.js';
+import { extractKeyframes } from './animations.js';
 
 const TSS_SOURCE = `
 @theme default {
@@ -90,5 +93,45 @@ describe('ThemeEngine', () => {
         ]);
         expect(engine.getVariable('--a')).toBe('red');
         expect(engine.rules.length).toBeGreaterThan(0);
+    });
+
+    // ── @keyframes pipeline ──
+
+    it('engine.load() preserves @keyframes through the tokenize→parse pipeline', () => {
+        const engine = new ThemeEngine();
+        const source = `@keyframes fade { 0% { opacity: 0; } 100% { opacity: 1; } }\nBox { bold: true; }`;
+        engine.load(source);
+
+        // Simulate the exact pipeline that engine.load() runs internally:
+        //   const tokens = tokenize(source);
+        //   this._stylesheet = parse(tokens);
+        const ast = parse(tokenize(source));
+        const decls = extractKeyframes(ast);
+
+        expect(decls).toHaveLength(1);
+        expect(decls[0].name).toBe('fade');
+        expect(decls[0].frames).toEqual({
+            '0%':   { opacity: '0' },
+            '100%': { opacity: '1' },
+        });
+
+        // Engine must still resolve regular rules after loading @keyframes
+        const style = engine.resolveStyle('Box');
+        expect(style.bold).toBe(true);
+    });
+
+    it('loadAll() preserves @keyframes from merged sources', () => {
+        const engine = new ThemeEngine();
+        const src1 = '@keyframes fadeIn { 0% { opacity: 0; } 100% { opacity: 1; } }';
+        const src2 = '@keyframes slideUp { 0% { y: 10; } 100% { y: 0; } }';
+        engine.loadAll([src1, src2]);
+
+        // Simulate the merged pipeline (what loadAll produces internally)
+        const merged = `${src1}\n${src2}`;
+        const ast = parse(tokenize(merged));
+        const decls = extractKeyframes(ast);
+
+        expect(decls).toHaveLength(2);
+        expect(decls.map(d => d.name)).toEqual(['fadeIn', 'slideUp']);
     });
 });

--- a/packages/tss/src/engine.ts
+++ b/packages/tss/src/engine.ts
@@ -77,12 +77,13 @@ export class ThemeEngine {
 
     /** Load multiple .tss sources (merged) */
     loadAll(sources: string[]): void {
-        const merged: TSSStylesheet = { themes: [], rules: [], mixins: new Map() };
+        const merged: TSSStylesheet = { themes: [], rules: [], mixins: new Map(), keyframes: [] };
         for (const src of sources) {
             const tokens = tokenize(src);
             const ast = parse(tokens);
             merged.themes.push(...ast.themes);
             merged.rules.push(...ast.rules);
+            merged.keyframes.push(...ast.keyframes);
             for (const [name, props] of ast.mixins) {
                 merged.mixins.set(name, props);
             }

--- a/packages/tss/src/engine.ts
+++ b/packages/tss/src/engine.ts
@@ -7,6 +7,7 @@ import { parse, type TSSStylesheet, type TSSRule, type TSSSelector, type TSSValu
 import { type Style, type Color, type BorderStyle, parseColor } from '@termuijs/core';
 import { evalCalc } from './calc.js';
 import { matchesPseudo } from './pseudo.js';
+import { extractKeyframes, type KeyframesDeclaration } from './animations.js';
 
 export function compile(source: string): string {
     const tokens = tokenize(source);
@@ -105,6 +106,11 @@ export class ThemeEngine {
     /** Get list of available theme names */
     get availableThemes(): string[] {
         return this._stylesheet?.themes.map(t => t.name) ?? [];
+    }
+
+    /** Get parsed @keyframes declarations from the loaded stylesheet */
+    getKeyframes(): KeyframesDeclaration[] {
+        return this._stylesheet ? extractKeyframes(this._stylesheet) : [];
     }
 
     /** Subscribe to theme changes */

--- a/packages/tss/src/index.ts
+++ b/packages/tss/src/index.ts
@@ -49,3 +49,7 @@ export type { AutoThemeProviderProps } from './AutoThemeProvider.js';
 export * from './media.js';
 export * from './importer.js';
 export { lighten, darken, alpha, evalColorFunction } from './color-functions.js';
+
+// @keyframes support
+export { extractKeyframes } from './animations.js';
+export type { KeyframesDeclaration } from './animations.js';

--- a/packages/tss/src/parser.ts
+++ b/packages/tss/src/parser.ts
@@ -10,6 +10,7 @@ export interface TSSStylesheet {
     themes: TSSTheme[];
     rules: TSSRule[];
     mixins: Map<string, TSSProperty[]>;
+    keyframes: TSSKeyframes[];
 }
 
 export interface TSSTheme {
@@ -41,11 +42,23 @@ export interface TSSRule {
     nested?: TSSRule[];
 }
 
+export interface TSSAnimationFrame {
+    /** Percentage string, e.g. '0%', '50%', '100%' */
+    offset: string;
+    /** Property declarations at this keyframe */
+    properties: TSSProperty[];
+}
+
+export interface TSSKeyframes {
+    name: string;
+    frames: TSSAnimationFrame[];
+}
+
 // ── Parser ──
 
 export function parse(tokens: Token[]): TSSStylesheet {
     let pos = 0;
-    const stylesheet: TSSStylesheet = { themes: [], rules: [], mixins: new Map() };
+    const stylesheet: TSSStylesheet = { themes: [], rules: [], mixins: new Map(), keyframes: [] };
 
     const peek = () => tokens[pos] ?? { type: TokenType.EOF, value: '', line: 0, col: 0 };
     const advance = () => tokens[pos++];
@@ -61,6 +74,8 @@ export function parse(tokens: Token[]): TSSStylesheet {
         } else if (peek().type === TokenType.AtMixin) {
             const { name, properties } = parseMixin();
             stylesheet.mixins.set(name, properties);
+        } else if (peek().type === TokenType.AtKeyframes) {
+            stylesheet.keyframes.push(parseKeyframes());
         } else if (peek().type === TokenType.Ident || peek().type === TokenType.Dot || peek().type === TokenType.PseudoClass) {
             stylesheet.rules.push(parseRule());
         } else {
@@ -108,6 +123,36 @@ export function parse(tokens: Token[]): TSSStylesheet {
         }
         expect(TokenType.RBrace);
         return { name, properties };
+    }
+
+    function parseKeyframes(): TSSKeyframes {
+        expect(TokenType.AtKeyframes);
+        const name = expect(TokenType.Ident).value;
+        expect(TokenType.LBrace);
+        const frames: TSSAnimationFrame[] = [];
+        while (peek().type !== TokenType.RBrace && peek().type !== TokenType.EOF) {
+            const offsetNum = expect(TokenType.Number).value;
+            expect(TokenType.Percent);
+            const offset = offsetNum + '%';
+            expect(TokenType.LBrace);
+            const properties: TSSProperty[] = [];
+            while (peek().type !== TokenType.RBrace && peek().type !== TokenType.EOF) {
+                if (peek().type === TokenType.Ident && tokens[pos + 1]?.type === TokenType.Colon) {
+                    const propName = advance().value;
+                    advance(); // skip Colon
+                    const value = parseValue();
+                    properties.push({ name: propName, value });
+                    if (peek().type === TokenType.Semicolon) advance();
+                } else {
+                    advance();
+                }
+            }
+            expect(TokenType.RBrace);
+            frames.push({ offset, properties });
+        }
+
+        expect(TokenType.RBrace);
+        return { name, frames };
     }
 
     function parseRule(): TSSRule {

--- a/packages/tss/src/tokenizer.ts
+++ b/packages/tss/src/tokenizer.ts
@@ -7,6 +7,7 @@ export enum TokenType {
     AtTheme = 'AT_THEME',
     AtMixin = 'AT_MIXIN',      // @mixin
     AtInclude = 'AT_INCLUDE',  // @include
+    AtKeyframes = 'AT_KEYFRAMES', // @keyframes
     LBrace = 'LBRACE',
     RBrace = 'RBRACE',
     Colon = 'COLON',
@@ -15,6 +16,7 @@ export enum TokenType {
     Comma = 'COMMA',
 
     // Values
+    Percent = 'PERCENT',      // %
     Ident = 'IDENT',
     String = 'STRING',
     Number = 'NUMBER',
@@ -91,8 +93,9 @@ export function tokenize(source: string): Token[] {
         if (ch === ';') { tokens.push({ type: TokenType.Semicolon, value: ';', line, col }); advance(); continue; }
         if (ch === '.') { tokens.push({ type: TokenType.Dot, value: '.', line, col }); advance(); continue; }
         if (ch === ',') { tokens.push({ type: TokenType.Comma, value: ',', line, col }); advance(); continue; }
+        if (ch === '%') { tokens.push({ type: TokenType.Percent, value: '%', line, col }); advance(); continue; }
 
-        // @ directives: @theme, @mixin, @include
+        // @ directives: @theme, @mixin, @include, @keyframes
         if (ch === '@') {
             const startCol = col;
             advance();
@@ -104,6 +107,8 @@ export function tokenize(source: string): Token[] {
                 tokens.push({ type: TokenType.AtMixin, value: '@mixin', line, col: startCol });
             } else if (word === 'include') {
                 tokens.push({ type: TokenType.AtInclude, value: '@include', line, col: startCol });
+            } else if (word === 'keyframes') {
+                tokens.push({ type: TokenType.AtKeyframes, value: '@keyframes', line, col: startCol });
             } else {
                 tokens.push({ type: TokenType.Ident, value: '@' + word, line, col: startCol });
             }


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

Adds @keyframes declaration support to @termuijs/tss.

This PR introduces tokenizer and parser support for @keyframes blocks, adds keyframe AST types, preserves keyframes through the engine pipeline (including loadAll() merging), and provides extractKeyframes() to convert parsed animations into a consumer-friendly format for handoff to @termuijs/motion.

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #314 

## Which package(s)?

<!-- Example: @termuijs/core, @termuijs/widgets, website. -->
@termuijs/tss

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/0ea29967-7ada-4e3b-83ec-9da126f5d72a`

## Screenshots / Recordings (UI changes)

Not applicable. This PR adds parser/engine support for TSS @keyframes declarations and does not introduce or modify any UI component.

## Notes for the Reviewer

- Added AtKeyframes and Percent token support in the tokenizer.
- Added TSSKeyframes and TSSAnimationFrame AST types.
- Added parseKeyframes() to parse @keyframes declarations.
- Extended TSSStylesheet with a keyframes collection.

- Added extractKeyframes() in animations.ts to convert parsed keyframes into the consumer-facing format:

    {
        "0%": { opacity: "0" },
        "100%": { opacity: "1" }
    }

- Fixed loadAll() to merge keyframes alongside themes, rules, and mixins.
- Added tests covering tokenizer, parser, extraction, and engine integration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `@keyframes` animation declarations in stylesheets

* **API**
  * New helper to extract keyframe definitions and a typed KeyframesDeclaration shape
  * Engine API exposes loaded keyframes via a public getKeyframes() method
  * Keyframes extraction is re-exported from the package entry point

* **Tests**
  * Comprehensive tests for tokenization, parsing, extraction, merging, and error cases for `@keyframes`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->