### PR TITLE
feat(ui): support async validators in form engine

### DIFF
--- a/packages/ui/src/Form.test.ts
+++ b/packages/ui/src/Form.test.ts
@@ -264,10 +264,10 @@ describe('Form — text editing', () => {
         expect(form.values).toEqual({ first: '', email: '' });
     });
 
-    it('editing clears existing validation error for that field', () => {
+    it('editing clears existing validation error for that field', async () => {
         const fields: FormField[] = [{ name: 'n', label: 'Name', type: 'text', required: true }];
         const { form, width, height } = makeForm(fields);
-        form.submit(); // triggers required error
+        await form.submit(); // triggers required error
         let rows = render_(form, width, height);
         expect(rows.join('\n')).toContain('Name is required');
 
@@ -280,43 +280,43 @@ describe('Form — text editing', () => {
 // ── 5. Required Validation ────────────────────────────
 
 describe('Form — required validation', () => {
-    it('required field with empty value generates error', () => {
+    it('required field with empty value generates error', async () => {
         const onSubmit = vi.fn();
         const fields: FormField[] = [{ name: 'n', label: 'Name', type: 'text', required: true }];
         const { form, width, height } = makeForm(fields, { onSubmit });
-        form.submit();
+        await form.submit();
         const rows = render_(form, width, height);
         expect(rows.join('\n')).toContain('Name is required');
         expect(onSubmit).not.toHaveBeenCalled();
     });
 
-    it('whitespace-only value is treated as empty by required validation', () => {
+    it('whitespace-only value is treated as empty by required validation', async () => {
         const onSubmit = vi.fn();
         const fields: FormField[] = [{ name: 'n', label: 'Name', type: 'text', required: true }];
         const { form } = makeForm(fields, { onSubmit });
         form.insertChar(' ');
         form.insertChar(' ');
-        form.submit();
+        await form.submit();
         expect(onSubmit).not.toHaveBeenCalled();
     });
 
-    it('multiple required fields each produce their own errors', () => {
+    it('multiple required fields each produce their own errors', async () => {
         const fields: FormField[] = [
             { name: 'a', label: 'Alpha', type: 'text', required: true },
             { name: 'b', label: 'Beta', type: 'text', required: true },
         ];
         const { form, width, height } = makeForm(fields);
-        form.submit();
+        await form.submit();
         const out = render_(form, width, height).join('\n');
         expect(out).toContain('Alpha is required');
         expect(out).toContain('Beta is required');
     });
 
-    it('non-required empty field does not block submission', () => {
+    it('non-required empty field does not block submission', async () => {
         const onSubmit = vi.fn();
         const fields: FormField[] = [{ name: 'opt', label: 'Optional', type: 'text' }];
         const { form } = makeForm(fields, { onSubmit });
-        form.submit();
+        await form.submit();
         expect(onSubmit).toHaveBeenCalledTimes(1);
     });
 });
@@ -324,7 +324,7 @@ describe('Form — required validation', () => {
 // ── 6. Custom Validation ──────────────────────────────
 
 describe('Form — custom validation', () => {
-    it('custom validator blocks submit when it returns an error string', () => {
+    it('custom validator blocks submit when it returns an error string', async () => {
         const onSubmit = vi.fn();
         const fields: FormField[] = [
             {
@@ -334,13 +334,13 @@ describe('Form — custom validation', () => {
         ];
         const { form, width, height } = makeForm(fields, { onSubmit });
         form.insertChar('x');
-        form.submit();
+        await form.submit();
         const out = render_(form, width, height).join('\n');
         expect(out).toContain('Must be a number');
         expect(onSubmit).not.toHaveBeenCalled();
     });
 
-    it('custom validator does not block submit when it returns null', () => {
+    it('custom validator does not block submit when it returns null', async () => {
         const onSubmit = vi.fn();
         const fields: FormField[] = [
             {
@@ -351,32 +351,32 @@ describe('Form — custom validation', () => {
         const { form } = makeForm(fields, { onSubmit });
         form.insertChar('4');
         form.insertChar('2');
-        form.submit();
+        await form.submit();
         expect(onSubmit).toHaveBeenCalledWith({ age: '42' });
     });
 
-    it('validator runs even when the field has a value', () => {
+    it('validator runs even when the field has a value', async () => {
         const validate = vi.fn().mockReturnValue(null);
         const fields: FormField[] = [{ name: 'n', label: 'N', type: 'text', validate }];
         const { form } = makeForm(fields);
         form.insertChar('X');
-        form.submit();
+        await form.submit();
         expect(validate).toHaveBeenCalledWith('X');
     });
 
-    it('multiple validators failing independently each render errors', () => {
+    it('multiple validators failing independently each render errors', async () => {
         const fields: FormField[] = [
             { name: 'a', label: 'A', type: 'text', validate: () => 'Error A' },
             { name: 'b', label: 'B', type: 'text', validate: () => 'Error B' },
         ];
         const { form, width, height } = makeForm(fields);
-        form.submit();
+        await form.submit();
         const out = render_(form, width, height).join('\n');
         expect(out).toContain('Error A');
         expect(out).toContain('Error B');
     });
 
-    it('required and custom validator can coexist – submit is blocked when value is empty', () => {
+    it('required and custom validator can coexist – submit is blocked when value is empty', async () => {
         const onSubmit = vi.fn();
         const fields: FormField[] = [
             {
@@ -385,7 +385,7 @@ describe('Form — custom validation', () => {
             },
         ];
         const { form } = makeForm(fields, { onSubmit });
-        form.submit();
+        await form.submit();
         expect(onSubmit).not.toHaveBeenCalled();
     });
 });
@@ -393,7 +393,7 @@ describe('Form — custom validation', () => {
 // ── 7. Successful Submission ──────────────────────────
 
 describe('Form — successful submission', () => {
-    it('onSubmit fires exactly once when all validation passes', () => {
+    it('onSubmit fires exactly once when all validation passes', async () => {
         const onSubmit = vi.fn();
         const fields: FormField[] = [
             { name: 'first', label: 'First', type: 'text', required: true },
@@ -403,29 +403,29 @@ describe('Form — successful submission', () => {
         form.insertChar('J'); form.insertChar('o'); form.insertChar('e');
         form.nextField();
         form.insertChar('4'); form.insertChar('2');
-        form.submit();
+        await form.submit();
         expect(onSubmit).toHaveBeenCalledTimes(1);
         expect(onSubmit).toHaveBeenCalledWith({ first: 'Joe', num: '42' });
     });
 
-    it('submitted payload matches values getter at submission time', () => {
+    it('submitted payload matches values getter at submission time', async () => {
         const onSubmit = vi.fn();
         const fields: FormField[] = [{ name: 'x', label: 'X', type: 'text' }];
         const { form } = makeForm(fields, { onSubmit });
         form.insertChar('H'); form.insertChar('i');
         const expected = form.values;
-        form.submit();
+        await form.submit();
         expect(onSubmit).toHaveBeenCalledWith(expected);
     });
 
-    it('no errors remain visible after successful submit', () => {
+    it('no errors remain visible after successful submit', async () => {
         // First submit fails, then we fix and resubmit
         const onSubmit = vi.fn();
         const fields: FormField[] = [{ name: 'n', label: 'Name', type: 'text', required: true }];
         const { form, width, height } = makeForm(fields, { onSubmit });
-        form.submit(); // fails
+        await form.submit(); // fails
         form.insertChar('A');
-        form.submit(); // succeeds
+        await form.submit(); // succeeds
         const out = render_(form, width, height).join('\n');
         expect(out).not.toContain('Name is required');
         expect(onSubmit).toHaveBeenCalledTimes(1);
@@ -501,10 +501,10 @@ describe('Form — rendering', () => {
         expect(out).toContain('[ Submit ]');
     });
 
-    it('renders inline validation error message', () => {
+    it('renders inline validation error message', async () => {
         const fields: FormField[] = [{ name: 'n', label: 'Name', type: 'text', required: true }];
         const { form, width, height } = makeForm(fields);
-        form.submit();
+        await form.submit();
         const out = render_(form, width, height).join('\n');
         expect(out).toContain('Name is required');
     });
@@ -572,15 +572,13 @@ describe('Form — edge cases', () => {
         }).not.toThrow();
     });
 
-    it('multiple consecutive submits do not throw', () => {
+    it('multiple consecutive submits do not throw', async () => {
         const onSubmit = vi.fn();
         const fields: FormField[] = [{ name: 'n', label: 'Name', type: 'text' }];
         const { form } = makeForm(fields, { onSubmit });
-        expect(() => {
-            form.submit();
-            form.submit();
-            form.submit();
-        }).not.toThrow();
+        await form.submit();
+        await form.submit();
+        await form.submit();
     });
 });
 
@@ -617,10 +615,10 @@ describe('Form — markDirty', () => {
         expect(spy).toHaveBeenCalled();
     });
 
-    it('markDirty is called on submit', () => {
+    it('markDirty is called on submit', async () => {
         const { form } = makeForm(TEXT_FIELDS);
         const spy = vi.spyOn(form as unknown as { markDirty(): void }, 'markDirty');
-        form.submit();
+        await form.submit();
         expect(spy).toHaveBeenCalled();
     });
 
@@ -642,39 +640,39 @@ describe('Form — markDirty', () => {
 // ── 11. Error Lifecycle ───────────────────────────────
 
 describe('Form — error lifecycle', () => {
-    it('errors appear after a failed submit', () => {
+    it('errors appear after a failed submit', async () => {
         const fields: FormField[] = [{ name: 'n', label: 'Name', type: 'text', required: true }];
         const { form, width, height } = makeForm(fields);
-        form.submit();
+        await form.submit();
         const out = render_(form, width, height).join('\n');
         expect(out).toContain('Name is required');
     });
 
-    it('errors disappear when the affected field is edited', () => {
+    it('errors disappear when the affected field is edited', async () => {
         const fields: FormField[] = [{ name: 'n', label: 'Name', type: 'text', required: true }];
         const { form, width, height } = makeForm(fields);
-        form.submit();
+        await form.submit();
         form.insertChar('A'); // edit clears error
         const out = render_(form, width, height).join('\n');
         expect(out).not.toContain('Name is required');
     });
 
-    it('re-submitting with empty field re-generates the error', () => {
+    it('re-submitting with empty field re-generates the error', async () => {
         const onSubmit = vi.fn();
         const fields: FormField[] = [{ name: 'n', label: 'Name', type: 'text', required: true }];
         const { form } = makeForm(fields, { onSubmit });
-        form.submit(); // first fail
-        form.submit(); // second fail
+        await form.submit(); // first fail
+        await form.submit(); // second fail
         expect(onSubmit).not.toHaveBeenCalled();
     });
 
-    it('successful submit clears all previous errors', () => {
+    it('successful submit clears all previous errors', async () => {
         const onSubmit = vi.fn();
         const fields: FormField[] = [{ name: 'n', label: 'Name', type: 'text', required: true }];
         const { form, width, height } = makeForm(fields, { onSubmit });
-        form.submit(); // fail
+        await form.submit(); // fail
         form.insertChar('B');
-        form.submit(); // pass
+        await form.submit(); // pass
         const out = render_(form, width, height).join('\n');
         expect(out).not.toContain('Name is required');
         expect(onSubmit).toHaveBeenCalledOnce();
@@ -708,7 +706,7 @@ describe('Form — existing tests', () => {
         screen.unmount();
     });
 
-    it('validation runs on submit and blocks invalid fields', () => {
+    it('validation runs on submit and blocks invalid fields', async () => {
         let form!: Form;
         const onSubmit = vi.fn();
         const fields: FormField[] = [
@@ -726,7 +724,7 @@ describe('Form — existing tests', () => {
         }, null));
 
         // Submit with no values -> should produce required error and not call onSubmit
-        form.submit();
+        await form.submit();
         screen.rerender();
 
         // Validation message should be rendered in the UI
@@ -739,7 +737,7 @@ describe('Form — existing tests', () => {
         form.insertChar('A'); form.insertChar('l'); form.insertChar('i');
         form.nextField();
         form.insertChar('x'); // invalid number
-        form.submit();
+        await form.submit();
         screen.rerender();
 
         const out2 = screen.lastFrame().join('\n');
@@ -749,7 +747,7 @@ describe('Form — existing tests', () => {
         screen.unmount();
     });
 
-    it('onSubmit fires with collected values when validation passes', () => {
+    it('onSubmit fires with collected values when validation passes', async () => {
         let form!: Form;
         const onSubmit = vi.fn();
         const fields: FormField[] = [
@@ -772,7 +770,7 @@ describe('Form — existing tests', () => {
         // Fill numeric field
         form.insertChar('4'); form.insertChar('2');
 
-        form.submit();
+        await form.submit();
         screen.rerender();
 
         expect(onSubmit).toHaveBeenCalledTimes(1);

--- a/packages/ui/src/Form.ts
+++ b/packages/ui/src/Form.ts
@@ -23,6 +23,7 @@ export class Form extends Widget {
     private _errorColor: Style['fg'];
     private _activeColor: Style['fg'];
     private _onSubmit?: (values: Record<string, string>) => void;
+    private _isValidating = false;
     focusable = true;
 
     constructor(fields: FormField[], options: FormOptions = {}) {
@@ -52,16 +53,32 @@ export class Form extends Widget {
         const f = this._fields[this._activeField]; const cur = this._values.get(f.name) ?? '';
         if (this._cursorPos > 0) { this._values.set(f.name, cur.slice(0, this._cursorPos - 1) + cur.slice(this._cursorPos)); this._cursorPos--; this.markDirty(); }
     }
-    submit(): void {
-        this._errors.clear(); let hasErr = false;
-        for (const f of this._fields) {
+    async submit(): Promise<void> {
+        this._errors.clear();
+        this._isValidating = true;
+        this.markDirty();
+
+        let hasErr = false;
+
+        const validationPromises = this._fields.map(async (f) => {
             const v = this._values.get(f.name) ?? '';
-            if (f.required && !v.trim()) { this._errors.set(f.name, `${f.label} is required`); hasErr = true; }
-            const e = validateInput(f.validate, v);
-            if (e) {
-                this._errors.set(f.name, e);
-                hasErr = true;}
+            if (f.required && !v.trim()) {
+                return { name: f.name, err: `${f.label} is required` };
+            }
+            const e = await validateInput(f.validate, v);
+            return { name: f.name, err: e };
+        });
+
+        const results = await Promise.all(validationPromises);
+
+        for (const { name, err } of results) {
+            if (err) {
+                this._errors.set(name, err);
+                hasErr = true;
+            }
         }
+
+        this._isValidating = false;
         if (!hasErr) this._onSubmit?.(this.values);
         this.markDirty();
     }
@@ -95,7 +112,11 @@ export class Form extends Widget {
         }
         if (row < height) {
             const isSub = this._activeField >= this._fields.length;
-            screen.writeString(x, y + row, isSub ? '  [ Submit ]' : '    Submit  ', { ...attrs, fg: isSub ? { type: 'named', name: 'green' } : attrs.fg, bold: isSub });
+            if (this._isValidating) {
+                screen.writeString(x, y + row, '  [ Validating... ]', { ...attrs, fg: { type: 'named', name: 'yellow' } });
+            } else {
+                screen.writeString(x, y + row, isSub ? '  [ Submit ]' : '    Submit  ', { ...attrs, fg: isSub ? { type: 'named', name: 'green' } : attrs.fg, bold: isSub });
+            }
         }
     }
 }

--- a/packages/ui/src/validation.test.ts
+++ b/packages/ui/src/validation.test.ts
@@ -4,12 +4,12 @@ import { z } from 'zod';
 import { validateInput } from './validation.js';
 
 describe('validateInput', () => {
-    it('returns undefined when validator is undefined', () => {
-        expect(validateInput(undefined, 'hello')).toBeUndefined();
+    it('returns undefined when validator is undefined', async () => {
+        expect(await validateInput(undefined, 'hello')).toBeUndefined();
     });
 
-    it('supports function validators', () => {
-        const result = validateInput(
+    it('supports function validators', async () => {
+        const result = await validateInput(
             (v) => v === 'ok' ? undefined : 'Invalid value',
             'bad',
         );
@@ -17,10 +17,10 @@ describe('validateInput', () => {
         expect(result).toBe('Invalid value');
     });
 
-    it('supports Standard Schema validators', () => {
+    it('supports Standard Schema validators', async () => {
         const schema = z.string().email();
 
-        const result = validateInput(
+        const result = await validateInput(
             schema,
             'not-an-email',
         );
@@ -28,14 +28,26 @@ describe('validateInput', () => {
         expect(result).toBeDefined();
     });
 
-    it('passes valid Standard Schema values', () => {
+    it('passes valid Standard Schema values', async () => {
         const schema = z.string().email();
 
-        const result = validateInput(
+        const result = await validateInput(
             schema,
             'test@example.com',
         );
 
         expect(result).toBeUndefined();
+    });
+
+    it('supports async function validators', async () => {
+        const result = await validateInput(
+            async (v) => {
+                await new Promise((resolve) => setTimeout(resolve, 10));
+                return v === 'ok' ? undefined : 'Async error';
+            },
+            'bad',
+        );
+
+        expect(result).toBe('Async error');
     });
 });

--- a/packages/ui/src/validation.ts
+++ b/packages/ui/src/validation.ts
@@ -2,29 +2,33 @@ import type { StandardSchemaV1 } from '@standard-schema/spec';
 
 export type InputValidator =
     | StandardSchemaV1
-    | ((v: unknown) => string | undefined | null);
+    | ((v: unknown) => string | undefined | null | Promise<string | undefined | null>);
 
-export function validateInput(
+export async function validateInput(
     validator: InputValidator | undefined,
     value: unknown,
-): string | undefined {
+): Promise<string | undefined> {
     if (!validator) {
         return undefined;
     }
 
     if (typeof validator === 'function') {
-        return validator(value) ?? undefined;
+        const result = validator(value);
+        if (result instanceof Promise) {
+            return (await result) ?? undefined;
+        }
+        return result ?? undefined;
     }
 
     const result = validator['~standard'].validate(value);
 
-    if (result instanceof Promise) {
-        throw new Error('Async validators are not supported');
-    }
+    // Resolve the promise if it is async, otherwise use the synchronous result directly
+    const resolvedResult = result instanceof Promise ? await result : result;
+    const issues = resolvedResult.issues;
 
-    if (!result.issues?.length) {
+    if (!issues?.length) {
         return undefined;
     }
 
-    return result.issues[0]?.message ?? 'Validation failed';
+    return issues[0]?.message ?? 'Validation failed';
 }


### PR DESCRIPTION
## Description

This PR entirely removes the limitation preventing asynchronous validators in the Form engine. Developers can now pass `async` functions (or asynchronous Standard Schema validators) to handle API checks, DB queries, etc., prior to form submission.

Key changes:
- `validateInput` now strictly returns a `Promise<string | undefined>`.
- `Form.ts` `submit()` acts completely asynchronously, utilizing `Promise.all` to validate fields concurrently.
- `Form.ts` now possesses an internal `_isValidating` state to display a `[ Validating... ]` UI hint while the asynchronous operations are in flight.
- Overhauled `Form.test.ts` entirely to leverage async/await during submission actions.

## Related Issue

Closes #1505

## Which package(s)?

@termuijs/ui

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/f49aa65e-aab2-4e9f-99d6-2174f339ecfe`

## Screenshots / Recordings (UI changes)

*N/A*

## Notes for the Reviewer

- The validation promises are handled with `Promise.all()` to ensure validation does not artificially serialize and bottleneck submission if multiple async network requests are required simultaneously!
- Tests were systematically ported, making `form.submit()` strictly an awaited action.
