### PR TITLE
fix: prevent infinite loop in MenuBar navigation when all items disabled

### DIFF
--- a/packages/ui/src/MenuBar.ts
+++ b/packages/ui/src/MenuBar.ts
@@ -69,7 +69,7 @@ export class MenuBar extends Widget {
 
     private _selectNextItem(): void {
         const items = this._menus[this._activeMenu]?.items ?? [];
-        if (items.length === 0) return;
+        if (items.length === 0 || items.every(i => i.disabled)) return;
         let n = this._activeItem;
         const start = n;
         do {
@@ -84,7 +84,7 @@ export class MenuBar extends Widget {
 
     private _selectPrevItem(): void {
         const items = this._menus[this._activeMenu]?.items ?? [];
-        if (items.length === 0) return;
+        if (items.length === 0 || items.every(i => i.disabled)) return;
         let n = this._activeItem;
         const start = n;
         do {


### PR DESCRIPTION
Fixes an issue where MenuBar would enter an infinite loop when selectNextMenu or selectPrevItem was triggered on a menu with entirely disabled items. The fix introduces an early return guard checking items.every(i => i.disabled). Resolves #1606.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MenuBar navigation to properly handle cases where menus have no available items or all items are disabled, improving navigation responsiveness and preventing unresponsive looping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->