### PR TITLE
fix: issue 1480 portal lifecycle

### DIFF
--- a/packages/jsx/src/reconciler.ts
+++ b/packages/jsx/src/reconciler.ts
@@ -528,11 +528,22 @@ function renderComponent(
  */
 /** @internal exposed for testing */
 export function _pruneInstancesForWidget(widget: Widget): void {
-    const instance = _instanceMap.get(widget);
-    if (instance && _fiberToWidgetMap.get(instance.fiber) === widget) {
-        _fiberToWidgetMap.delete(instance.fiber);
+    const inst = _instanceMap.get(widget);
+    if (inst && _fiberToWidgetMap.get(inst.fiber) === widget) {
+        _fiberToWidgetMap.delete(inst.fiber);
     }
     _instanceMap.delete(widget);
+
+    // Recursively clean up portal children registered on the fiber
+    // so they are removed from their target widgets when the portal owner is destroyed.
+    if (inst?.fiber?.portalChildren) {
+        for (const entry of inst.fiber.portalChildren) {
+            for (const portalWidget of entry.widgets) {
+                _pruneInstancesForWidget(portalWidget);
+            }
+        }
+        inst.fiber.portalChildren = undefined;
+    }
 
     const children = widget.children;
     if (Array.isArray(children)) {


### PR DESCRIPTION
## Description

When a widget that owns portals is destroyed or re-rendered, the reconciler's `_pruneInstancesForWidget()` function cleans up stale entries in the instance map. However, it only walks the widget tree's direct children — portaled subtrees attached via `fiber.portalChildren` are skipped. This causes orphaned entries in the instance map, leading to stale state, memory leaks, and potential crashes when the stale entries are later accessed.

## Changes

- Modified `_pruneInstancesForWidget()` in `packages/jsx/src/reconciler.ts` to recursively traverse `fiber.portalChildren` when building the set of active keys.
- Portaled widget trees are now properly tracked and their instance map entries are removed when the portal owner is pruned.

## Testing
- Verified that destroying a portal owner widget no longer leaves orphaned entries in the instance map.
- Existing portal rendering behaviour is unchanged.
- `npm test` passes.

Closes #1480 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a portal cleanup issue in the component reconciliation system that could cause resource leaks over time. The improvement ensures that all nested portal instances and their associated references are properly cleaned up during component lifecycle transitions, preventing potential memory issues and improving overall application stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->