### PR TITLE
test: add ASCII fallback coverage for ThinkingBlock

### DIFF
--- a/packages/widgets/src/display/ThinkingBlock.test.ts
+++ b/packages/widgets/src/display/ThinkingBlock.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { Screen, type KeyEvent } from '@termuijs/core';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Screen, type KeyEvent, caps } from '@termuijs/core';
 import { ThinkingBlock } from './ThinkingBlock.js';
 
 const key = (k: string): KeyEvent => ({ key: k, ctrl: false, alt: false, shift: false, raw: Buffer.alloc(0), stopPropagation: () => {}, preventDefault: () => {} });
@@ -10,6 +10,10 @@ function render(widget: ThinkingBlock) {
     widget.render(screen);
     return screen;
 }
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
 
 describe('ThinkingBlock', () => {
     it('renders collapsed state', () => {
@@ -47,4 +51,16 @@ describe('ThinkingBlock', () => {
 
         expect((block as any)._streaming).toBe(true);
     });
+
+    it('uses ASCII borders when caps.unicode is false', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+        const block = new ThinkingBlock();
+        block.handleKey(key('enter')); // expand
+        const screen = render(block);
+        expect(screen.back[0]?.[0]?.char).toBe('+');
+        expect(screen.back[0]?.[1]?.char).toBe('-');
+        const secondRow = screen.back[1];
+        expect(secondRow?.[0]?.char).toBe('|');
+    });
+
 });


### PR DESCRIPTION
## Description

Adds regression coverage for the ASCII fallback behaviour of the `ThinkingBlock` widget.

The widget already supports rendering ASCII borders when Unicode is unavailable, but this behavior was not covered by tests. This PR adds a dedicated test to verify that ASCII border characters (`+`, `-`, `|`) are rendered when `caps.unicode` is disabled.

## Related Issue

Closes #1547 

## Which package(s)?

`@termuijs/widgets`

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`[CONTRIBUTING.md]`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A (test-only change)

## Notes for the Reviewer

* Added a regression test for `ThinkingBlock` ASCII fallback rendering.
* The test mocks `caps.unicode` as `false` and verifies that ASCII border characters are rendered instead of Unicode box-drawing characters.
* No production code changes are included in this PR.
* Local widget tests pass successfully.
* Repository-wide build/typecheck failures appear unrelated to this change and originate from existing issues in other packages.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test suite with additional coverage to verify ASCII border rendering behavior when unicode mode is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->