### PR TITLE
feat(widgets): add widget render profiling statistics

### DIFF
--- a/packages/widgets/src/base/Widget.test.ts
+++ b/packages/widgets/src/base/Widget.test.ts
@@ -150,6 +150,60 @@ describe('Widget', () => {
         expect(w.callCount).toBe(2);
     });
 
+    it('tracks render count', () => {
+        const widget = new TestWidget();
+        const screen = new Screen(10, 5);
+    
+        widget.render(screen);
+        widget.render(screen);
+    
+        expect(
+            widget.getRenderStats().renderCount,
+        ).toBe(2);
+    });
+    
+    it('tracks last render duration', () => {
+        const widget = new TestWidget();
+        const screen = new Screen(10, 5);
+    
+        widget.render(screen);
+    
+        expect(
+            widget.getRenderStats().lastDurationMs,
+        ).toBeGreaterThanOrEqual(0);
+    });
+    
+    it('tracks total render duration', () => {
+        const widget = new TestWidget();
+        const screen = new Screen(10, 5);
+    
+        widget.render(screen);
+    
+        expect(
+            widget.getRenderStats().totalDurationMs,
+        ).toBeGreaterThanOrEqual(0);
+    });
+    
+    it('calculates average render duration', () => {
+        const widget = new TestWidget();
+        const screen = new Screen(10, 5);
+    
+        widget.render(screen);
+        widget.render(screen);
+    
+        expect(
+            widget.getAverageRenderDuration(),
+        ).toBeGreaterThanOrEqual(0);
+    });
+    
+    it('returns zero average when no renders occurred', () => {
+        const widget = new TestWidget();
+    
+        expect(
+            widget.getAverageRenderDuration(),
+        ).toBe(0);
+    });
+
     describe('destroy() lifecycle', () => {
         it('emits unmount and removes event listeners', () => {
             const w = new TestWidget();

--- a/packages/widgets/src/base/Widget.ts
+++ b/packages/widgets/src/base/Widget.ts
@@ -33,6 +33,12 @@ export interface WidgetEvents {
     unmount: void;
 }
 
+export interface RenderStats {
+    renderCount: number;
+    lastDurationMs: number;
+    totalDurationMs: number;
+}
+
 let _widgetIdCounter = 0;
 
 /** Reset the widget ID counter (for testing only). */
@@ -105,6 +111,12 @@ export abstract class Widget {
      * Newly created widgets start dirty.
      */
     protected _dirty = true;
+    /** Render profiling statistics */
+    private _renderStats: RenderStats = {
+        renderCount: 0,
+        lastDurationMs: 0,
+        totalDurationMs: 0,
+    };
 
     /** Enable animated layout transitions for size/position changes */
     public layoutTransition: Partial<SpringConfig> | SpringPresetName | boolean = false;
@@ -119,6 +131,17 @@ export abstract class Widget {
     /** Check if this widget is currently active (focused) */
     isActive(): boolean {
         return this.isFocused;
+    }
+
+    getRenderStats(): RenderStats {
+        return { ...this._renderStats };
+    }
+
+    getAverageRenderDuration(): number {
+        return this._renderStats.renderCount === 0
+            ? 0
+            : this._renderStats.totalDurationMs /
+                this._renderStats.renderCount;
     }
 
     /** Get the current style */
@@ -226,7 +249,12 @@ export abstract class Widget {
 
         // Render own content with error isolation
         try {
+            const start = performance.now();
             this._renderSelf(screen);
+            const duration = performance.now() - start;
+            this._renderStats.renderCount++;
+            this._renderStats.lastDurationMs = duration;
+            this._renderStats.totalDurationMs += duration;
             this._renderError = null;
             this._dirty = false;
         } catch (err) {

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -5,6 +5,7 @@
 // ── Base ──────────────────────────────────────────────
 export { Widget, _resetWidgetIdCounter } from './base/Widget.js';
 export type { WidgetEvents } from './base/Widget.js';
+export type { RenderStats } from './base/Widget.js';
 
 // ── Display Widgets ───────────────────────────────────
 export { Box } from './display/Box.js';


### PR DESCRIPTION
## Description

Adds widget-level render profiling statistics to `@termuijs/widgets`. This introduces APIs for tracking render count, last render duration, total render duration, and average render duration for individual widget instances. Unit tests have been added to validate profiling metrics and rendering behavior.

## Related Issue

Closes #1506 

## Which package(s)?

* `@termuijs/widgets`

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [x] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [x] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck` *(global typecheck currently reports unrelated pre-existing errors in example packages; widget package typecheck passes successfully)*
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

Not applicable (internal profiling API and tests only).

## Notes for the Reviewer

* Added `RenderStats` tracking to the base `Widget` class.
* Added `getRenderStats()` for accessing profiling metrics.
* Added `getAverageRenderDuration()` helper.
* Profiling is measured around `_renderSelf()` execution to capture widget-specific render cost.
* Added test coverage for render count, last render duration, total render duration, and average render duration calculations.
* No changes to widget rendering behaviour outside of statistics collection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Widgets now include render performance tracking with metrics for render count and duration statistics.
  * Added methods to retrieve render statistics and calculate average render duration.

* **Tests**
  * Added comprehensive test coverage for render performance tracking functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->