### PR TITLE
feat(store): add subscribeOnce

### DIFF
--- a/packages/store/src/store.test.ts
+++ b/packages/store/src/store.test.ts
@@ -81,6 +81,21 @@ describe('createStore', () => {
         expect(spy).toHaveBeenCalledOnce()
     })
 
+    it('subscribeOnce does not fire twice during a re-entrant update', () => {
+        const useStore = createStore((set) => ({
+            count: 0,
+        }))
+
+        const spy = vi.fn(() => {
+            useStore.setState({ count: 2 })
+        })
+
+        useStore.subscribeOnce(spy)
+        useStore.setState({ count: 1 })
+
+        expect(spy).toHaveBeenCalledTimes(1)
+    })
+
     it('multiple subscribers all get notified', () => {
         const useStore = createStore((set) => ({
             x: 0,

--- a/packages/store/src/store.test.ts
+++ b/packages/store/src/store.test.ts
@@ -66,6 +66,21 @@ describe('createStore', () => {
         expect(spy).not.toHaveBeenCalled()
     })
 
+    it('subscribeOnce fires only once', () => {
+        const useStore = createStore((set) => ({
+            count: 0,
+            inc: () => set((s) => ({ count: s.count + 1 })),
+        }))
+
+        const spy = vi.fn()
+        useStore.subscribeOnce(spy)
+
+        useStore.getState().inc()
+        useStore.getState().inc()
+
+        expect(spy).toHaveBeenCalledOnce()
+    })
+
     it('multiple subscribers all get notified', () => {
         const useStore = createStore((set) => ({
             x: 0,

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -356,14 +356,12 @@ export function createStore<T extends object>(
     const subscribeOnce = (listener: Listener<T>): (() => void) => {
         let unsub: (() => void) | null = null;
         const wrapper: Listener<T> = (state, prevState) => {
-            try {
-                listener(state, prevState);
-            } finally {
-                if (unsub) {
-                    unsub();
-                    unsub = null;
-                }
+            const currentUnsub = unsub;
+            if (currentUnsub) {
+                currentUnsub();
+                unsub = null;
             }
+            listener(state, prevState);
         };
         unsub = subscribe(wrapper);
         return () => {

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -166,6 +166,8 @@ export interface Store<T> {
     setState: SetState<T>;
     /** Subscribe to state changes */
     subscribe(listener: Listener<T>): () => void;
+    /** Subscribe once — listener fires on the next change and is immediately unsubscribed */
+    subscribeOnce(listener: Listener<T>): () => void;
     /** Destroy the store and remove all listeners */
     destroy(): void;
     /** Create a memoized selector — subscribers are notified only when the derived value changes */
@@ -351,6 +353,27 @@ export function createStore<T extends object>(
         };
     };
 
+    const subscribeOnce = (listener: Listener<T>): (() => void) => {
+        let unsub: (() => void) | null = null;
+        const wrapper: Listener<T> = (state, prevState) => {
+            try {
+                listener(state, prevState);
+            } finally {
+                if (unsub) {
+                    unsub();
+                    unsub = null;
+                }
+            }
+        };
+        unsub = subscribe(wrapper);
+        return () => {
+            if (unsub) {
+                unsub();
+                unsub = null;
+            }
+        };
+    };
+
     const destroy = (): void => {
         listeners.clear();
         if (writeTimeout) {
@@ -425,7 +448,7 @@ export function createStore<T extends object>(
         };
     };
 
-    const store: Store<T> = { getState, setState, subscribe, destroy, computed, reset, getInitialState };
+    const store: Store<T> = { getState, setState, subscribe, subscribeOnce, destroy, computed, reset, getInitialState };
 
     // Create the hook function
     function useStore(): T;
@@ -458,6 +481,7 @@ export function createStore<T extends object>(
     (useStore as any).getState = getState;
     (useStore as any).setState = setState;
     (useStore as any).subscribe = subscribe;
+    (useStore as any).subscribeOnce = subscribeOnce;
     (useStore as any).destroy = destroy;
     (useStore as any).computed = computed;
     (useStore as any).reset = reset;
@@ -474,6 +498,7 @@ export interface UseStore<T> {
     getState: GetState<T>;
     setState: SetState<T>;
     subscribe(listener: Listener<T>): () => void;
+    subscribeOnce(listener: Listener<T>): () => void;
     destroy(): void;
     computed<U>(selector: Selector<T, U>): Computed<U>;
     reset(): void;


### PR DESCRIPTION
## Summary

Adds a `subscribeOnce` helper to the store package.

The helper wraps the existing subscription mechanism and automatically unsubscribes after the first state change notification.

## Changes Made

* Added `subscribeOnce` to the store implementation
* Added `subscribeOnce` to the `Store<T>` interface
* Updated exports
* Added a test verifying the listener is only called once

## Validation

```bash
bun vitest run packages/store
bun run typecheck
```

All checks pass successfully.

Closes #489


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `subscribeOnce` to the store API, enabling one-time state change subscriptions that automatically unsubscribe after the first invocation (including safe handling during re-entrant updates).

* **Tests**
  * Added Vitest coverage to verify the one-time listener fires exactly once across multiple updates and does not re-trigger during listener-driven updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->