### PR TITLE
test(router): add validation boundary tests for malformed route param…

### DIFF
--- a/packages/router/src/validation.test.ts
+++ b/packages/router/src/validation.test.ts
@@ -58,4 +58,106 @@ describe('Router Parameter Validation', () => {
         expect(validateParams({ slug: '   ' }, schema).valid).toBe(false);
         expect(validateParams({}, schema).valid).toBe(false);
     });
+
+    // --- Boundary Tests: Malformed Route Parameters ---------------------------
+    describe('boundary: URI-encoded characters in param values', () => {
+        it('handles % encoded characters in param value', () => {
+            const schema = { slug: validators.string() };
+            expect(validateParams({ slug: 'hello%20world' }, schema).valid).toBe(true);
+        });
+
+        it('handles + encoded space in param value', () => {
+            const schema = { slug: validators.string() };
+            expect(validateParams({ slug: 'hello+world' }, schema).valid).toBe(true);
+        });
+
+        it('rejects param value that is only % with no valid encoding', () => {
+            const schema = { id: validators.number() };
+            expect(validateParams({ id: '%' }, schema).valid).toBe(false);
+        });
+    });
+
+    describe('boundary: empty string where param value is expected', () => {
+        it('rejects empty string for number validator', () => {
+            const schema = { id: validators.number() };
+            expect(validateParams({ id: '' }, schema).valid).toBe(false);
+        });
+
+        it('rejects empty string for string validator', () => {
+            const schema = { name: validators.string() };
+            expect(validateParams({ name: '' }, schema).valid).toBe(false);
+        });
+
+        it('rejects empty string for uuid validator', () => {
+            const schema = { userId: validators.uuid() };
+            expect(validateParams({ userId: '' }, schema).valid).toBe(false);
+        });
+
+        it('rejects empty string for enum validator', () => {
+            const schema = { action: validators.enum(['edit', 'view']) };
+            expect(validateParams({ action: '' }, schema).valid).toBe(false);
+        });
+    });
+
+    describe('boundary: numeric-only param values', () => {
+        it('accepts numeric-only param for number validator', () => {
+            const schema = { id: validators.number() };
+            expect(validateParams({ id: '42' }, schema).valid).toBe(true);
+        });
+
+        it('accepts large numeric param', () => {
+            const schema = { id: validators.number() };
+            expect(validateParams({ id: '9999999' }, schema).valid).toBe(true);
+        });
+
+        it('rejects numeric-only value for uuid validator', () => {
+            const schema = { userId: validators.uuid() };
+            expect(validateParams({ userId: '42' }, schema).valid).toBe(false);
+        });
+    });
+
+    describe('boundary: params with special characters (dots and dashes)', () => {
+        it('accepts param with dots for string validator', () => {
+            const schema = { version: validators.string() };
+            expect(validateParams({ version: '1.0.0' }, schema).valid).toBe(true);
+        });
+
+        it('accepts param with dashes for string validator', () => {
+            const schema = { slug: validators.string() };
+            expect(validateParams({ slug: 'my-blog-post' }, schema).valid).toBe(true);
+        });
+
+        it('accepts param with mixed dots and dashes', () => {
+            const schema = { slug: validators.string() };
+            expect(validateParams({ slug: 'v1.0-beta' }, schema).valid).toBe(true);
+        });
+
+        it('rejects param with only dots as a number', () => {
+            const schema = { id: validators.number() };
+            expect(validateParams({ id: '...' }, schema).valid).toBe(false);
+        });
+    });
+
+    describe('boundary: undefined and missing params', () => {
+        it('rejects undefined param for string validator', () => {
+            const schema = { name: validators.string() };
+            expect(validateParams({}, schema).valid).toBe(false);
+        });
+
+        it('rejects undefined param for number validator', () => {
+            const schema = { id: validators.number() };
+            expect(validateParams({}, schema).valid).toBe(false);
+        });
+
+        it('rejects undefined param for enum validator', () => {
+            const schema = { action: validators.enum(['edit', 'view']) };
+            expect(validateParams({}, schema).valid).toBe(false);
+        });
+
+        it('tracks correct error message for missing param', () => {
+            const schema = { id: validators.number() };
+            const result = validateParams({}, schema);
+            expect(result.errors).toContain("Invalid parameter: 'id' with value 'undefined'");
+        });
+    });
 });


### PR DESCRIPTION
**Title:** `test(router): add validation boundary tests for malformed route parameters`

**Description:**

## Summary
Adds targeted boundary tests to `packages/router/src/validation.test.ts` to verify defensive behavior when encountering edge cases in route parameters.

## Changes
Expanded test coverage in `packages/router/src/validation.test.ts` with 18 new boundary assertions across 5 describe blocks:
- **URI-encoded characters** — `%` and `+` encoded values in param strings
- **Empty string params** — empty string rejection across all validators (string, number, uuid, enum)
- **Numeric-only params** — acceptance for number validator, rejection for uuid
- **Special characters** — dots and dashes in param values (e.g. `v1.0-beta`, `my-blog-post`)
- **Undefined/missing params** — correct rejection and error message tracking for missing params

## Testing
All 23 tests in `validation.test.ts` pass:
```
✓ packages/router/src/validation.test.ts (23 tests)
```

## Related Issues
Closes #801

## Notes
- Used `validateParams` and `validators` directly from `validation.ts` — no router navigation needed
- Follows existing patterns from `scanner.test.ts` and `query.test.ts`
- No changes to source files, only test additions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded validation test coverage for router parameter handling, including boundary cases for URI encoding, empty inputs, numeric validation, special characters, and missing parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->