### PR TITLE
feat(widgets): add Ctrl+U and Ctrl+W clear shortcuts to TextInput

### DIFF
--- a/packages/widgets/src/input/TextInput.test.ts
+++ b/packages/widgets/src/input/TextInput.test.ts
@@ -303,6 +303,28 @@ describe('handleKey', () => {
         input.handleKey(createMockKeyEvent('enter'));
         expect(onSubmitSpy).toHaveBeenCalledWith('done');
     });
+
+    it('clears line on Ctrl+U', () => {
+        const input = new TextInput();
+        input.value = 'hello world';
+        input.moveCursorEnd();
+        input.handleKey(createMockKeyEvent('u', true)); // ctrl = true
+        expect(input.value).toBe('');
+    });
+
+    it('deletes previous word on Ctrl+W', () => {
+        const input = new TextInput();
+        input.value = 'hello world';
+        input.moveCursorEnd();
+        
+        input.handleKey(createMockKeyEvent('w', true));
+        expect(input.value).toBe('hello ');
+        expect((input as any)._cursorPos).toBe(6); // cursor at index 6, after space
+        
+        input.handleKey(createMockKeyEvent('w', true));
+        expect(input.value).toBe('');
+        expect((input as any)._cursorPos).toBe(0);
+    });
 });
 
 describe('Performance optimizations', () => {

--- a/packages/widgets/src/input/TextInput.ts
+++ b/packages/widgets/src/input/TextInput.ts
@@ -107,6 +107,31 @@ export class TextInput extends Widget {
         }
     }
 
+    deleteWordBack(): void {
+        if (this._cursorPos === 0) return;
+
+        const graphemes = splitGraphemes(this._value);
+        let i = this._cursorPos - 1;
+        
+        // Skip trailing spaces
+        while (i >= 0 && graphemes[i] === ' ') {
+            i--;
+        }
+        
+        // Find the start of the word
+        while (i >= 0 && graphemes[i] !== ' ') {
+            i--;
+        }
+        
+        const deleteStart = i + 1;
+        
+        graphemes.splice(deleteStart, this._cursorPos - deleteStart);
+        this._value = graphemes.join('');
+        this._cursorPos = deleteStart;
+        this._onChange?.(this._value);
+        this.markDirty();
+    }
+
     moveCursorLeft(): void {
         const next = Math.max(0, this._cursorPos - 1);
 
@@ -154,6 +179,13 @@ export class TextInput extends Widget {
     }
 
     clear(): void {
+        this._value = '';
+        this._cursorPos = 0;
+        this._onChange?.('');
+        this.markDirty();
+    }
+
+    clearLine(): void {
         this._value = '';
         this._cursorPos = 0;
         this._onChange?.('');
@@ -249,6 +281,20 @@ export class TextInput extends Widget {
                     event.stopPropagation();
                     return;
                 }
+            }
+        }
+
+        if (event.ctrl) {
+            if (event.key === 'u') {
+                this.clearLine();
+                event.preventDefault();
+                event.stopPropagation();
+                return;
+            } else if (event.key === 'w') {
+                this.deleteWordBack();
+                event.preventDefault();
+                event.stopPropagation();
+                return;
             }
         }
 


### PR DESCRIPTION
## Description

This PR adds two standard terminal readline shortcuts to the `TextInput` widget to significantly improve editing efficiency:
- **Ctrl+U**: Clears the entire input line and resets the cursor to `0`.
- **Ctrl+W**: Deletes the previous word (backwards from the cursor until a space is hit).

This was achieved by introducing `clearLine()` and `deleteWordBack()` methods and intercepting `event.ctrl && event.key` right before the main switch statement in `handleKey`. Thorough unit tests were added to ensure both shortcuts function accurately and manage cursor state appropriately.

## Related Issue

Closes #1508

## Which package(s)?

@termuijs/widgets

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/f49aa65e-aab2-4e9f-99d6-2174f339ecfe`

## Screenshots / Recordings (UI changes)

*N/A*

## Notes for the Reviewer

- In `TextInput.ts`, `deleteWordBack` carefully iterates backward, skipping trailing spaces first to ensure it acts exactly like a traditional shell `Ctrl+W` shortcut.
- The `event.ctrl` intercept was deliberately placed before the switch block to ensure single character logic in the `default` fallback doesn't accidentally trigger if a terminal sends modified escape sequences differently. 
- Covered by two explicit unit tests verifying state and cursor updates!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Text input now supports Ctrl+U keyboard shortcut to clear the entire line.
  * Text input now supports Ctrl+W keyboard shortcut to delete the previous word.

* **Tests**
  * Added keyboard shortcut tests to verify line-clearing and word-deletion behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->