### PR TITLE
feat(ui): add TagInput widget

### DIFF
--- a/packages/ui/src/TagInput.test.ts
+++ b/packages/ui/src/TagInput.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Screen, caps, createKeyEvent } from '@termuijs/core';
+import { TagInput } from './TagInput.js';
+
+/** Helper to build a KeyEvent with sensible defaults. */
+function key(k: string, mods: { ctrl?: boolean; alt?: boolean; shift?: boolean } = {}): ReturnType<typeof createKeyEvent> {
+    return createKeyEvent({
+        key: k,
+        raw: Buffer.from(k),
+        ctrl: mods.ctrl ?? false,
+        alt: mods.alt ?? false,
+        shift: mods.shift ?? false,
+    });
+}
+
+/** Render a TagInput into a fresh Screen and return all rows as a single string. */
+function renderToString(ti: TagInput, w = 40, h = 3): string {
+    const screen = new Screen(w, h);
+    ti.updateRect({ x: 0, y: 0, width: w, height: h });
+    ti.render(screen);
+    return screen.back.map(r => r.map(c => c.char).join('')).join('\n');
+}
+
+describe('TagInput', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('renders default tags', () => {
+        const ti = new TagInput({}, { defaultTags: ['react'] });
+        const output = renderToString(ti, 30, 3);
+        expect(output).toContain('react');
+        expect(ti.tags).toEqual(['react']);
+    });
+
+    it('typing then enter commits a chip', () => {
+        const ti = new TagInput();
+
+        ti.handleKey(key('h'));
+        ti.handleKey(key('i'));
+        ti.handleKey(key('enter'));
+
+        expect(ti.tags).toEqual(['hi']);
+
+        const output = renderToString(ti);
+        expect(output).toContain('hi');
+    });
+
+    it('backspace on empty draft removes the last chip', () => {
+        const ti = new TagInput({}, { defaultTags: ['alpha', 'beta'] });
+        expect(ti.tags).toEqual(['alpha', 'beta']);
+
+        // Draft is empty, so backspace removes the last chip
+        ti.handleKey(key('backspace'));
+        expect(ti.tags).toEqual(['alpha']);
+
+        ti.handleKey(key('backspace'));
+        expect(ti.tags).toEqual([]);
+    });
+
+    it('backspace on non-empty draft deletes draft character', () => {
+        const ti = new TagInput({}, { defaultTags: ['keep'] });
+
+        ti.handleKey(key('a'));
+        ti.handleKey(key('b'));
+        ti.handleKey(key('backspace'));
+
+        // Draft should be 'a', not removing a chip
+        expect(ti.tags).toEqual(['keep']);
+
+        ti.handleKey(key('enter'));
+        expect(ti.tags).toEqual(['keep', 'a']);
+    });
+
+    it('placeholder renders when empty', () => {
+        const ti = new TagInput({}, { placeholder: 'Add tags...' });
+        const output = renderToString(ti);
+        expect(output).toContain('Add tags...');
+    });
+
+    it('placeholder does not render when tags exist', () => {
+        const ti = new TagInput({}, { placeholder: 'Add tags...', defaultTags: ['foo'] });
+        const output = renderToString(ti);
+        expect(output).not.toContain('Add tags...');
+        expect(output).toContain('foo');
+    });
+
+    it('onChange fires on tag list changes', () => {
+        const changes: string[][] = [];
+        const ti = new TagInput({}, { onChange: (tags) => changes.push(tags) });
+
+        // Type and commit
+        ti.handleKey(key('a'));
+        ti.handleKey(key('enter'));
+        expect(changes).toHaveLength(1);
+        expect(changes[0]).toEqual(['a']);
+
+        // Type and commit another
+        ti.handleKey(key('b'));
+        ti.handleKey(key('enter'));
+        expect(changes).toHaveLength(2);
+        expect(changes[1]).toEqual(['a', 'b']);
+
+        // Remove last via backspace
+        ti.handleKey(key('backspace'));
+        expect(changes).toHaveLength(3);
+        expect(changes[2]).toEqual(['a']);
+    });
+
+    it('does not commit empty or whitespace-only draft', () => {
+        const ti = new TagInput();
+
+        // Enter on empty draft should not add a tag
+        ti.handleKey(key('enter'));
+        expect(ti.tags).toEqual([]);
+
+        // Spaces only
+        ti.handleKey(key(' '));
+        ti.handleKey(key(' '));
+        ti.handleKey(key('enter'));
+        expect(ti.tags).toEqual([]);
+    });
+
+    it('addTag and removeLast call markDirty', () => {
+        const ti = new TagInput();
+        const spy = vi.spyOn(ti, 'markDirty');
+
+        ti.addTag('test');
+        expect(spy).toHaveBeenCalled();
+
+        spy.mockClear();
+
+        ti.removeLast();
+        expect(spy).toHaveBeenCalled();
+    });
+
+    it('ASCII fallback chip renders when caps.unicode is false', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+
+        const ti = new TagInput({}, { defaultTags: ['node'] });
+        const output = renderToString(ti, 30, 3);
+
+        // ASCII fallback uses square brackets
+        expect(output).toContain('[node]');
+    });
+
+    it('unicode chip renders when caps.unicode is true', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+
+        const ti = new TagInput({}, { defaultTags: ['bun'] });
+        const output = renderToString(ti, 30, 3);
+
+        // Unicode uses angle quotes
+        expect(output).toContain('\u2039bun\u203a');
+    });
+
+    it('tags getter returns a copy, not a reference', () => {
+        const ti = new TagInput({}, { defaultTags: ['a'] });
+        const ref = ti.tags;
+        ref.push('b');
+        expect(ti.tags).toEqual(['a']);
+    });
+
+    it('does not react to ctrl or alt modified keys', () => {
+        const ti = new TagInput();
+        ti.handleKey(key('a', { ctrl: true }));
+        ti.handleKey(key('b', { alt: true }));
+        ti.handleKey(key('enter'));
+        // No characters should have been added to draft
+        expect(ti.tags).toEqual([]);
+    });
+});

--- a/packages/ui/src/TagInput.ts
+++ b/packages/ui/src/TagInput.ts
@@ -11,7 +11,7 @@
 // ─────────────────────────────────────────────────────
 
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, truncate, caps } from '@termuijs/core';
+import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, stringWidth, truncate, caps } from '@termuijs/core';
 
 export interface TagInputOptions {
     placeholder?: string;
@@ -121,18 +121,35 @@ export class TagInput extends Widget {
         display += this._draft;
 
         // Handle horizontal scrolling if content exceeds width
+        const displayWidth = stringWidth(display);
         const visibleWidth = width;
-        let scrollX = 0;
-        if (display.length > visibleWidth) {
-            scrollX = display.length - visibleWidth;
+        let scrollCols = 0;
+        if (displayWidth > visibleWidth) {
+            scrollCols = displayWidth - visibleWidth;
         }
 
-        const visibleText = display.slice(scrollX, scrollX + visibleWidth);
+        // Width-aware slice: iterate graphemes and accumulate until
+        // we have skipped scrollCols columns and collected visibleWidth columns.
+        const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+        let skipped = 0;
+        let accumulated = 0;
+        let visibleText = '';
+        for (const { segment } of segmenter.segment(display)) {
+            const w = stringWidth(segment);
+            if (skipped < scrollCols) {
+                skipped += w;
+                continue;
+            }
+            if (accumulated + w > visibleWidth) break;
+            visibleText += segment;
+            accumulated += w;
+        }
+
         screen.writeString(x, y, visibleText, attrs);
 
         // Show cursor at draft position when focused
         if (this.isFocused) {
-            const cursorPos = x + display.length - scrollX;
+            const cursorPos = x + displayWidth - scrollCols;
             if (cursorPos >= x && cursorPos < x + width) {
                 screen.setCell(cursorPos, y, {
                     char: ' ',

--- a/packages/ui/src/TagInput.ts
+++ b/packages/ui/src/TagInput.ts
@@ -1,0 +1,145 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/ui — TagInput widget
+//
+// A text input that tokenizes typed entries into removable
+// chips (tags).
+// - Typing characters appends to the pending draft text
+// - enter commits the draft as a chip and clears the draft
+// - backspace on an empty draft removes the last chip
+// - Committed chips render as bracketed tokens before the
+//   draft text
+// ─────────────────────────────────────────────────────
+
+import { Widget } from '@termuijs/widgets';
+import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, truncate, caps } from '@termuijs/core';
+
+export interface TagInputOptions {
+    placeholder?: string;
+    defaultTags?: string[];
+    onChange?: (tags: string[]) => void;
+}
+
+export class TagInput extends Widget {
+    private _tags: string[] = [];
+    private _draft = '';
+    private _placeholder: string;
+    private _onChange?: (tags: string[]) => void;
+
+    focusable = true;
+
+    constructor(
+        style: Partial<Style> = {},
+        options: TagInputOptions = {},
+    ) {
+        super(mergeStyles(defaultStyle(), { border: 'single', height: 3, ...style }));
+        this._placeholder = options.placeholder ?? '';
+        if (options.defaultTags) {
+            this._tags = [...options.defaultTags];
+        }
+        this._onChange = options.onChange;
+    }
+
+    /** The current list of committed tags. */
+    get tags(): string[] {
+        return [...this._tags];
+    }
+
+    /** Add a tag to the list. Empty/whitespace-only strings are ignored. */
+    addTag(tag: string): void {
+        const trimmed = tag.trim();
+        if (trimmed.length === 0) return;
+        this._tags.push(trimmed);
+        this._onChange?.(this.tags);
+        this.markDirty();
+    }
+
+    /** Remove the last tag from the list. No-op if the list is empty. */
+    removeLast(): void {
+        if (this._tags.length === 0) return;
+        this._tags.pop();
+        this._onChange?.(this.tags);
+        this.markDirty();
+    }
+
+    /**
+     * Handle key events. Call this from your input loop.
+     */
+    handleKey(event: KeyEvent): void {
+        switch (event.key) {
+            case 'return':
+            case 'enter':
+                if (this._draft.trim().length > 0) {
+                    this.addTag(this._draft);
+                    this._draft = '';
+                    this.markDirty();
+                }
+                break;
+
+            case 'backspace':
+                if (this._draft.length > 0) {
+                    this._draft = this._draft.slice(0, -1);
+                    this.markDirty();
+                } else {
+                    this.removeLast();
+                }
+                break;
+
+            default:
+                if (event.key && event.key.length === 1 && !event.ctrl && !event.alt) {
+                    this._draft += event.key;
+                    this.markDirty();
+                }
+        }
+    }
+
+    /** Format a single chip token using caps.unicode for glyph choice. */
+    private _formatChip(tag: string): string {
+        if (caps.unicode) {
+            return ` \u2039${tag}\u203a `;
+        }
+        return ` [${tag}] `;
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const rect = this._getContentRect();
+        const { x, y, width, height } = rect;
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this._style);
+
+        // Show placeholder when empty
+        if (this._tags.length === 0 && this._draft.length === 0) {
+            screen.writeString(x, y, truncate(this._placeholder, width), { ...attrs, dim: true });
+            return;
+        }
+
+        // Build the display string: chips followed by draft
+        let display = '';
+        for (const tag of this._tags) {
+            display += this._formatChip(tag);
+        }
+        display += this._draft;
+
+        // Handle horizontal scrolling if content exceeds width
+        const visibleWidth = width;
+        let scrollX = 0;
+        if (display.length > visibleWidth) {
+            scrollX = display.length - visibleWidth;
+        }
+
+        const visibleText = display.slice(scrollX, scrollX + visibleWidth);
+        screen.writeString(x, y, visibleText, attrs);
+
+        // Show cursor at draft position when focused
+        if (this.isFocused) {
+            const cursorPos = x + display.length - scrollX;
+            if (cursorPos >= x && cursorPos < x + width) {
+                screen.setCell(cursorPos, y, {
+                    char: ' ',
+                    ...attrs,
+                    inverse: true,
+                });
+            }
+        }
+    }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -104,6 +104,9 @@ export type { PasswordInputOptions } from './PasswordInput.js';
 export { NumberInput } from './NumberInput.js';
 export type { NumberInputOptions } from './NumberInput.js';
 
+export { TagInput } from './TagInput.js';
+export type { TagInputOptions } from './TagInput.js';
+
 export { MaskedInput } from './MaskedInput.js';
 export type { MaskedInputOptions } from './MaskedInput.js';
 


### PR DESCRIPTION
Add a TagInput widget to @termuijs/ui that tokenizes typed entries into removable chips, with backspace deletion of the last chip.

- TagInput.ts: widget with draft buffer, enter to commit, backspace to remove

- TagInput.test.ts: 13 tests covering all acceptance criteria

- index.ts: export TagInput and TagInputOptions

<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

Adds a `TagInput` widget to `@termuijs/ui` that lets users type text and press enter to commit it as a chip (tag). Backspace on an empty draft removes the last chip. Chips render with `caps.unicode` glyphs (`‹tag›`) with an ASCII fallback (`[tag]`). Includes 13 tests covering all acceptance criteria.

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #481 

## Which package(s)?

@termuijs/ui

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/172e996c-3943-4a86-8249-1f01922d0f64`

## Screenshots / Recordings (UI changes)

N/A — terminal widget, no visual UI changes.

## Notes for the Reviewer

- Follows the `NumberInput.ts` reference pattern for constructor shape, draft buffer, and `handleKey`.
- `addTag()` and `removeLast()` both call `markDirty()`.
- Chip glyphs use `caps.unicode` (`‹tag›`) with an ASCII fallback (`[tag]`).
- Empty or whitespace-only drafts are rejected on enter.
- `tags` getter returns a copy to prevent external mutation.
- The pre-existing `validation.test.ts` failure (missing `zod` module) and `@termuijs/adapters` typecheck errors are unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **TagInput** widget for entering and managing tags, with a customizable placeholder, optional default tags, chip-based tag display, horizontal scrolling, and keyboard-driven editing (type, Enter to commit, Backspace to remove).
  * Added an `onChange` callback that notifies whenever the tag list changes.
  * Exported `TagInput` and `TagInputOptions` for public use.
* **Behavior / Fixes**
  * Prevents committing empty/whitespace-only tags; renders chips with consistent quoting across character sets; returns defensive copies of the tag list.
* **Tests**
  * Added comprehensive tests for initialization, rendering/placeholder states, keyboard flows, add/remove updates, and modifier-key safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->