### PR TITLE
fix: force clear terminal on fullRender to prevent stale artifacts on…

### DIFF
--- a/packages/core/src/terminal/Renderer.ts
+++ b/packages/core/src/terminal/Renderer.ts
@@ -102,6 +102,7 @@ export class Renderer {
      */
     fullRender(): void {
         this._screen.invalidate();
+        this._terminal.writeSync('\x1b[2J\x1b[H');
         this._flush();
     }
 


### PR DESCRIPTION
Fixes stale ANSI characters lingering outside the new boundaries when a terminal is resized to be smaller. A \x1b[2J\x1b[H sequence is now dispatched synchronously inside fullRender() to ensure a clean slate before differential lines are drawn. Resolves #1607.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved full-screen terminal rendering to ensure cleaner and more reliable display updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->