### PR TITLE
fix(ui): support space key to confirm RadioGroup selection

### DIFF
--- a/packages/ui/src/RadioGroup.test.ts
+++ b/packages/ui/src/RadioGroup.test.ts
@@ -97,6 +97,18 @@ describe('RadioGroup', () => {
         expect(radio.selectedValue).toBe('light');
     });
 
+    it('onChange fires when a new option is confirmed with space', () => {
+        const onChange = vi.fn();
+        const radio = new RadioGroup({ options: OPTIONS, defaultValue: 'dark', onChange });
+
+        radio.selectNext(); // move focus to 'light'
+        radio.handleKey(createKeyEvent({ key: 'space', ctrl: false, shift: false, alt: false, raw: Buffer.alloc(0) }));
+
+        expect(onChange).toHaveBeenCalledOnce();
+        expect(onChange).toHaveBeenCalledWith('light');
+        expect(radio.selectedValue).toBe('light');
+    });
+
     it('onChange does not fire when confirming the already-selected option', () => {
         const onChange = vi.fn();
         const radio = new RadioGroup({ options: OPTIONS, defaultValue: 'dark', onChange });

--- a/packages/ui/src/RadioGroup.ts
+++ b/packages/ui/src/RadioGroup.ts
@@ -130,6 +130,9 @@ export class RadioGroup extends Widget {
             case 'enter':
                 this.confirm();
                 break;
+            case 'space':
+                this.confirm();
+                break;
         }
     }
 


### PR DESCRIPTION
## Description

This PR adds support for confirming the currently focused RadioGroup option using the Space key.

RadioGroup already supports confirmation via Enter. This change improves keyboard accessibility and brings RadioGroup behavior in line with other interactive controls such as Button, Switch, and CheckboxGroup.

A regression test has also been added to verify that Space triggers the same selection behavior as Enter.

## Related Issue

Closes #1591 

## Which package(s)?

@termuijs/ui

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [ ] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [x] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

This is a small accessibility-focused fix.

The implementation adds Space key support by reusing the existing `confirm()` code path already used for Enter, ensuring consistent behavior while keeping the change minimal.

A regression test has been included to verify that Space correctly confirms the focused option and triggers `onChange`.
