### PR TITLE
feat(ui): add SearchPanel and Workspace utility classes

### DIFF
--- a/packages/ui/src/SearchPanel.ts
+++ b/packages/ui/src/SearchPanel.ts
@@ -1,0 +1,32 @@
+export interface SearchPanelOptions {
+    placeholder?: string;
+    fuzzySearch?: boolean;
+    highlightMatches?: boolean;
+    shortcut?: string;
+}
+
+export class SearchPanel {
+    private _query = '';
+    readonly options: Required<SearchPanelOptions>;
+
+    constructor(options: SearchPanelOptions = {}) {
+        this.options = {
+            placeholder: options.placeholder ?? 'Search...',
+            fuzzySearch: options.fuzzySearch ?? true,
+            highlightMatches: options.highlightMatches ?? true,
+            shortcut: options.shortcut ?? 'Ctrl+F',
+        };
+    }
+
+    get query(): string { return this._query; }
+
+    setQuery(value: string): void { this._query = value; }
+
+    search(items: string[]): string[] {
+        if (!this._query) return items;
+        const q = this._query.toLowerCase();
+        return items.filter(item => item.toLowerCase().includes(q));
+    }
+
+    clear(): void { this._query = ''; }
+}

--- a/packages/ui/src/Workspace.ts
+++ b/packages/ui/src/Workspace.ts
@@ -1,0 +1,43 @@
+export interface WorkspaceOptions {
+    tabs: string[];
+    activeTab?: number;
+    shortcutEnabled?: boolean;
+    onTabChange?: (index: number, label: string) => void;
+}
+
+export class Workspace {
+    private _tabs: string[];
+    private _active: number;
+    readonly shortcutEnabled: boolean;
+    onTabChange?: (index: number, label: string) => void;
+
+    constructor(options: WorkspaceOptions) {
+        this._tabs = [...options.tabs];
+        this._active = Math.max(0, Math.min(options.activeTab ?? 0, options.tabs.length - 1));
+        this.shortcutEnabled = options.shortcutEnabled ?? true;
+        this.onTabChange = options.onTabChange;
+    }
+
+    get tabs(): string[] { return [...this._tabs]; }
+    get activeIndex(): number { return this._active; }
+    get activeTab(): string { return this._tabs[this._active]; }
+
+    switchTab(index: number): void {
+        if (index < 0 || index >= this._tabs.length || index === this._active) return;
+        this._active = index;
+        this.onTabChange?.(index, this._tabs[index]);
+    }
+
+    nextTab(): void { this.switchTab((this._active + 1) % this._tabs.length); }
+    previousTab(): void { this.switchTab((this._active - 1 + this._tabs.length) % this._tabs.length); }
+
+    saveLayout(): string {
+        return JSON.stringify({ tabs: this._tabs, activeIndex: this._active });
+    }
+
+    loadLayout(layout: string): void {
+        const data = JSON.parse(layout) as { tabs: string[]; activeIndex: number };
+        this._tabs = data.tabs;
+        this._active = data.activeIndex;
+    }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -255,3 +255,9 @@ export type { TokenUsageOptions } from './TokenUsage.js';
 
 export { createValidator } from './FormValidator.js';
 export type { ValidationRule, ValidationSchema, ValidationResult } from './FormValidator.js';
+
+export { SearchPanel } from './SearchPanel.js';
+export type { SearchPanelOptions } from './SearchPanel.js';
+
+export { Workspace } from './Workspace.js';
+export type { WorkspaceOptions } from './Workspace.js';


### PR DESCRIPTION
## Summary

- Adds `SearchPanel` — query filter utility with `search(items)`, `setQuery()`, `clear()`
- Adds `Workspace` — tab state manager with `nextTab()`, `previousTab()`, `saveLayout()`, `loadLayout()`
- Both exported from `@termuijs/ui`

Salvaged unique changes from #1638 and #1639 onto a clean branch from main (original PRs carried 20 unrelated baggage commits that could not be merged).

Co-authored-by: Karanjot786 <karanjots801@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search panel component with configurable options for match highlighting, fuzzy search, and keyboard shortcuts
  * Added workspace management system for tabbed interfaces with tab navigation and layout persistence capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->