### PR TITLE
feat: add loading spinner state to submit/action buttons

### DIFF
--- a/packages/widgets/src/input/Button.ts
+++ b/packages/widgets/src/input/Button.ts
@@ -2,8 +2,10 @@
 // @termuijs/widgets — Button widget
 // ─────────────────────────────────────────────────────
 
-import { type Screen, type Style, type Color, type KeyEvent, stringWidth, caps } from '@termuijs/core';
+import { type Screen, type Style, type Color, type KeyEvent, stringWidth, caps, prefersReducedMotion } from '@termuijs/core';
+import { timerPoolSubscribe } from '@termuijs/motion';
 import { Widget } from '../base/Widget.js';
+import { SPINNER_FRAMES } from '../feedback/Spinner.js';
 
 export type ButtonVariant = 'default' | 'primary' | 'danger' | 'ghost';
 
@@ -12,7 +14,13 @@ export interface ButtonOptions {
     disabled?: boolean;
     onPress?: () => void;
     color?: Color;
+    /** Show a loading spinner and suppress activation while true (default: false) */
+    loading?: boolean;
+    /** Label to display while loading (e.g. "Submitting...") — falls back to the normal label if omitted */
+    loadingText?: string;
 }
+
+const LOADING_SPINNER = SPINNER_FRAMES.dots;
 
 /** Background colors for each variant */
 const BG_COLORS: Record<ButtonVariant, Color> = {
@@ -42,6 +50,12 @@ export class Button extends Widget {
     private _disabled: boolean;
     private _onPress?: () => void;
     private _color?: Color;
+    private _loading: boolean;
+    private _loadingText?: string;
+    private _frames: string[];
+    private _interval: number;
+    private _startTime?: number;
+    private _timerUnsub?: () => void;
 
     constructor(label: string, style: Partial<Style> = {}, opts: ButtonOptions = {}) {
         super(style);
@@ -50,29 +64,80 @@ export class Button extends Widget {
         this._disabled = opts.disabled ?? false;
         this._onPress = opts.onPress;
         this._color = opts.color;
+        this._loading = opts.loading ?? false;
+        this._loadingText = opts.loadingText;
+        this._frames = caps.unicode ? LOADING_SPINNER.frames : LOADING_SPINNER.asciiFrames;
+        this._interval = LOADING_SPINNER.interval;
         this.focusable = true;
     }
 
     setLabel(label: string): void {
         if (this._label === label) return;
-
         this._label = label;
         this.markDirty();
     }
 
     setDisabled(disabled: boolean): void {
         if (this._disabled === disabled) return;
-        
         this._disabled = disabled;
         this.markDirty();
     }
 
+    /** Toggle the loading state. While loading, the button shows a spinner and ignores activation. */
+    setLoading(loading: boolean): void {
+        if (this._loading === loading) return;
+
+        this._loading = loading;
+        this.markDirty();
+
+        this._timerUnsub?.();
+        this._timerUnsub = undefined;
+        if (loading && !prefersReducedMotion()) {
+            this._startTime = Date.now();
+            this._timerUnsub = timerPoolSubscribe(this._interval, () => {
+                this.markDirty();
+            });
+        }
+    }
+
+    /** Update the text shown while loading (e.g. "Submitting..."). */
+    setLoadingText(loadingText: string | undefined): void {
+        this._loadingText = loadingText;
+        if (this._loading) this.markDirty();
+    }
+
     handleKey(event: KeyEvent): void {
-        if (this._disabled) return;
+        if (this._disabled || this._loading) return;
 
         if (event.key === 'enter' || event.key === 'space') {
             this._onPress?.();
         }
+    }
+
+    /** Lifecycle: start the spinner timer if mounted while already loading. */
+    mount(): void {
+        super.mount();
+        if (this._loading && !prefersReducedMotion()) {
+            this._startTime = Date.now();
+            this._timerUnsub = timerPoolSubscribe(this._interval, () => {
+                this.markDirty();
+            });
+        }
+    }
+
+    /** Lifecycle: stop the spinner timer. */
+    unmount(): void {
+        this._timerUnsub?.();
+        this._timerUnsub = undefined;
+        super.unmount();
+    }
+
+    /** Compute the current spinner frame character based on elapsed time. */
+    private _currentFrame(): string {
+        if (prefersReducedMotion() || this._startTime === undefined) return this._frames[0];
+        const elapsed = Date.now() - this._startTime;
+        const idx = Math.floor(elapsed / this._interval) % this._frames.length;
+        return this._frames[idx];
     }
 
     protected _renderSelf(screen: Screen): void {
@@ -81,12 +146,10 @@ export class Button extends Widget {
 
         const bg = this._color ?? BG_COLORS[this._variant];
         const fg = FG_COLORS[this._variant];
-        // Focus indicator: use accent color when focused
         const borderFg = this.isFocused
             ? { type: 'named' as const, name: 'cyan' as const }
             : fg;
 
-        // Choose border characters based on unicode support
         const tl = caps.unicode ? '┌' : '+';
         const tr = caps.unicode ? '┐' : '+';
         const bl = caps.unicode ? '└' : '+';
@@ -94,14 +157,15 @@ export class Button extends Widget {
         const hz = caps.unicode ? '─' : '-';
         const vt = caps.unicode ? '│' : '|';
 
-        // Padded text: " label "
-        const padded = ` ${this._label} `;
+        // Padded text: " label " — swap in spinner + loading text while loading
+        const displayLabel = this._loading
+            ? `${this._currentFrame()} ${this._loadingText ?? this._label}`
+            : this._label;
+        const padded = ` ${displayLabel} `;
         const textWidth = stringWidth(padded);
 
-        // Inner width is the area between left and right border
         const innerWidth = Math.min(textWidth, Math.max(0, width - 2));
 
-        // ── Row 0: top border ──
         if (height >= 1) {
             screen.setCell(x, y, { char: tl, fg: borderFg, bg });
             for (let c = 1; c <= innerWidth; c++) {
@@ -112,28 +176,19 @@ export class Button extends Widget {
             }
         }
 
-        // ── Row 1: content row ──
         if (height >= 2) {
             screen.setCell(x, y + 1, { char: vt, fg: borderFg, bg });
-            
-            // Center the text in the available width
             const startX = x + 1;
             const textStartX = startX + Math.floor((innerWidth - textWidth) / 2);
-            
-            // Write the centered label
             screen.writeString(textStartX, y + 1, padded, { fg: borderFg, bg });
-            
-            // Fill remaining space with background
             for (let c = textStartX + textWidth; c < startX + innerWidth; c++) {
                 screen.setCell(c, y + 1, { char: ' ', fg: borderFg, bg });
             }
-            
             if (innerWidth + 1 < width) {
                 screen.setCell(x + innerWidth + 1, y + 1, { char: vt, fg: borderFg, bg });
             }
         }
 
-        // ── Row 2: bottom border ──
         if (height >= 3) {
             screen.setCell(x, y + 2, { char: bl, fg: borderFg, bg });
             for (let c = 1; c <= innerWidth; c++) {

--- a/packages/widgets/src/input/Button.ts
+++ b/packages/widgets/src/input/Button.ts
@@ -118,6 +118,7 @@ export class Button extends Widget {
     mount(): void {
         super.mount();
         if (this._loading && !prefersReducedMotion()) {
+            this._timerUnsub?.();
             this._startTime = Date.now();
             this._timerUnsub = timerPoolSubscribe(this._interval, () => {
                 this.markDirty();


### PR DESCRIPTION
Closes #1657

## Changes
- Added `loading` and `loadingText` options to Button widget
- Button shows an animated spinner + optional text while loading
- Activation (Enter/Space) is ignored while loading to prevent duplicate submissions
- Respects reduced-motion and ASCII (NO_UNICODE) fallback, following existing Spinner widget conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Buttons now support a loading state (`loading`) with customizable loading text (`loadingText`)
  * While loading, button activation is disabled to help prevent accidental repeat actions
  * An animated loading indicator is shown during loading and respects system reduced-motion preferences
<!-- end of auto-generated comment: release notes by coderabbit.ai -->