### PR TITLE
refactor: remove deprecated constructor signatures from Badge and Tag (Closes #1370)

### DIFF
--- a/packages/widgets/src/display/Badge.test.ts
+++ b/packages/widgets/src/display/Badge.test.ts
@@ -120,44 +120,10 @@ describe('Badge', () => {
         expect(() => renderBadge('test', {}, {}, 0, 0)).not.toThrow();
     });
 
-    // ── 6. Constructor overloads ──────────────────────────────────────────
-    it('deprecated signature Badge(text, opts) produces console.warn', () => {
-        const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-        try {
-            new Badge('dep', { variant: 'info' });
-            expect(spy).toHaveBeenCalledWith(
-                'Badge(text, opts, style) is deprecated. Use Badge(text, style, opts) instead.',
-            );
-        } finally {
-            spy.mockRestore();
-        }
-    });
-
-    it('canonical signature Badge(text, style, opts) does not produce console.warn', () => {
-        const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-        try {
-            new Badge('canon', {}, { variant: 'info' });
-            expect(spy).not.toHaveBeenCalled();
-        } finally {
-            spy.mockRestore();
-        }
-    });
-
-    it('deprecated and canonical signatures produce equivalent output', () => {
-        const { screen: screen1 } = renderBadge('same', {}, { variant: 'error' });
-        // Construct with deprecated overload (opts as second arg)
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-        try {
-            const badge2 = new Badge('same', { variant: 'error' });
-            const screen2 = new Screen(20, 3);
-            badge2.updateRect({ x: 0, y: 0, width: 20, height: 3 });
-            badge2.render(screen2);
-            // First row should match
-            expect(screen2.back[0][0].char).toBe(screen1.back[0][0].char);
-            expect(screen2.back[1][2].char).toBe(screen1.back[1][2].char);
-            expect(warnSpy).toHaveBeenCalled();
-        } finally {
-            warnSpy.mockRestore();
-        }
+    // ── 6. Constructor signature ────────────────────────────────────────────
+    it('canonical signature Badge(text, style, opts) works correctly', () => {
+        const { badge } = renderBadge('test', {}, { variant: 'info' });
+        expect(badge.getText()).toBe('test');
+        expect(badge.getVariant()).toBe('info');
     });
 });

--- a/packages/widgets/src/display/Badge.ts
+++ b/packages/widgets/src/display/Badge.ts
@@ -31,32 +31,16 @@ const FG_COLOR: Color = { type: 'named', name: 'black' };
  * Renders a bordered box with the text on a colored background.
  * Uses `caps.unicode` to choose between Unicode box-drawing and ASCII fallback.
  *
- * CONSTRUCTOR (canonical): (text, style?, opts?)
- * @deprecated Badge(text, opts, style) is deprecated. Use Badge(text, style, opts) instead.
+ * CONSTRUCTOR: (text, style?, opts?)
  */
 export class Badge extends Widget {
     private _text: string;
     private _variant: BadgeVariant;
 
-    constructor(text: string, style?: Partial<Style>, opts?: BadgeOptions);
-    /** @deprecated Use Badge(text, style?, opts?) instead */
-    constructor(text: string, opts: BadgeOptions, style?: Partial<Style>);
-    constructor(text: string, styleOrOpts?: Partial<Style> | BadgeOptions, optsOrStyle?: BadgeOptions | Partial<Style>) {
-        // Detect old deprecated signature: Badge(text, opts, style)
-        if (styleOrOpts && 'variant' in styleOrOpts) {
-            console.warn('Badge(text, opts, style) is deprecated. Use Badge(text, style, opts) instead.');
-            const opts = styleOrOpts as BadgeOptions;
-            const style = optsOrStyle as Partial<Style> | undefined;
-            super(style ?? {});
-            this._text = text;
-            this._variant = opts.variant ?? 'neutral';
-        } else {
-            const style = styleOrOpts as Partial<Style> | undefined;
-            const opts = optsOrStyle as BadgeOptions | undefined;
-            super(style ?? {});
-            this._text = text;
-            this._variant = opts?.variant ?? 'neutral';
-        }
+    constructor(text: string, style?: Partial<Style>, opts?: BadgeOptions) {
+        super(style ?? {});
+        this._text = text;
+        this._variant = opts?.variant ?? 'neutral';
     }
 
     /** Update the badge text. */

--- a/packages/widgets/src/display/Tag.test.ts
+++ b/packages/widgets/src/display/Tag.test.ts
@@ -130,7 +130,7 @@ describe('Tag', () => {
     });
 
     it('does not mark dirty when variant is unchanged', () => {
-        const tag = new Tag('Hello', { variant: 'success' });
+        const tag = new Tag('Hello', {}, { variant: 'success' });
 
         tag.clearDirty();
         tag.setVariant('success');
@@ -147,42 +147,10 @@ describe('Tag', () => {
         expect(() => renderTag('test', {}, {}, 0, 0)).not.toThrow();
     });
 
-    // ── 6. Constructor overloads ──────────────────────────────────────────
-    it('deprecated signature Tag(text, opts) produces console.warn', () => {
-        const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-        try {
-            new Tag('dep', { variant: 'info' });
-            expect(spy).toHaveBeenCalledWith(
-                'Tag(text, opts, style) is deprecated. Use Tag(text, style, opts) instead.',
-            );
-        } finally {
-            spy.mockRestore();
-        }
-    });
-
-    it('canonical signature Tag(text, style, opts) does not produce console.warn', () => {
-        const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-        try {
-            new Tag('canon', {}, { variant: 'info' });
-            expect(spy).not.toHaveBeenCalled();
-        } finally {
-            spy.mockRestore();
-        }
-    });
-
-    it('deprecated and canonical signatures produce equivalent output', () => {
-        const { screen: screen1 } = renderTag('same', {}, { variant: 'error' });
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-        try {
-            const tag2 = new Tag('same', { variant: 'error' });
-            const screen2 = new Screen(20, 3);
-            tag2.updateRect({ x: 0, y: 0, width: 20, height: 3 });
-            tag2.render(screen2);
-            expect(screen2.back[0][0].char).toBe(screen1.back[0][0].char);
-            expect(screen2.back[1][2].char).toBe(screen1.back[1][2].char);
-            expect(warnSpy).toHaveBeenCalled();
-        } finally {
-            warnSpy.mockRestore();
-        }
+    // ── 6. Constructor signature ────────────────────────────────────────────
+    it('canonical signature Tag(text, style, opts) works correctly', () => {
+        const { tag } = renderTag('test', {}, { variant: 'info' });
+        expect(tag.getText()).toBe('test');
+        expect(tag.getVariant()).toBe('info');
     });
 });

--- a/packages/widgets/src/display/Tag.ts
+++ b/packages/widgets/src/display/Tag.ts
@@ -28,31 +28,16 @@ const FG_COLORS: Record<TagVariant, Color> = {
  * Renders a bordered box with the text colored by variant but no background.
  * Uses `caps.unicode` to choose between Unicode box-drawing and ASCII fallback.
  *
- * CONSTRUCTOR (canonical): (text, style?, opts?)
- * @deprecated Tag(text, opts, style) is deprecated. Use Tag(text, style, opts) instead.
+ * CONSTRUCTOR: (text, style?, opts?)
  */
 export class Tag extends Widget {
     private _text: string;
     private _variant: TagVariant;
 
-    constructor(text: string, style?: Partial<Style>, opts?: TagOptions);
-    /** @deprecated Use Tag(text, style?, opts?) instead */
-    constructor(text: string, opts: TagOptions, style?: Partial<Style>);
-    constructor(text: string, styleOrOpts?: Partial<Style> | TagOptions, optsOrStyle?: TagOptions | Partial<Style>) {
-        if (styleOrOpts && 'variant' in styleOrOpts) {
-            console.warn('Tag(text, opts, style) is deprecated. Use Tag(text, style, opts) instead.');
-            const opts = styleOrOpts as TagOptions;
-            const style = optsOrStyle as Partial<Style> | undefined;
-            super(style ?? {});
-            this._text = text;
-            this._variant = opts.variant ?? 'neutral';
-        } else {
-            const style = styleOrOpts as Partial<Style> | undefined;
-            const opts = optsOrStyle as TagOptions | undefined;
-            super(style ?? {});
-            this._text = text;
-            this._variant = opts?.variant ?? 'neutral';
-        }
+    constructor(text: string, style?: Partial<Style>, opts?: TagOptions) {
+        super(style ?? {});
+        this._text = text;
+        this._variant = opts?.variant ?? 'neutral';
     }
 
     /** Update the tag text. */

--- a/registry/components/badge/README.md
+++ b/registry/components/badge/README.md
@@ -11,8 +11,8 @@ import { Badge } from './index';
 const badge = new Badge('online');
 
 // Create a badge with a specific variant
-const successBadge = new Badge('verified', { variant: 'success' });
-const errorBadge = new Badge('error', { variant: 'error' });
+const successBadge = new Badge('verified', {}, { variant: 'success' });
+const errorBadge = new Badge('error', {}, { variant: 'error' });
 
 // Available variants: 'info', 'success', 'warning', 'error', 'neutral'
 ```
@@ -29,7 +29,7 @@ const errorBadge = new Badge('error', { variant: 'error' });
 ### Constructor
 
 ```typescript
-constructor(text: string, opts?: BadgeOptions, style?: Partial<Style>)
+constructor(text: string, style?: Partial<Style>, opts?: BadgeOptions)
 ```
 
 ### Methods
@@ -43,6 +43,6 @@ constructor(text: string, opts?: BadgeOptions, style?: Partial<Style>)
 
 ```typescript
 const container = new Box({ height: 5, width: 40 });
-container.addChild(new Badge('online', { variant: 'success' }));
-container.addChild(new Badge('offline', { variant: 'error' }));
+container.addChild(new Badge('online', {}, { variant: 'success' }));
+container.addChild(new Badge('offline', {}, { variant: 'error' }));
 ```


### PR DESCRIPTION
## Description

This PR removes deprecated constructor signatures from `Badge` and `Tag` and updates tests to use only the canonical constructor API.

### Changes

* Removed deprecated constructor overloads from `Badge.ts` and `Tag.ts`
* Removed associated `@deprecated` annotations and `console.warn` calls
* Updated tests to use the canonical constructor signature
* Removed tests covering deprecated behavior

## Related Issue

Closes #1370

## Which package(s)?

@termuijs/widgets

## Type of Change

* [x] ♻️ Refactor (`type:refactor`)
## GSSoC 2026 Participation

   - [x] Yes, I am a GSSoC 2026 contributor.

## Notes for Reviewer

This PR removes legacy deprecated APIs and standardizes usage on the canonical constructor signature without changing widget functionality.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed deprecated constructor overloads for Badge and Tag. Both now require the single standardized argument order: (text, style, options). Update any code using the legacy (text, options, style) order.

* **Documentation**
  * Usage examples and API docs updated to reflect the new constructor parameter order.

* **Tests**
  * Tests adjusted to exercise the canonical constructor; legacy-overload tests removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->