### PR TITLE
fix(core): implement multi-chunk bracketed paste state machine

### DIFF
--- a/packages/core/src/input/InputParser.test.ts
+++ b/packages/core/src/input/InputParser.test.ts
@@ -278,5 +278,77 @@ describe('InputParser', () => {
         sendKey(stdin, '\x1b[200~hello world\x1b[201~');
 
         expect(pasteHandler).toHaveBeenCalledWith('hello world');
-    }); 
+    });
+
+    it('handles multi-chunk paste spanning multiple data chunks', () => {
+        const stdin = createMockStdin();
+        const parser = new InputParser(stdin);
+
+        const pasteHandler = vi.fn();
+
+        parser.onPaste(pasteHandler);
+        parser.start();
+
+        // First chunk: paste-start marker + partial content
+        stdin.emit('data', Buffer.from('\x1b[200~hello ', 'utf8'));
+        expect(pasteHandler).not.toHaveBeenCalled();
+
+        // Second chunk: rest of content + paste-end marker
+        stdin.emit('data', Buffer.from('world\x1b[201~', 'utf8'));
+
+        expect(pasteHandler).toHaveBeenCalledWith('hello world');
+    });
+
+    it('handles paste with content split across three chunks', () => {
+        const stdin = createMockStdin();
+        const parser = new InputParser(stdin);
+
+        const pasteHandler = vi.fn();
+
+        parser.onPaste(pasteHandler);
+        parser.start();
+
+        stdin.emit('data', Buffer.from('\x1b[200~abc', 'utf8'));
+        stdin.emit('data', Buffer.from('def', 'utf8'));
+        stdin.emit('data', Buffer.from('ghi\x1b[201~', 'utf8'));
+
+        expect(pasteHandler).toHaveBeenCalledWith('abcdefghi');
+    });
+
+    it('emits paste event when both markers are in a single chunk', () => {
+        const stdin = createMockStdin();
+        const parser = new InputParser(stdin);
+
+        const pasteHandler = vi.fn();
+
+        parser.onPaste(pasteHandler);
+        parser.start();
+
+        stdin.emit('data', Buffer.from('before\x1b[200~content\x1b[201~after', 'utf8'));
+
+        expect(pasteHandler).toHaveBeenCalledWith('content');
+    });
+
+    it('recovers from partial paste via timeout', () => {
+        vi.useFakeTimers();
+        const stdin = createMockStdin();
+        const parser = new InputParser(stdin);
+
+        const pasteHandler = vi.fn();
+
+        parser.onPaste(pasteHandler);
+        parser.start();
+
+        // Start paste but never end it
+        stdin.emit('data', Buffer.from('\x1b[200~incomplete', 'utf8'));
+        expect(pasteHandler).not.toHaveBeenCalled();
+
+        // Advance time past the paste timeout
+        vi.advanceTimersByTime(600);
+
+        // Handler should not have been called (paste was aborted)
+        expect(pasteHandler).not.toHaveBeenCalled();
+
+        vi.useRealTimers();
+    });
 });

--- a/packages/core/src/input/InputParser.ts
+++ b/packages/core/src/input/InputParser.ts
@@ -38,6 +38,7 @@ export class InputParser {
     private _escapeBuffer: Buffer = Buffer.alloc(0);
     private _isPasting = false;
     private _pasteBuffer = '';
+    private _pasteTimeout: ReturnType<typeof setTimeout> | null = null;
     private _cursorRequests: Array<{
         resolve: (position: CursorPosition) => void;
         reject: (error: Error) => void;
@@ -106,6 +107,10 @@ export class InputParser {
             clearTimeout(this._graphemeTimeout);
             this._graphemeTimeout = null;
         }
+        if (this._pasteTimeout) {
+            clearTimeout(this._pasteTimeout);
+            this._pasteTimeout = null;
+        }
         this._escapeBuffer = Buffer.alloc(0);
         this._graphemeBuffer = '';
         this._decoder.end();
@@ -135,12 +140,38 @@ export class InputParser {
         const PASTE_START = '\x1b[200~';
         const PASTE_END = '\x1b[201~';
 
-        if (str.includes(PASTE_START) && str.includes(PASTE_END)) {
-            const pastedText = str
-                .replace(PASTE_START, '')
-                .replace(PASTE_END, '');
+        // ── Multi-chunk bracketed paste handling ──
 
-            this._events.emit('paste', pastedText);
+        // Check if this chunk contains the paste-start marker
+        if (!this._isPasting && str.includes(PASTE_START)) {
+            this._isPasting = true;
+            this._pasteBuffer = str.slice(str.indexOf(PASTE_START) + PASTE_START.length);
+            this._startPasteTimeout();
+
+            // Check if paste-end is also in this same chunk
+            if (this._pasteBuffer.includes(PASTE_END)) {
+                const pastedText = this._pasteBuffer.slice(0, this._pasteBuffer.indexOf(PASTE_END));
+                this._isPasting = false;
+                this._pasteBuffer = '';
+                this._clearPasteTimeout();
+                this._events.emit('paste', pastedText);
+            }
+            return;
+        }
+
+        // If we are inside a paste, accumulate content
+        if (this._isPasting) {
+            if (str.includes(PASTE_END)) {
+                this._pasteBuffer += str.slice(0, str.indexOf(PASTE_END));
+                const pastedText = this._pasteBuffer;
+                this._isPasting = false;
+                this._pasteBuffer = '';
+                this._clearPasteTimeout();
+                this._events.emit('paste', pastedText);
+            } else {
+                this._pasteBuffer += str;
+                this._startPasteTimeout();
+            }
             return;
         }
 
@@ -272,6 +303,27 @@ export class InputParser {
             }
         }
         return false;
+    }
+
+    /**
+     * Start or restart the paste inactivity timeout.
+     * If no additional paste data arrives within the timeout,
+     * the paste state is aborted to prevent stale state.
+     */
+    private _startPasteTimeout(): void {
+        this._clearPasteTimeout();
+        this._pasteTimeout = setTimeout(() => {
+            this._isPasting = false;
+            this._pasteBuffer = '';
+            this._pasteTimeout = null;
+        }, 500);
+    }
+
+    private _clearPasteTimeout(): void {
+        if (this._pasteTimeout) {
+            clearTimeout(this._pasteTimeout);
+            this._pasteTimeout = null;
+        }
     }
 
     /**


### PR DESCRIPTION
## Description
The bracketed paste handler required both `\x1b[200~` and `\x1b[201~` markers in the **same data chunk**. When paste content spans multiple stdin chunks (>4KB), the first chunk contains the start marker + partial content, and subsequent chunks contain more content + the end marker. The paste handler never fires, and the start marker falls through to the escape parser which silently discards it.

The `_isPasting` and `_pasteBuffer` fields were declared but never used.

## Fix
Replaced the single-chunk paste check with a proper state machine:
1. **Paste-start detection** — sets `_isPasting = true`, strips start marker, buffers content
2. **Paste-end detection** — emits accumulated `_pasteBuffer` as a `paste` event, resets state
3. **Cross-chunk accumulation** — content between markers is concatenated across chunks
4. **Same-chunk handling** — both markers in one chunk still works
5. **Timeout recovery** — 500ms inactivity timeout aborts stale paste state

## Tests
- Single-chunk paste (existing)
- Multi-chunk paste (two chunks)
- Three-chunk paste
- Both markers in one chunk with surrounding text
- Incomplete paste timeout recovery

Closes #1628