### PR TITLE
feat(router): add notFound route handler (#497)

### DIFF
--- a/packages/router/src/not-found.test.ts
+++ b/packages/router/src/not-found.test.ts
@@ -1,0 +1,97 @@
+// -----------------------------------------------------
+// @termuijs/router - Tests for configurable not-found routes
+// -----------------------------------------------------
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isVElement, unmountAll, type VNode } from '@termuijs/jsx';
+import { render, type TestInstance } from '@termuijs/testing';
+import { Router } from './router.js';
+import { RouterContext } from './hooks.js';
+
+function notFound(path: string): VNode {
+    return { type: 'text', props: {}, children: ['404 ' + path] };
+}
+
+let rendered: TestInstance | null = null;
+
+afterEach(() => {
+    rendered?.unmount();
+    rendered = null;
+    unmountAll();
+    vi.restoreAllMocks();
+});
+
+describe('Router notFound', () => {
+    it('renders notFound on unmatched path', () => {
+        const router = new Router({ notFound });
+        const navigate = vi.fn();
+        const error = vi.fn();
+        router.events.on('navigate', navigate);
+        router.events.on('error', error);
+
+        router.push('/missing');
+
+        expect(navigate).toHaveBeenCalledOnce();
+        expect(error).not.toHaveBeenCalled();
+        expect(router.currentPath).toBe('/missing');
+        expect(router.historyLength).toBe(1);
+
+        rendered = render(navigate.mock.calls[0][0].screen);
+        expect(rendered.getByText('404 /missing')).not.toBeNull();
+    });
+
+    it('notFound receives the attempted path', () => {
+        const captured = vi.fn(notFound);
+        const router = new Router({ notFound: captured });
+        const navigate = vi.fn();
+        router.events.on('navigate', navigate);
+
+        router.push('/lost');
+
+        rendered = render(navigate.mock.calls[0][0].screen);
+        expect(captured).toHaveBeenCalledWith('/lost');
+    });
+
+    it('emits navigate with the 404 screen', () => {
+        const router = new Router({ notFound });
+        const navigate = vi.fn();
+        const error = vi.fn();
+        router.events.on('navigate', navigate);
+        router.events.on('error', error);
+
+        router.push('/gone');
+
+        expect(navigate).toHaveBeenCalledOnce();
+        expect(error).not.toHaveBeenCalled();
+
+        const event = navigate.mock.calls[0][0];
+        expect(event.match.route.path).toBe('/gone');
+        expect(event.direction).toBe('push');
+        expect(isVElement(event.screen)).toBe(true);
+        if (!isVElement(event.screen)) {
+            throw new Error('Expected 404 screen to be a wrapped element');
+        }
+
+        const provider = event.screen.children[0];
+        expect(isVElement(provider)).toBe(true);
+        if (!isVElement(provider)) {
+            throw new Error('Expected 404 screen to include RouterContext.Provider');
+        }
+        expect(provider.type).toBe(RouterContext.Provider);
+    });
+
+    it('falls back to error when notFound is absent', () => {
+        const router = new Router();
+        const navigate = vi.fn();
+        const error = vi.fn();
+        router.events.on('navigate', navigate);
+        router.events.on('error', error);
+
+        router.push('/missing');
+
+        expect(error).toHaveBeenCalledOnce();
+        expect(navigate).not.toHaveBeenCalled();
+        expect(router.currentPath).toBe('/');
+        expect(router.historyLength).toBe(0);
+    });
+});

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -36,7 +36,7 @@ export interface RouterOptions {
     /** Maximum history entries (default: 100) */
     maxHistory?: number;
     /** Component rendered when no route matches */
-    notFound?: (path: string) => any;
+    notFound?: (path: string) => VNode;
 }
 
 export class Router {
@@ -45,7 +45,7 @@ export class Router {
     private _forwardStack: string[] = [];
     private _currentMatch: RouteMatch | null = null;
     private _maxHistory: number;
-    private _notFound?: (path: string) => any;
+    private _notFound?: (path: string) => VNode;
     private _pendingInitialPath: string | null = null;
     readonly events = new EventEmitter<RouterEvents>();
 

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -35,6 +35,8 @@ export interface RouterOptions {
     initialPath?: string;
     /** Maximum history entries (default: 100) */
     maxHistory?: number;
+    /** Component rendered when no route matches */
+    notFound?: (path: string) => any;
 }
 
 export class Router {
@@ -43,11 +45,13 @@ export class Router {
     private _forwardStack: string[] = [];
     private _currentMatch: RouteMatch | null = null;
     private _maxHistory: number;
+    private _notFound?: (path: string) => any;
     private _pendingInitialPath: string | null = null;
     readonly events = new EventEmitter<RouterEvents>();
 
     constructor(options: RouterOptions = {}) {
         this._maxHistory = options.maxHistory ?? 100;
+        this._notFound = options.notFound;
 
         if (options.initialPath) {
             this._pendingInitialPath = options.initialPath;
@@ -186,6 +190,22 @@ export class Router {
         return createElement(ErrorBoundary, { fallback: defaultErrorScreen }, withProvider);
     }
 
+    private _createNotFoundMatch(path: string): RouteMatch {
+        const route: Route = {
+            path,
+            component: () => this._notFound?.(path),
+            meta: {},
+        };
+
+        return {
+            route,
+            chain: [route],
+            params: {},
+            meta: {},
+            query: {},
+        };
+    }
+
     private _resolveRedirect(path: string, depth = 0): string | null {
         if (depth > 10) {
             this.events.emit('error', new Error(`Max redirect depth exceeded for path: ${path}`));
@@ -222,6 +242,38 @@ export class Router {
         const match = matchRoute(resolvedPath, this._routes);
 
         if (!match) {
+            if (this._notFound) {
+                if (options.clearForwardStack) {
+                    this._forwardStack = [];
+                }
+
+                const { modifyHistory = 'push', direction = 'push' } = options;
+
+                if (modifyHistory === 'push') {
+                    this._history.push(resolvedPath);
+
+                    if (this._history.length > this._maxHistory) {
+                        this._history = this._history.slice(-this._maxHistory);
+                    }
+                } else if (modifyHistory === 'replace') {
+                    if (this._history.length > 0) {
+                        this._history[this._history.length - 1] = resolvedPath;
+                    } else {
+                        this._history.push(resolvedPath);
+                    }
+                }
+
+                const notFoundMatch = this._createNotFoundMatch(resolvedPath);
+                this._currentMatch = notFoundMatch;
+
+                unmountAll();
+
+                const screen = this._wrapScreen(notFoundMatch);
+                const emitEvent = direction === 'back' ? 'back' : 'navigate';
+                this.events.emit(emitEvent, { match: notFoundMatch, screen, direction });
+                return;
+            }
+
             this.events.emit('error', new Error(`No route found for path: ${resolvedPath}`));
             return;
         }


### PR DESCRIPTION
## Description

Adds a configurable `notFound` handler to `@termuijs/router`. When navigation targets an unmatched path, the router now renders the provided 404 component through the normal `RouterContext.Provider` wrap pipeline and emits a `navigate` event while preserving existing error behavior when no handler is configured.

## Related Issue

Closes #497

## Which package(s)?

@termuijs/router

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.

## Screenshots / Recordings (UI changes)

N/A. This is a router API behavior change with unit test coverage.

## Notes for the Reviewer

Added focused tests for the configurable not-found handler, including unmatched path rendering, attempted path forwarding, `navigate` emission, and fallback error behavior when no handler is configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable “not found” handling to the router via a `notFound` option, allowing a custom fallback screen for unmatched paths. Navigation continues using the appropriate event behavior and respects history management settings (instead of stopping with an error-only flow).

* **Tests**
  * Added new automated coverage for unmatched-route scenarios, including custom fallback rendering, correct callback parameters, and validation of emitted navigation versus error behavior when `notFound` is not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->