### PR TITLE
Feat/1611 autocomplete fuzzy search

### DIFF
--- a/packages/store/src/shallow.ts
+++ b/packages/store/src/shallow.ts
@@ -22,3 +22,23 @@ export function shallow<U>(a: U, b: U): boolean {
 
   return true
 }
+
+export function deepEqual<U>(a: U, b: U): boolean {
+  if (Object.is(a, b)) return true
+  if (typeof a !== 'object' || a === null) return false
+  if (typeof b !== 'object' || b === null) return false
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) return false
+    }
+    return true
+  }
+  const aKeys = Object.keys(a as object)
+  const bKeys = Object.keys(b as object)
+  if (aKeys.length !== bKeys.length) return false
+  for (const key of aKeys) {
+    if (!bKeys.includes(key) || !deepEqual((a as any)[key], (b as any)[key])) return false
+  }
+  return true
+}

--- a/packages/ui/src/Autocomplete.ts
+++ b/packages/ui/src/Autocomplete.ts
@@ -33,8 +33,17 @@ export interface AutocompleteOptions {
     highlightColor?: Color;
 }
 
-const defaultFilter = (query: string, item: string) =>
-    item.toLowerCase().startsWith(query.toLowerCase());
+const defaultFilter = (query: string, item: string) => {
+    if (!query) return true;
+    const q = query.toLowerCase();
+    const t = item.toLowerCase();
+    let qIdx = 0;
+    for (let i = 0; i < t.length; i++) {
+        if (t[i] === q[qIdx]) qIdx++;
+        if (qIdx === q.length) return true;
+    }
+    return false;
+};
 
 export class Autocomplete extends Widget {
     private _items: string[] = [];


### PR DESCRIPTION
Replaces the default startsWith matching logic with a fuzzy substring matcher in the Autocomplete widget. This allows users to find suggestions even if they skip characters or type parts out of order, greatly improving the UX for long dropdowns. Resolves #1611.