### PR TITLE
fix(store): replace Object.is with structural equality in CreateHistr…

### DIFF
--- a/packages/store/src/history.test.ts
+++ b/packages/store/src/history.test.ts
@@ -90,4 +90,51 @@ describe('TemporalHistory Middleware', () => {
         expect(history.past).toEqual(['State 1', 'State 2']);
         expect(history.future).toEqual([]); // 'State 3' is erased forever
     });
+
+    // ── Object state deduplication ──────────────────────────────────────
+
+    it('does not push duplicate entries for structurally equal object states', () => {
+        const objectStore = createHistoryStore({ count: 0 });
+
+        objectStore.set({ count: 0 }); // different reference, identical content
+        objectStore.set({ count: 0 }); // again
+
+        const history = objectStore.getHistory();
+        expect(history.past.length).toBe(0); // was 2 before the fix
+    });
+
+    it('does push an entry when object content actually changes', () => {
+        const objectStore = createHistoryStore({ count: 0 });
+
+        objectStore.set({ count: 1 }); // genuinely different content
+
+        const history = objectStore.getHistory();
+        expect(history.past.length).toBe(1);
+        expect(objectStore.present).toEqual({ count: 1 });
+    });
+
+    it('does not push duplicate entries for structurally equal array states', () => {
+        const arrayStore = createHistoryStore([1, 2, 3]);
+
+        arrayStore.set([1, 2, 3]); // new array reference, same content
+
+        const history = arrayStore.getHistory();
+        expect(history.past.length).toBe(0);
+    });
+
+    it('accepts a custom equals function for non-serialisable types', () => {
+        const mapStore = createHistoryStore(
+            new Map([['x', 1]]),
+            {
+                equals: (a, b) =>
+                    a.size === b.size &&
+                    [...a.entries()].every(([k, v]) => b.get(k) === v),
+            }
+        );
+
+        mapStore.set(new Map([['x', 1]])); // same content, different reference
+
+        const history = mapStore.getHistory();
+        expect(history.past.length).toBe(0);
+    });
 });

--- a/packages/store/src/history.ts
+++ b/packages/store/src/history.ts
@@ -43,12 +43,37 @@ export interface TemporalStoreActions<T> {
  * immutable from the caller's perspective: `getHistory()` returns copies
  * of the arrays so external consumers cannot mutate internal state.
  */
-export function createHistoryStore<T>(initialPresent: T): TemporalStoreActions<T> {
+
+export interface HistoryStoreOptions<T> {
+    /**
+     * Custom equality function used to decide whether a new state is
+     * identical to the current present. Defaults to JSON.stringify
+     * structural equality. Pass a custom comparator for types that are
+     * not JSON-serialisable (e.g. containing Date, Map, Set).
+     *
+     * @example
+     * // Using a shallow comparator for flat objects:
+     * createHistoryStore(initial, {
+     *   equals: (a, b) => Object.keys(a).every(k => (a as any)[k] === (b as any)[k])
+     * })
+     */
+    equals?: (a: T, b: T) => boolean;
+}
+
+export function createHistoryStore<T>(initialPresent: T, options: HistoryStoreOptions<T>={}): TemporalStoreActions<T> {
     let timeline: TemporalHistory<T> = {
         past: [],
         present: initialPresent,
         future: [],
     }
+
+    const equals = options.equals ?? ((a: T, b: T): boolean => {
+        try {
+            return JSON.stringify(a) === JSON.stringify(b);
+        } catch {
+            return Object.is(a, b);
+        }
+    });
 
     return {
         // Readonly accessor for the current state.
@@ -58,7 +83,7 @@ export function createHistoryStore<T>(initialPresent: T): TemporalStoreActions<T
 
         // Push a new state if it is different from the current `present`.
         set(newState: T): void {
-            if (Object.is(timeline.present, newState)) return;
+            if(equals(timeline.present, newState)) return;
 
             timeline = {
                 past: [...timeline.past, timeline.present],


### PR DESCRIPTION
### Description
createHistoryStore.set() was using Object.is for deduplication instead of the JSON.stringify structural equality promised by the JSDoc comment. This caused duplicate history entries to be pushed for object and array states that were deeply equal but different references. This PR fixes the equality check and adds an optional equals comparator to HistoryStoreOptions<T> for non-serialisable types.

### Related Issue
Closes #1742 

### Which package(s)?
@termuijs/store

### Type of Change

 🐛 Bug fix (type:bug)
 🧪 Tests (type:testing)

### Checklist

 ⭐ You starred the repo. The needs-star check blocks your merge otherwise.
 Tests pass locally: bun vitest run
 Build passes: bun run build
 Typecheck passes: bun run typecheck
 You read CONTRIBUTING.md.
 Your PR title follows type: short description.
 No new any types without an inline comment explaining why.
 No unrelated refactors bundled into this PR.

### GSSoC 2026 Participation

 You are a GSSoC 2026 contributor.
Your GSSoC profile: https://gssoc.girlscript.org/profile/048e6a97-baaf-4a03-b6e5-bdfc6c38e173

### Screenshots / Recordings (UI changes)
No UI changes — pure logic fix in @termuijs/store.
Notes for the Reviewer
Root cause: set() on line 61 of history.ts used Object.is(timeline.present, newState) for its dedup guard. Object.is is reference equality — for primitive types like string this coincidentally works, which is why all existing tests passed. For object or array state, two deeply-equal values with different references always fail the check, causing a duplicate past[] entry on every set() call.

### What changed:

Added HistoryStoreOptions<T> interface with an optional equals?: (a: T, b: T) => boolean field
Added options: HistoryStoreOptions<T> = {} parameter to createHistoryStore
Defined a const equals inside the function body that defaults to JSON.stringify structural comparison with an Object.is fallback inside a try/catch (guards against circular references or BigInt which cause JSON.stringify to throw)
Replaced Object.is(timeline.present, newState) with equals(timeline.present, newState) — the only change to existing logic

### New tests added (all in history.test.ts):

Object state with same content does not push a duplicate entry
Object state with changed content does push an entry
Array state with same content does not push a duplicate entry
Custom equals function works correctly for non-serialisable types (Map)

All 8 existing tests pass unchanged since they use string state, where JSON.stringify equality is identical in behaviour to Object.is.
No breaking changes — options defaults to {} so all existing createHistoryStore(initial) call sites work without modification.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved state deduplication to prevent unnecessary history entries when states are structurally equivalent, even with different references.

* **New Features**
  * Added custom equality comparison option for history store to handle complex and non-serializable data types.

* **Tests**
  * Enhanced coverage for state deduplication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->