### PR TITLE
feat: add useWorker hook with exclusive group cancellation

### DIFF
--- a/packages/jsx/src/hooks/useWorker.test.ts
+++ b/packages/jsx/src/hooks/useWorker.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import { useWorker } from './useWorker.js';
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+
+    return {
+        promise,
+        resolve,
+        reject,
+    };
+}
+
+describe('useWorker', () => {
+    it('passes AbortSignal to worker', async () => {
+        let received!: AbortSignal;
+
+        const worker = useWorker(async signal => {
+            received = signal;
+            return 'ok';
+        });
+
+        const result = await worker.run();
+
+        expect(result).toBe('ok');
+        expect(received).toBeInstanceOf(AbortSignal);
+    });
+
+    it('cancels previous call in the same exclusive group', async () => {
+        const signals: AbortSignal[] = [];
+
+        const gate1 = deferred<void>();
+        const gate2 = deferred<void>();
+
+        const worker = useWorker(
+            async (signal, value: number) => {
+                signals.push(signal);
+
+                if (value === 1) {
+                    await gate1.promise;
+                } else {
+                    await gate2.promise;
+                }
+
+                return value;
+            },
+            {
+                exclusive: true,
+                group: 'search',
+            },
+        );
+
+        void worker.run(1);
+        void worker.run(2);
+
+        expect(signals).toHaveLength(2);
+        expect(signals[0].aborted).toBe(true);
+        expect(signals[1].aborted).toBe(false);
+
+        gate1.resolve();
+        gate2.resolve();
+    });
+
+    it('allows concurrent runs when not exclusive', async () => {
+        const signals: AbortSignal[] = [];
+
+        const gate1 = deferred<void>();
+        const gate2 = deferred<void>();
+
+        const worker = useWorker(async (signal, value: number) => {
+            signals.push(signal);
+
+            if (value === 1) {
+                await gate1.promise;
+            } else {
+                await gate2.promise;
+            }
+
+            return value;
+        });
+
+        void worker.run(1);
+        void worker.run(2);
+
+        expect(signals).toHaveLength(2);
+        expect(signals[0].aborted).toBe(false);
+        expect(signals[1].aborted).toBe(false);
+
+        gate1.resolve();
+        gate2.resolve();
+    });
+
+    it('cancel aborts the current run', async () => {
+        let signal!: AbortSignal;
+
+        const gate = deferred<void>();
+
+        const worker = useWorker(async s => {
+            signal = s;
+            await gate.promise;
+        });
+
+        void worker.run();
+
+        worker.cancel();
+
+        expect(signal.aborted).toBe(true);
+
+        gate.resolve();
+    });
+
+    it('does not cancel workers in different groups', async () => {
+        let signalA!: AbortSignal;
+        let signalB!: AbortSignal;
+
+        const gateA = deferred<void>();
+        const gateB = deferred<void>();
+
+        const workerA = useWorker(
+            async signal => {
+                signalA = signal;
+                await gateA.promise;
+            },
+            {
+                exclusive: true,
+                group: 'search',
+            },
+        );
+
+        const workerB = useWorker(
+            async signal => {
+                signalB = signal;
+                await gateB.promise;
+            },
+            {
+                exclusive: true,
+                group: 'upload',
+            },
+        );
+
+        void workerA.run();
+        void workerB.run();
+
+        expect(signalA.aborted).toBe(false);
+        expect(signalB.aborted).toBe(false);
+
+        gateA.resolve();
+        gateB.resolve();
+    });
+
+    it('updates status while running', async () => {
+        const gate = deferred<void>();
+
+        const worker = useWorker(async () => {
+            await gate.promise;
+            return 'done';
+        });
+
+        const promise = worker.run();
+
+        expect(worker.status).toBe('running');
+
+        gate.resolve();
+
+        await promise;
+
+        expect(worker.status).toBe('idle');
+    });
+});

--- a/packages/jsx/src/hooks/useWorker.ts
+++ b/packages/jsx/src/hooks/useWorker.ts
@@ -1,0 +1,67 @@
+export interface UseWorkerOptions {
+    exclusive?: boolean;
+    group?: string;
+}
+
+export interface UseWorkerResult<TArgs extends unknown[], TResult> {
+    run: (...args: TArgs) => Promise<TResult>;
+    cancel: () => void;
+    readonly status: 'idle' | 'running';
+}
+
+const groupControllers = new Map<string, AbortController>();
+
+export function useWorker<TArgs extends unknown[], TResult>(
+    worker: (
+        signal: AbortSignal,
+        ...args: TArgs
+    ) => Promise<TResult>,
+    options: UseWorkerOptions = {},
+): UseWorkerResult<TArgs, TResult> {
+    let controller: AbortController | null = null;
+    let status: 'idle' | 'running' = 'idle';
+
+    async function run(...args: TArgs): Promise<TResult> {
+        if (options.exclusive && options.group) {
+            const existing = groupControllers.get(options.group);
+
+            if (existing && !existing.signal.aborted) {
+                existing.abort();
+            }
+        }
+
+        controller = new AbortController();
+
+        if (options.exclusive && options.group) {
+            groupControllers.set(options.group, controller);
+        }
+
+        status = 'running';
+
+        try {
+            return await worker(controller.signal, ...args);
+        } finally {
+            status = 'idle';
+
+            if (
+                options.exclusive &&
+                options.group &&
+                groupControllers.get(options.group) === controller
+            ) {
+                groupControllers.delete(options.group);
+            }
+        }
+    }
+
+    function cancel(): void {
+        controller?.abort();
+    }
+
+    return {
+        run,
+        cancel,
+        get status() {
+            return status;
+        },
+    };
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -81,6 +81,12 @@ export type { UseModalResult } from './hooks/useModal.js';
 // ── Subprocess ──
 export { useSubprocess } from './hooks/useSubprocess.js';
 export type { UseSubprocessResult } from './hooks/useSubprocess.js';
+export { useWorker } from './hooks/useWorker.js';
+
+export type {
+    UseWorkerOptions,
+    UseWorkerResult,
+} from './hooks/useWorker.js';
 
 // ── Render ──
 export { render, renderApp } from './render.js';


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

<!-- What does this PR do? 1 to 3 sentences. -->


Adds a new `useWorker` hook to `@termuijs/jsx` for managing asynchronous operations with optional exclusive group cancellation.

When `exclusive: true` is enabled and a new task is started within the same group, any existing in-flight task in that group is automatically aborted using `AbortController`. This enables use cases such as search-as-you-type where stale requests should be cancelled before newer ones begin.

## Changes

### Added `useWorker` hook

Created:

* `packages/jsx/src/hooks/useWorker.ts`

Features:

* Wraps async worker functions
* Passes an `AbortSignal` to the worker
* Supports exclusive group cancellation
* Exposes:

  * `run(...)`
  * `cancel()`
  * `status`

### Exclusive group cancellation

Implemented a module-level controller registry:

```ts
const groupControllers = new Map<string, AbortController>();
```

Behavior:

* Starting a new worker in the same exclusive group aborts the previous worker
* Different groups operate independently
* Non-exclusive workers run concurrently

### Exports

Updated:

* `packages/jsx/src/index.ts`

Added exports for:

* `useWorker`
* `UseWorkerOptions`
* `UseWorkerResult`

## Tests

Added:

* `packages/jsx/src/hooks/useWorker.test.ts`

Test coverage includes:

* AbortSignal propagation to worker functions
* Cancellation of previous calls in the same exclusive group
* Concurrent execution for non-exclusive workers
* Manual cancellation via `cancel()`
* Isolation between different groups
* Status transitions (`idle` ↔ `running`)

All added tests pass locally.


## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #77

## Which package(s)?

<!-- Example: @termuijs/core, @termuijs/widgets, website. -->

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New React hook for running async workers with cancellation support and optional exclusive concurrency control by group, plus reactive status tracking.

* **Tests**
  * Added test suite verifying cancellation, exclusive group enforcement, concurrent execution, and status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->