### PR TITLE
fix(core): adjust pushClip for active translateY to fix nested clip coordinate mismatch

### DIFF
--- a/packages/core/src/terminal/Screen.test.ts
+++ b/packages/core/src/terminal/Screen.test.ts
@@ -131,6 +131,75 @@ describe('Screen', () => {
         // Old data is reset
         expect(screen.back[0][0].char).toBe(' ');
     });
+
+    it('pushClip with active translateY adjusts clip region correctly', () => {
+        const screen = new Screen(20, 10);
+        // Push a translate first (simulating a parent ScrollView)
+        screen.pushTranslateY(-3);
+        // Clip region should be adjusted by the current translate
+        screen.pushClip({ x: 0, y: 5, width: 10, height: 4 });
+
+        // setCell applies translate: row 8 + (-3) = 5. With adjusted clip at y=2 (5-3),
+        // 5 >= 2 and 5 < 6 should pass → visible
+        screen.setCell(1, 8, { char: 'A' });
+        expect(screen.back[5][1].char).toBe('A');
+
+        // setCell translates row 9 + (-3) = 6. Clip is at y=2, h=4 → y range [2, 6)
+        // 6 is NOT < 6 → clipped
+        screen.setCell(1, 9, { char: 'B' });
+        expect(screen.back[6][1].char).not.toBe('B');
+
+        screen.popClip();
+        screen.popTranslateY();
+    });
+
+    it('nested clips with active translate work correctly', () => {
+        const screen = new Screen(30, 20);
+        // Outer translate (simulating parent ScrollView with scrollOffset=2)
+        screen.pushTranslateY(-2);
+        screen.pushClip({ x: 0, y: 5, width: 20, height: 10 });
+
+        // Inner translate (simulating child ScrollView with scrollOffset=1)
+        screen.pushTranslateY(-1);
+        screen.pushClip({ x: 0, y: 8, width: 10, height: 5 });
+
+        // Total translate: -3. inner clip absolute y=8 → adjusted y = 8-3 = 5 in setCell space.
+        // Inner clip visual range: y ∈ [5, 10), row ∈ [8, 13) absolute.
+        // Content row 8 absolute → visual row 8-3=5 → inside clip (5 >= 5 && 5 < 10) ✓
+        screen.setCell(1, 8, { char: 'X' });
+        expect(screen.back[5][1].char).toBe('X');
+
+        // Content row 13 absolute → visual row 13-3=10 → outside clip (10 >= 10) → clipped
+        screen.setCell(1, 13, { char: 'Y' });
+        expect(screen.back[10][1].char).not.toBe('Y');
+
+        screen.popClip();
+        screen.popTranslateY();
+        screen.popClip();
+        screen.popTranslateY();
+    });
+
+    it('setCell is clipped by translate-adjusted region when parents have translate', () => {
+        const screen = new Screen(30, 20);
+        // Simulate: outer container at absolute y=10 with scrollOffset=5
+        screen.pushTranslateY(-5);
+        // Child clip region at absolute y=14, height=4
+        screen.pushClip({ x: 0, y: 14, width: 10, height: 4 });
+
+        // After translate: clip adjusted to y = 14 + (-5) = 9, height=4 → visual range [9, 13)
+        // Content that would render at absolute row 15 (first row inside child viewport)
+        // visual row = 15 + (-5) = 10 → inside clip (10 >= 9 && 10 < 13) ✓
+        screen.setCell(0, 15, { char: 'A' });
+        expect(screen.back[10][0].char).toBe('A');
+
+        // Content at absolute row 19 (outside child viewport)
+        // visual row = 19 + (-5) = 14 → outside clip (14 >= 13) → clipped
+        screen.setCell(0, 19, { char: 'B' });
+        expect(screen.back[14][0].char).not.toBe('B');
+
+        screen.popClip();
+        screen.popTranslateY();
+    });
 });
 
 describe('cellsEqual', () => {

--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -243,13 +243,22 @@ export class Screen {
      * any parent clip already on the stack (nested clipping).
      */
     pushClip(region: { x: number; y: number; width: number; height: number }): void {
+        // Convert region from absolute to the current visual coordinate space.
+        // setCell applies _translateY before checking the clip stack, so stored
+        // clip regions must be in the same visual space for the check to be correct.
+        const adjustedRegion = {
+            x: region.x,
+            y: region.y + this._translateY,
+            width: region.width,
+            height: region.height,
+        };
         if (this._clipStack.length > 0) {
             // Intersect with the current clip
             const parent = this._clipStack[this._clipStack.length - 1];
-            const x = Math.max(region.x, parent.x);
-            const y = Math.max(region.y, parent.y);
-            const right = Math.min(region.x + region.width, parent.x + parent.width);
-            const bottom = Math.min(region.y + region.height, parent.y + parent.height);
+            const x = Math.max(adjustedRegion.x, parent.x);
+            const y = Math.max(adjustedRegion.y, parent.y);
+            const right = Math.min(adjustedRegion.x + adjustedRegion.width, parent.x + parent.width);
+            const bottom = Math.min(adjustedRegion.y + adjustedRegion.height, parent.y + parent.height);
             if (right <= x || bottom <= y) {
                 // Fully clipped — push a zero-size region
                 this._clipStack.push({ x: 0, y: 0, width: 0, height: 0 });
@@ -257,7 +266,7 @@ export class Screen {
                 this._clipStack.push({ x, y, width: right - x, height: bottom - y });
             }
         } else {
-            this._clipStack.push({ ...region });
+            this._clipStack.push({ ...adjustedRegion });
         }
     }
 


### PR DESCRIPTION
## Description
`pushClip()` stores clip regions in **absolute terminal coordinates**, while `setCell()` applies `_translateY` to the row **before** checking the clip. When a parent widget applies a translate (e.g., ScrollView scrolling) and a child widget pushes a clip, the child's clip region doesn't account for the parent's translate offset. Content inside the inner clip is incorrectly clipped out.

## Fix
Adjusted `pushClip()` to convert the input region from absolute to visual coordinates by adding the current `_translateY` to `region.y` before storing. This makes the clip check in `setCell()` consistent with the translated coordinate space.

## Tests
- `pushClip with active translateY adjusts clip region correctly`
- `nested clips with active translate work correctly`
- `setCell is clipped by translate-adjusted region when parents have translate`

Closes #1630