### PR TITLE
feat(display): add FPSCounter widget

### DIFF
--- a/packages/widgets/src/display/FPSCounter.test.ts
+++ b/packages/widgets/src/display/FPSCounter.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { Screen } from '@termuijs/core';
+import { FPSCounter } from './FPSCounter.js';
+
+function row(screen: Screen, y: number): string {
+    return screen.back[y].map(c => c.char).join('');
+}
+
+describe('FPSCounter', () => {
+    it('stores latest fps value', () => {
+        const fps = new FPSCounter();
+
+        fps.updateFPS(60);
+
+        expect(fps.getFPS()).toBe(60);
+    });
+
+    it('marks dirty when fps changes', () => {
+        const fps = new FPSCounter();
+
+        fps.clearDirty();
+
+        fps.updateFPS(60);
+
+        expect(fps.isDirty).toBe(true);
+    });
+
+    it('calculates average fps', () => {
+        const fps = new FPSCounter();
+
+        fps.updateFPS(60);
+        fps.updateFPS(30);
+
+        expect(fps.getAverageFPS()).toBe(45);
+    });
+
+    it('renders fps information', () => {
+        const fps = new FPSCounter();
+
+        fps.updateFPS(60);
+
+        fps.updateRect({
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 5,
+        });
+
+        const screen = new Screen(20, 5);
+
+        fps.render(screen);
+
+        expect(row(screen, 0)).toContain('FPS: 60');
+    });
+
+    it('renders average fps', () => {
+        const fps = new FPSCounter();
+
+        fps.updateFPS(60);
+        fps.updateFPS(30);
+
+        fps.updateRect({
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 5,
+        });
+
+        const screen = new Screen(20, 5);
+
+        fps.render(screen);
+
+        expect(row(screen, 1)).toContain('Avg: 45.0');
+    });
+
+    it('tracks min and max fps', () => {
+        const fps = new FPSCounter();
+    
+        fps.updateFPS(60);
+        fps.updateFPS(30);
+        fps.updateFPS(90);
+    
+        fps.updateRect({
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 5,
+        });
+    
+        const screen = new Screen(20, 5);
+    
+        fps.render(screen);
+    
+        expect(row(screen, 2)).toContain('Min: 30');
+        expect(row(screen, 3)).toContain('Max: 90');
+    });
+    
+    it('ignores negative fps values', () => {
+        const fps = new FPSCounter();
+    
+        fps.updateFPS(-10);
+    
+        expect(fps.getFPS()).toBe(0);
+    });
+
+});

--- a/packages/widgets/src/display/FPSCounter.ts
+++ b/packages/widgets/src/display/FPSCounter.ts
@@ -1,4 +1,4 @@
-import { type Screen, type Style, styleToCellAttrs } from '@termuijs/core';
+import { type Screen, type Style, styleToCellAttrs, truncate } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
 export interface FPSCounterOptions {
@@ -61,7 +61,7 @@ export class FPSCounter extends Widget {
         screen.writeString(
             x,
             y + row++,
-            `FPS: ${this._fps}`.slice(0, width),
+            truncate(`FPS: ${this._fps}`, width),
             attrs,
         );
 
@@ -69,7 +69,7 @@ export class FPSCounter extends Widget {
             screen.writeString(
                 x,
                 y + row++,
-                `Avg: ${this.getAverageFPS().toFixed(1)}`.slice(0, width),
+                truncate(`Avg: ${this.getAverageFPS().toFixed(1)}`, width),
                 attrs,
             );
         }
@@ -78,7 +78,7 @@ export class FPSCounter extends Widget {
             screen.writeString(
                 x,
                 y + row++,
-                `Min: ${this._minFps === Infinity ? 0 : this._minFps}`.slice(0, width),
+                truncate(`Min: ${this._minFps === Infinity ? 0 : this._minFps}`, width),
                 attrs,
             );
         }
@@ -87,7 +87,7 @@ export class FPSCounter extends Widget {
             screen.writeString(
                 x,
                 y + row,
-                `Max: ${this._maxFps}`.slice(0, width),
+                truncate(`Max: ${this._maxFps}`, width),
                 attrs,
             );
         }

--- a/packages/widgets/src/display/FPSCounter.ts
+++ b/packages/widgets/src/display/FPSCounter.ts
@@ -1,0 +1,95 @@
+import { type Screen, type Style, styleToCellAttrs } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export interface FPSCounterOptions {
+    showAverage?: boolean;
+    showMinMax?: boolean;
+}
+
+export class FPSCounter extends Widget {
+    private _fps = 0;
+    private _minFps = Infinity;
+    private _maxFps = 0;
+    private _totalFps = 0;
+    private _samples = 0;
+
+    private _showAverage: boolean;
+    private _showMinMax: boolean;
+
+    constructor(
+        style: Partial<Style> = {},
+        opts: FPSCounterOptions = {},
+    ) {
+        super(style);
+
+        this._showAverage = opts.showAverage ?? true;
+        this._showMinMax = opts.showMinMax ?? true;
+    }
+
+    updateFPS(fps: number): void {
+        if (fps < 0) return;
+
+        this._fps = fps;
+        this._minFps = Math.min(this._minFps, fps);
+        this._maxFps = Math.max(this._maxFps, fps);
+
+        this._totalFps += fps;
+        this._samples++;
+
+        this.markDirty();
+    }
+
+    getFPS(): number {
+        return this._fps;
+    }
+
+    getAverageFPS(): number {
+        return this._samples === 0
+            ? 0
+            : this._totalFps / this._samples;
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width, height } = this._getContentRect();
+
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this._style);
+
+        let row = 0;
+
+        screen.writeString(
+            x,
+            y + row++,
+            `FPS: ${this._fps}`.slice(0, width),
+            attrs,
+        );
+
+        if (this._showAverage && row < height) {
+            screen.writeString(
+                x,
+                y + row++,
+                `Avg: ${this.getAverageFPS().toFixed(1)}`.slice(0, width),
+                attrs,
+            );
+        }
+
+        if (this._showMinMax && row < height) {
+            screen.writeString(
+                x,
+                y + row++,
+                `Min: ${this._minFps === Infinity ? 0 : this._minFps}`.slice(0, width),
+                attrs,
+            );
+        }
+
+        if (this._showMinMax && row < height) {
+            screen.writeString(
+                x,
+                y + row,
+                `Max: ${this._maxFps}`.slice(0, width),
+                attrs,
+            );
+        }
+    }
+}

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -30,6 +30,8 @@ export type { ToolCallOptions, ToolApprovalOptions, ToolCallStatus } from './dis
 export { Canvas } from './display/Canvas.js';
 export { Rating } from './display/Rating.js';
 export type { RatingOptions } from './display/Rating.js';
+export { FPSCounter } from './display/FPSCounter.js';
+export type { FPSCounterOptions } from './display/FPSCounter.js';
 export { Pty } from './display/Pty.js';
 export type { PtyOptions } from './display/Pty.js';
 export { PerformanceOverlay } from './display/PerformanceOverlay.js';


### PR DESCRIPTION
## Description

Adds a new `FPSCounter` widget to `@termuijs/widgets` for monitoring rendering performance in real time. The widget tracks current FPS, average FPS, minimum FPS, and maximum FPS through a simple `updateFPS()` API. Unit tests have been added to verify state updates, dirty-state behavior, rendering output, and edge cases.

## Related Issue

Closes #1502 

## Which package(s)?

* `@termuijs/widgets`

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [x] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

```text
FPS: 60
Avg: 45.0
Min: 30
Max: 90
```

## Notes for the Reviewer

* Added a new `FPSCounter` widget for displaying FPS metrics.
* Supports current FPS, average FPS, minimum FPS, and maximum FPS tracking.
* Uses `markDirty()` on updates to integrate with the existing rendering lifecycle.
* Added unit tests covering rendering, state updates, min/max tracking, average calculation, and invalid input handling.
* Kept the implementation lightweight and renderer-agnostic through a simple `updateFPS()` API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an FPS Counter widget that displays real-time FPS, with optional average FPS and min/max FPS readings. Includes configurable display options and auto-handling for cases where the display area is too small.
* **Tests**
  * Added a comprehensive test suite covering FPS value updates, average/min/max calculations, rendering output, dirty-state behavior, and edge cases such as negative FPS inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->