### PR TITLE
[feature] Add useViewMeta hook for terminal title and cursor shape

### DIFF
--- a/packages/jsx/src/hooks/useViewMeta.test.ts
+++ b/packages/jsx/src/hooks/useViewMeta.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    clearCurrentFiber,
+    createFiber,
+    destroyFiber,
+    runEffects,
+    setCurrentFiber,
+    setRequestRender,
+    type Fiber,
+} from '../hooks.js';
+import { useViewMeta } from './useViewMeta.js';
+
+describe('useViewMeta', () => {
+    let fiber: Fiber | null;
+    let writeSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        fiber = createFiber();
+        setCurrentFiber(fiber);
+        setRequestRender(vi.fn());
+        writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    });
+
+    afterEach(() => {
+        if (fiber) {
+            destroyFiber(fiber);
+        }
+        clearCurrentFiber();
+        vi.restoreAllMocks();
+    });
+
+    it('sets the window title', () => {
+        if (!fiber) {
+            throw new Error('Expected fiber');
+        }
+
+        useViewMeta({ title: 'My App' });
+        runEffects(fiber);
+
+        expect(writeSpy).toHaveBeenCalledWith('\x1b]0;My App\x07');
+    });
+
+    it('sets the cursor shape', () => {
+        if (!fiber) {
+            throw new Error('Expected fiber');
+        }
+
+        useViewMeta({ cursor: 'block' });
+        runEffects(fiber);
+        expect(writeSpy).toHaveBeenLastCalledWith('\x1b[2 q');
+
+        fiber.hookIndex = 0;
+        useViewMeta({ cursor: 'underline' });
+        runEffects(fiber);
+        expect(writeSpy).toHaveBeenLastCalledWith('\x1b[4 q');
+
+        fiber.hookIndex = 0;
+        useViewMeta({ cursor: 'bar' });
+        runEffects(fiber);
+        expect(writeSpy).toHaveBeenLastCalledWith('\x1b[6 q');
+    });
+
+    it('sets the mouse mode', () => {
+        if (!fiber) {
+            throw new Error('Expected fiber');
+        }
+
+        useViewMeta({ mouseMode: 'none' });
+        runEffects(fiber);
+        expect(writeSpy).toHaveBeenLastCalledWith('\x1b[?1000l\x1b[?1002l\x1b[?1006l');
+
+        fiber.hookIndex = 0;
+        useViewMeta({ mouseMode: 'click' });
+        runEffects(fiber);
+        expect(writeSpy).toHaveBeenLastCalledWith('\x1b[?1000h\x1b[?1006h');
+
+        fiber.hookIndex = 0;
+        useViewMeta({ mouseMode: 'drag' });
+        runEffects(fiber);
+        expect(writeSpy).toHaveBeenLastCalledWith('\x1b[?1000h\x1b[?1002h\x1b[?1006h');
+    });
+
+    it('restores defaults on unmount', () => {
+        if (!fiber) {
+            throw new Error('Expected fiber');
+        }
+
+        useViewMeta({ title: 'My App', cursor: 'bar', mouseMode: 'click' });
+        runEffects(fiber);
+        writeSpy.mockClear();
+
+        destroyFiber(fiber);
+        fiber = null;
+
+        expect(writeSpy).toHaveBeenNthCalledWith(1, '\x1b]0;\x07');
+        expect(writeSpy).toHaveBeenNthCalledWith(2, '\x1b[0 q');
+        expect(writeSpy).toHaveBeenNthCalledWith(3, '\x1b[?1000l\x1b[?1002l\x1b[?1006l');
+    });
+
+    it('restores only metadata fields that were set', () => {
+        if (!fiber) {
+            throw new Error('Expected fiber');
+        }
+
+        useViewMeta({ title: 'Details' });
+        runEffects(fiber);
+        writeSpy.mockClear();
+
+        destroyFiber(fiber);
+        fiber = null;
+
+        expect(writeSpy).toHaveBeenCalledTimes(1);
+        expect(writeSpy).toHaveBeenCalledWith('\x1b]0;\x07');
+    });
+
+    it('does not write on mount or unmount when no metadata is set', () => {
+        if (!fiber) {
+            throw new Error('Expected fiber');
+        }
+
+        useViewMeta({});
+        runEffects(fiber);
+
+        expect(writeSpy).not.toHaveBeenCalled();
+
+        destroyFiber(fiber);
+        fiber = null;
+
+        expect(writeSpy).not.toHaveBeenCalled();
+    });
+});

--- a/packages/jsx/src/hooks/useViewMeta.ts
+++ b/packages/jsx/src/hooks/useViewMeta.ts
@@ -1,0 +1,68 @@
+import { ansi } from '@termuijs/core';
+import { useEffect } from '../hooks.js';
+
+export type ViewMetaCursor = 'block' | 'underline' | 'bar';
+
+export type ViewMetaMouseMode = 'none' | 'click' | 'drag';
+
+export interface ViewMeta {
+    title?: string;
+    cursor?: ViewMetaCursor;
+    mouseMode?: ViewMetaMouseMode;
+}
+
+const defaultCursorShape = `${ansi.CSI}0 q`;
+const clickMouseMode = `${ansi.CSI}?1000h${ansi.CSI}?1006h`;
+const dragMouseMode = `${ansi.CSI}?1000h${ansi.CSI}?1002h${ansi.CSI}?1006h`;
+
+function writeAnsi(sequence: string): void {
+    process.stdout.write(sequence);
+}
+
+function mouseModeSequence(mode: ViewMetaMouseMode): string {
+    if (mode === 'click') {
+        return clickMouseMode;
+    }
+
+    if (mode === 'drag') {
+        return dragMouseMode;
+    }
+
+    return ansi.disableMouse;
+}
+
+export function useViewMeta(meta: ViewMeta): void {
+    const { title, cursor, mouseMode } = meta;
+
+    useEffect(() => {
+        const restoreTitle = title !== undefined;
+        const restoreCursor = cursor !== undefined;
+        const restoreMouseMode = mouseMode !== undefined;
+
+        if (title !== undefined) {
+            writeAnsi(ansi.setTitle(title));
+        }
+
+        if (cursor !== undefined) {
+            writeAnsi(ansi.cursorShape(cursor, false));
+        }
+
+        if (mouseMode !== undefined) {
+            writeAnsi(mouseModeSequence(mouseMode));
+        }
+
+        return () => {
+            if (restoreTitle) {
+                writeAnsi(ansi.setTitle(''));
+            }
+
+            if (restoreCursor) {
+                writeAnsi(defaultCursorShape);
+            }
+
+            if (restoreMouseMode) {
+                writeAnsi(ansi.disableMouse);
+            }
+        };
+    }, [title, cursor, mouseMode]);
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -131,3 +131,5 @@ export { useSet } from './hooks/useSet.js';
 export type { UseSetActions } from './hooks/useSet.js';
 export { useThrottle } from './hooks/useThrottle.js';
 export { useEventListener } from './hooks/useEventListener.js';
+export { useViewMeta } from './hooks/useViewMeta.js';
+export type { ViewMeta, ViewMetaCursor, ViewMetaMouseMode } from './hooks/useViewMeta.js';


### PR DESCRIPTION
## Description

Adds a `useViewMeta` hook to `@termuijs/jsx` for managing terminal window metadata from components. The hook can set the terminal title, cursor shape, and mouse mode with ANSI escape sequences, and restores only the metadata fields it changed when the component unmounts.

## Related Issue

Closes #67

## Which package(s)?

@termuijs/jsx

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.

## Screenshots / Recordings (UI changes)

N/A. This is a JSX hook/API change with unit test coverage.

## Notes for the Reviewer

Added focused tests for title, cursor shape, mouse mode, scoped cleanup on unmount, and the empty-options edge case.

Verified locally:

```bash
bun vitest run packages/jsx/src/hooks/useViewMeta.test.ts
bun vitest run packages/jsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new hook for controlling terminal UI metadata, including window title, cursor shape (block, underline, bar), and mouse mode (none, click, drag). Automatically restores default settings on unmount.

* **Tests**
  * Added comprehensive test suite covering all metadata configuration options and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->