### PR TITLE
feat(widgets): add Stepper widget for sequential step progress display

### DIFF
--- a/packages/widgets/src/display/Stepper.test.ts
+++ b/packages/widgets/src/display/Stepper.test.ts
@@ -1,0 +1,280 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for Stepper widget
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi } from 'vitest';
+import { Screen, caps } from '@termuijs/core';
+import { Stepper, type StepperStep } from './Stepper.js';
+
+// ── Helpers ───────────────────────────────────────────
+
+const STEPS: StepperStep[] = [
+    { label: 'Setup',  status: 'completed' },
+    { label: 'Config', status: 'active' },
+    { label: 'Review', status: 'pending' },
+    { label: 'Done',   status: 'pending' },
+];
+
+function renderStepper(
+    steps: StepperStep[] = STEPS,
+    opts: ConstructorParameters<typeof Stepper>[2] = {},
+    width = 60,
+    height = 10,
+): { widget: Stepper; screen: Screen } {
+    const widget = new Stepper(steps, {}, opts);
+    const screen = new Screen(width, height);
+    widget.updateRect({ x: 0, y: 0, width, height });
+    widget.render(screen);
+    return { widget, screen };
+}
+
+function rowText(screen: Screen, row: number): string {
+    let line = '';
+    for (let col = 0; col < screen.cols; col++) {
+        line += screen.back[row]?.[col]?.char ?? ' ';
+    }
+    return line.trimEnd();
+}
+
+function cellAt(screen: Screen, row: number, col: number) {
+    return screen.back[row]?.[col];
+}
+
+// ── Tests ─────────────────────────────────────────────
+
+describe('Stepper', () => {
+
+    describe('1. Horizontal render (default)', () => {
+        it('renders all step labels', () => {
+            vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+            const { screen } = renderStepper();
+            const text = rowText(screen, 0);
+            expect(text).toContain('Setup');
+            expect(text).toContain('Config');
+            expect(text).toContain('Review');
+            expect(text).toContain('Done');
+            vi.restoreAllMocks();
+        });
+
+        it('renders completed step with ✓ icon', () => {
+            vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+            const { screen } = renderStepper();
+            const text = rowText(screen, 0);
+            expect(text).toContain('✓');
+            vi.restoreAllMocks();
+        });
+
+        it('renders active step with ● icon', () => {
+            vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+            const { screen } = renderStepper();
+            const text = rowText(screen, 0);
+            expect(text).toContain('●');
+            vi.restoreAllMocks();
+        });
+
+        it('renders pending step with ○ icon', () => {
+            vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+            const { screen } = renderStepper();
+            const text = rowText(screen, 0);
+            expect(text).toContain('○');
+            vi.restoreAllMocks();
+        });
+
+        it('renders connectors between steps', () => {
+            vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+            const { screen } = renderStepper();
+            const text = rowText(screen, 0);
+            expect(text).toContain('─');
+            vi.restoreAllMocks();
+        });
+    });
+
+    describe('2. Vertical render', () => {
+        it('renders all step labels on separate rows', () => {
+            vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+            const { screen } = renderStepper(STEPS, { orientation: 'vertical' });
+            const rows = [0, 2, 4, 6].map(r => rowText(screen, r));
+            expect(rows[0]).toContain('Setup');
+            expect(rows[1]).toContain('Config');
+            expect(rows[2]).toContain('Review');
+            expect(rows[3]).toContain('Done');
+            vi.restoreAllMocks();
+        });
+
+        it('renders vertical connector between steps', () => {
+            vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+            const { screen } = renderStepper(STEPS, { orientation: 'vertical' });
+            // Row 1 is the connector between Setup and Config
+            expect(cellAt(screen, 1, 0)?.char).toBe('│');
+            vi.restoreAllMocks();
+        });
+    });
+
+    describe('3. Status colors', () => {
+        it('completed step icon has green color', () => {
+            vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+            const { screen } = renderStepper();
+            // First cell is the ✓ icon of completed step
+            const cell = cellAt(screen, 0, 0);
+            expect(cell?.fg).toEqual({ type: 'named', name: 'green' });
+            vi.restoreAllMocks();
+        });
+
+        it('active step icon has cyan color and is bold', () => {
+            vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+            const { screen } = renderStepper();
+            const text = rowText(screen, 0);
+            // Find ● position
+            const bulletIdx = text.indexOf('●');
+            const cell = cellAt(screen, 0, bulletIdx);
+            expect(cell?.fg).toEqual({ type: 'named', name: 'cyan' });
+            expect(cell?.bold).toBe(true);
+            vi.restoreAllMocks();
+        });
+
+        it('pending step icon is dim', () => {
+            vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+            const { screen } = renderStepper();
+            const text = rowText(screen, 0);
+            const circleIdx = text.indexOf('○');
+            const cell = cellAt(screen, 0, circleIdx);
+            expect(cell?.dim).toBe(true);
+            vi.restoreAllMocks();
+        });
+    });
+
+    describe('4. ASCII fallback', () => {
+        it('uses + for completed when caps.unicode is false', () => {
+            vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+            const { screen } = renderStepper();
+            const text = rowText(screen, 0);
+            expect(text).toContain('+');
+            expect(text).not.toContain('✓');
+            vi.restoreAllMocks();
+        });
+
+        it('uses * for active when caps.unicode is false', () => {
+            vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+            const { screen } = renderStepper();
+            const text = rowText(screen, 0);
+            expect(text).toContain('*');
+            expect(text).not.toContain('●');
+            vi.restoreAllMocks();
+        });
+
+        it('uses - for pending when caps.unicode is false', () => {
+            vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+            const { screen } = renderStepper();
+            const text = rowText(screen, 0);
+            expect(text).toContain('-');
+            expect(text).not.toContain('○');
+            vi.restoreAllMocks();
+        });
+
+        it('uses | for vertical connector when caps.unicode is false', () => {
+            vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+            const { screen } = renderStepper(STEPS, { orientation: 'vertical' });
+            expect(cellAt(screen, 1, 0)?.char).toBe('|');
+            vi.restoreAllMocks();
+        });
+    });
+
+    describe('5. setSteps', () => {
+        it('replaces steps and marks dirty', () => {
+            const { widget } = renderStepper();
+            widget.clearDirty();
+            widget.setSteps([{ label: 'New', status: 'active' }]);
+            expect(widget.isDirty).toBe(true);
+            expect(widget.getSteps()).toHaveLength(1);
+        });
+    });
+
+    describe('6. setStepStatus', () => {
+        it('updates a step status and marks dirty', () => {
+            const { widget } = renderStepper();
+            widget.clearDirty();
+            widget.setStepStatus(2, 'active');
+            expect(widget.isDirty).toBe(true);
+            expect(widget.getSteps()[2].status).toBe('active');
+        });
+
+        it('ignores out-of-bounds index', () => {
+            const { widget } = renderStepper();
+            expect(() => widget.setStepStatus(99, 'active')).not.toThrow();
+        });
+    });
+
+    describe('7. nextStep / prevStep', () => {
+        it('nextStep advances active to next step', () => {
+            const { widget } = renderStepper();
+            // Config (index 1) is active
+            widget.nextStep();
+            expect(widget.getSteps()[1].status).toBe('completed');
+            expect(widget.getSteps()[2].status).toBe('active');
+        });
+
+        it('nextStep marks dirty', () => {
+            const { widget } = renderStepper();
+            widget.clearDirty();
+            widget.nextStep();
+            expect(widget.isDirty).toBe(true);
+        });
+
+        it('nextStep does nothing when last step is active', () => {
+            const steps: StepperStep[] = [
+                { label: 'A', status: 'completed' },
+                { label: 'B', status: 'active' },
+            ];
+            const { widget } = renderStepper(steps);
+            widget.nextStep();
+            expect(widget.getSteps()[1].status).toBe('active');
+        });
+
+        it('prevStep moves active to previous step', () => {
+        const freshSteps: StepperStep[] = [
+            { label: 'Setup',  status: 'completed' },
+            { label: 'Config', status: 'active' },
+            { label: 'Review', status: 'pending' },
+        ];
+        const { widget } = renderStepper(freshSteps);
+        widget.prevStep();
+        expect(widget.getSteps()[0].status).toBe('active');
+        expect(widget.getSteps()[1].status).toBe('pending');
+    });
+
+        it('prevStep marks dirty', () => {
+            const { widget } = renderStepper();
+            widget.clearDirty();
+            widget.prevStep();
+            expect(widget.isDirty).toBe(true);
+        });
+
+        it('prevStep does nothing when first step is active', () => {
+            const steps: StepperStep[] = [
+                { label: 'A', status: 'active' },
+                { label: 'B', status: 'pending' },
+            ];
+            const { widget } = renderStepper(steps);
+            widget.prevStep();
+            expect(widget.getSteps()[0].status).toBe('active');
+        });
+    });
+
+    describe('8. Edge cases', () => {
+        it('handles empty steps array without error', () => {
+            expect(() => renderStepper([])).not.toThrow();
+        });
+
+        it('handles zero-size rect without error', () => {
+            expect(() => renderStepper(STEPS, {}, 0, 0)).not.toThrow();
+        });
+
+        it('uses pending as default status when not specified', () => {
+            vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+            const { screen } = renderStepper([{ label: 'NoStatus' }]);
+            const text = rowText(screen, 0);
+            expect(text).toContain('○');
+            vi.restoreAllMocks();
+        });
+    });
+});

--- a/packages/widgets/src/display/Stepper.ts
+++ b/packages/widgets/src/display/Stepper.ts
@@ -9,6 +9,7 @@ import {
     type Color,
     styleToCellAttrs,
     stringWidth,
+    truncate,
     caps,
 } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
@@ -63,7 +64,8 @@ export class Stepper extends Widget {
         opts: StepperOptions = {},
     ) {
         super(style);
-        this._steps = steps;
+        // Clone steps to prevent external mutation bypassing markDirty()
+        this._steps = steps.map(s => ({ ...s }));
         this._orientation = opts.orientation ?? 'horizontal';
         this._activeColor = opts.activeColor ?? { type: 'named', name: 'cyan' };
         this._completedColor = opts.completedColor ?? { type: 'named', name: 'green' };
@@ -72,15 +74,15 @@ export class Stepper extends Widget {
 
     // ── Public API ──────────────────────────────────────────────────────
 
-    /** Replace all steps. */
+    /** Replace all steps. Clones input to prevent external mutation. */
     setSteps(steps: StepperStep[]): void {
-        this._steps = steps;
+        this._steps = steps.map(s => ({ ...s }));
         this.markDirty();
     }
 
-    /** Get current steps. */
+    /** Get current steps. Returns copies to prevent external mutation. */
     getSteps(): StepperStep[] {
-        return this._steps;
+        return this._steps.map(s => ({ ...s }));
     }
 
     /** Update the status of a single step by index. */
@@ -184,9 +186,9 @@ export class Stepper extends Widget {
             const status = step.status ?? 'pending';
             const { icon, color, bold, dim } = this._stepStyle(status);
 
-            // Icon + label row
+            // Icon + label row — use truncate for correct terminal cell width clipping
             const line = icon + ' ' + step.label;
-            screen.writeString(x, y + row, line.slice(0, width), {
+            screen.writeString(x, y + row, truncate(line, width), {
                 ...attrs,
                 fg: color,
                 bold,

--- a/packages/widgets/src/display/Stepper.ts
+++ b/packages/widgets/src/display/Stepper.ts
@@ -1,0 +1,239 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Stepper widget
+// Renders sequential step progress with status indicators
+// ─────────────────────────────────────────────────────
+
+import {
+    type Screen,
+    type Style,
+    type Color,
+    styleToCellAttrs,
+    stringWidth,
+    caps,
+} from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export type StepStatus = 'completed' | 'active' | 'pending';
+export type StepperOrientation = 'horizontal' | 'vertical';
+
+export interface StepperStep {
+    /** Step label */
+    label: string;
+    /** Step status. Default: 'pending' */
+    status?: StepStatus;
+}
+
+export interface StepperOptions {
+    /** Layout direction. Default: 'horizontal' */
+    orientation?: StepperOrientation;
+    /** Color for active step. Default: cyan */
+    activeColor?: Color;
+    /** Color for completed step. Default: green */
+    completedColor?: Color;
+    /** Color for pending step. Default: white */
+    pendingColor?: Color;
+}
+
+/**
+ * Stepper — renders a sequence of steps with status indicators.
+ *
+ * Horizontal example:
+ *   ✓ Setup ──── ● Config ──── ○ Review ──── ○ Done
+ *
+ * Vertical example:
+ *   ✓ Setup
+ *   │
+ *   ● Config
+ *   │
+ *   ○ Review
+ *
+ * Icons: ✓/+ (completed), ●/* (active), ○/- (pending)
+ * Unicode fallback via caps.unicode.
+ */
+export class Stepper extends Widget {
+    private _steps: StepperStep[];
+    private _orientation: StepperOrientation;
+    private _activeColor: Color;
+    private _completedColor: Color;
+    private _pendingColor: Color;
+
+    constructor(
+        steps: StepperStep[],
+        style: Partial<Style> = {},
+        opts: StepperOptions = {},
+    ) {
+        super(style);
+        this._steps = steps;
+        this._orientation = opts.orientation ?? 'horizontal';
+        this._activeColor = opts.activeColor ?? { type: 'named', name: 'cyan' };
+        this._completedColor = opts.completedColor ?? { type: 'named', name: 'green' };
+        this._pendingColor = opts.pendingColor ?? { type: 'named', name: 'white' };
+    }
+
+    // ── Public API ──────────────────────────────────────────────────────
+
+    /** Replace all steps. */
+    setSteps(steps: StepperStep[]): void {
+        this._steps = steps;
+        this.markDirty();
+    }
+
+    /** Get current steps. */
+    getSteps(): StepperStep[] {
+        return this._steps;
+    }
+
+    /** Update the status of a single step by index. */
+    setStepStatus(index: number, status: StepStatus): void {
+        if (index < 0 || index >= this._steps.length) return;
+        this._steps[index].status = status;
+        this.markDirty();
+    }
+
+    /** Advance the active step to the next one. */
+    nextStep(): void {
+        const activeIdx = this._steps.findIndex(s => s.status === 'active');
+        if (activeIdx === -1 || activeIdx >= this._steps.length - 1) return;
+        this._steps[activeIdx].status = 'completed';
+        this._steps[activeIdx + 1].status = 'active';
+        this.markDirty();
+    }
+
+    /** Move the active step to the previous one. */
+    prevStep(): void {
+        const activeIdx = this._steps.findIndex(s => s.status === 'active');
+        if (activeIdx <= 0) return;
+        this._steps[activeIdx].status = 'pending';
+        this._steps[activeIdx - 1].status = 'active';
+        this.markDirty();
+    }
+
+    // ── Render ──────────────────────────────────────────────────────────
+
+    /** Render all steps with connectors and status icons. */
+    protected _renderSelf(screen: Screen): void {
+        const rect = this._getContentRect();
+        const { x, y, width, height } = rect;
+        if (width <= 0 || height <= 0 || this._steps.length === 0) return;
+
+        if (this._orientation === 'horizontal') {
+            this._renderHorizontal(screen, x, y, width);
+        } else {
+            this._renderVertical(screen, x, y, width, height);
+        }
+    }
+
+    // ── Private ─────────────────────────────────────────────────────────
+
+    /** Render steps left-to-right on a single row. */
+    private _renderHorizontal(
+        screen: Screen,
+        x: number,
+        y: number,
+        width: number,
+    ): void {
+        const attrs = styleToCellAttrs(this._style);
+        const connector = caps.unicode ? '────' : '----';
+        let cursorX = x;
+
+        for (let i = 0; i < this._steps.length; i++) {
+            if (cursorX >= x + width) break;
+            const step = this._steps[i];
+            const status = step.status ?? 'pending';
+            const { icon, color, bold, dim } = this._stepStyle(status);
+
+            // Icon
+            screen.setCell(cursorX, y, { char: icon, fg: color, bold, dim });
+            cursorX++;
+
+            // Space + label
+            const labelStr = ' ' + step.label;
+            const labelWidth = stringWidth(labelStr);
+            if (cursorX + labelWidth > x + width) break;
+            screen.writeString(cursorX, y, labelStr, { ...attrs, fg: color, bold, dim });
+            cursorX += labelWidth;
+
+            // Connector between steps (not after last)
+            if (i < this._steps.length - 1) {
+                const connWidth = stringWidth(connector);
+                if (cursorX + connWidth > x + width) break;
+                screen.writeString(cursorX, y, connector, {
+                    ...attrs,
+                    fg: { type: 'named', name: 'brightBlack' },
+                });
+                cursorX += connWidth;
+            }
+        }
+    }
+
+    /** Render steps top-to-bottom with vertical connectors. */
+    private _renderVertical(
+        screen: Screen,
+        x: number,
+        y: number,
+        width: number,
+        height: number,
+    ): void {
+        const attrs = styleToCellAttrs(this._style);
+        const connectorChar = caps.unicode ? '│' : '|';
+        let row = 0;
+
+        for (let i = 0; i < this._steps.length; i++) {
+            if (row >= height) break;
+            const step = this._steps[i];
+            const status = step.status ?? 'pending';
+            const { icon, color, bold, dim } = this._stepStyle(status);
+
+            // Icon + label row
+            const line = icon + ' ' + step.label;
+            screen.writeString(x, y + row, line.slice(0, width), {
+                ...attrs,
+                fg: color,
+                bold,
+                dim,
+            });
+            row++;
+
+            // Connector row between steps (not after last)
+            if (i < this._steps.length - 1 && row < height) {
+                screen.setCell(x, y + row, {
+                    char: connectorChar,
+                    fg: { type: 'named', name: 'brightBlack' },
+                });
+                row++;
+            }
+        }
+    }
+
+    /** Returns the icon, color, and text attributes for a given status. */
+    private _stepStyle(status: StepStatus): {
+        icon: string;
+        color: Color;
+        bold: boolean;
+        dim: boolean;
+    } {
+        switch (status) {
+            case 'completed':
+                return {
+                    icon: caps.unicode ? '✓' : '+',
+                    color: this._completedColor,
+                    bold: false,
+                    dim: false,
+                };
+            case 'active':
+                return {
+                    icon: caps.unicode ? '●' : '*',
+                    color: this._activeColor,
+                    bold: true,
+                    dim: false,
+                };
+            default:
+                return {
+                    icon: caps.unicode ? '○' : '-',
+                    color: this._pendingColor,
+                    bold: false,
+                    dim: true,
+                };
+        }
+    }
+}

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -200,6 +200,9 @@ export type { ShortcutItem, ShortcutBarOptions } from './display/ShortcutBar.js'
 export { Accordion } from './display/Accordion.js';
 export type { AccordionSection, AccordionOptions } from './display/Accordion.js';
 
+export { Stepper } from './display/Stepper.js';
+export type { StepperStep, StepperOptions, StepStatus, StepperOrientation } from './display/Stepper.js';
+
 
 // ── Missing layout elements restored ──
 export { QRCodePattern, QRCode } from './display/QRCode.js';


### PR DESCRIPTION
## Description
Adds a `Stepper` widget to `@termuijs/widgets` that renders sequential 
step progress with status indicators, connectors, and horizontal/vertical 
orientation support. Follows `Timeline.ts` patterns for rendering and 
status coloring.

## Related Issue
Closes #1336 

## Which package(s)?
`@termuijs/widgets`

## Type of Change
- [x] ✨ Feature (`type:feature`)

## Checklist
- [x] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read `CONTRIBUTING.md`.
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()`.
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation
- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/59d3c49d-74a1-4398-ac87-5ca01a67bc0a`

## Screenshots / Recordings (UI changes)
Horizontal: `✓ Setup ──── ● Config ──── ○ Review ──── ○ Done`
Vertical: each step on its own row with `│` connector between steps.
Unicode/ASCII fallback, status colors (green/cyan/white+dim), 
`nextStep()`/`prevStep()` navigation all covered by 26 tests.

## Notes for the Reviewer
- Follows `Timeline.ts` patterns: `_getContentRect()`, `this._style`, 
  `vi.spyOn(caps, 'unicode', 'get')` for unicode mocking
- Status icons: `✓`/`+` (completed), `●`/`*` (active), `○`/`-` (pending)
- `markDirty()` called in `setSteps()`, `setStepStatus()`, `nextStep()`, `prevStep()`
- Private `_stepStyle()` helper centralizes icon/color/bold/dim logic
- 26 tests across 8 describe blocks covering all features and edge cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Stepper widget for visualizing progress through sequential steps with support for horizontal and vertical layouts, customizable status colors, and step navigation controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->