### PR TITLE
fix(jsx): run useKeymap conflict detection on dynamic bindings

### DIFF
--- a/packages/jsx/src/hooks.test.ts
+++ b/packages/jsx/src/hooks.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { timerPoolUnsubscribeAll } from '@termuijs/motion';
 import {
     createFiber, setCurrentFiber, clearCurrentFiber,
-    useState, useEffect, useRef, useId, useCallback,
+    useState, useEffect, useRef, useId, useCallback, useKeymap,
     useAsync, useInterval, useInsertBefore, setRequestRender, setInsertBefore, runEffects, destroyFiber,
     type Fiber, type AsyncState,
 } from './hooks.js';
@@ -295,5 +295,55 @@ describe('useId', () => {
         clearCurrentFiber();
 
         expect(idA).not.toBe(idB);
+    });
+});
+
+
+describe('useKeymap conflict detection', () => {
+    let fiber: Fiber;
+    
+    beforeEach(() => {
+        fiber = createFiber();
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        setRequestRender(() => { });
+    });
+
+    afterEach(() => {
+        clearCurrentFiber();
+        vi.restoreAllMocks();
+    });
+
+    it('warns about conflicting keybindings on initial render', () => {
+        setCurrentFiber(fiber);
+        useKeymap([
+            { key: 'q', action: () => {} },
+            { key: 'q', action: () => {} }
+        ]);
+        clearCurrentFiber();
+        
+        expect(console.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('warns about conflicting keybindings on subsequent renders (dynamic bindings)', () => {
+        setCurrentFiber(fiber);
+        useKeymap([
+            { key: 'q', action: () => {} },
+        ]);
+        clearCurrentFiber();
+        
+        // No conflicts yet
+        expect(console.warn).not.toHaveBeenCalled();
+
+        // Trigger re-render with a dynamic conflict added
+        fiber.hookIndex = 0;
+        setCurrentFiber(fiber);
+        useKeymap([
+            { key: 'q', action: () => {} },
+            { key: 'q', action: () => {} }
+        ]);
+        clearCurrentFiber();
+        
+        // Warning should now be triggered on the re-render
+        expect(console.warn).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/jsx/src/hooks.ts
+++ b/packages/jsx/src/hooks.ts
@@ -336,18 +336,19 @@ export function useKeymap(bindings: KeyBinding[]): void {
     const fiber = currentFiber();
     const idx = fiber.hookIndex++;
 
-    if (idx >= fiber.hooks.length) {
-        // Dev-mode conflict detection on first render
-        if (process.env.NODE_ENV !== 'production') {
-            const seen = new Map<string, KeyBinding>();
-            for (const b of bindings) {
-                const key = `${b.key}|${b.ctrl ?? false}|${b.alt ?? false}|${b.shift ?? false}`;
-                if (seen.has(key)) {
-                    // Conflicting keybinding — silently ignore in dev mode
-                }
-                seen.set(key, b);
+    // Dev-mode conflict detection on every render (moved outside the init block)
+    if (process.env.NODE_ENV !== 'production') {
+        const seen = new Map<string, KeyBinding>();
+        for (const b of bindings) {
+            const key = `${b.key}|${b.ctrl ?? false}|${b.alt ?? false}|${b.shift ?? false}`;
+            if (seen.has(key)) {
+                console.warn(`[useKeymap] Conflicting keybinding detected for key: ${key}`);
             }
+            seen.set(key, b);
         }
+    }
+
+    if (idx >= fiber.hooks.length) {
         fiber.hooks.push({ value: bindings });
     } else {
         fiber.hooks[idx].value = bindings;
@@ -368,6 +369,7 @@ export function useKeymap(bindings: KeyBinding[]): void {
         }
     };
 }
+
 
 /**
  * useInsertBefore — register a persistent line above the inline viewport.


### PR DESCRIPTION
## Description

This PR fixes a bug in the `@termuijs/jsx` package where `useKeymap` conflict detection only ran during the initial render. By moving the dev-mode conflict detection out of the initialization block (`idx >= fiber.hooks.length`), the hook now correctly warns the developer via `console.warn` if dynamic bindings (e.g., toggled via state) overlap with existing shortcuts on subsequent renders.

## Related Issue

Closes #1512 

## Which package(s)?

@termuijs/jsx

## Type of Change


- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/f49aa65e-aab2-4e9f-99d6-2174f339ecfe`



## Notes for the Reviewer

Added a strict unit test suite (`useKeymap conflict detection`) in `hooks.test.ts` to ensure that conflict warnings trigger on both initial render and subsequent dynamic updates, successfully protecting the developer experience from silent conflict failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Keybinding conflict detection now runs on every render cycle and emits console warnings when duplicate keybindings are detected, providing better visibility into potential configuration conflicts.

* **Tests**
  * Added comprehensive test coverage for keybinding conflict detection behavior, validating that appropriate warnings are emitted both on initial component render and when duplicate conflicts are introduced during subsequent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->