### PR TITLE
feat: introduce bracketed paste mode toggles to core terminal

### DIFF
--- a/packages/core/src/terminal/paste.ts
+++ b/packages/core/src/terminal/paste.ts
@@ -1,0 +1,7 @@
+export function enableBracketedPaste() {
+    process.stdout.write('\x1b[?2004h');
+}
+
+export function disableBracketedPaste() {
+    process.stdout.write('\x1b[?2004l');
+}


### PR DESCRIPTION
Introduces paste.ts to the core terminal package, providing utilities (enableBracketedPaste and disableBracketedPaste) to toggle ANSI \x1b[?2004h and \x1b[?2004l. This is the first step towards seamless native OS clipboard paste support across TermUI text inputs. Resolves #1614.