### PR TITLE
feat(jsx): add useTypeahead hook

### DIFF
--- a/packages/jsx/src/hooks/useTypeahead.test.ts
+++ b/packages/jsx/src/hooks/useTypeahead.test.ts
@@ -1,0 +1,160 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/jsx — Tests for useTypeahead hook
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createKeyEvent } from '@termuijs/core';
+import { createVirtualClock } from '../../../testing/src/index.js';
+import { timerPoolSubscribe } from '@termuijs/motion';
+import { createFiber, setCurrentFiber, clearCurrentFiber, setRequestRender, runEffects } from '../hooks.js';
+import { useTypeahead } from './useTypeahead.js';
+
+function mockKeyEvent(key: string, ctrl = false, alt = false) {
+    return createKeyEvent({
+        key,
+        raw: Buffer.alloc(0),
+        ctrl,
+        alt,
+        shift: false,
+    });
+}
+
+describe('useTypeahead', () => {
+    let fiber = createFiber();
+    let clock: ReturnType<typeof createVirtualClock>;
+    let restoreClock: () => void;
+
+    beforeEach(() => {
+        fiber = createFiber();
+        setRequestRender(() => {});
+        clock = createVirtualClock();
+        restoreClock = timerPoolSubscribe(clock);
+    });
+
+    afterEach(() => {
+        clearCurrentFiber();
+        vi.restoreAllMocks();
+        restoreClock();
+    });
+
+    const renderHook = <T>(items: T[], getItemLabel: (item: T) => string, delayMs?: number) => {
+        setCurrentFiber(fiber);
+        const res = useTypeahead(items, getItemLabel, delayMs);
+        clearCurrentFiber();
+        runEffects(fiber);
+        return res;
+    };
+
+    const fruits = ['apple', 'banana', 'apricot', 'cherry'];
+
+    it('initializes with matchIndex -1', () => {
+        const result = renderHook(fruits, (f) => f);
+        expect(result).toBe(-1);
+    });
+
+    it('matches single character prefix case-insensitively', () => {
+        let result = renderHook(fruits, (f) => f);
+        expect(result).toBe(-1);
+
+        // Type 'b' -> match banana (index 1)
+        fiber.onInput?.(mockKeyEvent('b'));
+        result = renderHook(fruits, (f) => f);
+        expect(result).toBe(1);
+
+        // Type 'C' -> match cherry (index 3)
+        // Wait, 'C' is a new prefix if we wait for reset, let's advance time first
+        clock.advance(600);
+        fiber.onInput?.(mockKeyEvent('C'));
+        result = renderHook(fruits, (f) => f);
+        expect(result).toBe(3);
+    });
+
+    it('accumulates keypresses and matches multi-character prefix', () => {
+        let result = renderHook(fruits, (f) => f);
+
+        // Type 'a' -> matches 'apple' (index 0)
+        fiber.onInput?.(mockKeyEvent('a'));
+        result = renderHook(fruits, (f) => f);
+        expect(result).toBe(0);
+
+        // Type 'p' -> prefix is 'ap', still matches 'apple' (index 0)
+        fiber.onInput?.(mockKeyEvent('p'));
+        result = renderHook(fruits, (f) => f);
+        expect(result).toBe(0);
+
+        // Type 'r' -> prefix is 'apr', matches 'apricot' (index 2)
+        fiber.onInput?.(mockKeyEvent('r'));
+        result = renderHook(fruits, (f) => f);
+        expect(result).toBe(2);
+    });
+
+    it('resets buffer after inactivity delayMs', () => {
+        let result = renderHook(fruits, (f) => f);
+
+        // Type 'a' -> matches 'apple' (index 0)
+        fiber.onInput?.(mockKeyEvent('a'));
+        result = renderHook(fruits, (f) => f);
+        expect(result).toBe(0);
+
+        // Advance clock past delayMs (default 500ms)
+        clock.advance(600);
+
+        // Type 'b' -> matches 'banana' (index 1) because buffer was reset
+        fiber.onInput?.(mockKeyEvent('b'));
+        result = renderHook(fruits, (f) => f);
+        expect(result).toBe(1);
+    });
+
+    it('ignores keys that create a prefix matching nothing', () => {
+        let result = renderHook(fruits, (f) => f);
+
+        // Type 'a' -> matches 'apple' (index 0)
+        fiber.onInput?.(mockKeyEvent('a'));
+        result = renderHook(fruits, (f) => f);
+        expect(result).toBe(0);
+
+        // Type 'p' -> prefix 'ap' -> matches 'apple' (index 0)
+        fiber.onInput?.(mockKeyEvent('p'));
+        result = renderHook(fruits, (f) => f);
+        expect(result).toBe(0);
+
+        // Type 'x' -> proposed prefix 'apx' has no match.
+        // It should be ignored. The buffer should remain 'ap', and the match remains 'apple' (index 0)
+        fiber.onInput?.(mockKeyEvent('x'));
+        result = renderHook(fruits, (f) => f);
+        expect(result).toBe(0);
+
+        // Type 'r' -> proposed prefix 'apr' (since 'x' was ignored) matches 'apricot' (index 2)
+        fiber.onInput?.(mockKeyEvent('r'));
+        result = renderHook(fruits, (f) => f);
+        expect(result).toBe(2);
+    });
+
+    it('ignores non-printable keys and modifier keys', () => {
+        let result = renderHook(fruits, (f) => f);
+
+        // Down arrow (non-printable) -> should be ignored
+        fiber.onInput?.(mockKeyEvent('down'));
+        result = renderHook(fruits, (f) => f);
+        expect(result).toBe(-1);
+
+        // Ctrl + 'a' -> should be ignored
+        fiber.onInput?.(mockKeyEvent('a', true, false));
+        result = renderHook(fruits, (f) => f);
+        expect(result).toBe(-1);
+
+        // Alt + 'b' -> should be ignored
+        fiber.onInput?.(mockKeyEvent('b', false, true));
+        result = renderHook(fruits, (f) => f);
+        expect(result).toBe(-1);
+    });
+
+    it('handles empty items list safely', () => {
+        let result = renderHook([], (f) => f);
+        expect(result).toBe(-1);
+
+        fiber.onInput?.(mockKeyEvent('a'));
+        result = renderHook([], (f) => f);
+        expect(result).toBe(-1);
+    });
+});

--- a/packages/jsx/src/hooks/useTypeahead.ts
+++ b/packages/jsx/src/hooks/useTypeahead.ts
@@ -1,0 +1,72 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/jsx — useTypeahead hook
+// ─────────────────────────────────────────────────────
+import { useState, useInput, useEffect, useRef } from '../hooks.js';
+import { timerPoolSubscribe } from '@termuijs/motion';
+
+/**
+ * Accumulates printable character keypresses to navigate lists by typing.
+ *
+ * @param items List of options to search through.
+ * @param getItemLabel Mapping function to retrieve a string label from each item.
+ * @param delayMs Timeout in milliseconds before the search buffer resets (default: 500).
+ * @returns The index of the first matched item, or -1 if no search has run or matches were found.
+ */
+export function useTypeahead<T>(
+    items: T[],
+    getItemLabel: (item: T) => string,
+    delayMs = 500
+): number {
+    const [matchIndex, setMatchIndex] = useState(-1);
+    const prefixRef = useRef('');
+    const unsubscribeRef = useRef<(() => void) | null>(null);
+
+    // Clean up timer on unmount
+    useEffect(() => {
+        return () => {
+            if (unsubscribeRef.current !== null) {
+                unsubscribeRef.current();
+            }
+        };
+    }, []);
+
+    useInput((key, event) => {
+        // Only handle printable characters: length 1, no ctrl/alt modifiers
+        if (key.length !== 1 || event.ctrl || event.alt) return;
+
+        // Reset previous timer
+        if (unsubscribeRef.current !== null) {
+            unsubscribeRef.current();
+            unsubscribeRef.current = null;
+        }
+
+        const typedChar = key.toLowerCase();
+        const proposedPrefix = prefixRef.current + typedChar;
+
+        // Find the index of the first item whose label starts with the proposed prefix
+        const foundIndex = items.findIndex((item) =>
+            getItemLabel(item).toLowerCase().startsWith(proposedPrefix)
+        );
+
+        if (foundIndex !== -1) {
+            prefixRef.current = proposedPrefix;
+            setMatchIndex(foundIndex);
+        } else if (prefixRef.current === '') {
+            // No match at all even for the first character, do not match or update state.
+        } else {
+            // proposedPrefix has no match. Ignore the mismatching character,
+            // but keep the previous valid matching prefix active.
+        }
+
+        // Reset search string after inactivity delayMs
+        unsubscribeRef.current = timerPoolSubscribe(delayMs, () => {
+            prefixRef.current = '';
+            if (unsubscribeRef.current !== null) {
+                unsubscribeRef.current();
+                unsubscribeRef.current = null;
+            }
+        });
+    });
+
+    return matchIndex;
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -75,6 +75,7 @@ export type { UseFocusWithinOptions } from './hooks/useFocusWithin.js';
 export { useFocusTrap } from './hooks/useFocusTrap.js';
 export { useKeyboardNavigation } from './hooks/useKeyboardNavigation.js';
 export type { KeyboardNavigationOptions, KeyboardNavigationResult } from './hooks/useKeyboardNavigation.js';
+export { useTypeahead } from './hooks/useTypeahead.js';
 export { useModal } from './hooks/useModal.js';
 export type { UseModalResult } from './hooks/useModal.js';
 


### PR DESCRIPTION
Closes #78

<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

<!-- What does this PR do? 1 to 3 sentences. -->

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #

## Which package(s)?

<!-- Example: @termuijs/core, @termuijs/widgets, website. -->

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [ ] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [ ] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard typeahead navigation for lists. Users can now type characters to jump to items with matching labels (case-insensitive). The search buffer automatically resets after inactivity.

* **Tests**
  * Added comprehensive test suite for typeahead functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->