### PR TITLE
feat(ui): add Home/End navigation to Menu

### DIFF
--- a/packages/ui/src/Menu.test.ts
+++ b/packages/ui/src/Menu.test.ts
@@ -92,4 +92,66 @@ describe('Menu', () => {
         menu.handleKey(mockKeyEvent('escape'));
         expect(onClose).toHaveBeenCalled();
     });
+
+    it('home moves to first enabled item', () => {
+        const menu = new Menu({ items });
+        const screen = new Screen(20, 5);
+        menu.updateRect({ x: 0, y: 0, width: 20, height: 5 });
+
+        // Move down twice to land on 'Exit' (skipping disabled 'Save')
+        menu.handleKey(mockKeyEvent('down'));
+        menu.handleKey(mockKeyEvent('down'));
+        menu.render(screen);
+        expect(screen.back[3].some(c => c.bg?.name === 'cyan')).toBe(true);
+
+        // Press Home -> should jump to 'New' (index 0)
+        menu.handleKey(mockKeyEvent('home'));
+        menu.render(screen);
+        expect(screen.back[0].some(c => c.bg?.name === 'cyan')).toBe(true);
+    });
+
+    it('end moves to last enabled item (skips disabled)', () => {
+        const menu = new Menu({ items });
+        const screen = new Screen(20, 5);
+        menu.updateRect({ x: 0, y: 0, width: 20, height: 5 });
+
+        // Press End -> should land on 'Exit' (last enabled)
+        menu.handleKey(mockKeyEvent('end'));
+        menu.render(screen);
+        expect(screen.back[3].some(c => c.bg?.name === 'cyan')).toBe(true);
+    });
+
+    it('home/end are no-ops when already at extremes', () => {
+        const menu = new Menu({ items });
+
+        // At start (first enabled) Home should be a no-op
+        const spy = vi.spyOn(menu, 'markDirty');
+        menu.handleKey(mockKeyEvent('home'));
+        expect(spy).not.toHaveBeenCalled();
+        spy.mockRestore();
+
+        // Move to end, then End again should be a no-op
+        menu.handleKey(mockKeyEvent('end'));
+        const spy2 = vi.spyOn(menu, 'markDirty');
+        menu.handleKey(mockKeyEvent('end'));
+        expect(spy2).not.toHaveBeenCalled();
+        spy2.mockRestore();
+    });
+
+    it('end skips disabled items when computing last', () => {
+        const items2: MenuItem[] = [
+            { label: 'A', onSelect: vi.fn() },
+            { label: 'B', disabled: true },
+            { label: 'C', onSelect: vi.fn() },
+            { label: 'D', disabled: true },
+        ];
+        const menu = new Menu({ items: items2 });
+        const screen = new Screen(20, 5);
+        menu.updateRect({ x: 0, y: 0, width: 20, height: 5 });
+
+        menu.handleKey(mockKeyEvent('end'));
+        menu.render(screen);
+        // Last enabled is 'C' at index 2
+        expect(screen.back[2].some(c => c.bg?.name === 'cyan')).toBe(true);
+    });
 });

--- a/packages/ui/src/Menu.ts
+++ b/packages/ui/src/Menu.ts
@@ -98,6 +98,25 @@ export class Menu extends Widget {
             case 'down':
                 this._selectNext();
                 return true;
+            case 'home': {
+                const first = this._items.findIndex(i => !i.disabled);
+                if (first >= 0 && first !== this._selectedIndex) {
+                    this._selectedIndex = first;
+                    this.markDirty();
+                }
+                return true;
+            }
+            case 'end': {
+                let last = -1;
+                for (let i = this._items.length - 1; i >= 0; i--) {
+                    if (!this._items[i].disabled) { last = i; break; }
+                }
+                if (last >= 0 && last !== this._selectedIndex) {
+                    this._selectedIndex = last;
+                    this.markDirty();
+                }
+                return true;
+            }
             case 'enter':
             case 'space':
                 this._confirm();


### PR DESCRIPTION
## Description

This PR adds Home and End keyboard navigation support to `Menu`.

* `Home` moves selection to the first enabled menu item.
* `End` moves selection to the last enabled menu item.
* Disabled items are skipped during navigation.
* No unnecessary re-renders occur when the selection is already at the target item.

Regression tests have been added to verify Home/End navigation, disabled-item handling, and no-op behavior when already positioned on the first or last enabled item.

## Related Issue

Closes #1651

## Which package(s)?

@termuijs/ui

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [x] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [x] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [x] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

This change improves keyboard accessibility and consistency across interactive UI components.

The implementation follows the same Home/End navigation pattern recently added to other keyboard-navigable controls. Home and End only update selection when necessary, skip disabled items, and preserve all existing Menu behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard navigation support to menu: Home key moves focus to the first enabled menu item, End key moves focus to the last enabled menu item. Navigation intelligently skips disabled items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->