### PR TITLE
test: add reduced motion coverage for ThinkingBlock

### DIFF
--- a/packages/widgets/src/display/ThinkingBlock.test.ts
+++ b/packages/widgets/src/display/ThinkingBlock.test.ts
@@ -61,13 +61,13 @@ describe('ThinkingBlock', () => {
             motion,
             'timerPoolSubscribe',
         );
-    
+
         const block = new ThinkingBlock();
         block.setStreaming(true);
         block.mount();
         expect(timerSpy).not.toHaveBeenCalled();
     });
-    
+
     it('uses ASCII borders when caps.unicode is false', () => {
         const originalUnicode = caps.unicode;
         Object.defineProperty(caps, 'unicode', {

--- a/packages/widgets/src/display/ThinkingBlock.test.ts
+++ b/packages/widgets/src/display/ThinkingBlock.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { Screen, type KeyEvent } from '@termuijs/core';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Screen, type KeyEvent, caps } from '@termuijs/core';
 import { ThinkingBlock } from './ThinkingBlock.js';
 
 const key = (k: string): KeyEvent => ({ key: k, ctrl: false, alt: false, shift: false, raw: Buffer.alloc(0), stopPropagation: () => {}, preventDefault: () => {} });
@@ -10,6 +10,10 @@ function render(widget: ThinkingBlock) {
     widget.render(screen);
     return screen;
 }
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
 
 describe('ThinkingBlock', () => {
     it('renders collapsed state', () => {
@@ -47,4 +51,16 @@ describe('ThinkingBlock', () => {
 
         expect((block as any)._streaming).toBe(true);
     });
+
+    it('does not start animation when reduced motion is preferred', () => {
+        vi.spyOn(caps, 'motion', 'get').mockReturnValue(false);
+    
+        const block = new ThinkingBlock();
+    
+        block.setStreaming(true);
+        block.mount();
+    
+        expect((block as any)._timerUnsub).toBeUndefined();
+    });
+    
 });


### PR DESCRIPTION
## Description

Adds regression coverage for ThinkingBlock's reduced-motion behavior.

ThinkingBlock already respects `prefersReducedMotion()` by skipping its timer subscription when motion is disabled, but there was no automated test verifying this behavior. This PR adds a dedicated test to ensure animation does not start when reduced motion is preferred.

## Related Issue

Closes #1543

## Which package(s)?

@termuijs/widgets

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [x] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

* Added a regression test covering reduced-motion behaviour in `ThinkingBlock`.
* The test verifies that no animation timer is started when motion is disabled.
* Existing widget behavior is unchanged; this PR only adds test coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a unit test ensuring the streaming animation respects reduced motion preferences by not subscribing to motion timers when reduced motion is enabled.
  * Updated the ASCII border test to override Unicode handling using a safer property override with proper restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->