### PR TITLE
feat(motion): support multi-stop keyframes in interpolate

### DIFF
--- a/packages/motion/README.md
+++ b/packages/motion/README.md
@@ -382,6 +382,14 @@ For application tests, the virtual clock available through `@termuijs/testing` c
 
 ---
 
+# Changelog
+
+## 0.1.7 (upcoming)
+
+- **feat(motion):** `interpolate()` now supports multi-stop keyframe arrays with two or more stops. The input/output parameter types were widened from `[number, number]` (two-element tuple) to `number[]` (array). TypeScript callers relying on the stricter tuple type should update their signatures accordingly.
+
+---
+
 # Documentation
 
 Additional documentation is available at:

--- a/packages/motion/src/interpolate.test.ts
+++ b/packages/motion/src/interpolate.test.ts
@@ -48,12 +48,12 @@ describe('interpolate and mapRange', () => {
 
     it('interpolate with multi-stop arrays and clamping', () => {
         // Clamped out of bounds
-        expect(interpolate(-0.5, [0, 0.5, 1], [0, 10, 0])).toBe(0); 
-        expect(interpolate(1.5, [0, 0.5, 1], [0, 10, 0])).toBe(0); 
-        
+        expect(interpolate(-0.5, [0, 0.5, 1], [0, 10, 0])).toBe(0);
+        expect(interpolate(1.5, [0, 0.5, 1], [0, 10, 0])).toBe(0);
+
         // No clamp out of bounds
-        expect(interpolate(-0.5, [0, 0.5, 1], [0, 10, 0], { clamp: false })).toBe(-10); 
-        expect(interpolate(1.5, [0, 0.5, 1], [0, 10, 0], { clamp: false })).toBe(-10); 
+        expect(interpolate(-0.5, [0, 0.5, 1], [0, 10, 0], { clamp: false })).toBe(-10);
+        expect(interpolate(1.5, [0, 0.5, 1], [0, 10, 0], { clamp: false })).toBe(-10);
     });
 
     it('throws if lengths are mismatched or too small', () => {

--- a/packages/motion/src/interpolate.test.ts
+++ b/packages/motion/src/interpolate.test.ts
@@ -36,4 +36,28 @@ describe('interpolate and mapRange', () => {
         expect(interpolate(15, [0, 10], [0, 100])).toBe(100);
         expect(interpolate(15, [0, 10], [0, 100], { clamp: false })).toBe(150);
     });
+
+    it('interpolate maps multi-stop arrays', () => {
+        // Example: Bouncing animation [0, 0.5, 1] -> [0, 10, 0]
+        expect(interpolate(0, [0, 0.5, 1], [0, 10, 0])).toBe(0);
+        expect(interpolate(0.25, [0, 0.5, 1], [0, 10, 0])).toBe(5);
+        expect(interpolate(0.5, [0, 0.5, 1], [0, 10, 0])).toBe(10);
+        expect(interpolate(0.75, [0, 0.5, 1], [0, 10, 0])).toBe(5);
+        expect(interpolate(1, [0, 0.5, 1], [0, 10, 0])).toBe(0);
+    });
+
+    it('interpolate with multi-stop arrays and clamping', () => {
+        // Clamped out of bounds
+        expect(interpolate(-0.5, [0, 0.5, 1], [0, 10, 0])).toBe(0); 
+        expect(interpolate(1.5, [0, 0.5, 1], [0, 10, 0])).toBe(0); 
+        
+        // No clamp out of bounds
+        expect(interpolate(-0.5, [0, 0.5, 1], [0, 10, 0], { clamp: false })).toBe(-10); 
+        expect(interpolate(1.5, [0, 0.5, 1], [0, 10, 0], { clamp: false })).toBe(-10); 
+    });
+
+    it('throws if lengths are mismatched or too small', () => {
+        expect(() => interpolate(5, [0, 1], [0, 1, 2])).toThrow();
+        expect(() => interpolate(5, [0], [0])).toThrow();
+    });
 });

--- a/packages/motion/src/interpolate.ts
+++ b/packages/motion/src/interpolate.ts
@@ -37,20 +37,32 @@ export function mapRange(
 }
 
 /**
- * Maps an input value using tuple ranges.
+ * Maps an input value using multi-stop arrays.
  */
 export function interpolate(
     value: number,
-    inputRange: [number, number],
-    outputRange: [number, number],
+    inputRange: number[],
+    outputRange: number[],
     options?: InterpolateOptions
 ): number {
+    if (inputRange.length !== outputRange.length) {
+        throw new Error('inputRange and outputRange must have the same length.');
+    }
+    if (inputRange.length < 2) {
+        throw new Error('inputRange and outputRange must have at least 2 elements.');
+    }
+
+    let index = 0;
+    while (index < inputRange.length - 2 && value > inputRange[index + 1]) {
+        index++;
+    }
+
     return mapRange(
         value,
-        inputRange[0],
-        inputRange[1],
-        outputRange[0],
-        outputRange[1],
+        inputRange[index],
+        inputRange[index + 1],
+        outputRange[index],
+        outputRange[index + 1],
         options
     );
 }


### PR DESCRIPTION
## Description

- This PR updates the interpolate() function in the @termuijs/motion package to accept multi-stop keyframe arrays (arrays of length $n \ge 2$) rather than being strictly bound to 2-point tuples ([number, number]).

- It dynamically calculates the active segment by iterating through inputRange and applies the standard mapRange math exclusively to the two adjacent bounds, allowing developers to easily create complex animations (e.g., bouncing, pulsing) without manually chaining interpolations or writing verbose if/else bounds checks.

## Related Issue

Closes #1515

## Which package(s)?

@termuijs/motion

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/f49aa65e-aab2-4e9f-99d6-2174f339ecfe`

## Screenshots / Recordings (UI changes)

N/A - Non-visual mathematical animation helper.

## Notes for the Reviewer

- Existing `mapRange` signature is intentionally unmodified as its math strictly maps two bounds (`inMin`, `inMax`, `outMin`, `outMax`). The multi-stop logic is exclusively baked into `interpolate()` by wrapping `mapRange` calls around the resolved active segment array indices.
- Test coverage expanded to check array mismatches, out-of-bounds extrapolation, default clamping behavior, and midpoint mapping.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `interpolate` now supports multi-stop interpolation using array-based keyframes (two or more stops) and updates TypeScript types from fixed 2-point tuples to `number[]`.
* **Tests**
  * Added Vitest coverage for multi-stop interpolation, including default clamping and optional extrapolation when `clamp: false`.
  * Added error tests for invalid multi-stop array inputs (mismatched lengths or too few stops).
* **Documentation**
  * Updated the README with a changelog entry for the upcoming release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->