### PR TITLE
fix(core): eliminate render pipeline race condition — move dirty check inside deferred callback, add epoch guarding and mutual exclusion to swap

### DIFF
--- a/packages/core/src/app/App.ts
+++ b/packages/core/src/app/App.ts
@@ -344,17 +344,13 @@ export class App {
         // pick up all dirty state when it eventually runs.
         if (this._isRenderPending) return;
 
-        // Skip full render pass if neither the widget tree nor overlay layers
-        // have reported any changes.
-        if (this._rootWidget.isDirty === false && !this.layers.hasDirtyLayers()) {
-            return;
-        }
-
         this._isRenderPending = true;
 
         // Defer rendering to the end of the current macro-task poll pool.
         // This guarantees that multiple state updates called synchronously
-        // collapse into a single render frame.
+        // collapse into a single render frame. The dirty check is performed
+        // INSIDE the deferred callback, eliminating the race window between
+        // the check and the guard flag being set.
         setImmediate(() => {
             if (!this._mounted) {
                 this._isRenderPending = false;
@@ -362,6 +358,14 @@ export class App {
             }
 
             try {
+                // Skip full render pass if neither the widget tree nor overlay
+                // layers have reported any changes. Done inside the deferred
+                // callback so the dirty check and the _isRenderPending guard
+                // are never racy with concurrent requestRender() calls.
+                if (this._rootWidget.isDirty === false && !this.layers.hasDirtyLayers()) {
+                    return;
+                }
+
                 if (this._rootWidget.isDirty !== false) {
                     // Compute layout
                     const layoutRoot = this._rootWidget.getLayoutNode();

--- a/packages/core/src/terminal/Renderer.ts
+++ b/packages/core/src/terminal/Renderer.ts
@@ -64,10 +64,6 @@ export class Renderer {
         const interval = Math.floor(1000 / this._fps);
         this._frameTimer = setInterval(() => {
             this._onTick?.();
-            if (this._renderRequested) {
-                this._renderRequested = false;
-                this._flush();
-            }
         }, interval);
     }
 
@@ -115,6 +111,12 @@ export class Renderer {
      * emit only changed cells.
      */
     private _flush(): void {
+        // Capture the current epoch; if swap() has already been called by a
+        // duplicate callback, skip this flush to prevent buffer corruption.
+        const epoch = this._screen.epoch;
+        if (this._screen.flushEpoch === epoch) return;
+        this._screen.flushEpoch = epoch;
+
         const start = this._callbacks.size > 0 ? performance.now() : 0;
 
         // 1. Grab any logs that console.log() caught while we were rendering

--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -138,7 +138,7 @@ export class Screen {
     private _swapping = false;
 
     /** The epoch captured at the start of the current flush cycle. */
-    private _flushEpoch = 0;
+    private _flushEpoch = -1;
 
     /**
      * Stack of clipping regions. When non-empty, setCell/writeString

--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -128,6 +128,19 @@ export class Screen {
     back: Cell[][];
 
     /**
+     * Render epoch counter. Incremented on every swap so downstream consumers
+     * (e.g. Renderer._flush) can detect and skip stale frames from a previous
+     * epoch, preventing double-swap corruption.
+     */
+    private _epoch = 0;
+
+    /** True while swap() is executing to prevent re-entrant double-swap corruption. */
+    private _swapping = false;
+
+    /** The epoch captured at the start of the current flush cycle. */
+    private _flushEpoch = 0;
+
+    /**
      * Stack of clipping regions. When non-empty, setCell/writeString
      * only write to cells within the topmost clip rectangle.
      */
@@ -363,13 +376,36 @@ export class Screen {
         }
     }
 
+    /** Current render epoch — incremented after each swap. */
+    get epoch(): number {
+        return this._epoch;
+    }
+
+    /** The epoch captured at the start of the current flush cycle. */
+    get flushEpoch(): number {
+        return this._flushEpoch;
+    }
+    set flushEpoch(value: number) {
+        this._flushEpoch = value;
+    }
+
     /**
      * Swap front and back buffers. Called after rendering diffs.
+     * Uses mutual exclusion to prevent double-swap corruption when
+     * _flush() is called concurrently (e.g. from duplicate setImmediate
+     * callbacks).
      */
     swap(): void {
-        const temp = this.front;
-        this.front = this.back;
-        this.back = temp;
+        if (this._swapping) return;
+        this._swapping = true;
+        try {
+            const temp = this.front;
+            this.front = this.back;
+            this.back = temp;
+            this._epoch++;
+        } finally {
+            this._swapping = false;
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

The `setImmediate`-based render batching in `App.requestRender()` had a race
window between the dirty-flag check and the `_isRenderPending` guard. This
allowed duplicate `setImmediate` callbacks to be scheduled. When both callbacks
executed, `Screen.swap()` was called twice in a single frame cycle, corrupting
the front/back buffer pair and producing garbage ANSI output.

## Changes

**`packages/core/src/app/App.ts`**
- Moved the dirty-flag check (`this._dirty`) inside the `setImmediate` deferred
  callback so `_isRenderPending` is set before any concurrent `requestRender()`
  can see a false negative.

**`packages/core/src/terminal/Screen.ts`**
- Added an `_epoch` counter incremented on every successful `swap()`.
- Added a `_swapping` mutual-exclusion flag to prevent re-entrant double-swap.
- Added `flushEpoch` setter so `Renderer._flush()` can detect stale frames.

**`packages/core/src/terminal/Renderer.ts`**
- `_flush()` now captures the current screen epoch at entry and skips execution
  if `flushEpoch === epoch` (duplicate callback already swapped).
- Removed the `_renderRequested` check from the `setInterval` tick callback to
  eliminate the double-deferral layer (`setInterval` → `setImmediate`).

Fixes #1464

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved render coalescing by batching synchronous render requests within the same tick.
  * Prevented duplicate terminal flushes that could lead to corrupted output.
  * Added safeguards against overlapping/re-entrant swap and flush operations, improving terminal stability and visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->