### PR TITLE
feat(widgets): implement virtualization for Table and Tree

### DIFF
--- a/packages/widgets/src/data/Table.test.ts
+++ b/packages/widgets/src/data/Table.test.ts
@@ -61,4 +61,29 @@ describe('Table', () => {
         const table = new Table(COLUMNS, ROWS);
         expect(table.focusable).toBe(true);
     });
+
+        it('virtualizes rows and updates scroll offset via keyboard navigation', () => {
+        // Create 50 rows
+        const manyRows = Array.from({ length: 50 }).map((_, i) => ({ name: `Row${i}`, age: i }));
+        const table = new Table(COLUMNS, manyRows);
+        
+        // Mock a screen with a height of 10
+        table.updateRect({ x: 0, y: 0, width: 40, height: 10 });
+        
+        // Initially, selectedRow is 0, offset is 0
+        expect(table.selectedRow).toBe(0);
+        expect((table as any)._scrollOffset).toBe(0);
+
+        // Move down past the viewport
+        for (let i = 0; i < 20; i++) {
+            table.handleKey({ key: 'down' } as any);
+        }
+        
+        expect(table.selectedRow).toBe(20);
+        
+        // Table viewport dataHeight is 10 - 2 (header) = 8
+        // So if selected is 20, offset should be clamped to 20 - 8 + 1 = 13
+        expect((table as any)._scrollOffset).toBe(13);
+    });
+
 });

--- a/packages/widgets/src/data/Table.ts
+++ b/packages/widgets/src/data/Table.ts
@@ -5,6 +5,7 @@
 import { type Screen, type Style, type Color, type KeyEvent, styleToCellAttrs, stringWidth, truncate } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 import { type TableState } from './TableState.js';
+import { computeRange } from '../input/virtual-scroll.js';
 
 export interface TableColumn {
     /** Column header label */
@@ -54,6 +55,7 @@ export interface TableProps {
  * - Text alignment per column
  * - Truncation for overflow
  * - External state via `state` prop and `useTableState` hook
+ * - Virtualized scrolling
  */
 export class Table extends Widget {
     focusable = true;
@@ -67,6 +69,7 @@ export class Table extends Widget {
     private _state?: TableState;
     private _onStateChange?: (state: TableState) => void;
     private _selectedRow = 0;
+    private _scrollOffset = 0;
     private _sortColumn = '';
 
     constructor(
@@ -111,21 +114,22 @@ export class Table extends Widget {
 
     setRows(rows: TableRow[]): void {
         this._rows = rows;
+        this._clampScroll();
         this.markDirty();
         this._pushState();
     }
 
     sortByColumn(columnKey: string): void {
-    this._sortColumn = columnKey;
+        this._sortColumn = columnKey;
 
-    this._rows.sort((a, b) =>
-        String(a[columnKey] ?? '').localeCompare(
-            String(b[columnKey] ?? '')
-        )
-    );
+        this._rows.sort((a, b) =>
+            String(a[columnKey] ?? '').localeCompare(
+                String(b[columnKey] ?? '')
+            )
+        );
 
-    this.markDirty();
-}
+        this.markDirty();
+    }
 
     // ── External state sync ───────────────────────────
 
@@ -148,7 +152,25 @@ export class Table extends Widget {
             );
         }
 
+        this._clampScroll();
         this.markDirty();
+    }
+
+    private _clampScroll(): void {
+        const rect = this._getContentRect();
+        let visibleHeight = rect.height;
+        if (this._showHeader) {
+            visibleHeight -= 2; // header + separator
+        }
+        if (visibleHeight <= 0) { this._scrollOffset = 0; return; }
+
+        if (this._selectedRow < this._scrollOffset) {
+            this._scrollOffset = this._selectedRow;
+        }
+        if (this._selectedRow >= this._scrollOffset + visibleHeight) {
+            this._scrollOffset = this._selectedRow - visibleHeight + 1;
+        }
+        this._scrollOffset = Math.max(0, this._scrollOffset);
     }
 
     // ── Rendering ─────────────────────────────────────
@@ -166,40 +188,50 @@ export class Table extends Widget {
             width - (this._columns.length - 1) * sepWidth,
         );
 
-        let row = 0;
+        let headerOffset = 0;
 
         // Render header
-        if (this._showHeader && row < height) {
+        if (this._showHeader && headerOffset < height) {
             let cx = x;
             for (let c = 0; c < this._columns.length; c++) {
                 const col = this._columns[c];
                 const cellText = this._alignText(col.header, colWidths[c], col.align ?? 'left');
-                screen.writeString(cx, y + row, cellText, {
+                screen.writeString(cx, y + headerOffset, cellText, {
                     ...attrs,
                     fg: this._headerColor,
                     bold: true,
                 });
                 cx += colWidths[c];
                 if (c < this._columns.length - 1) {
-                    screen.writeString(cx, y + row, this._separator, { ...attrs, dim: true });
+                    screen.writeString(cx, y + headerOffset, this._separator, { ...attrs, dim: true });
                     cx += sepWidth;
                 }
             }
-            row++;
+            headerOffset++;
 
             // Header separator line
-            if (row < height) {
+            if (headerOffset < height) {
                 const sepLine = '─'.repeat(width);
-                screen.writeString(x, y + row, sepLine, { ...attrs, dim: true });
-                row++;
+                screen.writeString(x, y + headerOffset, sepLine, { ...attrs, dim: true });
+                headerOffset++;
             }
         }
 
-        // Render data rows
-        for (let r = 0; r < this._rows.length && row < height; r++) {
+        const dataHeight = height - headerOffset;
+        if (dataHeight <= 0) return;
+
+        // Use the virtualization engine
+        const range = computeRange(this._scrollOffset, dataHeight, this._rows.length, 0);
+
+        // Render data rows within the virtual range
+        for (let r = range.start; r < range.end; r++) {
             const dataRow = this._rows[r];
             const isStripe = this._stripe && r % 2 === 1;
             const isSelected = r === this._selectedRow;
+            
+            const screenY = y + headerOffset + (r - this._scrollOffset);
+            if (screenY < y || screenY >= y + height) continue;
+
             let cx = x;
 
             for (let c = 0; c < this._columns.length; c++) {
@@ -207,17 +239,17 @@ export class Table extends Widget {
                 const rawValue = String(dataRow[col.key] ?? '');
                 const cellText = this._alignText(rawValue, colWidths[c], col.align ?? 'left');
 
-                screen.writeString(cx, y + row, cellText, {
-    ...attrs,
-    bg: isSelected
-        ? { type: 'named', name: 'blue' }
-        : isStripe
-            ? this._stripeColor
-            : attrs.bg,
-});
+                screen.writeString(cx, screenY, cellText, {
+                    ...attrs,
+                    bg: isSelected
+                        ? { type: 'named', name: 'blue' }
+                        : isStripe
+                            ? this._stripeColor
+                            : attrs.bg,
+                });
                 cx += colWidths[c];
                 if (c < this._columns.length - 1) {
-                    screen.writeString(cx, y + row, this._separator, {
+                    screen.writeString(cx, screenY, this._separator, {
                         ...attrs,
                         dim: true,
                         bg: isStripe ? this._stripeColor : attrs.bg,
@@ -226,14 +258,13 @@ export class Table extends Widget {
                 }
             }
 
-            // Fill remaining width for stripe
-            if (isStripe) {
+            // Fill remaining width for stripe/selection highlight
+            if (isStripe || isSelected) {
+                const rowBg = isSelected ? { type: 'named' as const, name: 'blue' as const } : this._stripeColor;
                 for (let fx = cx; fx < x + width; fx++) {
-                    screen.setCell(fx, y + row, { char: ' ', bg: this._stripeColor });
+                    screen.setCell(fx, screenY, { char: ' ', bg: rowBg });
                 }
             }
-
-            row++;
         }
     }
 

--- a/packages/widgets/src/display/Tree.test.ts
+++ b/packages/widgets/src/display/Tree.test.ts
@@ -354,4 +354,31 @@ describe('Tree', () => {
             expect((tree as any)._visibleNodes.length).toBe(1);
         });
     });
+
+        describe('Virtualization', () => {
+        it('updates scroll offset via keyboard navigation when moving past viewport', () => {
+            // Generate many nodes
+            const manyNodes = Array.from({ length: 50 }).map((_, i) => ({ label: `Node${i}` }));
+            
+            // makeTree helper in this file accepts (nodes, onSelect, width, height)
+            // We set height to 10
+            const tree = makeTree(manyNodes, undefined, 40, 10);
+            
+            // Initially, selectedIndex is 0, offset is 0
+            expect(tree.selectedIndex).toBe(0);
+            expect((tree as any)._scrollOffset).toBe(0);
+
+            // Move down past the viewport
+            for (let i = 0; i < 20; i++) {
+                tree.handleKey('down');
+            }
+            
+            expect(tree.selectedIndex).toBe(20);
+            
+            // Viewport height is 10
+            // So if selected is 20, offset should be clamped to 20 - 10 + 1 = 11
+            expect((tree as any)._scrollOffset).toBe(11);
+        });
+    });
+
 });

--- a/packages/widgets/src/display/Tree.ts
+++ b/packages/widgets/src/display/Tree.ts
@@ -12,6 +12,7 @@ import {
     normalizeNavigationKey,
 } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
+import { computeRange } from '../input/virtual-scroll.js';
 
 export interface TreeNode {
     label: string;
@@ -42,6 +43,7 @@ interface VisibleEntry {
  * - onSelect callback for leaf nodes
  * - Unicode and ASCII fallback symbols
  * - Scrolling when tree exceeds visible height
+ * - Virtualized rendering
  */
 export class Tree extends Widget {
     private _nodes: TreeNode[];
@@ -216,16 +218,16 @@ export class Tree extends Widget {
         const expandedChevron  = useUnicode ? '▼ ' : 'v ';
         const leafPrefix       = useUnicode ? '• ' : '* ';
 
-        const visibleCount = Math.min(
-            this._visibleNodes.length - this._scrollOffset,
-            height,
-        );
+        // Use the virtualization engine
+        const range = computeRange(this._scrollOffset, height, this._visibleNodes.length, 0);
 
-        for (let i = 0; i < visibleCount; i++) {
-            const entryIdx = this._scrollOffset + i;
+        for (let entryIdx = range.start; entryIdx < range.end; entryIdx++) {
             const entry = this._visibleNodes[entryIdx];
             const { node, depth } = entry;
             const isSelected = entryIdx === this._selectedIndex;
+
+            const screenY = y + (entryIdx - this._scrollOffset);
+            if (screenY < y || screenY >= y + height) continue;
 
             // Build line text
             const indentStr = ' '.repeat(this._indent * depth);
@@ -249,14 +251,14 @@ export class Tree extends Widget {
                     ? { ...attrs, bold: true }
                     : attrs;
 
-            screen.writeString(x, y + i, line, cellStyle);
+            screen.writeString(x, screenY, line, cellStyle);
 
             // Fill rest of row for selection highlight
             if (isSelected && this.isFocused) {
                 const lineWidth = stringWidth(line);
                 const remaining = width - lineWidth;
                 for (let c = 0; c < remaining; c++) {
-                    screen.setCell(x + lineWidth + c, y + i, {
+                    screen.setCell(x + lineWidth + c, screenY, {
                         char: ' ',
                         ...cellStyle,
                     });


### PR DESCRIPTION
## Description

This PR implements virtualization for the `Table` and `Tree` widgets in `@termuijs/widgets`, ensuring they only render the visible rows (`y` to `y + height`) instead of looping through thousands of off-screen items and choking memory/rendering cycles.

It achieves this by reusing the core math engine (`computeRange`) from `virtual-scroll.ts`. 
- `Table` previously lacked a `_scrollOffset` altogether and could not scroll natively. It now maintains an offset and correctly clamps scroll on keyboard navigation.
- `Tree` previously relied on manual index tracking during rendering. It now leverages the standard `computeRange` math engine.
- Dedicated unit tests were added to both components to guarantee that `handleKey` navigation correctly updates the virtual scroll offset when moving past the visible viewport bounds.

## Related Issue

Closes #1509

## Which package(s)?

@termuijs/widgets

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [x] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [x] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/f49aa65e-aab2-4e9f-99d6-2174f339ecfe`

## Screenshots / Recordings (UI changes)

*N/A*

## Notes for the Reviewer

- **Table Virtualization**: Previously, `Table` didn't have any native scroll offset or scrolling capability; it just rendered from index 0 until it hit the screen height. I introduced `_scrollOffset` and `_clampScroll()` to correctly manage state, and then hooked `_renderSelf` into `computeRange` to only render the visible segment of `_rows`.
- **Tree Virtualization**: Refactored the manual `visibleCount` index math into the standardized `computeRange` engine for consistency across the codebase.
- **Testing**: Added explicit test suites to both `Table.test.ts` and `Tree.test.ts` to verify that rapidly firing keyboard navigation (`down`) successfully updates and clamps the internal virtual offset once it scrolls past the mocked viewport height.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled virtualized row rendering for Table and Tree widgets, significantly improving performance and responsiveness when working with large datasets. Selection and scroll behavior now work seamlessly during navigation.

* **Tests**
  * Added test coverage for virtualized row rendering during keyboard navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->