### PR TITLE
test: add reduced-motion coverage for StreamingText

### DIFF
--- a/packages/widgets/src/display/StreamingText.test.ts
+++ b/packages/widgets/src/display/StreamingText.test.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets — Tests for StreamingText widget
 // ─────────────────────────────────────────────────────
 
-import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { timerPoolUnsubscribeAll } from '@termuijs/motion';
 import { Screen, caps } from '@termuijs/core';
 import { StreamingText } from './StreamingText.js';
@@ -10,6 +10,10 @@ import { StreamingText } from './StreamingText.js';
 afterEach(() => {
     // Clean up any live timers started by mount()
     timerPoolUnsubscribeAll();
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
 });
 
 /** Helper: create widget, set rect, render to a screen, return both */
@@ -199,11 +203,12 @@ describe('StreamingText – cursor hidden', () => {
 
 // ── 8. mount/unmount lifecycle ────────────────────────────────────────────────
 describe('StreamingText – lifecycle', () => {
-    let origMotion: boolean;
-    beforeEach(() => { origMotion = caps.motion; (caps as any).motion = true; });
-    afterEach(() => { (caps as any).motion = origMotion; });
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
 
     it('mount() sets up _blinkUnsub', () => {
+        vi.spyOn(caps, 'motion', 'get').mockReturnValue(true);
         const widget = new StreamingText({ text: 'Hello' });
         expect((widget as any)._blinkUnsub).toBeUndefined();
         widget.mount();
@@ -211,7 +216,16 @@ describe('StreamingText – lifecycle', () => {
         widget.unmount();
     });
 
+    it('does not start cursor blinking when reduced motion is preferred', () => {
+        vi.spyOn(caps, 'motion', 'get').mockReturnValue(false);
+        const widget = new StreamingText({ text: 'Hello' });
+        widget.mount();
+        expect((widget as any)._blinkUnsub).toBeUndefined();
+        expect((widget as any)._cursorVisible).toBe(false);
+    });
+
     it('unmount() clears _blinkUnsub', () => {
+        vi.spyOn(caps, 'motion', 'get').mockReturnValue(true);
         const widget = new StreamingText({ text: 'Hello' });
         widget.mount();
         widget.unmount();
@@ -222,19 +236,14 @@ describe('StreamingText – lifecycle', () => {
 // ── 9. caps.unicode cursor fallback ──────────────────────────────────────────
 describe('StreamingText – caps.unicode cursor fallback', () => {
     it('uses ASCII cursor _ when caps.unicode is false and no explicit cursor given', () => {
-        const orig = caps.unicode;
-        (caps as any).unicode = false;
-        try {
-            const widget = new StreamingText({ text: 'Hi', speed: 0 });
-            (widget as any)._cursorVisible = true;
-            const screen = new Screen(40, 10);
-            widget.updateRect({ x: 0, y: 0, width: 40, height: 10 });
-            widget.render(screen);
-            const line = rowText(screen, 0);
-            expect(line).toBe('Hi_');
-        } finally {
-            (caps as any).unicode = orig;
-        }
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+        const widget = new StreamingText({ text: 'Hi', speed: 0 });
+        (widget as any)._cursorVisible = true;
+        const screen = new Screen(40, 10);
+        widget.updateRect({ x: 0, y: 0, width: 40, height: 10 });
+        widget.render(screen);
+        const line = rowText(screen, 0);
+        expect(line).toBe('Hi_');
     });
 });
 


### PR DESCRIPTION
## Description

Adds regression test coverage for `StreamingText` reduced-motion behavior.

This PR verifies that `StreamingText` does not start its cursor blink timer when reduced motion is enabled and helps prevent future accessibility regressions.

## Related Issue

Closes #1545 
## Which package(s)?

@termuijs/widgets

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [x] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

* Added regression coverage for reduced-motion behavior in `StreamingText`.
* Verifies that no blink timer is created when motion is disabled.
* Existing behavior when motion is enabled remains unchanged.
* No production code changes; test-only update.## Description



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability and maintainability through refined mocking practices in core component tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->