### PR TITLE
fix(display): handle wide unicode characters in Watermark

### DIFF
--- a/packages/widgets/src/display/Watermark.test.ts
+++ b/packages/widgets/src/display/Watermark.test.ts
@@ -76,4 +76,27 @@ describe('Watermark', () => {
         expect(watermark.isDirty).toBe(true);
     });
 
+    it('renders double-width unicode characters', () => {
+        const { screen } = renderWatermark('你好', {}, {}, 4, 1);
+    
+        expect(rowText(screen, 0)).toContain('你');
+        expect(rowText(screen, 0)).toContain('好');
+    });
+    
+    it('renders emoji watermark content', () => {
+        const { screen } = renderWatermark('😀', {}, {}, 4, 1);
+    
+        expect(rowText(screen, 0)).toContain('😀');
+    });
+
+    it('marks continuation cells for wide Unicode characters', () => {
+        const { screen } = renderWatermark('你', {}, {}, 4, 1);
+    
+        expect(screen.back[0][0].char).toBe('你');
+        expect(screen.back[0][0].width).toBe(2);
+    
+        expect(screen.back[0][1].char).toBe('');
+        expect(screen.back[0][1].width).toBe(0);
+    });
+    
 });

--- a/packages/widgets/src/display/Watermark.ts
+++ b/packages/widgets/src/display/Watermark.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets - Watermark widget
 // -----------------------------------------------------------------------------
 
-import { type Screen, type Style, type Color, styleToCellAttrs } from '@termuijs/core';
+import { type Screen, type Style, type Color, styleToCellAttrs, stringWidth } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
 export interface WatermarkOptions {
@@ -53,13 +53,24 @@ export class Watermark extends Widget {
             
             while (col < width) {
                 const char = segments[index];
+                const charWidth = Math.max(1, stringWidth(char));
+                
                 screen.setCell(x + col, y + row, {
                     char,
+                    width: charWidth,
                     ...attrs,
                 });
-                // TODO: we should handle double-width characters by skipping the next column if width=2
-                // but since Watermark traditionally filled cell by cell, we just let it be.
-                col++;
+                
+                for (let i = 1; i < charWidth; i++) {
+                    if (col + i < width) {
+                        screen.setCell(x + col + i, y + row, {
+                            char: '',
+                            width: 0,
+                            ...attrs,
+                        });
+                    }
+                }
+                col += charWidth;
                 index = (index + 1) % segments.length;
             }
         }


### PR DESCRIPTION

## Description

Fixes incorrect rendering of double-width Unicode characters in the `Watermark` widget.

The widget now accounts for grapheme display width when rendering watermark text and correctly marks continuation cells for wide Unicode characters. Added regression tests covering CJK characters, emoji rendering, and continuation-cell behavior.

## Related Issue

Closes #1494 

## Which package(s)?

`@termuijs/widgets`

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md](https://chatgpt.com/c/CONTRIBUTING.md)`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `[https://gssoc.girlscript.org/profile/<YOUR_PROFILE_ID](https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7)>`

## Screenshots / Recordings (UI changes)

N/A (rendering fix with regression tests)

## Notes for the Reviewer

* The issue was reproducible with double-width Unicode characters such as CJK glyphs.
* Added a regression test that validates continuation-cell handling for wide characters.
* Verified that the old implementation fails the new regression test and the updated implementation passes.
* Repository-wide typecheck currently reports unrelated errors in `examples/quiz-app`; this change does not modify that package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Watermark component now correctly handles and renders wide Unicode characters with improved cell alignment and spacing.

* **Tests**
  * Added test cases for wide character rendering, including verification of proper cell alignment and spacing for multi-width character content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->