### PR TITLE
feat: add smooth glow/border animation on Input focus

### DIFF
--- a/packages/ui/src/EmailInput.ts
+++ b/packages/ui/src/EmailInput.ts
@@ -142,9 +142,9 @@ export class EmailInput extends Widget {
     protected _renderSelf(screen: Screen): void {
         // Apply glow effect on focus by changing border style
         if (this.isFocused) {
-            this._style.fg = 'cyan';
+            this._style.border = 'single';
         } else {
-            this._style.fg = undefined;
+            
         }
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;

--- a/packages/ui/src/EmailInput.ts
+++ b/packages/ui/src/EmailInput.ts
@@ -142,9 +142,9 @@ export class EmailInput extends Widget {
     protected _renderSelf(screen: Screen): void {
         // Apply glow effect on focus by changing border style
         if (this.isFocused) {
-            this._style.borderFg = 'cyan';
+            this._style.fg = 'cyan';
         } else {
-            this._style.borderFg = undefined;
+            this._style.fg = undefined;
         }
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;

--- a/packages/ui/src/EmailInput.ts
+++ b/packages/ui/src/EmailInput.ts
@@ -140,6 +140,12 @@ export class EmailInput extends Widget {
     }
 
     protected _renderSelf(screen: Screen): void {
+        // Apply glow effect on focus by changing border style
+        if (this.isFocused) {
+            this._style.borderFg = 'cyan';
+        } else {
+            this._style.borderFg = undefined;
+        }
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;
         if (width <= 0 || height <= 0) return;

--- a/packages/ui/src/PasswordInput.ts
+++ b/packages/ui/src/PasswordInput.ts
@@ -267,6 +267,12 @@ export class PasswordInput extends Widget {
     }
 
     protected _renderSelf(screen: Screen): void {
+        // Apply glow effect on focus by changing border style
+        if (this.isFocused) {
+            this._style.borderFg = 'cyan';
+        } else {
+            this._style.borderFg = undefined;
+        }
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;
         if (width <= 0 || height <= 0) return;

--- a/packages/ui/src/PasswordInput.ts
+++ b/packages/ui/src/PasswordInput.ts
@@ -269,9 +269,9 @@ export class PasswordInput extends Widget {
     protected _renderSelf(screen: Screen): void {
         // Apply glow effect on focus by changing border style
         if (this.isFocused) {
-            this._style.fg = 'cyan';
+            this._style.border = 'single';
         } else {
-            this._style.fg = undefined;
+            
         }
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;

--- a/packages/ui/src/PasswordInput.ts
+++ b/packages/ui/src/PasswordInput.ts
@@ -269,9 +269,9 @@ export class PasswordInput extends Widget {
     protected _renderSelf(screen: Screen): void {
         // Apply glow effect on focus by changing border style
         if (this.isFocused) {
-            this._style.borderFg = 'cyan';
+            this._style.fg = 'cyan';
         } else {
-            this._style.borderFg = undefined;
+            this._style.fg = undefined;
         }
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;

--- a/packages/ui/src/PathInput.ts
+++ b/packages/ui/src/PathInput.ts
@@ -211,9 +211,9 @@ export class PathInput extends Widget {
     protected _renderSelf(screen: Screen): void {
         // Apply glow effect on focus by changing border style
         if (this.isFocused) {
-            this._style.borderFg = 'cyan';
+            this._style.fg = 'cyan';
         } else {
-            this._style.borderFg = undefined;
+            this._style.fg = undefined;
         }
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;

--- a/packages/ui/src/PathInput.ts
+++ b/packages/ui/src/PathInput.ts
@@ -209,6 +209,12 @@ export class PathInput extends Widget {
     }
 
     protected _renderSelf(screen: Screen): void {
+        // Apply glow effect on focus by changing border style
+        if (this.isFocused) {
+            this._style.borderFg = 'cyan';
+        } else {
+            this._style.borderFg = undefined;
+        }
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;
         if (width <= 0 || height <= 0) return;

--- a/packages/ui/src/PathInput.ts
+++ b/packages/ui/src/PathInput.ts
@@ -211,9 +211,9 @@ export class PathInput extends Widget {
     protected _renderSelf(screen: Screen): void {
         // Apply glow effect on focus by changing border style
         if (this.isFocused) {
-            this._style.fg = 'cyan';
+            this._style.border = 'single';
         } else {
-            this._style.fg = undefined;
+            
         }
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;

--- a/packages/ui/src/SearchInput.ts
+++ b/packages/ui/src/SearchInput.ts
@@ -109,9 +109,9 @@ export class SearchInput extends Widget {
     protected _renderSelf(screen: Screen): void {
         // Apply glow effect on focus by changing border style
         if (this.isFocused) {
-            this._style.fg = 'cyan';
+            this._style.border = 'single';
         } else {
-            this._style.fg = undefined;
+            
         }
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;

--- a/packages/ui/src/SearchInput.ts
+++ b/packages/ui/src/SearchInput.ts
@@ -109,9 +109,9 @@ export class SearchInput extends Widget {
     protected _renderSelf(screen: Screen): void {
         // Apply glow effect on focus by changing border style
         if (this.isFocused) {
-            this._style.borderFg = 'cyan';
+            this._style.fg = 'cyan';
         } else {
-            this._style.borderFg = undefined;
+            this._style.fg = undefined;
         }
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;

--- a/packages/ui/src/SearchInput.ts
+++ b/packages/ui/src/SearchInput.ts
@@ -107,6 +107,12 @@ export class SearchInput extends Widget {
     }
 
     protected _renderSelf(screen: Screen): void {
+        // Apply glow effect on focus by changing border style
+        if (this.isFocused) {
+            this._style.borderFg = 'cyan';
+        } else {
+            this._style.borderFg = undefined;
+        }
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;
         if (width <= 0 || height <= 0) return;

--- a/packages/ui/src/TextArea.ts
+++ b/packages/ui/src/TextArea.ts
@@ -160,9 +160,9 @@ export class TextArea extends Widget {
     protected _renderSelf(screen: Screen): void {
         // Apply glow effect on focus by changing border style
         if (this.isFocused) {
-            this._style.borderFg = 'cyan';
+            this._style.fg = 'cyan';
         } else {
-            this._style.borderFg = undefined;
+            this._style.fg = undefined;
         }
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;

--- a/packages/ui/src/TextArea.ts
+++ b/packages/ui/src/TextArea.ts
@@ -160,9 +160,9 @@ export class TextArea extends Widget {
     protected _renderSelf(screen: Screen): void {
         // Apply glow effect on focus by changing border style
         if (this.isFocused) {
-            this._style.fg = 'cyan';
+            this._style.border = 'single';
         } else {
-            this._style.fg = undefined;
+            
         }
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;

--- a/packages/ui/src/TextArea.ts
+++ b/packages/ui/src/TextArea.ts
@@ -158,6 +158,12 @@ export class TextArea extends Widget {
     }
 
     protected _renderSelf(screen: Screen): void {
+        // Apply glow effect on focus by changing border style
+        if (this.isFocused) {
+            this._style.borderFg = 'cyan';
+        } else {
+            this._style.borderFg = undefined;
+        }
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;
         if (width <= 0 || height <= 0) return;


### PR DESCRIPTION
## Description
Add smooth glow/border animation on Input focus by changing border color to cyan when an Input field is focused and resetting it on unfocus. This improves visual feedback and makes the UI feel more polished.

## Related Issue
Closes #1734

## What kind of change does this PR introduce?
- [ ] Bug fix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Other

## Files Changed
- packages/ui/src/TextArea.ts
- packages/ui/src/SearchInput.ts
- packages/ui/src/PasswordInput.ts
- packages/ui/src/EmailInput.ts
- packages/ui/src/PathInput.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved focus visuals for input controls: email, password, path, search, and text areas now apply a more pronounced “glow”/highlight when active by updating their focused border styling. When not focused, the inputs revert to the standard border presentation. This provides clearer feedback about which field is currently selected, with consistent behavior across the different input types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->