### PR TITLE
feat: export deepEqual utility for store state comparisons

### DIFF
--- a/packages/store/src/shallow.ts
+++ b/packages/store/src/shallow.ts
@@ -22,3 +22,23 @@ export function shallow<U>(a: U, b: U): boolean {
 
   return true
 }
+
+export function deepEqual<U>(a: U, b: U): boolean {
+  if (Object.is(a, b)) return true
+  if (typeof a !== 'object' || a === null) return false
+  if (typeof b !== 'object' || b === null) return false
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) return false
+    }
+    return true
+  }
+  const aKeys = Object.keys(a as object)
+  const bKeys = Object.keys(b as object)
+  if (aKeys.length !== bKeys.length) return false
+  for (const key of aKeys) {
+    if (!bKeys.includes(key) || !deepEqual((a as any)[key], (b as any)[key])) return false
+  }
+  return true
+}


### PR DESCRIPTION
Adds and exports a deepEqual function alongside the existing shallow equality helper. This provides developers with an official way to subscribe to complex nested state without missing re-renders caused by array reference identity checks. Resolves #1610.