### PR TITLE
fix(store): prevent Set iteration mutation bug in signals

### DIFF
--- a/packages/store/src/mutate.test.ts
+++ b/packages/store/src/mutate.test.ts
@@ -26,4 +26,23 @@ describe('mutate helper', () => {
         expect(listener).toHaveBeenCalledTimes(1);
         expect(listener).toHaveBeenCalledWith(['a']);
     });
+
+    it('is safe against listener mutation during iteration', () => {
+        const sig = signal({ count: 0 });
+        const listenerSkipped = vi.fn();
+        
+        const unsub1 = sig.subscribe(() => {
+            // A UI state change causes a child component to unmount, removing its listener
+            unsub2(); 
+        });
+        
+        const unsub2 = sig.subscribe(listenerSkipped);
+
+        // Trigger the loop
+        mutate(sig);
+        
+        // listenerSkipped should NOT be called because unsub1 unsubscribed it 
+        // before the snapshot loop reached it.
+        expect(listenerSkipped).not.toHaveBeenCalled();
+    });
 });

--- a/packages/store/src/mutate.ts
+++ b/packages/store/src/mutate.ts
@@ -27,7 +27,11 @@ export function signal<T>(initialValue: T): Signal<T> {
         set value(newVal: T) {
             if (!Object.is(_value, newVal)) {
                 _value = newVal;
-                listeners.forEach((l) => l(_value));
+                // Snapshot to prevent mutation-during-iteration bugs
+                const snapshot = Array.from(listeners);
+                for (let i = 0; i < snapshot.length; i++) {
+                    if (listeners.has(snapshot[i])) snapshot[i](_value);
+                }
             }
         },
         subscribe(listener: Listener<T>) {
@@ -37,7 +41,11 @@ export function signal<T>(initialValue: T): Signal<T> {
             };
         },
         _setDirty() {
-            listeners.forEach((l) => l(_value));
+            // Snapshot to prevent mutation-during-iteration bugs
+            const snapshot = Array.from(listeners);
+            for (let i = 0; i < snapshot.length; i++) {
+                if (listeners.has(snapshot[i])) snapshot[i](_value);
+            }
         }
     };
 }


### PR DESCRIPTION
## Description

This PR fixes a critical bug where `Set` iteration during signal mutation could result in unpredictable behavior or skipped listeners. When a listener triggered a UI component unmount, its cleanup function would delete a listener from the `Set` while the `forEach` loop was still running. The `signal` implementation now takes a snapshot (`Array.from(listeners)`) before iterating, safely preventing mutation-during-iteration bugs, matching the established `EventEmitter` pattern.

## Related Issue

Closes #1513 

## Which package(s)?

@termuijs/store

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x ] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/f49aa65e-aab2-4e9f-99d6-2174f339ecfe`


## Notes for the Reviewer

A new strict unit test (`is safe against listener mutation during iteration`) was added to `mutate.test.ts` to simulate the exact unmounting scenario and guarantee the iteration logic remains solid going forward.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Signal notifications now safely handle listener modifications during iteration by using snapshot-based listener tracking, preventing unexpected behavior when listeners are added or removed during update notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->