### PR TITLE
fix(store): remove eager state mutation in batch, fix race window

### DIFF
--- a/packages/store/src/store.test.ts
+++ b/packages/store/src/store.test.ts
@@ -388,6 +388,38 @@ describe('middleware', () => {
         // No listeners should have fired
         expect(spy).not.toHaveBeenCalled()
     })
+
+    it('setState outside batch after batch call is not overwritten by commit', async () => {
+        const useStore = createStore((set) => ({
+            x: 0,
+            y: 0,
+        }))
+        const spy = vi.fn()
+        useStore.subscribe(spy)
+
+        batch(() => {
+            useStore.setState({ x: 1 })
+        })
+
+        // Between batch return and microtask, setState outside batch
+        useStore.setState({ y: 2 })
+
+        await new Promise(resolve => queueMicrotask(resolve))
+
+        expect(useStore.getState()).toEqual({ x: 1, y: 2 })
+    })
+
+    it('getState inside batch returns pending batch state', () => {
+        const useStore = createStore((set) => ({
+            count: 0,
+        }))
+
+        batch(() => {
+            useStore.setState({ count: 1 })
+            // Inside the batch, getState should see the pending value
+            expect(useStore.getState().count).toBe(1)
+        })
+    })
 })
 
 describe('persistence', () => {

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -32,7 +32,8 @@ import type { EqualityFn } from './shallow.js'
 interface BatchEntry<T> {
     prevState: T;
     nextState: T;
-    commit: () => void;
+    changes: Partial<T>;
+    commit: () => T;
     rollback: () => void;
 }
 
@@ -108,10 +109,10 @@ function flushBatch(threw: boolean) {
         queueMicrotask(() => {
             const stores = Array.from(_batchStores.entries());
             _batchStores.clear();
-            for (const [listeners, { prevState, nextState ,commit }] of stores) {
-                commit();
+            for (const [listeners, { prevState, commit }] of stores) {
+                const newState = commit();
                 for (const listener of listeners) {
-                    listener(nextState, prevState);
+                    listener(newState, prevState);
                 }
             }
         });
@@ -299,16 +300,19 @@ export function createStore<T extends object>(
                     // We're in a batch: defer listener notifications and track the final state
                     const existing = _batchStores.get(listeners);
                     if (!existing) {
+                        // Track only the keys changed inside the batch so commit can merge
+                        // onto any intermediate non-batched updates without overwriting them.
+                        const changes: Partial<T> = { ...finalPartial };
                         _batchStores.set(listeners, {
                             prevState,
                             nextState,
-                            commit: () => { state = nextState; persistState(); },
+                            changes,
+                            commit: () => { state = { ...state, ...changes } as T; persistState(); return state; },
                             rollback: () => { state = prevState; },
                         });
                     } else {
-                        // Update to the new nextState, but keep the original prevState
+                        Object.assign(existing.changes, finalPartial);
                         existing.nextState = nextState;
-                        existing.commit = () => { state = nextState; persistState(); };
                     }
                 } else {
                     state = nextState; 
@@ -398,14 +402,24 @@ export function createStore<T extends object>(
         }
         if (_batchDepth > 0) {
             const existing = _batchStores.get(listeners);
+            // Compute which keys actually changed so commit can merge instead of replace
+            const changedKeys = Object.keys(nextState).filter(
+                k => !Object.is((nextState as any)[k], (baseState as any)[k])
+            );
+            const changes: Partial<T> = {};
+            for (const k of changedKeys) {
+                (changes as any)[k] = (nextState as any)[k];
+            }
             if (!existing) {
                 _batchStores.set(listeners, {
                     prevState,
                     nextState,
-                    commit: () => { state = nextState; persistState(); },
+                    changes,
+                    commit: () => { state = { ...state, ...changes } as T; persistState(); return state; },
                     rollback: () => { state = prevState; },
                 });
             } else {
+                Object.assign(existing.changes, changes);
                 existing.nextState = nextState;
             }
         } else {

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -279,14 +279,14 @@ export function createStore<T extends object>(
         const prevState = state;
 
         // When in a batch, function updaters should see the pending batch state
-        const batchState = _batchDepth > 0 ? _batchStores.get(listeners)?.nextState ?? state : state;
+        const batchState: T = _batchDepth > 0 ? _batchStores.get(listeners)?.nextState ?? state : state;
         const nextPartial = typeof partial === 'function'
             ? (partial as (state: T) => Partial<T>)(batchState)
             : partial;
 
         const applyUpdate = (finalPartial: Partial<T>): T => {
             // When in a batch, compute nextState from pending batch state if available
-            const baseState = _batchDepth > 0 ? _batchStores.get(listeners)?.nextState ?? state : state;
+            const baseState: T = _batchDepth > 0 ? _batchStores.get(listeners)?.nextState ?? state : state;
             const nextState = { ...baseState, ...finalPartial };
 
             // Only notify if at least one key's value actually changed
@@ -389,7 +389,7 @@ export function createStore<T extends object>(
     const mutate = (recipe: (draft: T) => void): void => {
         const prevState = state;
         // When in a batch, produce from pending batch state
-        const baseState = _batchDepth > 0 ? _batchStores.get(listeners)?.nextState ?? state : state;
+        const baseState: T = _batchDepth > 0 ? _batchStores.get(listeners)?.nextState ?? state : state;
         const nextState = produce(baseState, (draft) => {
             recipe(draft as T);
         });

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -277,8 +277,11 @@ export function createStore<T extends object>(
 
     const setState: SetState<T> = (partial) => {
         const prevState = state;
+
+        // When in a batch, function updaters should see the pending batch state
+        const batchState = _batchDepth > 0 ? _batchStores.get(listeners)?.nextState ?? state : state;
         const nextPartial = typeof partial === 'function'
-            ? (partial as (state: T) => Partial<T>)(state)
+            ? (partial as (state: T) => Partial<T>)(batchState)
             : partial;
 
         const applyUpdate = (finalPartial: Partial<T>): T => {
@@ -307,7 +310,6 @@ export function createStore<T extends object>(
                         existing.nextState = nextState;
                         existing.commit = () => { state = nextState; persistState(); };
                     }
-                    state = nextState;
                 } else {
                     state = nextState; 
                     // Not in a batch: notify immediately
@@ -343,7 +345,13 @@ export function createStore<T extends object>(
         }
     };
 
-    const getState: GetState<T> = () => state;
+    const getState: GetState<T> = () => {
+        if (_batchDepth > 0) {
+            const entry = _batchStores.get(listeners);
+            if (entry) return entry.nextState;
+        }
+        return state;
+    };
 
     const subscribe = (listener: Listener<T>): (() => void) => {
         listeners.add(listener);
@@ -380,13 +388,14 @@ export function createStore<T extends object>(
     };
     const mutate = (recipe: (draft: T) => void): void => {
         const prevState = state;
-        const nextState = produce(state, (draft) => {
+        // When in a batch, produce from pending batch state
+        const baseState = _batchDepth > 0 ? _batchStores.get(listeners)?.nextState ?? state : state;
+        const nextState = produce(baseState, (draft) => {
             recipe(draft as T);
         });
-        if (Object.is(prevState, nextState)) {
+        if (Object.is(baseState, nextState)) {
             return;
         }
-        state = nextState;
         if (_batchDepth > 0) {
             const existing = _batchStores.get(listeners);
             if (!existing) {
@@ -400,6 +409,7 @@ export function createStore<T extends object>(
                 existing.nextState = nextState;
             }
         } else {
+            state = nextState;
             for (const listener of listeners) {
                 listener(nextState, prevState);
             }


### PR DESCRIPTION
## Description
In `batch()`, `setState` eagerly assigns `state = nextState` at line 310 **before** the microtask commit runs. This creates a race window where any synchronous non-batched `setState()` or `mutate()` call that reads `getState()` sees the intermediate batched value and writes changes that are later **silently overwritten** by the batch's `commit()`.

The same bug exists in `mutate()` at line 389.

## Fix
1. **Removed** `state = nextState` inside the batch path in `setState` (line 310) — only `commit()` sets final state
2. **Removed** `state = nextState` inside the batch path in `mutate` (line 389) — moved to non-batch path only
3. **Updated** `getState()` to return pending batch `nextState` when `_batchDepth > 0`, so in-batch reads see correct intermediate state
4. **Updated** `setState` function updaters to receive pending batch state when inside a batch
5. **Updated** `mutate` to produce from pending batch state when inside a batch

## Tests
- `setState outside batch after batch call is not overwritten by commit`
- `getState inside batch returns pending batch state`

Closes #1627

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batching behavior for state updates and reads. `getState()` now correctly reflects pending updates during an active batch, and state mutations within batches compute from the in-flight state rather than the previously committed state, ensuring more consistent behavior when batching multiple updates together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->