### PR TITLE
feat(store): add mutate() helper for in-place signal mutations

### DIFF
--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -25,3 +25,7 @@ export type { TemporalHistory, TemporalStoreActions } from './history.js'
 
 export { createLogger } from './logger.js';
 export type { LoggerOptions } from './logger.js';
+
+export { signal, mutate } from './mutate.js';
+export type { Signal } from './mutate.js';
+

--- a/packages/store/src/mutate.test.ts
+++ b/packages/store/src/mutate.test.ts
@@ -1,0 +1,29 @@
+import { expect, it, describe, vi } from 'vitest';
+import { signal, mutate } from './mutate.js';
+
+describe('mutate helper', () => {
+    it('without mutate(), an in-place push alone does NOT trigger a re-render', () => {
+        const items = signal<string[]>([]);
+        const listener = vi.fn();
+        items.subscribe(listener);
+
+        // In-place mutation without mutate() or reassignment
+        items.value.push('a');
+        
+        // Listener should not be called because the setter wasn't triggered
+        expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('mutate(signal) triggers a re-render after in-place mutations', () => {
+        const items = signal<string[]>([]);
+        const listener = vi.fn();
+        items.subscribe(listener);
+
+        items.value.push('a');
+        mutate(items);
+
+        // mutate() should forcefully trigger the listeners
+        expect(listener).toHaveBeenCalledTimes(1);
+        expect(listener).toHaveBeenCalledWith(['a']);
+    });
+});

--- a/packages/store/src/mutate.ts
+++ b/packages/store/src/mutate.ts
@@ -1,0 +1,53 @@
+// ─────────────────────────────────────────────────────
+// Signal and Mutate helpers
+// ─────────────────────────────────────────────────────
+
+type Listener<T> = (value: T) => void;
+
+export interface Signal<T> {
+    /** The current value of the signal */
+    value: T;
+    /** Subscribe to changes */
+    subscribe: (listener: Listener<T>) => () => void;
+    /** Internal method to forcefully trigger a re-render/update */
+    _setDirty: () => void;
+}
+
+/**
+ * Creates a reactive signal.
+ */
+export function signal<T>(initialValue: T): Signal<T> {
+    let _value = initialValue;
+    const listeners = new Set<Listener<T>>();
+
+    return {
+        get value() {
+            return _value;
+        },
+        set value(newVal: T) {
+            if (!Object.is(_value, newVal)) {
+                _value = newVal;
+                listeners.forEach((l) => l(_value));
+            }
+        },
+        subscribe(listener: Listener<T>) {
+            listeners.add(listener);
+            return () => {
+                listeners.delete(listener);
+            };
+        },
+        _setDirty() {
+            listeners.forEach((l) => l(_value));
+        }
+    };
+}
+
+/**
+ * Forces a re-render for a signal, even if its internal reference hasn't changed.
+ * Useful for in-place mutations like array.push() or object property updates.
+ *
+ * @param sig The signal to mutate
+ */
+export function mutate<T>(sig: Signal<T>): void {
+    sig._setDirty();
+}


### PR DESCRIPTION
## Description

Adds mutate() and a basic signal implementation to @termuijs/store for supporting in-place state mutations.

mutate() triggers updates after array/object mutations without requiring object reallocation. Tests cover behavior with and without mutate().



## Related Issue
Closes #65 

## Which package(s)?

@termuijs/store

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/f49aa65e-aab2-4e9f-99d6-2174f339ecfe`

## Screenshots / Recordings (UI changes)
(N/A - Pure mathematical utility functions with no UI)

## Notes for the Reviewer

Added a minimal signal implementation alongside mutate() since the issue examples referenced signal, but it was not previously available in @termuijs/store.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New reactive signal API with subscription support available in the store package
  * Added `signal()` function to create reactive state containers
  * Added `mutate()` function to trigger notifications on in-place modifications
  * Exported `Signal` type for type-safe signal handling

* **Tests**
  * Added comprehensive test coverage for signal creation, mutations, and subscriber notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->