### PR TITLE
feat: enhance SplitPane with vertical resizing and layout persistence

### DIFF
--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -127,7 +127,7 @@ export type { DraggableOptions, DroppableOptions } from './layout/DragAndDrop.js
 export { Fill } from './layout/Fill.js';
 export type { FillOptions } from './layout/Fill.js';
 export { SplitPane } from './layout/SplitPane.js';
-export type { SplitPaneOptions } from './layout/SplitPane.js';
+export type { SplitPaneOptions, SplitDirection } from './layout/SplitPane.js';
 
 // ── Feedback Widgets ──────────────────────────────────
 export { ProgressBar } from './feedback/ProgressBar.js';

--- a/packages/widgets/src/layout/SplitPane.ts
+++ b/packages/widgets/src/layout/SplitPane.ts
@@ -2,7 +2,13 @@
 // @termuijs/widgets — SplitPane layout widget
 // ─────────────────────────────────────────────────────
 
-import { type Screen, type Style, type KeyEvent, caps, styleToCellAttrs } from '@termuijs/core';
+import {
+    type Screen,
+    type Style,
+    type KeyEvent,
+    caps,
+    styleToCellAttrs,
+} from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
 export type SplitDirection = 'horizontal' | 'vertical';
@@ -15,16 +21,12 @@ export interface SplitPaneOptions {
 }
 
 /**
- * SplitPane — two-pane horizontal layout with a draggable divider.
- *
- * The left pane occupies columns [0, leftWidth − 1], the divider sits at
- * leftWidth, and the right pane occupies [leftWidth + 1, totalWidth − 1].
- * Use shift+left / shift+right to resize when focused.
+ * SplitPane — two-pane resizable layout widget.
  */
 export class SplitPane extends Widget {
     private _ratio: number;
     private readonly _minSize: number;
-    private readonly _direction: SplitDirection;
+    private _direction: SplitDirection;
     private readonly _persistent: boolean;
 
     constructor(
@@ -34,10 +36,12 @@ export class SplitPane extends Widget {
         opts: SplitPaneOptions = {},
     ) {
         super(style);
+
         this._ratio = opts.ratio ?? 0.5;
         this._minSize = opts.minSize ?? 1;
         this._direction = opts.direction ?? 'horizontal';
         this._persistent = opts.persistent ?? false;
+
         this.focusable = true;
         this.addChild(left);
         this.addChild(right);
@@ -48,47 +52,95 @@ export class SplitPane extends Widget {
     }
 
     setRatio(ratio: number): void {
-        const totalWidth = this._getContentRect().width;
-        this._ratio = totalWidth > 0 ? this._clampRatio(ratio, totalWidth) : ratio;
-        this.markDirty();
+        const content = this._getContentRect();
+
+        const totalSize =
+            this._direction === 'horizontal'
+                ? content.width
+                : content.height;
+
+        const newRatio =
+            totalSize > 0 ? this._clampRatio(ratio, totalSize) : ratio;
+
+        if (newRatio !== this._ratio) {
+            this._ratio = newRatio;
+            this.markDirty();
+        }
     }
 
     handleKey(event: KeyEvent): void {
         if (!event.shift) return;
 
-        const totalWidth = this._getContentRect().width;
-        if (totalWidth <= 0) return;
+        const content = this._getContentRect();
 
-        const step = 1 / totalWidth;
+        const totalSize =
+            this._direction === 'horizontal'
+                ? content.width
+                : content.height;
+
+        if (totalSize <= 0) return;
+
+        const step = 1 / totalSize;
+
         if (
-            (this._direction === 'horizontal' && event.key === 'left') ||
-            (this._direction === 'vertical' && event.key === 'up')
+            (this._direction === 'horizontal' &&
+                event.key === 'left') ||
+            (this._direction === 'vertical' &&
+                event.key === 'up')
         ) {
             this.setRatio(this._ratio - step);
         } else if (
-            (this._direction === 'horizontal' && event.key === 'right') ||
-            (this._direction === 'vertical' && event.key === 'down')
+            (this._direction === 'horizontal' &&
+                event.key === 'right') ||
+            (this._direction === 'vertical' &&
+                event.key === 'down')
         ) {
             this.setRatio(this._ratio + step);
         }
     }
 
     saveLayout(): string {
-    if (!this._persistent) {
-        return '';
+        if (!this._persistent) {
+            return '';
+        }
+
+        return JSON.stringify({
+            ratio: this._ratio,
+            direction: this._direction,
+        });
     }
 
-    return JSON.stringify({
-        ratio: this._ratio,
-        direction: this._direction,
-    });
-}
+    loadLayout(data: string): void {
+        try {
+            const layout = JSON.parse(data);
 
-loadLayout(data: string): void {
-    const layout = JSON.parse(data);
-    this._ratio = layout.ratio ?? this._ratio;
-    this.markDirty();
-}
+            let changed = false;
+
+            if (
+                typeof layout.ratio === 'number' &&
+                layout.ratio !== this._ratio
+            ) {
+                this._ratio = layout.ratio;
+                changed = true;
+            }
+
+            if (
+                layout.direction === 'horizontal' ||
+                layout.direction === 'vertical'
+            ) {
+                if (layout.direction !== this._direction) {
+                    this._direction = layout.direction;
+                    changed = true;
+                }
+            }
+
+            if (changed) {
+                this.markDirty();
+            }
+        } catch {
+            // Ignore malformed layout data
+        }
+    }
 
     override syncLayout(): void {
         super.syncLayout();
@@ -96,49 +148,94 @@ loadLayout(data: string): void {
     }
 
     protected _renderSelf(screen: Screen): void {
-        const content = this._getContentRect();
-        const { x, y, width, height } = content;
-        if (width <= 0 || height <= 0) return;
+        const { x, y, width, height } = this._getContentRect();
 
-        const leftWidth = Math.floor(this._ratio * width);
-        const dividerX = x + leftWidth;
+        if (width <= 0 || height <= 0) {
+            return;
+        }
+
         const dividerChar = caps.unicode ? '│' : '|';
         const attrs = styleToCellAttrs(this._style);
 
-        for (let row = 0; row < height; row++) {
-            screen.setCell(dividerX, y + row, { char: dividerChar, ...attrs });
+        if (this._direction === 'horizontal') {
+            const firstSize = Math.floor(this._ratio * width);
+            const dividerX = x + firstSize;
+
+            for (let row = 0; row < height; row++) {
+                screen.setCell(dividerX, y + row, {
+                    char: dividerChar,
+                    ...attrs,
+                });
+            }
+        } else {
+            const firstSize = Math.floor(this._ratio * height);
+            const dividerY = y + firstSize;
+
+            for (let col = 0; col < width; col++) {
+                screen.setCell(col + x, dividerY, {
+                    char: '─',
+                    ...attrs,
+                });
+            }
         }
     }
 
-    private _clampRatio(ratio: number, totalWidth: number): number {
-        const minRatio = this._minSize / totalWidth;
-        const maxRatio = 1 - this._minSize / totalWidth;
+    private _clampRatio(
+        ratio: number,
+        totalSize: number,
+    ): number {
+        const minRatio = this._minSize / totalSize;
+        const maxRatio = 1 - this._minSize / totalSize;
+
         return Math.max(minRatio, Math.min(maxRatio, ratio));
     }
 
     private _positionChildren(): void {
         const left = this._children[0];
         const right = this._children[1];
-        if (!left || !right) return;
 
-        const content = this._getContentRect();
-        const totalWidth = content.width;
-        if (totalWidth <= 0) return;
+        if (!left || !right) {
+            return;
+        }
 
-        const leftWidth = Math.floor(this._ratio * totalWidth);
+        const { x, y, width, height } = this._getContentRect();
 
-        left.updateRect({
-            x: content.x,
-            y: content.y,
-            width: leftWidth,
-            height: content.height,
-        });
+        if (width <= 0 || height <= 0) {
+            return;
+        }
 
-        right.updateRect({
-            x: content.x + leftWidth + 1,
-            y: content.y,
-            width: Math.max(0, totalWidth - leftWidth - 1),
-            height: content.height,
-        });
+        if (this._direction === 'horizontal') {
+            const firstWidth = Math.floor(this._ratio * width);
+
+            left.updateRect({
+                x,
+                y,
+                width: firstWidth,
+                height,
+            });
+
+            right.updateRect({
+                x: x + firstWidth + 1,
+                y,
+                width: Math.max(0, width - firstWidth - 1),
+                height,
+            });
+        } else {
+            const firstHeight = Math.floor(this._ratio * height);
+
+            left.updateRect({
+                x,
+                y,
+                width,
+                height: firstHeight,
+            });
+
+            right.updateRect({
+                x,
+                y: y + firstHeight + 1,
+                width,
+                height: Math.max(0, height - firstHeight - 1),
+            });
+        }
     }
 }

--- a/packages/widgets/src/layout/SplitPane.ts
+++ b/packages/widgets/src/layout/SplitPane.ts
@@ -5,11 +5,13 @@
 import { type Screen, type Style, type KeyEvent, caps, styleToCellAttrs } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
+export type SplitDirection = 'horizontal' | 'vertical';
+
 export interface SplitPaneOptions {
-    /** Horizontal split ratio for the left pane (0–1, default: 0.5) */
     ratio?: number;
-    /** Minimum width in cells for each pane (default: 1) */
     minSize?: number;
+    direction?: SplitDirection;
+    persistent?: boolean;
 }
 
 /**
@@ -22,6 +24,8 @@ export interface SplitPaneOptions {
 export class SplitPane extends Widget {
     private _ratio: number;
     private readonly _minSize: number;
+    private readonly _direction: SplitDirection;
+    private readonly _persistent: boolean;
 
     constructor(
         left: Widget,
@@ -32,6 +36,8 @@ export class SplitPane extends Widget {
         super(style);
         this._ratio = opts.ratio ?? 0.5;
         this._minSize = opts.minSize ?? 1;
+        this._direction = opts.direction ?? 'horizontal';
+        this._persistent = opts.persistent ?? false;
         this.focusable = true;
         this.addChild(left);
         this.addChild(right);
@@ -54,12 +60,35 @@ export class SplitPane extends Widget {
         if (totalWidth <= 0) return;
 
         const step = 1 / totalWidth;
-        if (event.key === 'left') {
+        if (
+            (this._direction === 'horizontal' && event.key === 'left') ||
+            (this._direction === 'vertical' && event.key === 'up')
+        ) {
             this.setRatio(this._ratio - step);
-        } else if (event.key === 'right') {
+        } else if (
+            (this._direction === 'horizontal' && event.key === 'right') ||
+            (this._direction === 'vertical' && event.key === 'down')
+        ) {
             this.setRatio(this._ratio + step);
         }
     }
+
+    saveLayout(): string {
+    if (!this._persistent) {
+        return '';
+    }
+
+    return JSON.stringify({
+        ratio: this._ratio,
+        direction: this._direction,
+    });
+}
+
+loadLayout(data: string): void {
+    const layout = JSON.parse(data);
+    this._ratio = layout.ratio ?? this._ratio;
+    this.markDirty();
+}
 
     override syncLayout(): void {
         super.syncLayout();


### PR DESCRIPTION
## Description

Added a new `SplitPane` widget for creating resizable terminal layouts.

### Changes
- Added SplitPane component
- Added keyboard resizing support
- Added configurable split ratio and minimum size
- Exported SplitPane in widgets public API

Closes #1693

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SplitPane now supports configurable horizontal and vertical layout directions, including correct divider rendering and child positioning for vertical splits.
  * Added `direction` and `persistent` options to control orientation and whether the split state is saved.
  * Introduced `saveLayout()` and `loadLayout()` to persist and restore the split ratio and orientation (malformed data is safely ignored).
  * Keyboard resizing is now direction-aware (Shift+Left/Right for horizontal, Shift+Up/Down for vertical).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->