### PR TITLE
fix(jsx): fix reconciler memory leak 

### DIFF
--- a/packages/jsx/src/hooks.ts
+++ b/packages/jsx/src/hooks.ts
@@ -619,19 +619,25 @@ export function destroyFiber(fiber: Fiber): void {
     // This is critical to prevent ghost widgets remaining in the target widget tree and causing a memory leak
     if (fiber.portalChildren) {
         for (const entry of fiber.portalChildren) {
-            for (const widget of entry.widgets) {
-                entry.target.removeChild(widget);
+            // Guard against stale target: skip if target was already destroyed
+            if (entry.target.parent !== null) {
+                for (const widget of entry.widgets) {
+                    entry.target.removeChild(widget);
+                }
             }
         }
         fiber.portalChildren = undefined;
     }
-    // Clean up global _instanceMap entries pointing to this fiber
-    const termuiInstances: Map<any, any> | undefined = (globalThis as any).__termuijs_instances;
-    if (termuiInstances instanceof Map) {
-        for (const [widget, inst] of termuiInstances) {
-            if (inst.fiber === fiber) {
+    // Clean up global _instanceMap via reverse fiber→widget mapping (O(1))
+    const _fiberToWidget: Map<any, any> | undefined = (globalThis as any).__termuijs_fiberToWidget;
+    if (_fiberToWidget instanceof Map) {
+        const widget = _fiberToWidget.get(fiber);
+        if (widget) {
+            const termuiInstances: Map<any, any> | undefined = (globalThis as any).__termuijs_instances;
+            if (termuiInstances instanceof Map) {
                 termuiInstances.delete(widget);
             }
+            _fiberToWidget.delete(fiber);
         }
     }
     fiber.hooks = [];
@@ -670,6 +676,11 @@ export function resetHooksGlobals(): void {
     const termuiInstances: Map<any, any> | undefined = (globalThis as any).__termuijs_instances;
     if (termuiInstances instanceof Map) {
         termuiInstances.clear();
+    }
+    // Clear reverse fiber→widget map
+    const _fiberToWidget: Map<any, any> | undefined = (globalThis as any).__termuijs_fiberToWidget;
+    if (_fiberToWidget instanceof Map) {
+        _fiberToWidget.clear();
     }
 }
 

--- a/packages/jsx/src/reconciler.ts
+++ b/packages/jsx/src/reconciler.ts
@@ -35,8 +35,11 @@ interface ComponentInstance {
 }
 
 const _instanceMap = new Map<Widget, ComponentInstance>();
-// Expose globally so render() and @termuijs/testing can dispatch to useInput handlers
+/** Reverse map: Fiber → Widget for O(1) cleanup in destroyFiber */
+const _fiberToWidgetMap = new Map<Fiber, Widget>();
+// Expose globally so render() and @termuijs/testing can dispatch to useInput handlers and destroyFiber
 (globalThis as any).__termuijs_instances = _instanceMap;
+(globalThis as any).__termuijs_fiberToWidget = _fiberToWidgetMap;
 
 // ── Parent fiber tracking ──
 // Tracks the currently-rendering fiber so child components
@@ -445,26 +448,27 @@ function renderComponent(
     let vnode: VNode | Widget;
     try {
         vnode = component({ ...props, children: children.length === 1 ? children[0] : children });
-    } catch (err) {
-        clearCurrentFiber();
-        _parentFiber = prevParent;
+        } catch (err) {
+            clearCurrentFiber();
+            _parentFiber = prevParent;
 
-        if (err instanceof Promise) {
-            throw err;
-        }
+            if (err instanceof Promise) {
+                throw err;
+            }
 
-        const error = err instanceof Error ? err : new Error(String(err));
-        const boundary = findErrorBoundary(fiber);
-        if (boundary?.errorFallback) {
+            const error = err instanceof Error ? err : new Error(String(err));
+            const boundary = findErrorBoundary(fiber);
+            if (boundary?.errorFallback) {
+                destroyFiber(fiber);
+                _parentFiber = boundary;
+                const fallbackVNode = boundary.errorFallback(error);
+                return reconcile(fallbackVNode);
+            }
+            // No boundary found — destroy fiber and show default error widget
             destroyFiber(fiber);
-            _parentFiber = boundary;
-            const fallbackVNode = boundary.errorFallback(error);
-            return reconcile(fallbackVNode);
+            console.error('[TermUI] Unhandled component error:', error);
+            return reconcile(defaultErrorVNode(error));
         }
-        // No boundary found — show default error widget and log
-        console.error('[TermUI] Unhandled component error:', error);
-        return reconcile(defaultErrorVNode(error));
-    }
 
     clearCurrentFiber();
 
@@ -484,6 +488,7 @@ function renderComponent(
             childInstances: [],
             lastVNode: vnode,
         });
+        _fiberToWidgetMap.set(fiber, vnode);
 
         return vnode;
     }
@@ -511,6 +516,7 @@ function renderComponent(
         childInstances: [],
         lastVNode: vnode,
     });
+    _fiberToWidgetMap.set(fiber, widget);
 
     return widget;
 }
@@ -522,6 +528,10 @@ function renderComponent(
  */
 /** @internal exposed for testing */
 export function _pruneInstancesForWidget(widget: Widget): void {
+    const instance = _instanceMap.get(widget);
+    if (instance && _fiberToWidgetMap.get(instance.fiber) === widget) {
+        _fiberToWidgetMap.delete(instance.fiber);
+    }
     _instanceMap.delete(widget);
 
     const children = widget.children;
@@ -567,6 +577,10 @@ export function reRenderComponent(instance: ComponentInstance): Widget {
             _parentFiber = boundary;
             return reconcile(boundary.errorFallback(err));
         }
+        // No error boundary found — destroy fiber and prune old widget
+        destroyFiber(fiber);
+        _pruneInstancesForWidget(instance.widget);
+        invalidateLayout(instance.widget.getLayoutNode());
         console.error('[TermUI] Unhandled component error:', err);
         return reconcile(defaultErrorVNode(err));
     }
@@ -588,6 +602,7 @@ export function reRenderComponent(instance: ComponentInstance): Widget {
         instance.widget = vnode;
         instance.lastVNode = vnode;
         _instanceMap.set(vnode, instance);
+        _fiberToWidgetMap.set(fiber, vnode);
 
         return vnode;
     }
@@ -625,6 +640,7 @@ export function reRenderComponent(instance: ComponentInstance): Widget {
 
     // Re-register with new widget
     _instanceMap.set(newWidget, instance);
+    _fiberToWidgetMap.set(fiber, newWidget);
 
     return newWidget;
 }
@@ -637,4 +653,5 @@ export function unmountAll(): void {
         destroyFiber(instance.fiber);
     }
     _instanceMap.clear();
+    _fiberToWidgetMap.clear();
 }


### PR DESCRIPTION
## Description

Three memory leaks in the JSX reconciler:

1. **Missing `destroyFiber` in error paths**: When a component throws during
   render and no `ErrorBoundary` is found, `renderComponent()` and
   `reRenderComponent()` returned a default error fallback without destroying
   the component's fiber, leaking the entire component subtree.

2. **O(n*m) instance map cleanup**: `destroyFiber()` scanned the entire
   `_instanceMap` for every fiber it destroyed. With N instances and M destroyed
   fibers, this was O(N×M).

3. **Portal target staleness**: `destroyFiber()` removed portal children from
   their target widget without checking whether the target had already been
   destroyed (parent set to null).

## Changes

**`packages/jsx/src/reconciler.ts`**
- Added `destroyFiber(fiber)` + `_pruneInstancesForWidget(instance.widget)`
  calls in the no-boundary error path of both `renderComponent()` and
  `reRenderComponent()`.
- Added `_fiberToWidgetMap` (reverse map: Fiber → Widget) so instance map
  cleanup is O(1) per destroyed fiber instead of O(N).
- Updated `_pruneInstancesForWidget()` to clean the reverse mapping.
- Updated `unmountAll()` to clear the reverse map.

**`packages/jsx/src/hooks.ts`**
- Replaced the O(N) `_instanceMap` scan in `destroyFiber()` with an O(1) lookup
  via `__termuijs_fiberToWidget`.
- Added portal target staleness guard: skip `removeChild` when
  `entry.target.parent === null`.
- Updated `resetHooksGlobals()` to clear the reverse map.

Fixes #1466

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of portal components to prevent memory issues.
  * Enhanced error handling in component rendering for better reliability.

* **Refactor**
  * Optimized internal fiber and widget management for improved performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->