### PR TITLE
fix(data): restore row navigation support in DataGrid

### DIFF
--- a/packages/widgets/src/data/DataGrid.test.ts
+++ b/packages/widgets/src/data/DataGrid.test.ts
@@ -194,17 +194,17 @@ describe('DataGrid', () => {
     
     it('up and down keys move the selected row', () => {
         const grid = new DataGrid(COLUMNS, ROWS);
-    
-        expect((grid as any)._selectedRow).toBe(0);
-    
+
+        expect(grid.selectedRow).toBe(0);
+
         grid.handleKey(keyOf('down'));
-        expect((grid as any)._selectedRow).toBe(1);
-    
+        expect(grid.selectedRow).toBe(1);
+
         grid.handleKey(keyOf('down'));
-        expect((grid as any)._selectedRow).toBe(2);
-    
+        expect(grid.selectedRow).toBe(2);
+
         grid.handleKey(keyOf('up'));
-        expect((grid as any)._selectedRow).toBe(1);
+        expect(grid.selectedRow).toBe(1);
     });
 
 });

--- a/packages/widgets/src/data/DataGrid.test.ts
+++ b/packages/widgets/src/data/DataGrid.test.ts
@@ -191,4 +191,20 @@ describe('DataGrid', () => {
         expect(grid.sortDirection).toBe('asc');
         expect(grid.sortKey).toBe('name');
     });
+    
+    it('up and down keys move the selected row', () => {
+        const grid = new DataGrid(COLUMNS, ROWS);
+    
+        expect((grid as any)._selectedRow).toBe(0);
+    
+        grid.handleKey(keyOf('down'));
+        expect((grid as any)._selectedRow).toBe(1);
+    
+        grid.handleKey(keyOf('down'));
+        expect((grid as any)._selectedRow).toBe(2);
+    
+        grid.handleKey(keyOf('up'));
+        expect((grid as any)._selectedRow).toBe(1);
+    });
+
 });

--- a/packages/widgets/src/data/DataGrid.ts
+++ b/packages/widgets/src/data/DataGrid.ts
@@ -141,18 +141,26 @@ export class DataGrid extends Table {
             case 'S':
                 if (!event.ctrl && !event.alt) this.cycleSort();
                 break;
+        
             case '/':
                 this._filterOpen = true;
                 this.markDirty();
                 break;
+        
             case 'escape':
                 this.clearFilter();
                 break;
+        
             case 'left':
                 this.setSelectedColumn(this._selectedCol - 1);
                 break;
+        
             case 'right':
                 this.setSelectedColumn(this._selectedCol + 1);
+                break;
+        
+            default:
+                super.handleKey(event);
                 break;
         }
     }

--- a/packages/widgets/src/data/Table.ts
+++ b/packages/widgets/src/data/Table.ts
@@ -102,6 +102,10 @@ export class Table extends Widget {
         this._onStateChange = onStateChange;
     }
 
+    // ── Public API ────────────────────────────────────
+
+    get selectedRow(): number { return this._selectedRow; }
+
     // ── Mutations ─────────────────────────────────────
 
     setRows(rows: TableRow[]): void {


### PR DESCRIPTION

## Description

This PR restores row navigation support in `DataGrid` by ensuring Up and Down arrow key events are correctly handled and propagated.

It also adds regression test coverage to verify row selection changes as expected when navigating with keyboard controls, preventing future regressions.

## Related Issue

Closes #1498 

## Which package(s)?

@termuijs/widgets

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck` *(fails due to existing unrelated errors in `@termuijs/example-quiz-app`)*
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

* Added a regression test that initially failed because row navigation was not being handled.
* Verified the fix by running:

  * `bun vitest packages/widgets/src/data/DataGrid.test.ts --run`
  * `bun vitest packages/widgets/src/data --run`
* All DataGrid tests pass and the full data widget test suite passes (245/245).
* Repository-wide typecheck currently fails due to pre-existing issues in `@termuijs/example-quiz-app`, unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced DataGrid keyboard controls with shortcuts to open/clear the filter and move selection across columns.
  * Table now publicly exposes the current selected row index for easier inspection and UI coordination.
* **Bug Fixes**
  * Improved key handling so unrecognized keys fall back to the base table behavior instead of being ignored.
* **Tests**
  * Added/updated coverage to verify up/down arrow navigation updates the DataGrid’s selected row as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->