### PR TITLE
fix(ui): render active tab content in Tabs widget

### DIFF
--- a/packages/ui/src/Tabs.test.ts
+++ b/packages/ui/src/Tabs.test.ts
@@ -4,7 +4,8 @@
 
 import { describe, it, expect } from 'vitest';
 import { Tabs } from './Tabs.js';
-import { Box } from '@termuijs/widgets';
+import { Box, Text } from '@termuijs/widgets';
+import { Screen } from '@termuijs/core';
 
 const makeTabs = () => new Tabs([
     { label: 'Home', content: new Box() },
@@ -47,5 +48,61 @@ describe('Tabs', () => {
         tabs.prevTab();
         expect(tabs.activeIndex).toBe(0);
         expect(Number.isFinite(tabs.activeIndex)).toBe(true);
+    });
+
+    it('renders active tab content below the tab bar', () => {
+        const tabs = new Tabs([
+            { label: 'Home', content: new Text('Home Content') },
+            { label: 'Settings', content: new Text('Settings Content') },
+        ], { border: 'none' });
+        const screen = new Screen(40, 10);
+        tabs.updateRect({ x: 0, y: 0, width: 40, height: 10 });
+        tabs.render(screen);
+        const row2 = screen.back[2].map(c => c.char).join('');
+        expect(row2).toContain('Home Content');
+    });
+
+    it('renders different content after switching tabs', () => {
+        const tabs = new Tabs([
+            { label: 'Home', content: new Text('Home Content') },
+            { label: 'Settings', content: new Text('Settings Content') },
+        ], { border: 'none' });
+        const screen = new Screen(40, 10);
+        tabs.updateRect({ x: 0, y: 0, width: 40, height: 10 });
+        tabs.selectTab(1);
+        tabs.render(screen);
+        const row2 = screen.back[2].map(c => c.char).join('');
+        expect(row2).toContain('Settings Content');
+        expect(row2).not.toContain('Home Content');
+    });
+
+    it('renders content inside content area when border is none', () => {
+        const tabs = new Tabs([
+            { label: 'One', content: new Text('Visible') },
+        ], { border: 'none' });
+        const screen = new Screen(20, 5);
+        tabs.updateRect({ x: 0, y: 0, width: 20, height: 5 });
+        tabs.render(screen);
+        const row2 = screen.back[2].map(c => c.char).join('');
+        expect(row2).toContain('Visible');
+    });
+
+    it('does not crash when content is undefined', () => {
+        const tabs = new Tabs([]);
+        const screen = new Screen(40, 10);
+        tabs.updateRect({ x: 0, y: 0, width: 40, height: 10 });
+        expect(() => tabs.render(screen)).not.toThrow();
+    });
+
+    it('does not render content when height is too small', () => {
+        const content = new Text('Should Not Appear');
+        const tabs = new Tabs([
+            { label: 'Tiny', content },
+        ]);
+        const screen = new Screen(20, 2);
+        tabs.updateRect({ x: 0, y: 0, width: 20, height: 2 });
+        tabs.render(screen);
+        const all = screen.back.map(r => r.map(c => c.char).join('')).join('');
+        expect(all).not.toContain('Should Not Appear');
     });
 });

--- a/packages/ui/src/Tabs.ts
+++ b/packages/ui/src/Tabs.ts
@@ -57,5 +57,14 @@ export class Tabs extends Widget {
             if (i < this._tabs.length - 1) { screen.writeString(col, y, caps.unicode ? '│' : '|', { ...attrs, dim: true }); col++; }
         }
         if (height > 1) screen.writeString(x, y + 1, '─'.repeat(width), { ...attrs, dim: true });
+
+        // Render active tab content below the separator
+        if (height > 2) {
+            const content = this.activeContent;
+            if (content) {
+                content.updateRect({ x, y: y + 2, width, height: height - 2 });
+                content.render(screen);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description

Fixes #1528 

The \Tabs\ widget rendered tab header labels and a separator line but never called \ender()\ on the active tab's content widget. The content area was always blank.

## Change

In \Tabs._renderSelf()\, after drawing the separator at row \y + 1\, the active content widget now gets its rect updated and \ender(screen)\ called below the tab bar.

## Tests

- renders active tab content below the tab bar
- renders different content after switching tabs
- does not crash when content is undefined (empty tabs)
- does not render content when height is too small

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tabs component now renders active tab content below the tab labels
  * Content dynamically updates when switching between tabs
  * Gracefully handles edge cases including missing content and limited display space

<!-- end of auto-generated comment: release notes by coderabbit.ai -->