### PR TITLE
feat(testing): add pressKey, pressKeys and getOutput helpers

### DIFF
--- a/packages/testing/src/render.test.tsx
+++ b/packages/testing/src/render.test.tsx
@@ -137,6 +137,34 @@ describe("render harness", () => {
     });
 
     describe("fireKey", () => {
+        describe("pressKey", () => {
+            it("aliases fireKey", () => {
+                const screen = render(<Counter />);
+
+                screen.pressKey("+");
+
+                expect(screen.renderToString()).toContain("Count: 1");
+            });
+        });
+
+        describe("pressKeys", () => {
+            it("fires multiple keys", () => {
+                const screen = render(<Counter />);
+
+                screen.pressKeys(["+", "+", "+"]);
+
+                expect(screen.renderToString()).toContain("Count: 3");
+            });
+        });
+
+        describe("getOutput", () => {
+            it("returns rendered output", () => {
+                const screen = render(<Hello />);
+
+                expect(screen.getOutput()).toContain("Hello World");
+            });
+        });
+        
         it("delivers key events to rendered components", () => {
             const screen = render(<Counter />);
 

--- a/packages/testing/src/render.ts
+++ b/packages/testing/src/render.ts
@@ -94,6 +94,18 @@ export interface TestInstance {
         modifiers?: { ctrl?: boolean; shift?: boolean; alt?: boolean },
     ): void;
 
+    pressKey(
+        key: string,
+        modifiers?: { ctrl?: boolean; shift?: boolean; alt?: boolean },
+    ): void;
+
+    pressKeys(
+        keys: string[],
+        modifiers?: { ctrl?: boolean; shift?: boolean; alt?: boolean },
+    ): void;
+
+    getOutput(): string;
+
     /** Simulate a mouse event at (x, y). */
     fireMouse(x: number, y: number, init?: Partial<MouseEvent>): void;
 
@@ -405,6 +417,8 @@ export function render(
                 },
             };
 
+        
+
             const instances: Map<Widget, any> = (globalThis as any)
                 .__termuijs_instances;
             const rootInstance = instances?.get(rootWidget);
@@ -420,6 +434,16 @@ export function render(
                 container.addChild(newRoot);
                 rootWidget = newRoot;
                 renderToScreen(container, screen);
+            }
+        },
+
+        pressKey(key: string, modifiers?: { ctrl?: boolean; shift?: boolean; alt?: boolean }): void {
+            instance.fireKey(key, modifiers);
+        },
+
+        pressKeys(keys: string[], modifiers?: { ctrl?: boolean; shift?: boolean; alt?: boolean }): void {
+            for (const key of keys) {
+                instance.fireKey(key, modifiers);
             }
         },
 
@@ -529,6 +553,10 @@ export function render(
 
         renderToString(): string {
             return this.toString();
+        },
+
+        getOutput(): string {
+            return this.renderToString();
         },
 
         fireResize(cols: number, rows: number): void {


### PR DESCRIPTION
## Description

Adds `pressKey`, `pressKeys`, and `getOutput` helper methods to the testing render harness. These methods provide a simpler API for simulating keyboard input and retrieving stable rendered output for assertions and snapshot testing in a terminal-free test environment.

## Related Issue

Closes #73

## Which package(s)?

@termuijs/testing

## Type of Change

* [x] 🧪 Tests (`type:testing`)
* [x] ✨ Feature (`type:feature`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read `CONTRIBUTING.md`.
* [x] Your PR title follows `type: short description`.
* [ ] Widget state mutators call `markDirty()` (not applicable)
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: https://gssoc.girlscript.org/profile/e28902d6-ac09-4030-a305-38827f21efb0

## Screenshots / Recordings (UI changes)

Not applicable. This change affects the testing harness only.

## Notes for the Reviewer

### Added APIs

* `pressKey(key, modifiers?)`

  * Alias for existing `fireKey()` functionality.
* `pressKeys(keys, modifiers?)`

  * Dispatches multiple key events sequentially.
* `getOutput()`

  * Returns the current rendered output using `renderToString()`.

### Tests Added

* Verifies `pressKey()` dispatches keyboard input.
* Verifies `pressKeys()` handles multiple key presses.
* Verifies `getOutput()` returns rendered content.

All tests in `packages/testing/src/render.test.tsx` pass successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyboard input methods: `pressKey()` simulates individual key presses and `pressKeys()` fires multiple keys in sequence, with full support for keyboard modifiers (Ctrl, Shift, Alt)
  * New `getOutput()` method for easy access to rendered component output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->