### PR TITLE
feat(widgets): add emptyMessage customization to List widget

### DIFF
--- a/packages/widgets/src/input/List.test.ts
+++ b/packages/widgets/src/input/List.test.ts
@@ -3,6 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi } from 'vitest';
+import { Screen } from '@termuijs/core';
 import { List, type ListItem } from './List.js';
 
 describe('List', () => {
@@ -71,4 +72,16 @@ describe('List', () => {
         list.selectNext();
         expect(list.isDirty).toBe(true);
     });
+
+        it('renders emptyMessage when the list is empty', () => {
+        const list = new List({ items: [], emptyMessage: 'No files found' });
+        list.updateRect({ x: 0, y: 0, width: 20, height: 3 });
+        
+        const screen = new Screen(20, 3);
+        list.render(screen);
+
+        const rendered = screen.back.map(row => row.map(c => c.char).join('')).join('\n');
+        expect(rendered).toContain('No files found');
+    });
+
 });

--- a/packages/widgets/src/input/List.ts
+++ b/packages/widgets/src/input/List.ts
@@ -20,7 +20,10 @@ export interface ListProps {
     state?: ListState;
     /** Called whenever selection or scroll changes */
     onStateChange?: (state: ListState) => void;
+    /** Message to display when the list is empty */
+    emptyMessage?: string;
 }
+
 
 /**
  * List — a scrollable, selectable list of items.
@@ -39,6 +42,7 @@ export class List extends Widget {
     private _onSelect?: (item: ListItem, index: number) => void;
     private _state?: ListState;
     private _onStateChange?: (state: ListState) => void;
+    private _emptyMessage?: string;
 
     constructor(
         itemsOrProps: ListItem[] | ListProps,
@@ -56,6 +60,8 @@ export class List extends Widget {
             this._state = props.state;
             this._onStateChange = props.onStateChange;
             this._onSelect = props.onSelect ?? onSelect;
+            this._emptyMessage = props.emptyMessage;
+
 
             // Initialise from external state if provided
             if (props.state) {
@@ -129,12 +135,22 @@ export class List extends Widget {
 
     // ── Rendering ─────────────────────────────────────
 
-    protected _renderSelf(screen: Screen): void {
+       protected _renderSelf(screen: Screen): void {
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;
         if (width <= 0 || height <= 0) return;
 
         const attrs = styleToCellAttrs(this._style);
+
+        // Render Empty State if no items exist
+        if (this._items.length === 0 && this._emptyMessage) {
+            const msg = truncate(this._emptyMessage, width);
+            const msgX = x + Math.floor((width - stringWidth(msg)) / 2);
+            const msgY = y + Math.floor(height / 2);
+            screen.writeString(msgX, msgY, msg, { ...attrs, dim: true });
+            return;
+        }
+
         const visibleCount = Math.min(this._items.length - this._scrollOffset, height);
 
         for (let i = 0; i < visibleCount; i++) {


### PR DESCRIPTION
## Description

This PR adds an "Empty State" feature to the `@termuijs/widgets` `List` component. Previously, rendering a `List` with an empty data array resulted in a completely blank box, leaving users wondering if the widget was broken or just empty.

Developers can now pass an optional `emptyMessage` string (e.g., `"No files found"`) in the `ListProps`. When the items array is empty, this message is automatically centered horizontally and vertically inside the widget's content rect and styled with the `dim` attribute.

## Related Issue

Closes #1510

## Which package(s)?

@termuijs/widgets

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/f49aa65e-aab2-4e9f-99d6-2174f339ecfe`

## Screenshots / Recordings (UI changes)

*N/A*

## Notes for the Reviewer

Added a strict unit test suite (`renders emptyMessage when the list is empty`) in `List.test.ts` to ensure the correct text is written to the screen buffer when `items` is empty and `emptyMessage` is provided.
