### PR TITLE
fix: correctly handle wrapping and disabled skips in LinearPrompt

### DIFF
--- a/packages/ui/src/LinearPrompt.ts
+++ b/packages/ui/src/LinearPrompt.ts
@@ -39,18 +39,24 @@ export class LinearPrompt extends Widget {
     }
 
     selectNext(): void {
-        let n = this._selectedIndex + 1;
-        while (n < this._options.length && this._options[n].disabled) n++;
-        if (n < this._options.length) {
+        if (this._options.length === 0) return;
+        let n = this._selectedIndex;
+        do {
+            n = (n + 1) % this._options.length;
+        } while (n !== this._selectedIndex && this._options[n].disabled);
+        if (this._selectedIndex !== n && !this._options[n].disabled) {
             this._selectedIndex = n;
             this.markDirty();
         }
     }
 
     selectPrev(): void {
-        let n = this._selectedIndex - 1;
-        while (n >= 0 && this._options[n].disabled) n--;
-        if (n >= 0) {
+        if (this._options.length === 0) return;
+        let n = this._selectedIndex;
+        do {
+            n = (n - 1 + this._options.length) % this._options.length;
+        } while (n !== this._selectedIndex && this._options[n].disabled);
+        if (this._selectedIndex !== n && !this._options[n].disabled) {
             this._selectedIndex = n;
             this.markDirty();
         }


### PR DESCRIPTION
 Replaces the non-wrapping linear loops with circular do...while loops in LinearPrompt navigation. This correctly handles wrapping back to the end of the list and successfully skips disabled items at the boundaries without jumping over valid options. Resolves #1609.