### PR TITLE
refactor: replace default export with named export in ShortcutHelpOverlay(Closes #1372)

### DIFF
--- a/packages/ui/src/components/ShortcutHelpOverlay.test.tsx
+++ b/packages/ui/src/components/ShortcutHelpOverlay.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import ShortcutHelpOverlayDefault, {
+import {
     ShortcutHelpOverlay,
     type Shortcut,
     type ShortcutHelpOverlayProps,
@@ -8,10 +8,6 @@ import ShortcutHelpOverlayDefault, {
 describe('ShortcutHelpOverlay', () => {
     it('exports a named function component', () => {
         expect(typeof ShortcutHelpOverlay).toBe('function');
-    });
-
-    it('default export matches named export', () => {
-        expect(ShortcutHelpOverlayDefault).toBe(ShortcutHelpOverlay);
     });
 
     it('Shortcut shape has key and label strings', () => {

--- a/packages/ui/src/components/ShortcutHelpOverlay.tsx
+++ b/packages/ui/src/components/ShortcutHelpOverlay.tsx
@@ -121,5 +121,3 @@ export function ShortcutHelpOverlay({ shortcuts = DEFAULT_SHORTCUTS }: ShortcutH
     if (!visible) return null as any;
     return <ShortcutHelpOverlayContent shortcuts={shortcuts} onClose={() => setVisible(false)} />;
 }
-
-export default ShortcutHelpOverlay;


### PR DESCRIPTION
## Description

This PR replaces the default export in `ShortcutHelpOverlay` with a named export to comply with the project's "Named exports only" guideline.

### Changes

* Removed `export default ShortcutHelpOverlay`
* Updated tests to use named imports only
* Removed the test validating the default export
* Verified existing package exports and usages continue to use named exports

## Related Issue

Closes #1372

## Which package(s)?

@termuijs/ui

## Type of Change

* [x] ♻️ Refactor (`type:refactor`)

## GSSoC 2026 Participation

* [x] Yes, I am participating in GSSoC 2026.

## Notes for Reviewer

This change removes the remaining default export from `ShortcutHelpOverlay` and aligns the component with the project's named export convention. No functional behavior was changed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated ShortcutHelpOverlay component with improved visibility state handling and refined export structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->