### PR TITLE
feat(core): add setCursorShape via DECSCUSR

### DIFF
--- a/packages/core/src/terminal/Terminal.test.ts
+++ b/packages/core/src/terminal/Terminal.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'events';
 import { Terminal } from './Terminal.js';
-import { bell, notify } from '../utils/ansi.js';
+import { bell, notify, cursorShape } from '../utils/ansi.js';
 
 function createFakeStdout() {
     return {
@@ -53,6 +53,78 @@ describe('ansi helpers', () => {
 
     it('notify("hi") returns OSC 9 notification sequence', () => {
         expect(notify('hi')).toBe('\x1b]9;hi\x07');
+    });
+});
+
+describe('cursorShape ansi helper', () => {
+    it('block + blink writes \\x1b[1 q', () => {
+        expect(cursorShape('block', true)).toBe('\x1b[1 q');
+    });
+
+    it('block + steady writes \\x1b[2 q', () => {
+        expect(cursorShape('block', false)).toBe('\x1b[2 q');
+    });
+
+    it('underline + blink writes \\x1b[3 q', () => {
+        expect(cursorShape('underline', true)).toBe('\x1b[3 q');
+    });
+
+    it('underline + steady writes \\x1b[4 q', () => {
+        expect(cursorShape('underline', false)).toBe('\x1b[4 q');
+    });
+
+    it('bar + blink writes \\x1b[5 q', () => {
+        expect(cursorShape('bar', true)).toBe('\x1b[5 q');
+    });
+
+    it('bar + steady writes \\x1b[6 q', () => {
+        expect(cursorShape('bar', false)).toBe('\x1b[6 q');
+    });
+
+    it('omitting blink defaults to blinking', () => {
+        expect(cursorShape('block')).toBe('\x1b[1 q');
+        expect(cursorShape('underline')).toBe('\x1b[3 q');
+        expect(cursorShape('bar')).toBe('\x1b[5 q');
+    });
+});
+
+describe('Terminal.setCursorShape', () => {
+    it('setCursorShape block + blink writes correct DECSCUSR sequence', () => {
+        const stdout = createFakeStdout();
+        const terminal = new Terminal({ stdout });
+
+        terminal.setCursorShape('block', true);
+
+        expect(stdout.write).toHaveBeenCalledWith('\x1b[1 q');
+    });
+
+    it('setCursorShape bar + steady writes correct DECSCUSR sequence', () => {
+        const stdout = createFakeStdout();
+        const terminal = new Terminal({ stdout });
+
+        terminal.setCursorShape('bar', false);
+
+        expect(stdout.write).toHaveBeenCalledWith('\x1b[6 q');
+    });
+
+    it('setCursorShape underline default blink writes correct DECSCUSR sequence', () => {
+        const stdout = createFakeStdout();
+        const terminal = new Terminal({ stdout });
+
+        terminal.setCursorShape('underline');
+
+        expect(stdout.write).toHaveBeenCalledWith('\x1b[3 q');
+    });
+
+    it('hideCursor and showCursor are unchanged', () => {
+        const stdout = createFakeStdout();
+        const terminal = new Terminal({ stdout });
+
+        terminal.hideCursor();
+        expect(stdout.write).toHaveBeenCalledWith('\x1b[?25l');
+
+        terminal.showCursor();
+        expect(stdout.write).toHaveBeenCalledWith('\x1b[?25h');
     });
 });
 

--- a/packages/core/src/terminal/Terminal.ts
+++ b/packages/core/src/terminal/Terminal.ts
@@ -188,6 +188,11 @@ export class Terminal {
     hideCursor(): void { this.write(ansi.hideCursor); }
     showCursor(): void { this.write(ansi.showCursor); }
 
+    /** Set the cursor shape via DECSCUSR. Default blink = true. */
+    setCursorShape(shape: ansi.CursorShape, blink?: boolean): void {
+        this.write(ansi.cursorShape(shape, blink));
+    }
+
     /** Ring the terminal bell (BEL). */
     bell(): void { this.write(ansi.bell); }
 

--- a/packages/core/src/utils/ansi.ts
+++ b/packages/core/src/utils/ansi.ts
@@ -21,6 +21,19 @@ export const showCursor = `${CSI}?25h`;
 export const saveCursorPosition = `${CSI}s`;
 export const restoreCursorPosition = `${CSI}u`;
 
+export type CursorShape = 'block' | 'bar' | 'underline';
+
+/** DECSCUSR: CSI Ps SP q. blink toggles steady vs blinking. */
+export function cursorShape(shape: CursorShape, blink = true): string {
+    const codes: Record<CursorShape, number> = {
+        block: 1,
+        underline: 3,
+        bar: 5,
+    };
+    const code = codes[shape] + (blink ? 0 : 1);
+    return `${CSI}${code} q`;
+}
+
 export function moveTo(col: number, row: number): string {
     return `${CSI}${row + 1};${col + 1}H`;
 }


### PR DESCRIPTION
Add CursorShape type and cursorShape() helper to ansi.ts, and Terminal.setCursorShape() method to switch between block, bar, and underline cursors.

- ansi.ts: CursorShape type + cursorShape(shape, blink) helper

- Terminal.ts: setCursorShape method delegates to ansi.cursorShape

- Terminal.test.ts: 11 new tests covering all DECSCUSR codes and defaults

<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

Adds `setCursorShape` to `Terminal` so apps can switch between block, bar, and underline cursors via DECSCUSR (`CSI Ps SP q`). A `CursorShape` type and `cursorShape()` helper are added to `ansi.ts`, and `Terminal.setCursorShape()` delegates to it. All six DECSCUSR codes (blinking/steady × block/underline/bar) are covered by 11 new tests.

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #457 

## Which package(s)?

@termuijs/core

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/172e996c-3943-4a86-8249-1f01922d0f64`

## Screenshots / Recordings (UI changes)

N/A — no visual UI changes. This adds a terminal escape sequence API.

## Notes for the Reviewer

- This is a purely additive change. No existing types, methods, or behavior were modified.
- `hideCursor` / `showCursor` are verified unchanged by a dedicated test case.
- `setCursorShape` follows the same pattern as `hideCursor()` / `showCursor()` — delegates to the `ansi` helper via `this.write()`.
- DECSCUSR codes: block 1/2, underline 3/4, bar 5/6 (odd = blink, even = steady). Default `blink` is `true`.
- The `CursorShape` type is accessible to consumers via the existing `export * as ansi` re-export in `index.ts`.
- The pre-existing `@termuijs/adapters` typecheck failure (RAGChat.ts) is unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cursor shape customization capabilities. Users can now control cursor appearance with support for block, bar, and underline styles, including an optional blinking toggle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->