### PR TITLE
fix(jsx): log unmount errors instead of silently swallowing them

### DIFF
--- a/packages/jsx/src/render.ts
+++ b/packages/jsx/src/render.ts
@@ -15,13 +15,17 @@ import { createElement } from './createElement.js';
 import { setCurrentApp } from './runtime.js';
 
 /**
- * Shared inline unmount helper — used by both the dev-server-backed path
- * and the fallback path so cleanup logic stays synchronized.
+ * Unmount a list of apps. Swallow any errors thrown by `unmount()` but log
+ * a single error message for observability. Exported only for tests.
  */
-function _unmountApps(apps: Array<{ unmount?: () => void }>): void {
+export function unmountApps(apps: Array<{ unmount?: () => void }>): void {
     apps.forEach((app) => {
         if (typeof app.unmount === 'function') {
-            try { app.unmount(); } catch {}
+            try {
+                app.unmount();
+            } catch (err) {
+                console.error('[jsx] Error during unmount():', err);
+            }
         }
     });
 }
@@ -162,7 +166,7 @@ export async function render(
                     // dev-server unavailable — use local helper for cleanup
                     const apps = (globalThis as any).__termuijs_apps;
                     if (Array.isArray(apps)) {
-                        _unmountApps(apps);
+                        unmountApps(apps);
                         (globalThis as any).__termuijs_apps = [];
                     }
                 });

--- a/packages/jsx/src/unmountHelpers.test.ts
+++ b/packages/jsx/src/unmountHelpers.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import { unmountApps } from './render.js';
+
+describe('unmountApps', () => {
+    it('logs errors, completes cleanup, and does not rethrow', () => {
+        const err = new Error('boom');
+        const throwing = { unmount: vi.fn(() => { throw err; }) };
+        const called = { unmount: vi.fn(() => { /* ok */ }) };
+
+        const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        // Should not throw
+        expect(() => unmountApps([throwing, called])).not.toThrow();
+
+        // Ensure the second unmount still ran
+        expect(called.unmount).toHaveBeenCalledTimes(1);
+
+        // Ensure we logged the error exactly once with the expected message
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith('[jsx] Error during unmount():', err);
+
+        spy.mockRestore();
+    });
+});

--- a/packages/jsx/src/unmountHelpers.test.ts
+++ b/packages/jsx/src/unmountHelpers.test.ts
@@ -9,16 +9,18 @@ describe('unmountApps', () => {
 
         const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-        // Should not throw
-        expect(() => unmountApps([throwing, called])).not.toThrow();
+        try {
+            // Should not throw
+            expect(() => unmountApps([throwing, called])).not.toThrow();
 
-        // Ensure the second unmount still ran
-        expect(called.unmount).toHaveBeenCalledTimes(1);
+            // Ensure the second unmount still ran
+            expect(called.unmount).toHaveBeenCalledTimes(1);
 
-        // Ensure we logged the error exactly once with the expected message
-        expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy).toHaveBeenCalledWith('[jsx] Error during unmount():', err);
-
-        spy.mockRestore();
+            // Ensure we logged the error exactly once with the expected message
+            expect(spy).toHaveBeenCalledTimes(1);
+            expect(spy).toHaveBeenCalledWith('[jsx] Error during unmount():', err);
+        } finally {
+            spy.mockRestore();
+        }
     });
 });


### PR DESCRIPTION
## Description

Fixes a bug in `@termuijs/jsx` where errors thrown during `app.unmount()` were silently swallowed during cleanup.

This change preserves the existing non-throwing cleanup behavior while logging unmount failures for improved observability and debugging. A regression test has been added to verify the behavior.

## Related Issue

Closes #1757 

## Which package(s)?

@termuijs/jsx

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)
* [x] 🧪 Tests (`type:testing`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read `CONTRIBUTING.md`.
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

Previously, unmount errors were caught and ignored using an empty catch block, making cleanup failures difficult to diagnose.

This PR:

* Preserves the existing cleanup flow
* Logs unmount errors for observability
* Adds a regression test ensuring:

  * cleanup continues after an unmount failure
  * errors do not escape
  * logging occurs exactly once with the expected message


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup reliability by handling errors during app unmount and logging a clear, single error message instead of failing silently.

* **New Features**
  * Exposed a public `unmountApps` utility for reliably unmounting multiple apps.

* **Tests**
  * Added a test suite covering error scenarios to ensure unmount continues for subsequent apps and that logging occurs as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->