### PR TITLE
fix(core): cap ChordMatcher buffer to prevent unbounded growth

### DIFF
--- a/packages/core/src/input/ChordMatcher.ts
+++ b/packages/core/src/input/ChordMatcher.ts
@@ -11,6 +11,7 @@ export interface Chord {
 
 export interface ChordMatcherOptions {
   timeoutMs?: number;
+  maxBufferSize?: number;
 }
 
 function getKeyEventToken(event: KeyEvent): string {
@@ -27,10 +28,12 @@ export class ChordMatcher {
   private _nextId = 0;
   private _buffer: string[] = [];
   private _timeoutMs: number;
+  private _maxBufferSize: number;
   private _timer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(opts?: ChordMatcherOptions) {
     this._timeoutMs = opts?.timeoutMs ?? 800;
+    this._maxBufferSize = opts?.maxBufferSize ?? 10;
   }
 
   bind(keys: string[], handler: () => void): () => void {
@@ -49,6 +52,12 @@ export class ChordMatcher {
 
     const token = getKeyEventToken(event);
     let candidate = [...this._buffer, token];
+
+    if (candidate.length > this._maxBufferSize) {
+      this._buffer = [];
+      candidate = [token];
+    }
+
     let matchingBindings = this._getMatchingBindings(candidate);
 
     if (matchingBindings.length === 0) {


### PR DESCRIPTION
## Description

`ChordMatcher` stores every key press in its internal buffer without a size limit. Holding down a key floods the buffer, and the chord is never matched against the expected sequence, breaking chord detection.

## Changes

- Added `maxBufferSize` option (default 10) to the `ChordMatcher` constructor
- Before attempting a match, checks if buffer length exceeds the limit
- When over limit, resets the buffer, then continues to match the current key against the expected chord

## Testing

- Verified unbounded key presses no longer break chord matching
- Buffer resets cleanly when limit is exceeded
- Existing chord tests continue to pass

Closes #1711