### PR TITLE
Fix focusmanager index corruption

### DIFF
--- a/packages/core/src/events/FocusManager.test.ts
+++ b/packages/core/src/events/FocusManager.test.ts
@@ -264,4 +264,33 @@ describe('FocusManager Re-entrancy', () => {
         // After re-entrant focusNext, should end up on 'c'
         expect(fm.currentId).toBe('c');
     });
+
+    it('registering a new focusable that sorts before current does not change current focus', () => {
+        const fm = new FocusManager();
+        // A (10), B (20)
+        fm.register(makeWidget('a', 10, true));
+        fm.register(makeWidget('b', 20, true));
+
+        // Focus B
+        fm.focusWidget('b');
+        expect(fm.currentId).toBe('b');
+
+        // Inspect internal state before insertion
+        const beforeFocusables = (fm as any)._focusables.map((f: any) => f.id);
+        const beforeIndex = (fm as any)._currentIndex;
+
+        // Register C with lower tabIndex that sorts before existing items
+        fm.register(makeWidget('c', 5, true));
+
+        const afterFocusables = (fm as any)._focusables.map((f: any) => f.id);
+        const afterIndex = (fm as any)._currentIndex;
+
+        // Current focused ID should remain 'b'
+        expect(fm.currentId).toBe('b');
+
+        // For debugging/diagnostic purposes, ensure the array changed order
+        expect(beforeFocusables).not.toEqual(afterFocusables);
+        // And the index should have been adjusted so that it still points to 'b'
+        expect((fm as any)._focusables[afterIndex].id).toBe('b');
+    });
 });

--- a/packages/core/src/events/FocusManager.test.ts
+++ b/packages/core/src/events/FocusManager.test.ts
@@ -275,22 +275,10 @@ describe('FocusManager Re-entrancy', () => {
         fm.focusWidget('b');
         expect(fm.currentId).toBe('b');
 
-        // Inspect internal state before insertion
-        const beforeFocusables = (fm as any)._focusables.map((f: any) => f.id);
-        const beforeIndex = (fm as any)._currentIndex;
-
         // Register C with lower tabIndex that sorts before existing items
         fm.register(makeWidget('c', 5, true));
 
-        const afterFocusables = (fm as any)._focusables.map((f: any) => f.id);
-        const afterIndex = (fm as any)._currentIndex;
-
-        // Current focused ID should remain 'b'
+        // Observable behavior: focused id must remain 'b'
         expect(fm.currentId).toBe('b');
-
-        // For debugging/diagnostic purposes, ensure the array changed order
-        expect(beforeFocusables).not.toEqual(afterFocusables);
-        // And the index should have been adjusted so that it still points to 'b'
-        expect((fm as any)._focusables[afterIndex].id).toBe('b');
     });
 });

--- a/packages/core/src/events/FocusManager.ts
+++ b/packages/core/src/events/FocusManager.ts
@@ -93,8 +93,19 @@ export class FocusManager {
      * they are not lost when App has not yet subscribed to them.
      */
     register(focusable: Focusable): void {
+        // Preserve currently focused id so that sorting the master list
+        // does not accidentally change which widget is focused.
+        const prevFocusedId = this.currentId;
+
         this._focusables.push(focusable);
         this._focusables.sort((a, b) => a.tabIndex - b.tabIndex);
+
+        // If there was a previously focused widget, relocate _currentIndex
+        // to point to the same widget after the sort.
+        if (prevFocusedId) {
+            const newIdx = this._focusables.findIndex(f => f.id === prevFocusedId);
+            if (newIdx >= 0) this._currentIndex = newIdx;
+        }
 
         // Auto-focus the first widget if nothing is focused
         if (this._currentIndex < 0 && focusable.focusable) {


### PR DESCRIPTION
## Description

Fixes a bug in `FocusManager` where dynamically registering a new focusable could unexpectedly change the currently focused widget.

When the internal focusable list is reordered by `tabIndex`, `_currentIndex` could become stale and point to a different widget. This change preserves focus identity across registration reordering and adds a regression test covering the scenario.

## Related Issue

Closes #1759

## Which package(s)?

@termuijs/core

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)
* [x] 🧪 Tests (`type:testing`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

### Reproduction

1. Register focusable A (`tabIndex = 10`)
2. Register focusable B (`tabIndex = 20`)
3. Focus B
4. Register focusable C (`tabIndex = 5`)

Before this change:

* Focusables reorder to `[C, A, B]`
* `_currentIndex` remains unchanged
* Focus unexpectedly changes from `B` to `A`

After this change:

* Focusables still reorder correctly
* `_currentIndex` is updated to track the same focused widget
* Focus remains on `B`

A regression test has been added to verify that dynamically registering a focusable that sorts before the currently focused widget does not change focus unexpectedly.
