### PR TITLE
fix(core): defer focus events in _changeFocus to prevent re-entrancy

### DIFF
--- a/packages/core/src/events/FocusManager.test.ts
+++ b/packages/core/src/events/FocusManager.test.ts
@@ -197,3 +197,71 @@ describe('FocusManager Spatial Navigation', () => {
         expect(fm.currentId).toBe('close');
     });
 });
+
+describe('FocusManager Re-entrancy', () => {
+    it('unregister in blur handler does not corrupt _currentIndex', () => {
+        const fm = new FocusManager();
+        fm.register(makeWidget('a', 0, true));
+        fm.register(makeWidget('b', 1, true));
+        fm.register(makeWidget('c', 2, true));
+
+        fm.focusWidget('a');
+        expect(fm.currentId).toBe('a');
+
+        // On blur of 'a', unregister 'a'
+        fm.on('blur', (event) => {
+            if (event.targetId === 'a') {
+                fm.unregister('a');
+            }
+        });
+
+        fm.focusWidget('b');
+
+        // After the blur handler unregistered 'a', focus should go to 'b'
+        expect(fm.currentId).toBe('b');
+        expect(fm.isFocused('b')).toBe(true);
+    });
+
+    it('unregister in focus handler does not cause out-of-bounds access', () => {
+        const fm = new FocusManager();
+        fm.register(makeWidget('a', 0, true));
+        fm.register(makeWidget('b', 1, true));
+        fm.register(makeWidget('c', 2, true));
+
+        fm.focusWidget('a');
+
+        // On focus of 'c', unregister 'c'
+        fm.on('focus', (event) => {
+            if (event.targetId === 'c') {
+                fm.unregister('c');
+            }
+        });
+
+        fm.focusWidget('c');
+
+        // Focus should have moved to 'c' before it was unregistered
+        // After unregister, the next available widget gets focus
+        expect(fm.currentId).toBe('b');
+    });
+
+    it('re-entrant focusNext from focus handler does not corrupt state', () => {
+        const fm = new FocusManager();
+        fm.register(makeWidget('a', 0, true));
+        fm.register(makeWidget('b', 1, true));
+        fm.register(makeWidget('c', 2, true));
+
+        fm.focusWidget('a');
+
+        // On focus of 'b', immediately move to next
+        fm.on('focus', (event) => {
+            if (event.targetId === 'b') {
+                fm.focusNext();
+            }
+        });
+
+        fm.focusWidget('b');
+
+        // After re-entrant focusNext, should end up on 'c'
+        expect(fm.currentId).toBe('c');
+    });
+});

--- a/packages/core/src/events/FocusManager.ts
+++ b/packages/core/src/events/FocusManager.ts
@@ -427,14 +427,25 @@ export class FocusManager {
 
     private _changeFocus(newIndex: number): void {
         const oldId = this.currentId;
+        const events: Array<{ type: string; data: FocusEvent }> = [];
+
         if (oldId) {
-            this._events.emit('blur', { targetId: oldId, type: 'blur', epoch: this._epoch++ });
+            events.push({ type: 'blur', data: { targetId: oldId, type: 'blur', epoch: this._epoch++ } });
         }
         this._currentIndex = newIndex;
-        this._events.emit('focus', {
-            targetId: this._focusables[newIndex].id,
+        events.push({
             type: 'focus',
-            epoch: this._epoch++,
+            data: {
+                targetId: this._focusables[newIndex].id,
+                type: 'focus',
+                epoch: this._epoch++,
+            },
         });
+
+        // Flush events after state is fully updated so that any re-entrant calls
+        // (e.g., handlers that call unregister()) see the finalized _currentIndex.
+        for (const evt of events) {
+            this._events.emit(evt.type, evt.data);
+        }
     }
 }

--- a/packages/core/src/events/FocusManager.ts
+++ b/packages/core/src/events/FocusManager.ts
@@ -427,7 +427,7 @@ export class FocusManager {
 
     private _changeFocus(newIndex: number): void {
         const oldId = this.currentId;
-        const events: Array<{ type: string; data: FocusEvent }> = [];
+        const events: Array<{ type: 'focus' | 'blur'; data: FocusEvent }> = [];
 
         if (oldId) {
             events.push({ type: 'blur', data: { targetId: oldId, type: 'blur', epoch: this._epoch++ } });


### PR DESCRIPTION
## Description
`_changeFocus()` emits `blur` and `focus` events **synchronously**. Any subscriber can call `unregister()`, which mutates `_focusables` and adjusts `_currentIndex`. After handlers return, `_changeFocus` unconditionally overwrites `_currentIndex = newIndex` with the **original pre-unregister value**, corrupting focus state.

## Fix
Deferred event emission (Approach A): collect blur/focus events into a queue, update `_currentIndex` first, then flush events. This ensures any re-entrant `unregister()` or `focusNext()` calls see the finalized `_currentIndex`.

## Tests
- `unregister in blur handler does not corrupt _currentIndex`
- `unregister in focus handler does not cause out-of-bounds access`
- `re-entrant focusNext from focus handler does not corrupt state`

Closes #1629