### PR TITLE
fix(ui): clean up store subscription on NotificationCenter.destroy()

### DIFF
--- a/packages/ui/src/NotificationCenter.test.ts
+++ b/packages/ui/src/NotificationCenter.test.ts
@@ -339,6 +339,38 @@ describe('NotificationCenter rendering and lifecycle', () => {
         expect(renderCenter(center)).not.toContain('+ After');
     });
 
+    it('destroy() cleans up store subscription and ignores later store updates', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+        const center = new NotificationCenter({ width: 24 });
+
+        store.push('Before', 'info');
+        expect(renderCenter(center)).toContain('i Before');
+
+        center.destroy();
+        expect(renderCenter(center)).not.toContain('i Before');
+
+        store.push('After', 'success');
+        expect(renderCenter(center)).not.toContain('+ After');
+    });
+
+    it('destroy() is safe to call multiple times', () => {
+        const center = new NotificationCenter({ width: 24 });
+        center.destroy();
+        center.destroy();
+        // No error thrown
+    });
+
+    it('destroy() stops store callbacks from firing on the widget', () => {
+        const center = new NotificationCenter({ width: 24 });
+        const markDirtySpy = vi.spyOn(center, 'markDirty');
+
+        center.destroy();
+        markDirtySpy.mockClear();
+
+        store.push('After destroy', 'info');
+        expect(markDirtySpy).not.toHaveBeenCalled();
+    });
+
     it('renders safely for zero-sized screens, empty messages, many notifications, and long messages', () => {
         vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
         const center = new NotificationCenter({ width: 80, maxVisible: 100 });

--- a/packages/ui/src/NotificationCenter.ts
+++ b/packages/ui/src/NotificationCenter.ts
@@ -155,10 +155,21 @@ export class NotificationCenter extends Widget {
     }
 
     override unmount(): void {
-        this._unsub?.();
-        this._unsub = undefined;
-        this._current = [];
+        this._cleanup();
         super.unmount();
+    }
+
+    override destroy(): void {
+        this._cleanup();
+        super.destroy();
+    }
+
+    private _cleanup(): void {
+        if (this._unsub) {
+            this._unsub();
+            this._unsub = undefined;
+        }
+        this._current = [];
     }
 
     protected override _renderSelf(screen: Screen): void {


### PR DESCRIPTION
## Summary

Fixes a memory leak in `NotificationCenter` where the store subscription was never cleaned up when the widget was destroyed via `destroy()`.

Closes #1662

## Root Cause

`NotificationCenter` subscribes to `NotificationStore` in its constructor and only unsubscribes in `unmount()`. The base `Widget.destroy()` method does not call `unmount()` — it only clears children, emits the unmount event, removes event listeners, and nulls the parent. This left the store subscription alive, causing:

- Memory leaks (instances never garbage collected)
- Callbacks firing on destroyed widgets (calling `markDirty()` on dead instances)
- Unbounded subscription growth in long-running apps

## Fix

Extracted the subscription cleanup logic into a private `_cleanup()` method and call it from both `unmount()` and a new `destroy()` override:

```typescript
override unmount(): void {
    this._cleanup();
    super.unmount();
}

override destroy(): void {
    this._cleanup();
    super.destroy();
}

private _cleanup(): void {
    if (this._unsub) {
        this._unsub();
        this._unsub = undefined;
    }
    this._current = [];
}
```

## Tests added

| Test | What it verifies |
|------|-----------------|
| destroy() cleans up store subscription and ignores later store updates | The original bug scenario |
| destroy() is safe to call multiple times | Idempotency |
| destroy() stops store callbacks from firing on the widget | No markDirty after destroy |

## Verification

- All 2155 UI tests pass (including 3 new tests)
- Typecheck passes across all packages
- No breaking changes to public API


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * NotificationCenter now properly cleans up subscriptions when destroyed.
  * Callbacks are prevented from executing after component destruction.
  * `destroy()` can be safely called multiple times without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->