### PR TITLE
feat(ui): support Home/End navigation in RadioGroup

### DIFF
--- a/packages/ui/src/RadioGroup.test.ts
+++ b/packages/ui/src/RadioGroup.test.ts
@@ -83,6 +83,36 @@ describe('RadioGroup', () => {
         expect(radio.focusedIndex).toBe(0);
     });
 
+    it('handleKey home moves focus to first enabled option without confirming', () => {
+        const radio = new RadioGroup({ options: OPTIONS, defaultValue: 'light' });
+        radio.handleKey(createKeyEvent({ key: 'home', ctrl: false, shift: false, alt: false, raw: Buffer.alloc(0) }));
+        expect(radio.focusedIndex).toBe(0);
+        // value should not change until confirmed
+        expect(radio.selectedValue).toBe('light');
+    });
+
+    it('handleKey home is a no-op when already at first enabled option', () => {
+        const radio = new RadioGroup({ options: OPTIONS, defaultValue: 'dark' });
+        const spy = vi.spyOn(radio as any, 'markDirty');
+        radio.handleKey(createKeyEvent({ key: 'home', ctrl: false, shift: false, alt: false, raw: Buffer.alloc(0) }));
+        expect(radio.focusedIndex).toBe(0);
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('handleKey end moves focus to last enabled option (skips disabled)', () => {
+        const radio = new RadioGroup({ options: OPTIONS_WITH_DISABLED, defaultValue: 'dark' });
+        radio.handleKey(createKeyEvent({ key: 'end', ctrl: false, shift: false, alt: false, raw: Buffer.alloc(0) }));
+        expect(radio.focusedIndex).toBe(2);
+    });
+
+    it('handleKey end is a no-op when already at last enabled option', () => {
+        const radio = new RadioGroup({ options: OPTIONS, defaultValue: 'system' });
+        const spy = vi.spyOn(radio as any, 'markDirty');
+        radio.handleKey(createKeyEvent({ key: 'end', ctrl: false, shift: false, alt: false, raw: Buffer.alloc(0) }));
+        expect(radio.focusedIndex).toBe(2);
+        expect(spy).not.toHaveBeenCalled();
+    });
+
     // ── 3. onChange fires on Enter confirm ─────────────
 
     it('onChange fires when a new option is confirmed with enter', () => {

--- a/packages/ui/src/RadioGroup.test.ts
+++ b/packages/ui/src/RadioGroup.test.ts
@@ -93,7 +93,7 @@ describe('RadioGroup', () => {
 
     it('handleKey home is a no-op when already at first enabled option', () => {
         const radio = new RadioGroup({ options: OPTIONS, defaultValue: 'dark' });
-        const spy = vi.spyOn(radio as any, 'markDirty');
+        const spy = vi.spyOn(radio, 'markDirty');
         radio.handleKey(createKeyEvent({ key: 'home', ctrl: false, shift: false, alt: false, raw: Buffer.alloc(0) }));
         expect(radio.focusedIndex).toBe(0);
         expect(spy).not.toHaveBeenCalled();
@@ -107,7 +107,7 @@ describe('RadioGroup', () => {
 
     it('handleKey end is a no-op when already at last enabled option', () => {
         const radio = new RadioGroup({ options: OPTIONS, defaultValue: 'system' });
-        const spy = vi.spyOn(radio as any, 'markDirty');
+        const spy = vi.spyOn(radio, 'markDirty');
         radio.handleKey(createKeyEvent({ key: 'end', ctrl: false, shift: false, alt: false, raw: Buffer.alloc(0) }));
         expect(radio.focusedIndex).toBe(2);
         expect(spy).not.toHaveBeenCalled();

--- a/packages/ui/src/RadioGroup.ts
+++ b/packages/ui/src/RadioGroup.ts
@@ -127,6 +127,26 @@ export class RadioGroup extends Widget {
             case 'down':
                 this.selectNext();
                 break;
+            case 'home': {
+                // Move focus to first enabled option (no-op if already there)
+                let n = 0;
+                while (n < this._options.length && this._options[n]?.disabled) n++;
+                if (n < this._options.length && n !== this._focusedIndex) {
+                    this._focusedIndex = n;
+                    this.markDirty();
+                }
+                break;
+            }
+            case 'end': {
+                // Move focus to last enabled option (no-op if already there)
+                let m = this._options.length - 1;
+                while (m >= 0 && this._options[m]?.disabled) m--;
+                if (m >= 0 && m !== this._focusedIndex) {
+                    this._focusedIndex = m;
+                    this.markDirty();
+                }
+                break;
+            }
             case 'enter':
                 this.confirm();
                 break;


### PR DESCRIPTION
## Description

This PR adds Home and End keyboard navigation support to RadioGroup.

* Home moves focus to the first enabled option.
* End moves focus to the last enabled option.
* Disabled options are skipped during navigation.
* Navigation follows existing RadioGroup behavior and only triggers a re-render when the focused option actually changes.

Regression tests have been added to verify Home/End navigation, disabled-option handling, and no-op behavior when already focused on the first or last enabled option.

## Related Issue

Closes #1649 

## Which package(s)?

@termuijs/ui

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [x] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [x] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

This change improves keyboard accessibility and consistency across interactive UI components.

The implementation mirrors the Home/End navigation behavior recently added to SegmentedControl while preserving existing RadioGroup navigation semantics. Home and End only update focus when necessary and avoid unnecessary re-renders when already positioned on the first or last enabled option.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RadioGroup now responds to Home and End key presses for keyboard navigation. Home moves focus to the first enabled option; End moves focus to the last enabled option, without changing the current selection.

* **Tests**
  * Added test coverage for Home and End key behavior in RadioGroup, including edge cases when already positioned at the first or last option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->