### PR TITLE
fix(ui): clear debounce timer on SearchInput destroy

### DIFF
--- a/packages/ui/src/SearchInput.test.ts
+++ b/packages/ui/src/SearchInput.test.ts
@@ -111,4 +111,21 @@ describe('SearchInput', () => {
         // The icon and placeholder should start at x=2
         expect(row[2]?.char).not.toBe(' ');
     });
+
+        it('clears the debounce timer when destroyed to prevent memory leaks', () => {
+        vi.useFakeTimers();
+        const onSearch = vi.fn();
+        const input = new SearchInput({ debounce: 100, onSearch });
+        
+        input.handleKey(typeChar('a'));
+        
+        // Destroy the component while the timer is still running
+        input.destroy();
+        
+        vi.advanceTimersByTime(100);
+        
+        // The timer should have been cleared, so onSearch should NOT fire
+        expect(onSearch).not.toHaveBeenCalled();
+    });
+
 });

--- a/packages/ui/src/SearchInput.ts
+++ b/packages/ui/src/SearchInput.ts
@@ -101,6 +101,11 @@ export class SearchInput extends Widget {
         }
     }
 
+    override destroy(): void {
+        this._cancelDebounce();
+        super.destroy();
+    }
+
     protected _renderSelf(screen: Screen): void {
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;


### PR DESCRIPTION
## Description

This PR fixes a memory leak in the `@termuijs/ui` package where `SearchInput` components left orphaned `setTimeout` debounce timers running even after the component was unmounted or destroyed. The `SearchInput` class now overrides the `destroy()` method to proactively clear `_debounceTimer` before calling `super.destroy()`.

## Related Issue

Closes #1511

## Which package(s)?

@termuijs/ui

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [x] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/f49aa65e-aab2-4e9f-99d6-2174f339ecfe`

## Screenshots / Recordings (UI changes)

*N/A*

## Notes for the Reviewer

Added a strict unit test suite (`clears the debounce timer when destroyed to prevent memory leaks`) in `SearchInput.test.ts` to ensure that fake timers can advance without throwing an unexpected `onSearch` event after `destroy()` is called.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SearchInput now properly cleans up pending search operations when the component is destroyed, preventing stray callbacks from executing and improving overall application performance and memory usage.

* **Tests**
  * Added unit test coverage verifying that SearchInput correctly cancels scheduled operations during destruction, ensuring no unexpected search callbacks are triggered after component removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->