### PR TITLE
fix(core): reset _isRenderPending on dirty-check early return

### DIFF
--- a/packages/core/src/app/App.test.ts
+++ b/packages/core/src/app/App.test.ts
@@ -470,7 +470,33 @@ describe('App', () => {
             await mountPromise.catch(() => {});
         });
 
-        it('unsubscribes focus handlers on unmount', async () => {
+        it('requestRender schedules new callback after clean-tree early return', async () => {
+        const root = createMockRootWidget();
+        const renderSpy = vi.fn();
+        (root as any).render = renderSpy;
+
+        const app = new App(root, createInteractiveTestOptions());
+        const mountPromise = app.mount();
+        await new Promise(r => setImmediate(r));
+
+        // Root is clean now. requestRender should hit the early return path.
+        (root as any).isDirty = false;
+        app.requestRender();
+        await new Promise(r => setImmediate(r));
+
+        // Mark dirty and request another render — should NOT be silently dropped
+        (root as any).isDirty = true;
+        const renderCountBefore = renderSpy.mock.calls.length;
+        app.requestRender();
+        await new Promise(r => setImmediate(r));
+
+        expect(renderSpy.mock.calls.length).toBeGreaterThan(renderCountBefore);
+
+        app.exit(0);
+        await mountPromise.catch(() => {});
+    });
+
+    it('unsubscribes focus handlers on unmount', async () => {
             const { root, first, second } = createFocusTestRoot();
             const app = new App(root, createInteractiveTestOptions());
 

--- a/packages/core/src/app/App.ts
+++ b/packages/core/src/app/App.ts
@@ -366,6 +366,7 @@ export class App {
                 // callback so the dirty check and the _isRenderPending guard
                 // are never racy with concurrent requestRender() calls.
                 if (this._rootWidget.isDirty === false && !this.layers.hasDirtyLayers()) {
+                    this._isRenderPending = false;
                     return;
                 }
 


### PR DESCRIPTION
## Description
In `requestRender()`, the deferred callback early-returns when the widget tree and layers are both clean (line 368-369) but **bypasses the `finally` block** that resets `_isRenderPending` to `false`. Once hit, `_isRenderPending` stays `true` forever, causing every subsequent `requestRender()` to bail out at the guard — the UI freezes permanently.

## Fix
Added `this._isRenderPending = false;` before the early return on the clean-tree path, ensuring the guard flag is always released.

## Test
Added `requestRender schedules new callback after clean-tree early return` — verifies that after a clean-tree render pass, a subsequent `requestRender()` with dirty widgets still triggers rendering.

Closes #1626

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where rendering updates could be permanently skipped in certain application states.

* **Tests**
  * Added integration test verifying correct render request handling when the widget tree is in a clean state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->