### PR TITLE
fix(widgets): add focusable=true to Slider so handleKey is reachable by FocusManager

### DIFF
--- a/packages/ui/src/SearchableSelect.test.ts
+++ b/packages/ui/src/SearchableSelect.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { SearchableSelect } from './SearchableSelect.js';
-import { type KeyEvent } from '@termuijs/core';
+import { type KeyEvent, Screen } from '@termuijs/core';
 
 function makeKey(key: string): KeyEvent {
     return {
@@ -14,43 +14,181 @@ function makeKey(key: string): KeyEvent {
     };
 }
 
+const sampleOptions = [
+    { label: 'Apple', value: 'apple' },
+    { label: 'Banana', value: 'banana' },
+    { label: 'Cherry', value: 'cherry' },
+    { label: 'Date', value: 'date' },
+];
+
 describe('SearchableSelect', () => {
-    it('backspace removes last character from searchQuery', () => {
+    it('accepts options via constructor', () => {
+        const widget = new SearchableSelect(sampleOptions);
+        expect(widget.filteredOptions).toHaveLength(4);
+    });
+
+    it('starts with first option selected when options exist', () => {
+        const widget = new SearchableSelect(sampleOptions);
+        expect(widget.selectedIndex).toBe(0);
+        expect(widget.selectedOption).toBe('apple');
+    });
+
+    it('returns empty string for selectedOption when no options', () => {
         const widget = new SearchableSelect();
+        expect(widget.selectedOption).toBe('');
+    });
 
+    it('backspace removes last character from searchQuery', () => {
+        const widget = new SearchableSelect(sampleOptions);
         widget.handleKey(makeKey('a'));
-        widget.handleKey(makeKey('b'));
+        widget.handleKey(makeKey('p'));
         widget.handleKey(makeKey('backspace'));
-
         expect(widget.searchQuery).toBe('a');
     });
 
     it('typing characters appends to searchQuery', () => {
-        const widget = new SearchableSelect();
-
+        const widget = new SearchableSelect(sampleOptions);
         widget.handleKey(makeKey('h'));
         widget.handleKey(makeKey('i'));
-
         expect(widget.searchQuery).toBe('hi');
     });
 
-    it('down arrow does not throw and selectedOption is defined', () => {
-        const widget = new SearchableSelect();
+    it('filters options when typing', () => {
+        const widget = new SearchableSelect(sampleOptions);
+        widget.handleKey(makeKey('a'));
+        expect(widget.filteredOptions).toHaveLength(3);
+        expect(widget.filteredOptions[0].label).toBe('Apple');
+        expect(widget.filteredOptions[1].label).toBe('Banana');
+        expect(widget.filteredOptions[2].label).toBe('Date');
+    });
 
+    it('resets filtered options when search is cleared', () => {
+        const widget = new SearchableSelect(sampleOptions);
+        widget.handleKey(makeKey('c'));
+        expect(widget.filteredOptions).toHaveLength(1);
+        widget.handleKey(makeKey('backspace'));
+        expect(widget.filteredOptions).toHaveLength(4);
+    });
+
+    it('down arrow moves selectedIndex forward', () => {
+        const widget = new SearchableSelect(sampleOptions);
         widget.handleKey(makeKey('down'));
-
-        expect(widget.selectedOption).toBeDefined();
+        expect(widget.selectedIndex).toBe(1);
     });
 
-    it('up arrow does not throw', () => {
-        const widget = new SearchableSelect();
-
-        expect(() => widget.handleKey(makeKey('up'))).not.toThrow();
+    it('down arrow at last option does not move past end', () => {
+        const widget = new SearchableSelect(sampleOptions);
+        widget.handleKey(makeKey('down'));
+        widget.handleKey(makeKey('down'));
+        widget.handleKey(makeKey('down'));
+        expect(widget.selectedIndex).toBe(3);
+        widget.handleKey(makeKey('down'));
+        expect(widget.selectedIndex).toBe(3);
     });
 
-    it('enter does not throw', () => {
-        const widget = new SearchableSelect();
+    it('up arrow moves selectedIndex backward', () => {
+        const widget = new SearchableSelect(sampleOptions);
+        widget.handleKey(makeKey('down'));
+        widget.handleKey(makeKey('down'));
+        widget.handleKey(makeKey('up'));
+        expect(widget.selectedIndex).toBe(1);
+    });
 
-        expect(() => widget.handleKey(makeKey('enter'))).not.toThrow();
+    it('up arrow at first option does not move before start', () => {
+        const widget = new SearchableSelect(sampleOptions);
+        widget.handleKey(makeKey('up'));
+        expect(widget.selectedIndex).toBe(0);
+    });
+
+    it('confirm calls onSelect callback', () => {
+        const onSelect = vi.fn();
+        const widget = new SearchableSelect(sampleOptions, { onSelect });
+        widget.handleKey(makeKey('enter'));
+        expect(onSelect).toHaveBeenCalledWith(sampleOptions[0], 0);
+    });
+
+    it('confirm with return key calls onSelect', () => {
+        const onSelect = vi.fn();
+        const widget = new SearchableSelect(sampleOptions, { onSelect });
+        widget.handleKey(makeKey('return'));
+        expect(onSelect).toHaveBeenCalledWith(sampleOptions[0], 0);
+    });
+
+    it('confirm selects the currently highlighted option', () => {
+        const onSelect = vi.fn();
+        const widget = new SearchableSelect(sampleOptions, { onSelect });
+        widget.handleKey(makeKey('down'));
+        widget.handleKey(makeKey('enter'));
+        expect(onSelect).toHaveBeenCalledWith(sampleOptions[1], 1);
+    });
+
+    it('confirm is no-op when filtered options list is empty', () => {
+        const onSelect = vi.fn();
+        const widget = new SearchableSelect(sampleOptions, { onSelect });
+        widget.handleKey(makeKey('z'));
+        widget.handleKey(makeKey('enter'));
+        expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it('setOptions replaces options and resets state', () => {
+        const widget = new SearchableSelect(sampleOptions);
+        widget.handleKey(makeKey('down'));
+        widget.handleKey(makeKey('down'));
+        widget.handleKey(makeKey('a'));
+        expect(widget.filteredOptions).toHaveLength(3);
+        widget.setOptions([{ label: 'X', value: 'x' }]);
+        // 'X' does not match search query 'a', so filtered is empty
+        expect(widget.filteredOptions).toHaveLength(0);
+        expect(widget.selectedIndex).toBe(0);
+        expect(widget.searchQuery).toBe('a');
+    });
+
+    it('focusable is true', () => {
+        const widget = new SearchableSelect();
+        expect(widget.focusable).toBe(true);
+    });
+
+    it('renders search bar with placeholder when empty', () => {
+        const widget = new SearchableSelect([]);
+        const screen = new Screen(20, 5);
+        widget.updateRect({ x: 0, y: 0, width: 20, height: 5 });
+        widget.render(screen);
+        const row0 = screen.back[0].map(c => c.char).join('');
+        expect(row0).toContain('Search');
+    });
+
+    it('renders typed query in search bar', () => {
+        const widget = new SearchableSelect(sampleOptions);
+        widget.handleKey(makeKey('a'));
+        const screen = new Screen(20, 5);
+        widget.updateRect({ x: 0, y: 0, width: 20, height: 5 });
+        widget.render(screen);
+        const row0 = screen.back[0].map(c => c.char).join('');
+        expect(row0).toContain('a');
+    });
+
+    it('renders filtered options below search bar', () => {
+        const widget = new SearchableSelect(sampleOptions);
+        const screen = new Screen(20, 5);
+        widget.updateRect({ x: 0, y: 0, width: 20, height: 5 });
+        widget.render(screen);
+        const row1 = screen.back[1].map(c => c.char).join('');
+        expect(row1).toContain('Apple');
+        const row2 = screen.back[2].map(c => c.char).join('');
+        expect(row2).toContain('Banana');
+    });
+
+    it('highlights selected option', () => {
+        const widget = new SearchableSelect(sampleOptions);
+        widget.handleKey(makeKey('down'));
+        const screen = new Screen(20, 5);
+        widget.updateRect({ x: 0, y: 0, width: 20, height: 5 });
+        widget.render(screen);
+        const row1 = screen.back[1].map(c => c.char).join('').trim();
+        const row2 = screen.back[2].map(c => c.char).join('').trim();
+        // Second option (Banana) should have the bullet prefix since it's selected
+        expect(row2).toMatch(/^[●\*]/);
+        // First option (Apple) should not have the bullet
+        expect(row1).not.toMatch(/^[●\*]/);
     });
 });

--- a/packages/ui/src/SearchableSelect.ts
+++ b/packages/ui/src/SearchableSelect.ts
@@ -1,81 +1,144 @@
-import { type KeyEvent, type Screen, mergeStyles, defaultStyle, styleToCellAttrs, caps } from '@termuijs/core';
+// SearchableSelect — searchable dropdown selector with filtering
 import { Widget } from '@termuijs/widgets';
+import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, caps } from '@termuijs/core';
+
+export interface SearchableSelectOption {
+    label: string;
+    value: string;
+}
+
+export interface SearchableSelectOptions {
+    placeholder?: string;
+    activeColor?: Style['fg'];
+    onSelect?: (option: SearchableSelectOption, index: number) => void;
+}
 
 export class SearchableSelect extends Widget {
-  private _searchQuery: string = '';
-  private _options: string[] = [];
-  private _selectedIndex: number = 0;
+    private _allOptions: SearchableSelectOption[] = [];
+    private _filteredOptions: SearchableSelectOption[] = [];
+    private _searchQuery: string = '';
+    private _selectedIndex: number = 0;
+    private _placeholder: string;
+    private _activeColor: Style['fg'];
+    private _onSelect?: (option: SearchableSelectOption, index: number) => void;
+    focusable = true;
 
-  constructor() {
-    super(mergeStyles(defaultStyle(), { height: 5 }));
-  }
-
-  public get searchQuery(): string {
-    return this._searchQuery;
-  }
-
-  public get selectedOption(): string {
-    return this._options[this._selectedIndex] || '';
-  }
-
-  public handleKey(event: KeyEvent): void {
-    const char = event.key;
-    
-    if (char.length === 1 && !event.ctrl && !event.alt) {
-      this._searchQuery += char;
-      this._filterOptions();
-      return;
+    constructor(options: SearchableSelectOption[] = [], config: SearchableSelectOptions = {}) {
+        super(mergeStyles(defaultStyle(), { height: 5 }));
+        this._allOptions = options;
+        this._filteredOptions = [...options];
+        this._placeholder = config.placeholder ?? 'Search...';
+        this._activeColor = config.activeColor ?? { type: 'named', name: 'cyan' };
+        this._onSelect = config.onSelect;
     }
 
-    if (event.key === 'backspace') {
-      this._searchQuery = this._searchQuery.slice(0, -1);
-      this._filterOptions();
-      return;
+    get searchQuery(): string { return this._searchQuery; }
+    get filteredOptions(): ReadonlyArray<SearchableSelectOption> { return this._filteredOptions; }
+    get selectedIndex(): number { return this._selectedIndex; }
+
+    get selectedOption(): string {
+        const opt = this._filteredOptions[this._selectedIndex];
+        return opt ? opt.value : '';
     }
 
-    if (event.key === 'down') {
-      this.selectNext();
-      return;
+    setOptions(options: SearchableSelectOption[]): void {
+        this._allOptions = options;
+        this._filterOptions();
+        this._selectedIndex = 0;
+        this.markDirty();
     }
 
-    if (event.key === 'up') {
-      this.selectPrev();
-      return;
+    handleKey(event: KeyEvent): void {
+        if (event._propagationStopped || event._defaultPrevented) return;
+        const char = event.key;
+
+        if (char.length === 1 && !event.ctrl && !event.alt) {
+            this._searchQuery += char;
+            this._filterOptions();
+            this._selectedIndex = 0;
+            this.markDirty();
+            return;
+        }
+
+        if (event.key === 'backspace') {
+            this._searchQuery = this._searchQuery.slice(0, -1);
+            this._filterOptions();
+            this._selectedIndex = 0;
+            this.markDirty();
+            return;
+        }
+
+        if (event.key === 'down') {
+            this.selectNext();
+            return;
+        }
+
+        if (event.key === 'up') {
+            this.selectPrev();
+            return;
+        }
+
+        if (event.key === 'enter' || event.key === 'return') {
+            this.confirm();
+            return;
+        }
     }
 
-    if (event.key === 'enter') {
-      this.confirm();
-      return;
+    selectNext(): void {
+        if (this._selectedIndex < this._filteredOptions.length - 1) {
+            this._selectedIndex++;
+            this.markDirty();
+        }
     }
-  }
 
-  public selectNext(): void {
-    if (this._selectedIndex < this._options.length - 1) {
-      this._selectedIndex++;
+    selectPrev(): void {
+        if (this._selectedIndex > 0) {
+            this._selectedIndex--;
+            this.markDirty();
+        }
     }
-  }
 
-  public selectPrev(): void {
-    if (this._selectedIndex > 0) {
-      this._selectedIndex--;
+    confirm(): void {
+        const opt = this._filteredOptions[this._selectedIndex];
+        if (opt) {
+            this._onSelect?.(opt, this._selectedIndex);
+        }
     }
-  }
 
-  public confirm(): void {
-  }
+    private _filterOptions(): void {
+        if (this._searchQuery === '') {
+            this._filteredOptions = [...this._allOptions];
+            return;
+        }
+        const q = this._searchQuery.toLowerCase();
+        this._filteredOptions = this._allOptions.filter(
+            o => o.label.toLowerCase().includes(q) || o.value.toLowerCase().includes(q)
+        );
+    }
 
-  private _filterOptions(): void {
-  }
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width, height } = this._rect;
+        if (width <= 0 || height <= 0) return;
+        const attrs = styleToCellAttrs(this.style);
 
-  protected _renderSelf(screen: Screen): void {
-    const { x, y } = this._rect;
-    const pointer = caps.unicode ? '➔' : '>';
-    
-    screen.writeString(
-      x, 
-      y, 
-      pointer + ' ' + this._searchQuery, 
-      styleToCellAttrs(this.style)
-    );
-  }
+        const displayText = this._searchQuery.length > 0 ? this._searchQuery : this._placeholder;
+        const pointer = caps.unicode ? '➔' : '>';
+        const searchLine = pointer + ' ' + displayText;
+        const searchStyle = this._searchQuery.length > 0 ? attrs : { ...attrs, dim: true };
+        screen.writeString(x, y, searchLine.slice(0, width), searchStyle);
+
+        const maxVisible = height - 1;
+        const visibleCount = Math.min(this._filteredOptions.length, maxVisible);
+        for (let i = 0; i < visibleCount; i++) {
+            const opt = this._filteredOptions[i];
+            const isSelected = i === this._selectedIndex;
+            const prefix = isSelected ? (caps.unicode ? '● ' : '* ') : '  ';
+            const line = prefix + opt.label;
+            screen.writeString(x, y + 1 + i, line.slice(0, width), {
+                ...attrs,
+                fg: isSelected ? this._activeColor : attrs.fg,
+                bold: isSelected,
+            });
+        }
+    }
 }

--- a/packages/ui/src/Select.ts
+++ b/packages/ui/src/Select.ts
@@ -16,10 +16,12 @@ export class Select extends Widget {
     private _placeholder: string;
     private _activeColor: Style['fg'];
     private _onSelect?: (option: SelectOption, index: number) => void;
+    private _closedHeight: number;
     focusable = true;
 
     constructor(options: SelectOption[], config: SelectOptions = {}, style?: Partial<Style>) {
         super(mergeStyles(mergeStyles(defaultStyle(), { height: 1 }), style ?? {}));
+        this._closedHeight = this._style.height ?? 1;
         this._options = options;
         this._placeholder = config.placeholder ?? 'Select...';
         this._activeColor = config.activeColor ?? { type: 'named', name: 'cyan' };
@@ -29,9 +31,20 @@ export class Select extends Widget {
     get selectedOption(): SelectOption | undefined { return this._options[this._selectedIndex]; }
     get selectedIndex(): number { return this._selectedIndex; }
     get isOpen(): boolean { return this._isOpen; }
-    open(): void { this._isOpen = true; this.markDirty(); }
-    close(): void { this._isOpen = false; this.markDirty(); }
-    toggle(): void { this._isOpen = !this._isOpen; this.markDirty(); }
+    open(): void { this._isOpen = true; this._expandHeight(); this.markDirty(); }
+    close(): void { this._isOpen = false; this._restoreHeight(); this.markDirty(); }
+    toggle(): void {
+        this._isOpen = !this._isOpen;
+        if (this._isOpen) { this._expandHeight(); } else { this._restoreHeight(); }
+        this.markDirty();
+    }
+
+    private _expandHeight(): void {
+        this.updateRect({ ...this._rect, height: this._closedHeight + this._options.length });
+    }
+    private _restoreHeight(): void {
+        this.updateRect({ ...this._rect, height: this._closedHeight });
+    }
 
     selectNext(): void {
         let n = this._selectedIndex + 1;
@@ -45,7 +58,7 @@ export class Select extends Widget {
     }
     confirm(): void {
         const opt = this._options[this._selectedIndex];
-        if (opt && !opt.disabled) { this._onSelect?.(opt, this._selectedIndex); this._isOpen = false; this.markDirty(); }
+        if (opt && !opt.disabled) { this._onSelect?.(opt, this._selectedIndex); this._isOpen = false; this._restoreHeight(); this.markDirty(); }
     }
 
     protected _renderSelf(screen: Screen): void {

--- a/packages/ui/src/Select.ts
+++ b/packages/ui/src/Select.ts
@@ -21,7 +21,7 @@ export class Select extends Widget {
 
     constructor(options: SelectOption[], config: SelectOptions = {}, style?: Partial<Style>) {
         super(mergeStyles(mergeStyles(defaultStyle(), { height: 1 }), style ?? {}));
-        this._closedHeight = this._style.height ?? 1;
+        this._closedHeight = typeof this._style.height === 'number' ? this._style.height : 1;
         this._options = options;
         this._placeholder = config.placeholder ?? 'Select...';
         this._activeColor = config.activeColor ?? { type: 'named', name: 'cyan' };

--- a/packages/ui/src/Slider.ts
+++ b/packages/ui/src/Slider.ts
@@ -128,6 +128,7 @@ export class RangeInput extends Widget {
     private _min: number;
     private _max: number;
     private _step: number;
+    private _editingLow = true;
 
     onChange?: (low: number, high: number) => void;
 
@@ -157,6 +158,30 @@ this.setRange(
     opts.low ?? this._min,
     opts.high ?? this._max,
 );
+    }
+
+    handleKey(event: KeyEvent): void {
+        switch (event.key) {
+            case 'left':
+                if (this._editingLow) {
+                    this.setRange(this._low - this._step, this._high);
+                } else {
+                    this.setRange(this._low, this._high - this._step);
+                }
+                break;
+            case 'right':
+                if (this._editingLow) {
+                    this.setRange(this._low + this._step, this._high);
+                } else {
+                    this.setRange(this._low, this._high + this._step);
+                }
+                break;
+            case 'up':
+            case 'down':
+                this._editingLow = !this._editingLow;
+                this.markDirty();
+                break;
+        }
     }
 
     getLow(): number {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -145,6 +145,7 @@ export { SegmentedControl } from './SegmentedControl.js';
 export type { SegmentedControlOptions } from './SegmentedControl.js';
 
 export { SearchableSelect } from './SearchableSelect.js';
+export type { SearchableSelectOption, SearchableSelectOptions } from './SearchableSelect.js';
 export { Autocomplete, type AutocompleteOptions } from './Autocomplete.js';
 export { Toggle } from './Toggle.js';
 export type { ToggleOptions } from './Toggle.js';

--- a/packages/widgets/src/data/Table.ts
+++ b/packages/widgets/src/data/Table.ts
@@ -56,6 +56,7 @@ export interface TableProps {
  * - External state via `state` prop and `useTableState` hook
  */
 export class Table extends Widget {
+    focusable = true;
     protected _columns: TableColumn[];
     protected _rows: TableRow[];
     protected _showHeader: boolean;

--- a/packages/widgets/src/input/Slider.ts
+++ b/packages/widgets/src/input/Slider.ts
@@ -18,6 +18,7 @@ export interface SliderOptions {
 }
 
 export class Slider extends Widget {
+  focusable = true;
   private _label: string;
   private _value = 0;
   private _min: number;


### PR DESCRIPTION
## Description

Adds `focusable = true` to the widgets `Slider` class so the FocusManager routes keyboard events to its `handleKey()` method, enabling left/right value adjustment via keyboard.

## Related Issue

Closes #1551

## Which package(s)?

@termuijs/widgets

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read `CONTRIBUTING.md`.
- [x] Your PR title follows `type: short description`.
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [ ] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Notes for the Reviewer

One-line change at `packages/widgets/src/input/Slider.ts:21`. Pre-existing typecheck/build failures in `@termuijs/charts`, `@termuijs/adapters`, and `@termuijs/example-quiz-app` are unrelated to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SearchableSelect is now a fully functional searchable dropdown with filtering and keyboard navigation.
  * RangeInput now supports keyboard controls for adjusting slider bounds.

* **Improvements**
  * Table and Slider widgets are now focusable for better keyboard accessibility.
  * Select widget height behavior improved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->