### PR TITLE
fix(widgets): ensure page navigation moves at least one item

### DIFF
--- a/packages/widgets/src/input/VirtualList.test.ts
+++ b/packages/widgets/src/input/VirtualList.test.ts
@@ -89,6 +89,40 @@ describe('VirtualList', () => {
         });
     });
 
+    describe('pageUp/pageDown with viewport smaller than itemHeight', () => {
+        // Create a list with layout so _getContentRect() is computed.
+        function createListSmallViewport() {
+            const list = new VirtualList({
+                totalItems: 10,
+                renderItem: (i) => `Item ${i}`,
+                itemHeight: 5, // large item height
+                style: { width: 40, height: 6 }, // content height will be 4 (< itemHeight)
+            });
+            const node = list.getLayoutNode();
+            computeLayout(node, 40, 6);
+            list.syncLayout();
+            return list;
+        }
+
+        it('pageDown moves at least one when pageSize would be 0', () => {
+            const list = createListSmallViewport();
+            expect(list.selectedIndex).toBe(0);
+
+            list.pageDown();
+            // pageDown should advance by at least 1 even when floor(height/itemHeight) === 0
+            expect(list.selectedIndex).toBeGreaterThanOrEqual(1);
+        });
+
+        it('pageUp moves at least one when pageSize would be 0', () => {
+            const list = createListSmallViewport();
+            list.scrollTo(3);
+            expect(list.selectedIndex).toBe(3);
+
+            list.pageUp();
+            expect(list.selectedIndex).toBeLessThan(3);
+        });
+    });
+
     describe('data management', () => {
         it('setTotalItems updates the count', () => {
             const list = createList(100);

--- a/packages/widgets/src/input/VirtualList.test.ts
+++ b/packages/widgets/src/input/VirtualList.test.ts
@@ -109,8 +109,8 @@ describe('VirtualList', () => {
             expect(list.selectedIndex).toBe(0);
 
             list.pageDown();
-            // pageDown should advance by at least 1 even when floor(height/itemHeight) === 0
-            expect(list.selectedIndex).toBeGreaterThanOrEqual(1);
+            // pageDown should advance by exactly 1 (pageSize === 1 in this setup)
+            expect(list.selectedIndex).toBe(1);
         });
 
         it('pageUp moves at least one when pageSize would be 0', () => {
@@ -119,7 +119,8 @@ describe('VirtualList', () => {
             expect(list.selectedIndex).toBe(3);
 
             list.pageUp();
-            expect(list.selectedIndex).toBeLessThan(3);
+            // pageUp should move up by exactly 1 (from 3 -> 2)
+            expect(list.selectedIndex).toBe(2);
         });
     });
 

--- a/packages/widgets/src/input/VirtualList.ts
+++ b/packages/widgets/src/input/VirtualList.ts
@@ -164,7 +164,7 @@ export class VirtualList extends Widget {
     pageUp(): void {
         this._runScrollAction(() => {
             const rect = this._getContentRect();
-            const pageSize = Math.floor(rect.height / this._itemHeight);
+            const pageSize = Math.max(1, Math.floor(rect.height / this._itemHeight));
             this._selectedIndex = Math.max(0, this._selectedIndex - pageSize);
             this._clampScroll();
             this.markDirty();
@@ -175,7 +175,7 @@ export class VirtualList extends Widget {
     pageDown(): void {
         this._runScrollAction(() => {
             const rect = this._getContentRect();
-            const pageSize = Math.floor(rect.height / this._itemHeight);
+            const pageSize = Math.max(1, Math.floor(rect.height / this._itemHeight));
             this._selectedIndex = Math.min(this._totalItems - 1, this._selectedIndex + pageSize);
             this._clampScroll();
             this.markDirty();


### PR DESCRIPTION
## Description

This PR fixes an edge case in `VirtualList` where `pageUp()` and `pageDown()` could become no-ops when the viewport height was smaller than `itemHeight`.

The page size calculation now guarantees a minimum value of `1`, ensuring page navigation always moves the selection when movement is possible. Regression tests have been added to cover both `pageUp()` and `pageDown()` behavior in small viewport scenarios.

## Related Issue

Closes #1653 

## Which package(s)?

@termuijs/widgets

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)
* [x] 🧪 Tests (`type:testing`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

When the viewport content height is smaller than `itemHeight`, the previous implementation computed a page size of `0`, causing `pageUp()` and `pageDown()` to have no effect.

This change updates the page size calculation to use a minimum value of `1`, preserving expected navigation behavior while keeping existing scrolling logic unchanged.

Regression tests have been added to verify both page navigation methods in this edge-case scenario.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed page navigation (up/down) in virtual list when viewport height is smaller than item height—selection now advances by at least one item per action.

* **Tests**
  * Added test coverage for page navigation edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->