### PR TITLE
fix(core): add benchmark field to render-loop payload

### DIFF
--- a/packages/core/src/benchmark/render-loop.test.ts
+++ b/packages/core/src/benchmark/render-loop.test.ts
@@ -30,6 +30,7 @@ describe('render-loop benchmark', () => {
         const payload = JSON.parse(jsonStr);
 
         expect(payload.version).toBe(1);
+        expect(payload.benchmark).toBe('render-loop');
         expect(payload.runMs).toBe(1000);
         expect(payload.results).toHaveLength(3);
 

--- a/packages/core/src/benchmark/render-loop.ts
+++ b/packages/core/src/benchmark/render-loop.ts
@@ -86,6 +86,7 @@ function main(): void {
 
     const payload = {
         version: 1,
+        benchmark: 'render-loop',
         runMs: RUN_MS,
         node: process.versions.node,
         bun: process.versions.bun ?? null,


### PR DESCRIPTION
## Description

This PR fixes a benchmark schema mismatch in `packages/core/src/benchmark/render-loop.ts`.

`run-all.ts` expects every benchmark result payload to contain a `benchmark` string field. While all other benchmark scripts emit this field, `render-loop.ts` omitted it, causing `bun run bench` to fail with `Invalid result: missing or invalid benchmark field`.

This PR adds the missing `benchmark` field and includes a regression test to ensure the benchmark name is present in the emitted payload.

## Related Issue

Closes #1462 

## Which package(s)?

@termuijs/core

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)
* [x] 🧪 Tests (`type:testing`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

### Root Cause

`packages/core/src/benchmark/run-all.ts` validates benchmark payloads and requires a `benchmark` string field.

All benchmark scripts emitted this field except `render-loop.ts`, causing benchmark execution to fail with:

```text
Invalid result: missing or invalid benchmark field
```

### Changes

* Added `benchmark: 'render-loop'` to the emitted benchmark payload.
* Added a regression assertion in `render-loop.test.ts` verifying the benchmark name is present.

### Verification

Reproduced on the current `main` branch:

```bash
bun run bench
```

Before the fix:

```text
Failed to parse benchmark result from render-loop.ts:
Error: Invalid result: missing or invalid benchmark field
```

After the fix:

* `bun vitest run packages/core/src/benchmark/render-loop.test.ts`
* `bun run bench`

Both complete successfully and benchmark aggregation works as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated benchmark test assertions to verify identifier field inclusion in result payloads.

* **Chores**
  * Enhanced benchmark result payload structure for improved CI automation integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->