### PR TITLE
test: add Unicode edge case coverage for Watermark

### DIFF
--- a/packages/widgets/src/display/Watermark.test.ts
+++ b/packages/widgets/src/display/Watermark.test.ts
@@ -98,5 +98,43 @@ describe('Watermark', () => {
         expect(screen.back[0][1].char).toBe('');
         expect(screen.back[0][1].width).toBe(0);
     });
+
+    it('renders nothing for empty text', () => {
+        const { screen } = renderWatermark('', {}, {}, 4, 1);
+
+        expect(rowText(screen, 0)).toBe('    ');
+    });
+
+    it('renders flag emoji as a single double-width grapheme', () => {
+        const { screen } = renderWatermark('🇺🇸', {}, {}, 4, 1);
+
+        expect(screen.back[0][0].char).toBe('🇺🇸');
+        expect(screen.back[0][0].width).toBe(2);
+        expect(screen.back[0][1].char).toBe('');
+        expect(screen.back[0][1].width).toBe(0);
+    });
+
+    it('renders ZWJ family emoji as one grapheme cluster', () => {
+        const family = '👨‍👩‍👧‍👦';
+        const { screen } = renderWatermark(family, {}, {}, 6, 1);
+
+        expect(rowText(screen, 0)).toContain(family);
+        expect(screen.back[0][0].width).toBeGreaterThanOrEqual(1);
+    });
+
+    it('handles combining marks as a single grapheme', () => {
+        const composed = 'e\u0301'; // e + combining acute (should form é)
+        const { screen } = renderWatermark(composed, {}, {}, 4, 1);
+
+        expect(rowText(screen, 0)).toContain('é');
+    });
+
+    it('renders double-width char in a single-column screen without throwing', () => {
+        const { screen } = renderWatermark('你', {}, {}, 1, 1);
+
+        // getLine filters continuation cells; single-column should still contain the character
+        expect(rowText(screen, 0)).toBe('你');
+        expect(screen.back[0][0].width).toBe(2);
+    });
     
 });

--- a/packages/widgets/src/display/Watermark.test.ts
+++ b/packages/widgets/src/display/Watermark.test.ts
@@ -119,7 +119,7 @@ describe('Watermark', () => {
         const { screen } = renderWatermark(family, {}, {}, 6, 1);
 
         expect(rowText(screen, 0)).toContain(family);
-        expect(screen.back[0][0].width).toBeGreaterThanOrEqual(1);
+        expect(screen.back[0][0].width).toBe(2);
     });
 
     it('handles combining marks as a single grapheme', () => {

--- a/packages/widgets/src/display/Watermark.test.ts
+++ b/packages/widgets/src/display/Watermark.test.ts
@@ -58,43 +58,43 @@ describe('Watermark', () => {
 
     it('does not mark dirty when setText receives the same value', () => {
         const watermark = new Watermark('CONFIDENTIAL');
-    
+
         watermark.clearDirty();
-    
+
         watermark.setText('CONFIDENTIAL');
-    
+
         expect(watermark.isDirty).toBe(false);
     });
-    
+
     it('marks dirty when setText receives a different value', () => {
         const watermark = new Watermark('CONFIDENTIAL');
-    
+
         watermark.clearDirty();
-    
+
         watermark.setText('INTERNAL');
-    
+
         expect(watermark.isDirty).toBe(true);
     });
 
     it('renders double-width unicode characters', () => {
         const { screen } = renderWatermark('你好', {}, {}, 4, 1);
-    
+
         expect(rowText(screen, 0)).toContain('你');
         expect(rowText(screen, 0)).toContain('好');
     });
-    
+
     it('renders emoji watermark content', () => {
         const { screen } = renderWatermark('😀', {}, {}, 4, 1);
-    
+
         expect(rowText(screen, 0)).toContain('😀');
     });
 
     it('marks continuation cells for wide Unicode characters', () => {
         const { screen } = renderWatermark('你', {}, {}, 4, 1);
-    
+
         expect(screen.back[0][0].char).toBe('你');
         expect(screen.back[0][0].width).toBe(2);
-    
+
         expect(screen.back[0][1].char).toBe('');
         expect(screen.back[0][1].width).toBe(0);
     });
@@ -136,5 +136,5 @@ describe('Watermark', () => {
         expect(rowText(screen, 0)).toBe('你');
         expect(screen.back[0][0].width).toBe(2);
     });
-    
+
 });


### PR DESCRIPTION
## Description

This PR adds additional test coverage for Unicode and grapheme-cluster edge cases in the Watermark widget. The new tests verify correct handling of empty text, flag emojis, ZWJ emoji sequences, combining characters, and double-width characters in narrow layouts.

## Related Issue

Closes #1588 

## Which package(s)?

@termuijs/widgets

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A (test-only change)

## Notes for the Reviewer

This is a test-only contribution and does not modify production code or widget behavior. The added tests focus on Unicode rendering edge cases that are commonly problematic in terminal-based interfaces, helping prevent future regressions in grapheme segmentation and character width handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded Watermark test coverage with new edge-case scenarios including empty text, flag emoji handling, complex emoji clusters (ZWJ sequences), combining marks, and double-width character rendering on constrained screen widths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->