### PR TITLE
test(widgets): add unit tests for useTableState

### DIFF
--- a/packages/widgets/src/data/TableState.test.ts
+++ b/packages/widgets/src/data/TableState.test.ts
@@ -1,0 +1,99 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for useTableState
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import { useTableState } from './TableState.js';
+import type { TableRow } from './Table.js';
+
+// ── Helpers ───────────────────────────────────────────
+
+const makeRow = (cells: string[]): TableRow => ({
+    cells,
+} as unknown as TableRow);
+
+const makeRows = (): TableRow[] => [
+    makeRow(['Alice', '30', 'Engineer']),
+    makeRow(['Bob',   '25', 'Designer']),
+    makeRow(['Carol', '35', 'Manager']),
+];
+
+// ── Tests ─────────────────────────────────────────────
+
+describe('useTableState', () => {
+
+    // ── initialization ────────────────────────────────
+
+    it('initializes with provided rows', () => {
+        const state = useTableState({ rows: makeRows() });
+        expect(state.rows).toHaveLength(3);
+    });
+
+    it('initializes scrollOffset to 0', () => {
+        const state = useTableState({ rows: makeRows() });
+        expect(state.scrollOffset).toBe(0);
+    });
+
+    // ── setRows ───────────────────────────────────────
+
+    it('setRows() updates the rows', () => {
+        const state = useTableState({ rows: makeRows() });
+        const newRows: TableRow[] = [makeRow(['Dave', '28', 'Dev'])];
+        state.setRows(newRows);
+        expect(state.rows).toHaveLength(1);
+        expect(state.rows[0].cells).toContain('Dave');
+    });
+
+    it('setRows() clamps scrollOffset when new list is shorter', () => {
+        const state = useTableState({ rows: makeRows() });
+        state.scrollNext();
+        state.scrollNext(); // scrollOffset = 2
+        state.setRows([makeRow(['Only', '1', 'Row'])]);
+        expect(state.scrollOffset).toBe(0);
+    });
+
+    it('setRows() keeps scrollOffset when still valid', () => {
+        const state = useTableState({ rows: makeRows() });
+        state.scrollNext(); // scrollOffset = 1
+        state.setRows(makeRows()); // same length
+        expect(state.scrollOffset).toBe(1);
+    });
+
+    it('setRows() resets scrollOffset to 0 on empty rows', () => {
+        const state = useTableState({ rows: makeRows() });
+        state.scrollNext();
+        state.setRows([]);
+        expect(state.scrollOffset).toBe(0);
+    });
+
+    // ── scrollNext ────────────────────────────────────
+
+    it('scrollNext() increments scrollOffset', () => {
+        const state = useTableState({ rows: makeRows() });
+        state.scrollNext();
+        expect(state.scrollOffset).toBe(1);
+    });
+
+    it('scrollNext() increments multiple times', () => {
+        const state = useTableState({ rows: makeRows() });
+        state.scrollNext();
+        state.scrollNext();
+        expect(state.scrollOffset).toBe(2);
+    });
+
+    // ── scrollPrev ────────────────────────────────────
+
+    it('scrollPrev() decrements scrollOffset', () => {
+        const state = useTableState({ rows: makeRows() });
+        state.scrollNext();
+        state.scrollNext(); // at 2
+        state.scrollPrev();
+        expect(state.scrollOffset).toBe(1);
+    });
+
+    it('scrollPrev() does not go below 0', () => {
+        const state = useTableState({ rows: makeRows() });
+        state.scrollPrev(); // already at 0
+        expect(state.scrollOffset).toBe(0);
+    });
+});


### PR DESCRIPTION

## Description
Adds 10 unit tests for useTableState in @termuijs/widgets which had no 
test coverage. Tests cover initialization, setRows with scrollOffset 
clamping, scrollNext and scrollPrev including boundary behavior.

## Related Issue
Closes #1752

## Which package(s)?

@termuijs/widgets

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: https://gssoc.girlscript.org/profile/790b367a-48ea-45f6-af27-c353fb2d49cb 



## Notes for the Reviewer

TableState.ts had zero test coverage. All 10 tests pass locally.
Full widgets suite (125 files, 1370 tests) passes with no regressions.

 I reviewed each test case against the source code manually and verified all pass locally.