### PR TITLE
fix(scripts): export validateThemeName and prevent CLI execution on import

### DIFF
--- a/packages/dev-server/src/install-theme-regression.test.ts
+++ b/packages/dev-server/src/install-theme-regression.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { validateThemeName } from '../../../scripts/install-theme.js';
+
+describe('scripts/install-theme validateThemeName (regression)', () => {
+  it('allows supported themes', () => {
+    expect(() => validateThemeName('dark')).not.toThrow();
+  });
+
+  it('rejects unsupported themes with message', () => {
+    expect(() => validateThemeName('hacker')).toThrow('Unsupported theme: hacker');
+  });
+});

--- a/packages/dev-server/src/install-theme-regression.test.ts
+++ b/packages/dev-server/src/install-theme-regression.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { validateThemeName } from '../../../scripts/install-theme.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
 
 describe('scripts/install-theme validateThemeName (regression)', () => {
   it('allows supported themes', () => {

--- a/scripts/install-theme.js
+++ b/scripts/install-theme.js
@@ -4,6 +4,7 @@
 // ─────────────────────────────────────────────────────
 
 import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 /**
  * Validate theme name to prevent command injection
@@ -17,7 +18,7 @@ import { execFileSync } from 'node:child_process';
     'solarized',
     'dracula',
   ]);
-function validateThemeName(name) {
+export function validateThemeName(name) {
 
   if (!name || name.length === 0) {
     throw new Error('Theme name cannot be empty');
@@ -65,13 +66,15 @@ function installTheme(themeName) {
   }
 }
 
-// Get theme name from command line arguments
-const themeName = process.argv[2];
+// Only run CLI behavior when executed directly (not when imported in tests)
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const themeName = process.argv[2];
 
-if (!themeName) {
-  console.error('Usage: install-theme <theme-name>');
-  console.error('Example: install-theme dark');
-  process.exit(1);
+  if (!themeName) {
+    console.error('Usage: install-theme <theme-name>');
+    console.error('Example: install-theme dark');
+    process.exit(1);
+  }
+
+  installTheme(themeName);
 }
-
-installTheme(themeName);


### PR DESCRIPTION
## Description

This PR fixes an issue in `scripts/install-theme.js` where `validateThemeName` was imported by tests but was not exported from the module.

During investigation, importing the module was also found to execute CLI logic immediately, which could trigger `process.exit(1)` when no command-line arguments were provided. This PR exports `validateThemeName`, guards CLI execution so it only runs when executed directly, and adds a regression test covering importability and validator behavior.

## Related Issue

Closes #1459 

## Which package(s)?

scripts

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read `CONTRIBUTING.md`.
* [x] Your PR title follows `type: short description`.
* [x] No unrelated refactors bundled into this PR.
* [x] Regression test added.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

### Root Cause

Before this change:

```js
import { validateThemeName } from './install-theme.js';
```

failed because `validateThemeName` was not exported.

After exporting the function, importing the module still executed CLI logic and could call `process.exit(1)` during import.

### Changes

* Export `validateThemeName`
* Guard CLI execution using a direct-execution check
* Add regression coverage for importability and validator behavior

### Verification

Reproduced original failure:

```text
SyntaxError: The requested module './install-theme.js' does not provide an export named 'validateThemeName'
```

Verified that:

* The original implementation fails the regression test.
* The patched implementation passes.
* Direct CLI behavior and exit codes remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a regression test suite to confirm theme-name validation: supported themes are accepted, while unsupported themes are rejected with the exact error message.

* **Refactor**
  * Improved the theme installation script’s structure by exporting the theme-name validation logic for reuse.
  * Made the script’s CLI behavior run only when executed directly, improving safety when imported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->