### PR TITLE
feat: add mixin support and application utility to tss

### DIFF
--- a/packages/tss/src/mixin.ts
+++ b/packages/tss/src/mixin.ts
@@ -1,0 +1,5 @@
+import { Style } from '@termuijs/core';
+export type Mixin = Partial<Style>;
+export function applyMixin(base: Partial<Style>, mixin: Mixin): Partial<Style> {
+    return { ...base, ...mixin };
+}


### PR DESCRIPTION
Introduces mixin.ts to the tss engine, allowing developers to define reusable partial styles (Mixin) and apply them using the applyMixin utility. This sets the foundation for more DRY, SCSS-like styling configurations within TermUI applications. Resolves #1612.