### PR TITLE
accessibility: restore prefersReducedMotion in Skeleton

### DIFF
--- a/packages/widgets/src/feedback/Skeleton.test.ts
+++ b/packages/widgets/src/feedback/Skeleton.test.ts
@@ -24,10 +24,16 @@ describe('Skeleton', () => {
 
     it('creates skeleton and subscribes to timer', () => {
         const s = new Skeleton();
+
         s.updateRect({ x: 0, y: 0, width: 5, height: 1 });
+
         const screen = new Screen(5, 1);
         s.render(screen);
-        const row = screen.back[0].map((c: { char: string }) => c.char).join('');
+
+        const row = screen.back[0]
+            .map((c: { char: string }) => c.char)
+            .join('');
+
         expect(row.length).toBe(5);
         expect(row.trim()).not.toBe('');
         expect(motion.timerPoolSubscribe).toHaveBeenCalled();
@@ -35,48 +41,57 @@ describe('Skeleton', () => {
 
     it('renders initial state', () => {
         const s = new Skeleton();
+
         s.updateRect({ x: 0, y: 0, width: 5, height: 2 });
 
         const screen = new Screen(5, 2);
         s.render(screen);
 
         for (let r = 0; r < 2; r++) {
-            expect(screen.back[r].map(c => c.char).join('')).toBe('░░░░░');
+            expect(
+                screen.back[r].map(c => c.char).join('')
+            ).toBe('░░░░░');
         }
     });
 
     it('updates on timer tick', () => {
         const s = new Skeleton();
+
         s.updateRect({ x: 0, y: 0, width: 5, height: 1 });
 
         const screen1 = new Screen(5, 1);
         s.render(screen1);
 
-        if (timerCallback) timerCallback();
+        timerCallback?.();
 
         const screen2 = new Screen(5, 1);
         s.render(screen2);
 
-        expect(screen2.back[0].map(c => c.char).join('')).toBe('▒▒▒▒▒');
+        expect(
+            screen2.back[0].map(c => c.char).join('')
+        ).toBe('▒▒▒▒▒');
     });
 
-    it('does not animate when caps.motion is false', () => {
+    it('does not animate when reduced motion is preferred', () => {
         vi.spyOn(caps, 'motion', 'get').mockReturnValue(false);
 
-        const s = new Skeleton();
+        new Skeleton();
+
         expect(motion.timerPoolSubscribe).not.toHaveBeenCalled();
     });
 
     it('respects custom chars', () => {
         const s = new Skeleton({}, { chars: ['X', 'X'] });
+
         s.updateRect({ x: 0, y: 0, width: 3, height: 1 });
 
         const screen = new Screen(3, 1);
         s.render(screen);
 
-        expect(screen.back[0].map(c => c.char).join('')).toBe('XXX');
+        expect(
+            screen.back[0].map(c => c.char).join('')
+        ).toBe('XXX');
     });
-
 
     it('unmount unsubscribes timer', () => {
         const unsub = vi.fn();
@@ -84,6 +99,7 @@ describe('Skeleton', () => {
         vi.spyOn(motion, 'timerPoolSubscribe').mockReturnValue(unsub);
 
         const s = new Skeleton();
+
         s.unmount();
 
         expect(unsub).toHaveBeenCalled();

--- a/packages/widgets/src/feedback/Skeleton.ts
+++ b/packages/widgets/src/feedback/Skeleton.ts
@@ -1,4 +1,4 @@
-import { type Screen, type Style, type Color, caps } from '@termuijs/core';
+import { type Screen, type Style, type Color, caps, prefersReducedMotion } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 import { timerPoolSubscribe } from '@termuijs/motion';
 
@@ -25,7 +25,7 @@ export class Skeleton extends Widget {
 
         this._chars = opts.chars ?? (caps.unicode ? ['░', '▒'] : ['-', '#']);
 
-        if (caps.motion) {
+        if (!prefersReducedMotion()) {
             this._unsubscribe = timerPoolSubscribe(this._intervalMs, () => {
                 this._frame = 1 - this._frame;
                 this._shimmerPos++;


### PR DESCRIPTION

## Description

Restores use of `prefersReducedMotion()` in the Skeleton widget.

A previous refactor reintroduced a direct `caps.motion` check, bypassing the reduced-motion accessibility abstraction used by other motion-enabled widgets. This change restores consistency and updates the related test coverage.

## Related Issue

Closes #1516 

## Which package(s)?

`@termuijs/widgets`

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [x] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)
 
## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

* Replaced the direct `caps.motion` check in `Skeleton.ts` with `prefersReducedMotion()`.
* Updated the related accessibility test to reflect reduced-motion behavior.
* This restores consistency with other motion-enabled widgets such as Spinner, StreamingText, and ThinkingBlock.## Description

Restores use of `prefersReducedMotion()` in the Skeleton widget.

A previous refactor reintroduced a direct `caps.motion` check, bypassing the reduced-motion accessibility abstraction used by other motion-enabled widgets. This change restores consistency and updates the related test coverage.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced animation behavior in the feedback component to better respect user accessibility preferences for reduced motion

* **Tests**
  * Updated test suite with improved structure and formatting for better maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->