### PR TITLE
feat: add PerformanceOverlay widget

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export type { TerminalOptions } from './terminal/Terminal.js';
 export { Screen, emptyCell, cellsEqual } from './terminal/Screen.js';
 export type { Cell } from './terminal/Screen.js';
 export { Renderer } from './terminal/Renderer.js';
+export type { FrameStats } from './terminal/Renderer.js';
 export { LayerManager } from './terminal/LayerManager.js';
 export type { Layer } from './terminal/LayerManager.js';
 export { caps, prefersReducedMotion, shouldUseColor, prefersHighContrast } from './terminal/env-caps.js';

--- a/packages/widgets/src/display/PerformanceOverlay.test.ts
+++ b/packages/widgets/src/display/PerformanceOverlay.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { Screen } from '@termuijs/core';
+import { PerformanceOverlay } from './PerformanceOverlay.js';
+
+function screenText(screen: Screen): string {
+    return screen.back
+        .map(row => row.map(cell => cell.char).join(''))
+        .join('\n');
+}
+
+describe('PerformanceOverlay', () => {
+    it('marks dirty when stats are updated', () => {
+        const overlay = new PerformanceOverlay();
+
+        overlay.clearDirty();
+
+        overlay.updateStats({
+            durationMs: 2.5,
+            cellsChanged: 100,
+            bytesWritten: 512,
+        });
+
+        expect(overlay.isDirty).toBe(true);
+    });
+
+    it('stores updated stats', () => {
+        const overlay = new PerformanceOverlay();
+
+        overlay.updateStats({
+            durationMs: 3.1,
+            cellsChanged: 50,
+            bytesWritten: 200,
+        });
+
+        expect(overlay.stats.durationMs).toBe(3.1);
+        expect(overlay.stats.cellsChanged).toBe(50);
+        expect(overlay.stats.bytesWritten).toBe(200);
+    });
+
+    it('renders frame duration', () => {
+        const overlay = new PerformanceOverlay();
+
+        overlay.updateStats({
+            durationMs: 2.5,
+            cellsChanged: 100,
+            bytesWritten: 512,
+        });
+
+        overlay.updateRect({
+            x: 0,
+            y: 0,
+            width: 30,
+            height: 5,
+        });
+
+        const screen = new Screen(30, 5);
+
+        overlay.render(screen);
+
+        expect(screenText(screen)).toContain('Frame: 2.5ms');
+    });
+
+    it('renders cells changed', () => {
+        const overlay = new PerformanceOverlay();
+
+        overlay.updateStats({
+            durationMs: 1.0,
+            cellsChanged: 123,
+            bytesWritten: 512,
+        });
+
+        overlay.updateRect({
+            x: 0,
+            y: 0,
+            width: 30,
+            height: 5,
+        });
+
+        const screen = new Screen(30, 5);
+
+        overlay.render(screen);
+
+        expect(screenText(screen)).toContain('Cells: 123');
+    });
+
+    it('renders bytes written', () => {
+        const overlay = new PerformanceOverlay();
+
+        overlay.updateStats({
+            durationMs: 1.0,
+            cellsChanged: 123,
+            bytesWritten: 2048,
+        });
+
+        overlay.updateRect({
+            x: 0,
+            y: 0,
+            width: 30,
+            height: 5,
+        });
+
+        const screen = new Screen(30, 5);
+
+        overlay.render(screen);
+
+        expect(screenText(screen)).toContain('Bytes: 2048');
+    });
+});

--- a/packages/widgets/src/display/PerformanceOverlay.ts
+++ b/packages/widgets/src/display/PerformanceOverlay.ts
@@ -1,0 +1,44 @@
+import { type Screen, type Style } from '@termuijs/core';
+import { styleToCellAttrs } from '@termuijs/core';
+import type { FrameStats } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export class PerformanceOverlay extends Widget {
+    private _stats: FrameStats = {
+        cellsChanged: 0,
+        bytesWritten: 0,
+        durationMs: 0,
+    };
+
+    constructor(style: Partial<Style> = {}) {
+        super(style);
+    }
+
+    updateStats(stats: FrameStats): void {
+        this._stats = stats;
+        this.markDirty();
+    }
+
+    get stats(): FrameStats {
+        return this._stats;
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width, height } = this._getContentRect();
+
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this._style);
+
+        const lines = [
+            'Performance',
+            `Frame: ${this._stats.durationMs.toFixed(1)}ms`,
+            `Cells: ${this._stats.cellsChanged}`,
+            `Bytes: ${this._stats.bytesWritten}`,
+        ];
+
+        for (let i = 0; i < lines.length && i < height; i++) {
+            screen.writeString(x, y + i, lines[i]!, attrs);
+        }
+    }
+}

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -31,6 +31,7 @@ export { Rating } from './display/Rating.js';
 export type { RatingOptions } from './display/Rating.js';
 export { Pty } from './display/Pty.js';
 export type { PtyOptions } from './display/Pty.js';
+export { PerformanceOverlay } from './display/PerformanceOverlay.js';
 
 // ── Virtual Scroll Helpers ────────────────────────────
 export { computeRange, computeVariableRange } from './input/virtual-scroll.js';


### PR DESCRIPTION
## Description

Adds a new `PerformanceOverlay` widget to `@termuijs/widgets` for displaying runtime rendering diagnostics. The widget can be updated with renderer frame statistics and displays frame duration, changed cell count, and bytes written. Comprehensive tests have been added to verify rendering behavior and state updates.

## Related Issue

Closes #1500 

## Which package(s)?

* `@termuijs/widgets`
* `@termuijs/core` (exports `FrameStats` type)

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [x] ✨ Feature (`type:feature`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 📝 Docs (`type:docs`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build` *(workspace build currently has unrelated package issues)*
* [ ] Typecheck passes: `bun run typecheck` *(workspace typecheck currently has unrelated package issues)*
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/YOUR_PROFILE_ID`

## Screenshots / Recordings (UI changes)

Example overlay output:

```text
Performance
Frame: 2.1ms
Cells: 143
Bytes: 512
```

## Notes for the Reviewer

* Added `PerformanceOverlay` widget in `@termuijs/widgets`.
* Added tests covering rendering and dirty-state updates.
* Exported `FrameStats` from `@termuijs/core` public API so widget consumers can use the shared type.
* The widget is intentionally renderer-agnostic and receives stats through `updateStats()` rather than directly depending on `Renderer`.## Description

Adds a new `PerformanceOverlay` widget to `@termuijs/widgets` for displaying runtime rendering diagnostics. The widget can be updated with renderer frame statistics and displays frame duration, changed cell count, and bytes written. Comprehensive tests have been added to verify rendering behavior and state updates.

