### PR TITLE
fix(ui): make SearchableSelect fully functional

### DIFF
--- a/packages/ui/src/SearchableSelect.ts
+++ b/packages/ui/src/SearchableSelect.ts
@@ -1,6 +1,6 @@
 // SearchableSelect — searchable dropdown selector with filtering
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, caps } from '@termuijs/core';
+import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, caps, truncate } from '@termuijs/core';
 
 export interface SearchableSelectOption {
     label: string;
@@ -125,7 +125,7 @@ export class SearchableSelect extends Widget {
         const pointer = caps.unicode ? '➔' : '>';
         const searchLine = pointer + ' ' + displayText;
         const searchStyle = this._searchQuery.length > 0 ? attrs : { ...attrs, dim: true };
-        screen.writeString(x, y, searchLine.slice(0, width), searchStyle);
+        screen.writeString(x, y, truncate(searchLine, width), searchStyle);
 
         const maxVisible = height - 1;
         const visibleCount = Math.min(this._filteredOptions.length, maxVisible);
@@ -134,7 +134,7 @@ export class SearchableSelect extends Widget {
             const isSelected = i === this._selectedIndex;
             const prefix = isSelected ? (caps.unicode ? '● ' : '* ') : '  ';
             const line = prefix + opt.label;
-            screen.writeString(x, y + 1 + i, line.slice(0, width), {
+            screen.writeString(x, y + 1 + i, truncate(line, width), {
                 ...attrs,
                 fg: isSelected ? this._activeColor : attrs.fg,
                 bold: isSelected,


### PR DESCRIPTION
## Description

Fixes #1529

SearchableSelect was a non-functional stub with 5 critical issues:
1. No way to set options — constructor took no params, no setter existed
2. \_filterOptions()\ was empty — typing did nothing
3. \confirm()\ was empty — Enter did nothing
4. \selectNext()\/\selectPrev()\ never called \markDirty()\
5. \ocusable\ was never set

## Changes

- **Constructor**: accepts \options: SearchableSelectOption[]\ and \config: SearchableSelectOptions\ (both optional for backwards compat)
- **\_filterOptions()\**: filters by label and value case-insensitively
- **\confirm()\**: invokes \onSelect\ callback with selected option and index
- **\markDirty()\**: added to \selectNext\, \selectPrev\, \handleKey\, \setOptions\
- **\ocusable = true\**: widget can receive keyboard focus
- **\_renderSelf()\**: now renders filtered options list below the search bar with selection highlight
- **\setOptions()\**: new public method for runtime option replacement
- **Exports**: \SearchableSelectOption\ and \SearchableSelectOptions\ types added to package exports

Tests: 21 tests (up from 5), all passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text truncation in SearchableSelect component for better terminal display formatting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->