### PR TITLE
feat(widgets): add braille variant and variant option to Spinner

### DIFF
--- a/packages/widgets/src/feedback/Spinner.test.ts
+++ b/packages/widgets/src/feedback/Spinner.test.ts
@@ -71,6 +71,14 @@ describe('Spinner', () => {
         expect(interval).toBe(120);
     });
 
+    it('supports variant property override', () => {
+        const spinner = new Spinner({}, { variant: 'braille' });
+        const interval = (spinner as unknown as { _interval: number })._interval;
+        expect(interval).toBe(80);
+        const frames = (spinner as unknown as { _frames: string[] })._frames;
+        expect(frames[0]).toBe('⠋');
+    });
+
     it('supports custom interval overrides', () => {
         const spinner = new Spinner({}, { preset: 'dots', interval: 200 });
         const interval = (spinner as unknown as { _interval: number })._interval;

--- a/packages/widgets/src/feedback/Spinner.ts
+++ b/packages/widgets/src/feedback/Spinner.ts
@@ -15,6 +15,11 @@ export const SPINNER_FRAMES: Record<string, { frames: string[]; asciiFrames: str
         asciiFrames: ['|', '/', '-', '\\'],
         interval: 80,
     },
+    /**
+     * Alias for `dots`. Uses the same braille character frames and interval.
+     * Provided as a more semantically descriptive name when the intent is to
+     * convey a "braille spinner" rather than a generic dots animation.
+     */
     braille: {
         frames: ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'],
         asciiFrames: ['|', '/', '-', '\\'],
@@ -72,7 +77,12 @@ export interface SpinnerOptions {
     spinner?: string | { frames: string[]; interval: number };
     /** Spinner preset name (preferred option) */
     preset?: string;
-    /** Animation variant (dots, line, braille, etc.) */
+    /**
+     * Animation variant (dots, line, braille, etc.).
+     * Equivalent to `preset` — provided for semantic clarity when callers
+     * prefer to think of the choice as a visual "variant" rather than a
+     * configuration preset. If both are supplied, `variant` takes precedence.
+     */
     variant?: string;
     /** Text label displayed after the spinner */
     label?: string;

--- a/packages/widgets/src/feedback/Spinner.ts
+++ b/packages/widgets/src/feedback/Spinner.ts
@@ -15,6 +15,11 @@ export const SPINNER_FRAMES: Record<string, { frames: string[]; asciiFrames: str
         asciiFrames: ['|', '/', '-', '\\'],
         interval: 80,
     },
+    braille: {
+        frames: ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'],
+        asciiFrames: ['|', '/', '-', '\\'],
+        interval: 80,
+    },
     line: {
         frames: ['-', '\\', '|', '/'],
         asciiFrames: ['-', '\\', '|', '/'],
@@ -67,6 +72,8 @@ export interface SpinnerOptions {
     spinner?: string | { frames: string[]; interval: number };
     /** Spinner preset name (preferred option) */
     preset?: string;
+    /** Animation variant (dots, line, braille, etc.) */
+    variant?: string;
     /** Text label displayed after the spinner */
     label?: string;
     /** Color for the spinner frames */
@@ -106,7 +113,7 @@ export class Spinner extends Widget {
     constructor(style: Partial<Style> = {}, options: SpinnerOptions = {}) {
         super({ height: 1, ...style });
 
-        const presetName = options.preset ?? (typeof options.spinner === 'string' ? options.spinner : undefined);
+        const presetName = options.variant ?? options.preset ?? (typeof options.spinner === 'string' ? options.spinner : undefined);
         const spinnerDef = presetName
             ? (SPINNER_FRAMES[presetName] ?? SPINNER_FRAMES.dots)
             : (typeof options.spinner === 'object' ? options.spinner : SPINNER_FRAMES.dots);


### PR DESCRIPTION
Adds the explicit braille variant and variant option mapping to presets to support standard animation variants.

- Spinner.ts: Added explicit `braille` preset to `SPINNER_FRAMES` and extended `SpinnerOptions` to support the `variant` property mapped to `preset`.
- Spinner.test.ts: Added unit tests validating the `variant` property override functionality.

<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

This PR extends the `Spinner` widget to fully support the requested animation variants. It introduces the `variant` option in `SpinnerOptions` and specifically maps the explicit `braille` variant, allowing developers to create consistent terminal loading experiences as proposed.

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #1114

## Which package(s)?

@termuijs/widgets

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/172e996c-3943-4a86-8249-1f01922d0f64`

## Screenshots / Recordings (UI changes)

-No such changes

## Notes for the Reviewer

The `dots`, `line`, `arc`, `bounce`, and `pulse` variants (along with color, interval, and `NO_MOTION` fallbacks) were already available natively in the widget under `preset`. This PR maps the user-requested `variant` keyword to the existing logic and registers the `braille` preset explicitly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new braille spinner variant as an additional animation option for loading indicators across the application.

* **Tests**
  * Added comprehensive test coverage for the braille spinner variant, validating animation frames and timing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->