### PR TITLE
Fix #1680: Add mouseenter/mouseleave event handling based on widget bounds

### DIFF
--- a/packages/core/src/app/App.ts
+++ b/packages/core/src/app/App.ts
@@ -87,6 +87,7 @@ export class App {
     private _unsubUncaughtException: (() => void) | null = null;
     private _unsubUnhandledRejection: (() => void) | null = null;
     private _widgetById = new Map<string, any>(); // any: Widget shape varies; narrowed at retrieval
+    private _hoveredWidgetId: string | null = null;
     private _pendingFocusState = new Map<string, boolean>();
 
     private _consecutiveRenderFailures = 0;
@@ -217,6 +218,26 @@ export class App {
         // Forward mouse events
         this._unsubMouse = this.input.onMouse((event) => {
             this.events.emit('mouse', event);
+
+            if (event.type === 'mousemove') {
+                const hitWidget = this._findWidgetAt(event.x, event.y);
+                const hitId = hitWidget?.id ?? null;
+
+                if (hitId !== this._hoveredWidgetId) {
+                    const prevWidget = this._hoveredWidgetId
+                        ? this._widgetById.get(this._hoveredWidgetId)
+                        : null;
+                    if (prevWidget) {
+                        prevWidget.events.emit('mouseleave', event);
+                    }
+
+                    if (hitWidget) {
+                        hitWidget.events.emit('mouseenter', event);
+                    }
+
+                    this._hoveredWidgetId = hitId;
+                }
+            }
         });
 
         // Forward paste events
@@ -565,6 +586,18 @@ export class App {
         }
     }
 
+    private _findWidgetAt(x: number, y: number): any {
+        let found: any = null;
+        for (const widget of this._widgetById.values()) {
+            const r = widget.rect;
+            if (!r) continue;
+            if (x >= r.x && x < r.x + r.width && y >= r.y && y < r.y + r.height) {
+                found = widget;
+            }
+        }
+        return found;
+    }
+
     private _isFocusAwareWidget(widget: unknown): widget is FocusAwareWidget {
         return typeof widget === 'object'
             && widget !== null
@@ -574,3 +607,5 @@ export class App {
             && typeof widget.isFocused === 'boolean';
     }
 }
+
+

--- a/packages/core/src/app/App.ts
+++ b/packages/core/src/app/App.ts
@@ -135,6 +135,7 @@ export class App {
         }
 
         this._mounted = true;
+        this._hoveredWidgetId = null;
         // Focus subscriptions are interactive-only; fallback mount returns
         // without unmount(), so constructor subscriptions would leak there.
         this._subscribeFocusEvents();
@@ -228,11 +229,11 @@ export class App {
                         ? this._widgetById.get(this._hoveredWidgetId)
                         : null;
                     if (prevWidget) {
-                        prevWidget.events.emit('mouseleave', event);
+                        prevWidget.events.emit('mouseleave', { ...event, type: 'mouseleave' });
                     }
 
                     if (hitWidget) {
-                        hitWidget.events.emit('mouseenter', event);
+                        hitWidget.events.emit('mouseenter', { ...event, type: 'mouseenter' });
                     }
 
                     this._hoveredWidgetId = hitId;
@@ -303,6 +304,7 @@ export class App {
     unmount(exitCode: number = 0): void {
         if (!this._mounted) return;
         this._mounted = false;
+        this._hoveredWidgetId = null;
 
         this._rootWidget.unmount?.();
         this.events.emit('unmount', undefined as any); // as any: EventEmitter generic requires a value; payload is intentionally void
@@ -586,8 +588,8 @@ export class App {
         }
     }
 
-    private _findWidgetAt(x: number, y: number): any {
-        let found: any = null;
+    private _findWidgetAt(x: number, y: number): any { // any: widget shape varies; narrowed at retrieval
+        let found: any = null; // any: WidgetNode shape not statically known at traversal
         for (const widget of this._widgetById.values()) {
             const r = widget.rect;
             if (!r) continue;
@@ -607,5 +609,11 @@ export class App {
             && typeof widget.isFocused === 'boolean';
     }
 }
+
+
+
+
+
+
 
 

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -54,7 +54,7 @@ export function createKeyEvent(base: {
  */
 export type MouseEventType =
     | 'mousedown' | 'mouseup' | 'mousemove' | 'scroll'
-    | 'dblclick' | 'drag' | 'dragend';
+    | 'dblclick' | 'drag' | 'dragend' | 'mouseenter' | 'mouseleave';
 export type MouseButton = 'left' | 'middle' | 'right' | 'none';
 
 /**


### PR DESCRIPTION
Fixes #1680

   Added hover detection logic in App.ts that tracks mouse position and 
   determines which widget the cursor is currently inside using widget 
   bounds. When the hovered widget changes, it emits 'mouseenter' and 
   'mouseleave' events on the widget's event emitter, which the useHover() 
   hook listens to.

   Also added 'mouseenter' and 'mouseleave' to the MouseEventType union 
   in types.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added widget hover detection and tracking: The app now performs hit-testing during mouse movement to accurately identify which widget is being hovered. It automatically emits mouseenter and mouseleave events when hover state changes, enabling widgets to respond dynamically to user interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->