### PR TITLE
feat(feedback): add runtime setters for EmptyState

### DIFF
--- a/packages/widgets/src/feedback/EmptyState.test.ts
+++ b/packages/widgets/src/feedback/EmptyState.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { Screen, caps } from '@termuijs/core';
+import { Screen } from '@termuijs/core';
 import { EmptyState } from './EmptyState.js';
 
 afterEach(() => {
@@ -106,4 +106,72 @@ describe('EmptyState', () => {
         expect(es.isDirty).toBe(false);
     });
     
+    it('setIcon marks widget dirty', () => {
+        const es = new EmptyState('Title');
+    
+        es.clearDirty();
+        es.setIcon('📦');
+    
+        expect(es.isDirty).toBe(true);
+    });
+    
+    it('setHint marks widget dirty', () => {
+        const es = new EmptyState('Title');
+    
+        es.clearDirty();
+        es.setHint('Press Enter');
+    
+        expect(es.isDirty).toBe(true);
+    });
+    
+    it('does not mark dirty when icon is unchanged', () => {
+        const es = new EmptyState(
+            'Title',
+            {},
+            { icon: '📦' },
+        );
+    
+        es.clearDirty();
+        es.setIcon('📦');
+    
+        expect(es.isDirty).toBe(false);
+    });
+    
+    it('does not mark dirty when hint is unchanged', () => {
+        const es = new EmptyState(
+            'Title',
+            {},
+            { hint: 'Press Enter' },
+        );
+    
+        es.clearDirty();
+        es.setHint('Press Enter');
+    
+        expect(es.isDirty).toBe(false);
+    });
+    
+    it('setHint updates rendered hint', () => {
+        const es = new EmptyState('No data');
+    
+        es.setHint('Press Enter');
+        es.updateRect({ x: 0, y: 0, width: 40, height: 7 });
+    
+        const screen = new Screen(40, 7);
+        es.render(screen);
+    
+        expect(row(screen, 6).trim()).toContain('Press Enter');
+    });
+    
+    it('setIcon updates rendered icon', () => {
+        const es = new EmptyState('No data');
+    
+        es.setIcon('📦');
+        es.updateRect({ x: 0, y: 0, width: 30, height: 5 });
+    
+        const screen = new Screen(30, 5);
+        es.render(screen);
+    
+        expect(row(screen, 1).trim()).toBe('📦');
+    });
+
 });

--- a/packages/widgets/src/feedback/EmptyState.ts
+++ b/packages/widgets/src/feedback/EmptyState.ts
@@ -35,6 +35,20 @@ export class EmptyState extends Widget {
         this.markDirty();
     }
 
+    setIcon(icon: string): void {
+        if (this._icon === icon) return;
+    
+        this._icon = icon;
+        this.markDirty();
+    }
+    
+    setHint(hint: string): void {
+        if (this._hint === hint) return;
+    
+        this._hint = hint;
+        this.markDirty();
+    }
+
     protected _renderSelf(screen: Screen): void {
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;


### PR DESCRIPTION
## Description

Adds runtime setter APIs for the `EmptyState` widget.

This PR introduces `setIcon()` and `setHint()` methods, allowing applications to update the icon and hint text after initialization without recreating the widget. The implementation follows the existing patterns used by `setTitle()` and `setDescription()`, including dirty-state tracking through `markDirty()`.

Additional tests have been added to verify rendering updates, dirty-state behavior, and unchanged-value guards.

## Related Issue

Closes #1496 

## Which package(s)?

@termuijs/widgets

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [x] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [ ] 🧪 Tests (`type:testing`)
* [x] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest packages/widgets/src/feedback/EmptyState.test.ts --run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

This change focuses on API consistency within `EmptyState`. The widget already supported runtime updates for title and description, but icon and hint required widget recreation. This PR adds equivalent setter APIs and accompanying test coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `setIcon` and `setHint` methods to the EmptyState widget, enabling dynamic updates to icon and hint text.
  * These methods efficiently detect value changes and automatically trigger widget re-rendering when updates occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->