### PR TITLE
feat(store): add selector equality support

### DIFF
--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -32,4 +32,6 @@ export type { LoggerOptions } from './logger.js';
 
 export { signal, mutate } from './mutate.js';
 export type { Signal } from './mutate.js';
+export type { EqualityFn } from './shallow.js';
+export { shallow } from './shallow.js';
 

--- a/packages/store/src/shallow.test.ts
+++ b/packages/store/src/shallow.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest'
+import { shallow } from './shallow.js'
+import { createStore } from './store.js'
+
+describe('shallow', () => {
+  it('returns true for equal flat objects', () => {
+    expect(shallow({ a: 1, b: 2 }, { a: 1, b: 2 })).toBe(true)
+  })
+
+  it('returns false when a value differs', () => {
+    expect(shallow({ a: 1, b: 2 }, { a: 1, b: 3 })).toBe(false)
+  })
+
+  it('returns false when key sets differ', () => {
+    expect(shallow({ a: 1 }, { a: 1, b: 2 })).toBe(false)
+  })
+})
+
+describe('useStore selector with shallow', () => {
+  it('selector with shallow skips notify on equal slice', () => {
+    const useStore = createStore({ obj: { a: 1, b: 2 }, other: 0 })
+    const spy = vi.fn()
+
+    let prev = useStore.getState().obj
+    const unsub = useStore.subscribe(() => {
+      const next = useStore.getState().obj
+      if (!shallow(prev, next)) {
+        prev = next
+        spy(next)
+      }
+    })
+
+    // mutate other key only; obj unchanged shallowly
+    useStore.setState({ other: 1 })
+    expect(spy).toHaveBeenCalledTimes(0)
+    unsub()
+  })
+
+  it('selector with shallow notifies on changed slice', () => {
+    const useStore = createStore({ obj: { a: 1, b: 2 }, other: 0 })
+    const spy = vi.fn()
+
+    let prev = useStore.getState().obj
+    const unsub = useStore.subscribe(() => {
+      const next = useStore.getState().obj
+      if (!shallow(prev, next)) {
+        prev = next
+        spy(next)
+      }
+    })
+
+    // change nested value
+    useStore.setState({ obj: { a: 1, b: 3 } })
+    expect(spy).toHaveBeenCalledTimes(1)
+    unsub()
+  })
+})

--- a/packages/store/src/shallow.ts
+++ b/packages/store/src/shallow.ts
@@ -1,0 +1,21 @@
+// Shallow equality helper
+
+export type EqualityFn<U> = (a: U, b: U) => boolean
+
+export function shallow<U>(a: U, b: U): boolean {
+  if (Object.is(a, b)) return true
+
+  if (typeof a !== 'object' || a === null) return false
+  if (typeof b !== 'object' || b === null) return false
+
+  const aKeys = Object.keys(a as any)
+  const bKeys = Object.keys(b as any)
+  if (aKeys.length !== bKeys.length) return false
+
+  for (const key of aKeys) {
+    if (!bKeys.includes(key)) return false
+    if (!Object.is((a as any)[key], (b as any)[key])) return false
+  }
+
+  return true
+}

--- a/packages/store/src/shallow.ts
+++ b/packages/store/src/shallow.ts
@@ -8,13 +8,16 @@ export function shallow<U>(a: U, b: U): boolean {
   if (typeof a !== 'object' || a === null) return false
   if (typeof b !== 'object' || b === null) return false
 
-  const aKeys = Object.keys(a as any)
-  const bKeys = Object.keys(b as any)
+  const aRec = a as Record<string, unknown>
+  const bRec = b as Record<string, unknown>
+  const aKeys = Object.keys(aRec)
+  const bKeys = Object.keys(bRec)
   if (aKeys.length !== bKeys.length) return false
 
+  const bKeysSet = new Set(bKeys)
   for (const key of aKeys) {
-    if (!bKeys.includes(key)) return false
-    if (!Object.is((a as any)[key], (b as any)[key])) return false
+    if (!bKeysSet.has(key)) return false
+    if (!Object.is(aRec[key], bRec[key])) return false
   }
 
   return true

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -24,6 +24,7 @@ import { useState, useEffect, useRef } from '@termuijs/jsx';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
+import type { EqualityFn } from './shallow.js'
 
 // ── Batch Mechanism ──
 
@@ -450,8 +451,8 @@ export function createStore<T extends object>(
 
     // Create the hook function
     function useStore(): T;
-    function useStore<U>(selector: Selector<T, U>): U;
-    function useStore<U>(selector?: Selector<T, U>): T | U {
+    function useStore<U>(selector: Selector<T, U>, equalityFn?: EqualityFn<U>): U;
+    function useStore<U>(selector?: Selector<T, U>, equalityFn?: EqualityFn<U>): T | U {
         const select = selector ?? ((s: T) => s as unknown as U);
 
         // Use useState to trigger re-renders
@@ -459,11 +460,18 @@ export function createStore<T extends object>(
         const selectorRef = useRef(select);
         selectorRef.current = select;
 
+        // Store equalityFn in a ref to avoid stale closures
+        const equalityRef = useRef<EqualityFn<U> | undefined>(equalityFn as EqualityFn<U> | undefined);
+        equalityRef.current = equalityFn as EqualityFn<U> | undefined;
+
         useEffect(() => {
             let prevSelected = selectorRef.current(store.getState());
             const unsubscribe = store.subscribe((newState) => {
                 const newSelected = selectorRef.current(newState);
-                if (!Object.is(prevSelected, newSelected)) {
+                const areEqual = equalityRef.current
+                    ? equalityRef.current(prevSelected as U, newSelected as U)
+                    : Object.is(prevSelected, newSelected);
+                if (!areEqual) {
                     prevSelected = newSelected;
                     setSelectedState(newSelected);
                 }


### PR DESCRIPTION
## Summary

Adds optional selector equality support to the store hook and introduces a reusable shallow comparator.

## Changes

* Added `EqualityFn` support to `useStore(selector, equalityFn)`
* Added `shallow()` comparator
* Preserved existing `Object.is` behavior when no comparator is provided
* Stored equality function in a ref to avoid stale comparisons
* Exported `shallow` from the store package
* Added tests covering shallow equality and selector notification behavior

## Validation

```bash
bun vitest run packages/store
bun run typecheck
bun run build
```

All checks pass successfully.

Closes #489


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a shallow equality helper for comparing objects with identical keys and values
  * Extended useStore hook to accept an optional equality function for fine-grained selector comparison control

* **Tests**
  * Added comprehensive test suite verifying equality behavior and store selector integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->