### PR TITLE
accessibility: add reduced motion support to Typewriter

### DIFF
--- a/packages/widgets/src/display/Typewriter.test.ts
+++ b/packages/widgets/src/display/Typewriter.test.ts
@@ -159,4 +159,19 @@ describe('Typewriter', () => {
     const row = screen.back[0].map((c) => c.char).join('');
     expect(row.trim()).toBe('');
   });
+
+  it('reveals all text immediately when reduced motion is preferred', () => {
+    vi.spyOn(caps, 'motion', 'get').mockReturnValue(false);
+  
+    const tw = new Typewriter('hello');
+  
+    tw.tick();
+  
+    const row = renderRow(tw);
+  
+    expect(row).toContain('hello');
+    expect(row).not.toContain('▋');
+    expect(row).not.toContain('_');
+  });
+
 });

--- a/packages/widgets/src/display/Typewriter.test.ts
+++ b/packages/widgets/src/display/Typewriter.test.ts
@@ -23,6 +23,7 @@ describe('Typewriter', () => {
   });
 
   it('reveals one character per tick by default', () => {
+    vi.spyOn(caps, 'motion', 'get').mockReturnValue(true);
     const tw = new Typewriter('hello');
     tw.updateRect({ x: 0, y: 0, width: 20, height: 1 });
 
@@ -41,6 +42,7 @@ describe('Typewriter', () => {
   });
 
   it('reveals speed characters per tick when speed > 1', () => {
+    vi.spyOn(caps, 'motion', 'get').mockReturnValue(true);
     const tw = new Typewriter('hello', {}, { speed: 2 });
     tw.tick();
     const row = renderRow(tw);
@@ -49,6 +51,7 @@ describe('Typewriter', () => {
   });
 
   it('matches the spec snippet: two ticks on "hello" contain "he"', () => {
+    vi.spyOn(caps, 'motion', 'get').mockReturnValue(true);
     const screen = new Screen(20, 1);
     const tw = new Typewriter('hello');
     tw.updateRect({ x: 0, y: 0, width: 20, height: 1 });
@@ -60,6 +63,7 @@ describe('Typewriter', () => {
   });
 
   it('tick past the end stops at the full text (no-op)', () => {
+    vi.spyOn(caps, 'motion', 'get').mockReturnValue(true);
     const tw = new Typewriter('hi');
     // Two ticks to fully reveal "hi".
     tw.tick();
@@ -72,6 +76,7 @@ describe('Typewriter', () => {
   });
 
   it('does not render cursor once fully revealed', () => {
+    vi.spyOn(caps, 'motion', 'get').mockReturnValue(true);
     vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
     const tw = new Typewriter('hi');
     tw.tick();
@@ -81,6 +86,7 @@ describe('Typewriter', () => {
   });
 
   it('renders cursor glyph while text is being revealed (unicode)', () => {
+    vi.spyOn(caps, 'motion', 'get').mockReturnValue(true);
     vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
     const tw = new Typewriter('hello');
     tw.tick(); // reveals 'h', cursor follows
@@ -89,6 +95,7 @@ describe('Typewriter', () => {
   });
 
   it('renders ASCII fallback cursor when caps.unicode is false', () => {
+    vi.spyOn(caps, 'motion', 'get').mockReturnValue(true);
     vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
     const tw = new Typewriter('hello');
     tw.tick();
@@ -121,6 +128,7 @@ describe('Typewriter', () => {
   });
 
   it('setText then tick reveals new text', () => {
+    vi.spyOn(caps, 'motion', 'get').mockReturnValue(true);
     const tw = new Typewriter('hello');
     tw.tick();
     tw.setText('world');
@@ -130,6 +138,7 @@ describe('Typewriter', () => {
   });
 
   it('respects a caller-supplied cursor string', () => {
+    vi.spyOn(caps, 'motion', 'get').mockReturnValue(true);
     const tw = new Typewriter('hello', {}, { cursor: '|' });
     tw.tick();
     const row = renderRow(tw);

--- a/packages/widgets/src/display/Typewriter.test.ts
+++ b/packages/widgets/src/display/Typewriter.test.ts
@@ -171,16 +171,15 @@ describe('Typewriter', () => {
 
   it('reveals all text immediately when reduced motion is preferred', () => {
     vi.spyOn(caps, 'motion', 'get').mockReturnValue(false);
-  
+
     const tw = new Typewriter('hello');
-  
+
     tw.tick();
-  
+
     const row = renderRow(tw);
-  
+
     expect(row).toContain('hello');
     expect(row).not.toContain('▋');
     expect(row).not.toContain('_');
   });
-
 });

--- a/packages/widgets/src/display/Typewriter.ts
+++ b/packages/widgets/src/display/Typewriter.ts
@@ -1,5 +1,5 @@
 import { Widget } from '../base/Widget.js';
-import { type Screen, type Style, caps, styleToCellAttrs, stringWidth } from '@termuijs/core';
+import { type Screen, type Style, caps, styleToCellAttrs, stringWidth, prefersReducedMotion } from '@termuijs/core';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // TypewriterOptions
@@ -60,10 +60,19 @@ export class Typewriter extends Widget {
 
   /** Advance the reveal head by `speed` characters. No-op once fully revealed. */
   tick(): void {
-    const len = Array.from(segmenter.segment(this._text)).length;
-    if (this._revealed >= len) return;
-    this._revealed = Math.min(this._revealed + this._speed, len);
-    this.markDirty();
+      const len = Array.from(segmenter.segment(this._text)).length;
+  
+      if (prefersReducedMotion()) {
+          if (this._revealed >= len) return;
+          this._revealed = len;
+          this.markDirty();
+          return;
+      }
+  
+      if (this._revealed >= len) return;
+  
+      this._revealed = Math.min(this._revealed + this._speed, len);
+      this.markDirty();
   }
 
   /** Return the reveal counter to zero. */

--- a/packages/widgets/src/display/Typewriter.ts
+++ b/packages/widgets/src/display/Typewriter.ts
@@ -60,19 +60,19 @@ export class Typewriter extends Widget {
 
   /** Advance the reveal head by `speed` characters. No-op once fully revealed. */
   tick(): void {
-      const len = Array.from(segmenter.segment(this._text)).length;
-  
-      if (prefersReducedMotion()) {
-          if (this._revealed >= len) return;
-          this._revealed = len;
-          this.markDirty();
-          return;
-      }
-  
+    const len = Array.from(segmenter.segment(this._text)).length;
+
+    if (prefersReducedMotion()) {
       if (this._revealed >= len) return;
-  
-      this._revealed = Math.min(this._revealed + this._speed, len);
+      this._revealed = len;
       this.markDirty();
+      return;
+    }
+
+    if (this._revealed >= len) return;
+
+    this._revealed = Math.min(this._revealed + this._speed, len);
+    this.markDirty();
   }
 
   /** Return the reveal counter to zero. */


### PR DESCRIPTION
## Description

This PR adds reduced-motion accessibility support to the `Typewriter` widget. When `prefersReducedMotion()` returns `true`, the widget now reveals the full text immediately instead of animating character-by-character. A regression test has also been added to verify the behavior.

## Related Issue

Closes #1525 

## Which package(s)?

* @termuijs/widgets

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [x] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md](https://chatgpt.com/c/CONTRIBUTING.md)`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

`Typewriter` previously ignored the global reduced-motion preference and always required incremental animation via `tick()`. This change aligns its behavior with other accessibility-aware widgets such as `StreamingText`, `ThinkingBlock`, `Spinner`, `Marquee`, and `Skeleton` by immediately revealing the final text when motion is disabled. A dedicated regression test has been added to prevent future regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Updated the Typewriter component to respect reduced-motion settings. When reduced motion is enabled, it now reveals the full text immediately and omits cursor glyphs.

* **Tests**
  * Expanded automated coverage for both reduced-motion and non-reduced-motion behavior, including instant full-text rendering and ensuring no cursor characters are displayed under reduced motion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->