### PR TITLE
feat(adapters): add useExeca and useShell hooks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -357,6 +357,7 @@
         "@types/node": "^22.0.0",
         "conf": "^10.2.0",
         "dotenv": "^16.0.0",
+        "execa": "^8.0.1",
         "tsup": "^8.3.0",
         "typescript": "^5.7.0",
         "zod": "^3.0.0",
@@ -368,6 +369,7 @@
         "commander": "^15.0.0",
         "conf": "^10.2.0",
         "dotenv": "^16.0.0",
+        "execa": "^8.0.0",
         "keytar": "^7.9.0",
         "openai": "^4.0.0",
         "simple-git": "^3.27.0",
@@ -380,6 +382,7 @@
         "commander",
         "conf",
         "dotenv",
+        "execa",
         "keytar",
         "openai",
         "simple-git",
@@ -879,6 +882,8 @@
 
     "create-termui-app": ["create-termui-app@workspace:packages/create-termui-app"],
 
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
     "data-grid-example": ["data-grid-example@workspace:examples/data-grid"],
 
     "debounce-fn": ["debounce-fn@4.0.0", "", { "dependencies": { "mimic-fn": "^3.0.0" } }, "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ=="],
@@ -901,6 +906,8 @@
 
     "examples-weather": ["examples-weather@workspace:examples/weather"],
 
+    "execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
+
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
@@ -915,11 +922,19 @@
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "get-stream": ["get-stream@8.0.1", "", {}, "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA=="],
+
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
+    "human-signals": ["human-signals@5.0.0", "", {}, "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ=="],
+
     "is-obj": ["is-obj@2.0.0", "", {}, "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="],
+
+    "is-stream": ["is-stream@3.0.0", "", {}, "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
 
@@ -973,6 +988,8 @@
 
     "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
+    "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
+
     "mimic-fn": ["mimic-fn@3.1.0", "", {}, "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ=="],
 
     "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
@@ -982,6 +999,8 @@
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
     "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "npm-run-path": ["npm-run-path@5.3.0", "", { "dependencies": { "path-key": "^4.0.0" } }, "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -996,6 +1015,8 @@
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
     "path-exists": ["path-exists@3.0.0", "", {}, "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -1025,7 +1046,13 @@
 
     "semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
 
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
@@ -1034,6 +1061,8 @@
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
+
+    "strip-final-newline": ["strip-final-newline@3.0.0", "", {}, "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="],
 
     "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
 
@@ -1071,6 +1100,8 @@
 
     "vitest": ["vitest@4.1.8", "", { "dependencies": { "@vitest/expect": "4.1.8", "@vitest/mocker": "4.1.8", "@vitest/pretty-format": "4.1.8", "@vitest/runner": "4.1.8", "@vitest/snapshot": "4.1.8", "@vitest/spy": "4.1.8", "@vitest/utils": "4.1.8", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.8", "@vitest/browser-preview": "4.1.8", "@vitest/browser-webdriverio": "4.1.8", "@vitest/coverage-istanbul": "4.1.8", "@vitest/coverage-v8": "4.1.8", "@vitest/ui": "4.1.8", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig=="],
 
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -1087,6 +1118,10 @@
 
     "@termuijs/ui/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
+    "execa/onetime": ["onetime@6.0.0", "", { "dependencies": { "mimic-fn": "^4.0.0" } }, "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ=="],
+
+    "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
+
     "onetime/mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
@@ -1102,5 +1137,7 @@
     "@termuijs/example-todo/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@termuijs/quick/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "execa/onetime/mimic-fn": ["mimic-fn@4.0.0", "", {}, "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="],
   }
 }

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -41,7 +41,8 @@
     "dotenv": "^16.0.0",
     "typescript": "^5.7.0",
     "tsup": "^8.3.0",
-    "zod": "^3.0.0"
+    "zod": "^3.0.0",
+    "execa": "^8.0.1"
   },
   "peerDependencies": {
     "@octokit/rest": "^21.0.0",
@@ -53,7 +54,8 @@
     "chalk": "^5.0.0",
     "dotenv": "^16.0.0",
     "simple-git": "^3.27.0",
-    "keytar": "^7.9.0"
+    "keytar": "^7.9.0",
+    "execa": "^8.0.0"
   },
   "peerDependenciesMeta": {
     "@octokit/rest": {
@@ -84,6 +86,9 @@
       "optional": true
     },
     "keytar": {
+      "optional": true
+    },
+    "execa": {
       "optional": true
     }
   },

--- a/packages/adapters/src/execa/index.test.ts
+++ b/packages/adapters/src/execa/index.test.ts
@@ -1,0 +1,110 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/adapters — Tests for useExeca
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useExeca, useShell } from './index.js';
+import { Readable } from 'node:stream';
+import { execa } from 'execa';
+
+vi.mock('execa', () => {
+  return {
+    execa: vi.fn(),
+  };
+});
+
+describe('useExeca', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function createMockChild(chunks: string[], exitCode = 0) {
+    const stream = Readable.from(chunks);
+    const promise = new Promise<any>((resolve, reject) => {
+      stream.on('end', () => {
+        if (exitCode === 0) {
+          resolve({ exitCode, all: stream });
+        } else {
+          const err = new Error(`Command failed with exit code ${exitCode}`);
+          (err as any).exitCode = exitCode;
+          reject(err);
+        }
+      });
+    });
+
+    return Object.assign(promise, {
+      all: stream,
+    });
+  }
+
+  it('streams lines of stdout/stderr as they emit', async () => {
+    const mockChild = createMockChild(['hello\nworld', '\nfoo\nbar\n']);
+    vi.mocked(execa).mockReturnValue(mockChild as any);
+
+    const { run } = useExeca();
+    const lines: string[] = [];
+    for await (const line of run('test-cmd', ['arg1'])) {
+      lines.push(line);
+    }
+
+    expect(execa).toHaveBeenCalledWith('test-cmd', ['arg1'], {
+      all: true,
+      buffer: false,
+    });
+    expect(lines).toEqual(['hello', 'world', 'foo', 'bar']);
+  });
+
+  it('accepts command array', async () => {
+    const mockChild = createMockChild(['ok\n']);
+    vi.mocked(execa).mockReturnValue(mockChild as any);
+
+    const { run } = useExeca();
+    const lines: string[] = [];
+    for await (const line of run(['my-cmd', 'arg1', 'arg2'], { env: { DEBUG: '1' } })) {
+      lines.push(line);
+    }
+
+    expect(execa).toHaveBeenCalledWith('my-cmd', ['arg1', 'arg2'], {
+      all: true,
+      buffer: false,
+      env: { DEBUG: '1' },
+    });
+    expect(lines).toEqual(['ok']);
+  });
+
+  it('merges global options with local options', async () => {
+    const mockChild = createMockChild(['ok\n']);
+    vi.mocked(execa).mockReturnValue(mockChild as any);
+
+    const { run } = useExeca({ env: { GLOBAL: 'yes' }, timeout: 1000 });
+    const iterator = run('my-cmd', { env: { LOCAL: 'yes' } });
+    await iterator.next();
+
+    expect(execa).toHaveBeenCalledWith('my-cmd', [], {
+      all: true,
+      buffer: false,
+      env: { GLOBAL: 'yes', LOCAL: 'yes' },
+      timeout: 1000,
+    });
+  });
+
+  it('propagates errors when command fails with non-zero exit code', async () => {
+    const mockChild = createMockChild(['some error\n'], 1);
+    vi.mocked(execa).mockReturnValue(mockChild as any);
+
+    const { run } = useExeca();
+    const lines: string[] = [];
+
+    await expect(async () => {
+      for await (const line of run('fail-cmd')) {
+        lines.push(line);
+      }
+    }).rejects.toThrow('Command failed with exit code 1');
+
+    expect(lines).toEqual(['some error']);
+  });
+
+  it('exposes useShell as an alias of useExeca', () => {
+    expect(useShell).toBe(useExeca);
+  });
+});

--- a/packages/adapters/src/execa/index.test.ts
+++ b/packages/adapters/src/execa/index.test.ts
@@ -13,33 +13,49 @@ vi.mock('execa', () => {
   };
 });
 
+interface MockError extends Error {
+  exitCode: number;
+}
+
+interface MockChildResult {
+  exitCode: number;
+  all: Readable;
+}
+
+interface MockChild extends Promise<MockChildResult> {
+  all: Readable;
+}
+
 describe('useExeca', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  function createMockChild(chunks: string[], exitCode = 0) {
+  function createMockChild(chunks: string[], exitCode = 0): MockChild {
     const stream = Readable.from(chunks);
-    const promise = new Promise<any>((resolve, reject) => {
+    const promise = new Promise<MockChildResult>((resolve, reject) => {
       stream.on('end', () => {
         if (exitCode === 0) {
           resolve({ exitCode, all: stream });
         } else {
-          const err = new Error(`Command failed with exit code ${exitCode}`);
-          (err as any).exitCode = exitCode;
+          const err = new Error(`Command failed with exit code ${exitCode}`) as MockError;
+          err.exitCode = exitCode;
           reject(err);
         }
       });
     });
 
-    return Object.assign(promise, {
+    // Cast is necessary to assign the 'all' property to the promise
+    const mockChild = Object.assign(promise, {
       all: stream,
-    });
+    }) as MockChild;
+    return mockChild;
   }
 
   it('streams lines of stdout/stderr as they emit', async () => {
     const mockChild = createMockChild(['hello\nworld', '\nfoo\nbar\n']);
-    vi.mocked(execa).mockReturnValue(mockChild as any);
+    // Cast to unknown and then to ReturnType<typeof execa> is needed to satisfy mock return type structure
+    vi.mocked(execa).mockReturnValue(mockChild as unknown as ReturnType<typeof execa>);
 
     const { run } = useExeca();
     const lines: string[] = [];
@@ -56,7 +72,8 @@ describe('useExeca', () => {
 
   it('accepts command array', async () => {
     const mockChild = createMockChild(['ok\n']);
-    vi.mocked(execa).mockReturnValue(mockChild as any);
+    // Cast to unknown and then to ReturnType<typeof execa> is needed to satisfy mock return type structure
+    vi.mocked(execa).mockReturnValue(mockChild as unknown as ReturnType<typeof execa>);
 
     const { run } = useExeca();
     const lines: string[] = [];
@@ -74,7 +91,8 @@ describe('useExeca', () => {
 
   it('merges global options with local options', async () => {
     const mockChild = createMockChild(['ok\n']);
-    vi.mocked(execa).mockReturnValue(mockChild as any);
+    // Cast to unknown and then to ReturnType<typeof execa> is needed to satisfy mock return type structure
+    vi.mocked(execa).mockReturnValue(mockChild as unknown as ReturnType<typeof execa>);
 
     const { run } = useExeca({ env: { GLOBAL: 'yes' }, timeout: 1000 });
     const iterator = run('my-cmd', { env: { LOCAL: 'yes' } });
@@ -90,16 +108,19 @@ describe('useExeca', () => {
 
   it('propagates errors when command fails with non-zero exit code', async () => {
     const mockChild = createMockChild(['some error\n'], 1);
-    vi.mocked(execa).mockReturnValue(mockChild as any);
+    // Cast to unknown and then to ReturnType<typeof execa> is needed to satisfy mock return type structure
+    vi.mocked(execa).mockReturnValue(mockChild as unknown as ReturnType<typeof execa>);
 
     const { run } = useExeca();
     const lines: string[] = [];
 
-    await expect(async () => {
+    const promise = (async () => {
       for await (const line of run('fail-cmd')) {
         lines.push(line);
       }
-    }).rejects.toThrow('Command failed with exit code 1');
+    })();
+
+    await expect(promise).rejects.toThrow('Command failed with exit code 1');
 
     expect(lines).toEqual(['some error']);
   });

--- a/packages/adapters/src/execa/index.test.ts
+++ b/packages/adapters/src/execa/index.test.ts
@@ -24,6 +24,9 @@ interface MockChildResult {
 
 interface MockChild extends Promise<MockChildResult> {
   all: Readable;
+  exitCode: number | null;
+  killed: boolean;
+  kill(): void;
 }
 
 describe('useExeca', () => {
@@ -33,8 +36,14 @@ describe('useExeca', () => {
 
   function createMockChild(chunks: string[], exitCode = 0): MockChild {
     const stream = Readable.from(chunks);
+    let rejectPromise: ((err: any) => void) | null = null;
+    let resolvePromise: ((val: MockChildResult) => void) | null = null;
+
     const promise = new Promise<MockChildResult>((resolve, reject) => {
+      resolvePromise = resolve;
+      rejectPromise = reject;
       stream.on('end', () => {
+        mockChild.exitCode = exitCode;
         if (exitCode === 0) {
           resolve({ exitCode, all: stream });
         } else {
@@ -48,6 +57,18 @@ describe('useExeca', () => {
     // Cast is necessary to assign the 'all' property to the promise
     const mockChild = Object.assign(promise, {
       all: stream,
+      exitCode: null as number | null,
+      killed: false,
+      kill: () => {
+        mockChild.killed = true;
+        mockChild.exitCode = -1;
+        stream.destroy();
+        if (rejectPromise) {
+          const err = new Error('Process was killed') as MockError;
+          err.exitCode = -1;
+          rejectPromise(err);
+        }
+      },
     }) as MockChild;
     return mockChild;
   }
@@ -123,6 +144,26 @@ describe('useExeca', () => {
     await expect(promise).rejects.toThrow('Command failed with exit code 1');
 
     expect(lines).toEqual(['some error']);
+  });
+
+  it('kills the child process if the consumer exits the loop early', async () => {
+    const mockChild = createMockChild(['line1\n', 'line2\n']);
+    mockChild.exitCode = null;
+    mockChild.killed = false;
+
+    const killSpy = vi.spyOn(mockChild, 'kill');
+
+    // Cast to unknown and then to ReturnType<typeof execa> is needed to satisfy mock return type structure
+    vi.mocked(execa).mockReturnValue(mockChild as unknown as ReturnType<typeof execa>);
+
+    const { run } = useExeca();
+
+    for await (const line of run('test-cmd')) {
+      expect(line).toBe('line1');
+      break;
+    }
+
+    expect(killSpy).toHaveBeenCalled();
   });
 
   it('exposes useShell as an alias of useExeca', () => {

--- a/packages/adapters/src/execa/index.ts
+++ b/packages/adapters/src/execa/index.ts
@@ -3,6 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import type { Options } from 'execa';
+import { execa } from 'execa';
 
 export interface UseExecaResult {
   run(
@@ -31,6 +32,22 @@ async function getExeca(): Promise<typeof import('execa')> {
   }
 }
 
+function isExecaCallable(obj: unknown): obj is typeof execa {
+  return typeof obj === 'function';
+}
+
+function isExecaModuleWithExeca(obj: unknown): obj is { execa: typeof execa } {
+  return typeof obj === 'object' && obj !== null && 'execa' in obj && typeof (obj as { execa: unknown }).execa === 'function';
+}
+
+function isExecaModuleWithDefault(obj: unknown): obj is { default: typeof execa } {
+  return typeof obj === 'object' && obj !== null && 'default' in obj && typeof (obj as { default: unknown }).default === 'function';
+}
+
+function isOptions(obj: unknown): obj is Options {
+  return typeof obj === 'object' && obj !== null && !Array.isArray(obj);
+}
+
 /**
  * Hook to execute external commands using execa.
  * Streams stdout and stderr interleaved as an AsyncIterable of lines.
@@ -42,9 +59,18 @@ export function useExeca(globalOpts?: Options): UseExecaResult {
       argsOrOpts?: string[] | Options,
       opts?: Options
     ): AsyncGenerator<string, void, unknown> {
-      const execaModule = await getExeca();
-      // Type assertion is needed to support fallback resolutions across bundler modules
-      const execaFn = (execaModule.execa ?? (execaModule as any).default ?? execaModule) as typeof execaModule.execa;
+      const execaModule: unknown = await getExeca();
+      let execaFn: typeof execa;
+
+      if (isExecaModuleWithExeca(execaModule)) {
+        execaFn = execaModule.execa;
+      } else if (isExecaModuleWithDefault(execaModule)) {
+        execaFn = execaModule.default;
+      } else if (isExecaCallable(execaModule)) {
+        execaFn = execaModule;
+      } else {
+        throw new Error('useExeca: Resolved execa module is not callable.');
+      }
 
       let file: string;
       let args: string[] = [];
@@ -56,16 +82,16 @@ export function useExeca(globalOpts?: Options): UseExecaResult {
         }
         file = cmd[0];
         args = cmd.slice(1);
-        if (argsOrOpts && !Array.isArray(argsOrOpts)) {
-          options = argsOrOpts as Options;
+        if (isOptions(argsOrOpts)) {
+          options = argsOrOpts;
         }
       } else {
         file = cmd;
         if (Array.isArray(argsOrOpts)) {
           args = argsOrOpts;
           options = opts ?? {};
-        } else if (argsOrOpts) {
-          options = argsOrOpts as Options;
+        } else if (isOptions(argsOrOpts)) {
+          options = argsOrOpts;
         }
       }
 
@@ -80,27 +106,42 @@ export function useExeca(globalOpts?: Options): UseExecaResult {
         } : undefined,
       };
 
-      const child = execaFn(file, args, mergedOpts);
-      const stream = child.all;
-      if (!stream) {
-        throw new Error('useExeca: stdout/stderr stream (child.all) is not available.');
-      }
+      // child is typed as any to support all dynamic overloads returned by execaFn at runtime
+      let child: any;
+      try {
+        child = execaFn(file, args, mergedOpts);
+        const stream = child.all;
+        if (!stream) {
+          throw new Error('useExeca: stdout/stderr stream (child.all) is not available.');
+        }
 
-      let buffer = '';
-      for await (const chunk of stream) {
-        const chunkStr = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
-        buffer += chunkStr;
-        const lines = buffer.split(/\r?\n/);
-        buffer = lines.pop() ?? '';
-        for (const line of lines) {
-          yield line;
+        let buffer = '';
+        for await (const chunk of stream) {
+          const chunkStr = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+          buffer += chunkStr;
+          const lines = buffer.split(/\r?\n/);
+          buffer = lines.pop() ?? '';
+          for (const line of lines) {
+            yield line;
+          }
+        }
+        if (buffer) {
+          yield buffer;
+        }
+
+        await child;
+      } finally {
+        if (child) {
+          if (child.exitCode === null && !child.killed) {
+            child.kill();
+          }
+          try {
+            await child;
+          } catch {
+            // Ignore error on cleanup if the consumer exited early
+          }
         }
       }
-      if (buffer) {
-        yield buffer;
-      }
-
-      await child;
     },
   };
 }

--- a/packages/adapters/src/execa/index.ts
+++ b/packages/adapters/src/execa/index.ts
@@ -1,0 +1,111 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/adapters — execa integration
+// ─────────────────────────────────────────────────────
+
+import type { Options } from 'execa';
+
+export interface UseExecaResult {
+  run(
+    cmd: string | string[],
+    argsOrOpts?: string[] | Options,
+    opts?: Options
+  ): AsyncGenerator<string, void, unknown>;
+}
+
+let _execaModule: typeof import('execa') | undefined;
+
+/**
+ * Lazily loads the execa module.
+ */
+async function getExeca(): Promise<typeof import('execa')> {
+  if (_execaModule) return _execaModule;
+  try {
+    _execaModule = await import('execa');
+    return _execaModule;
+  } catch (err) {
+    throw new Error(
+      'useExeca() requires the optional peer dependency `execa`. ' +
+        'Please install `execa@^8.0.0` or newer in your project before using useExeca().',
+      { cause: err }
+    );
+  }
+}
+
+/**
+ * Hook to execute external commands using execa.
+ * Streams stdout and stderr interleaved as an AsyncIterable of lines.
+ */
+export function useExeca(globalOpts?: Options): UseExecaResult {
+  return {
+    async *run(
+      cmd: string | string[],
+      argsOrOpts?: string[] | Options,
+      opts?: Options
+    ): AsyncGenerator<string, void, unknown> {
+      const execaModule = await getExeca();
+      // Type assertion is needed to support fallback resolutions across bundler modules
+      const execaFn = (execaModule.execa ?? (execaModule as any).default ?? execaModule) as typeof execaModule.execa;
+
+      let file: string;
+      let args: string[] = [];
+      let options: Options = {};
+
+      if (Array.isArray(cmd)) {
+        if (cmd.length === 0) {
+          throw new Error('useExeca: Command array must not be empty.');
+        }
+        file = cmd[0];
+        args = cmd.slice(1);
+        if (argsOrOpts && !Array.isArray(argsOrOpts)) {
+          options = argsOrOpts as Options;
+        }
+      } else {
+        file = cmd;
+        if (Array.isArray(argsOrOpts)) {
+          args = argsOrOpts;
+          options = opts ?? {};
+        } else if (argsOrOpts) {
+          options = argsOrOpts as Options;
+        }
+      }
+
+      const mergedOpts: Options = {
+        ...globalOpts,
+        ...options,
+        all: true,
+        buffer: false,
+        env: (globalOpts?.env || options?.env) ? {
+          ...globalOpts?.env,
+          ...options?.env,
+        } : undefined,
+      };
+
+      const child = execaFn(file, args, mergedOpts);
+      const stream = child.all;
+      if (!stream) {
+        throw new Error('useExeca: stdout/stderr stream (child.all) is not available.');
+      }
+
+      let buffer = '';
+      for await (const chunk of stream) {
+        const chunkStr = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+        buffer += chunkStr;
+        const lines = buffer.split(/\r?\n/);
+        buffer = lines.pop() ?? '';
+        for (const line of lines) {
+          yield line;
+        }
+      }
+      if (buffer) {
+        yield buffer;
+      }
+
+      await child;
+    },
+  };
+}
+
+/**
+ * Convenience alias for useExeca.
+ */
+export const useShell = useExeca;

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -41,3 +41,6 @@ export { useDotenv } from './dotenv/index.js'
 export type { DotenvValues, UseDotenvResult } from './dotenv/index.js'
 export { useLocalStorage } from './localStorage/index.js'
 export type { LocalStorageAdapter } from './localStorage/index.js'
+
+export { useExeca, useShell } from './execa/index.js'
+export type { UseExecaResult } from './execa/index.js'


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

This PR implements the `useExeca` hook and its convenience alias `useShell` under the `@termuijs/adapters` package. The hook lazily resolves the optional peer dependency `execa`, spawns external commands, merges global/local environment options, and streams stdout/stderr interleaved as an `AsyncIterable<string>` line-by-line.

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #84 

## Which package(s)?

@termuijs/adapters

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/901726b7-d593-41ba-b695-a4b8000cb3ff`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->
N/A (This PR introduces non-visual utility hooks in `@termuijs/adapters`).

## Notes for the Reviewer

* **Optional Peer Dependency**: Implemented using lazy dynamic `import('execa')` inside the runner generator, ensuring that `@termuijs/adapters` does not fail to load if `execa` is not installed.
* **Argument Overloads**: Supports both string command with argument list/options and command arrays (`run(['ls', '-la'])`).
* **Line Splitting**: Stream chunks are aggregated and split by newline (`\r?\n`) to correctly yield line-by-line in real time.
* **Options Merging**: Safely merges options and conditionally performs a deep merge on `env` properties without overwriting with empty objects, maintaining default process environment inheritance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-execution adapter that runs commands and streams real-time stdout/stderr lines, supports both string and array command forms, merges global and per-call options (env, timeout), and includes a shell-style alias.

* **Tests**
  * Added tests covering streaming output, option merging, argument forms, error-on-non-zero-exit behavior, and child-process cleanup when iteration stops.

* **Chores**
  * Updated package metadata to declare the runtime adapter dependency as an optional peer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->