### PR TITLE
fix(widgets): clamp Tree selection after visible node shrink

### DIFF
--- a/packages/widgets/src/display/Tree.test.ts
+++ b/packages/widgets/src/display/Tree.test.ts
@@ -371,8 +371,9 @@ describe('Tree', () => {
         expect(tree.selectedIndex).toBe(2);
 
         // Simulate external mutation and force a rebuild.
-        // No public API reproduces this scenario while preserving selection,
-        // so we call the private rebuild to simulate an external data change.
+        // The cast is required: there is no public API that reproduces an
+        // external node mutation while preserving the pre-mutation selection,
+        // so the test invokes the private rebuild helper to simulate that case.
         nodes[0].expanded = false;
         (tree as any)._buildVisibleNodes();
 

--- a/packages/widgets/src/display/Tree.test.ts
+++ b/packages/widgets/src/display/Tree.test.ts
@@ -355,6 +355,31 @@ describe('Tree', () => {
         });
     });
 
+    it('clamps selectedIndex when visible nodes shrink (external collapse)', () => {
+        const nodes: TreeNode[] = [
+            { label: 'Parent', expanded: true, children: [
+                { label: 'Child A' },
+                { label: 'Child B' },
+            ] },
+            { label: 'Sibling' },
+        ];
+
+        const tree = makeTree(nodes);
+        // visible: Parent(0), Child A(1), Child B(2), Sibling(3)
+        tree.handleKey('down'); // -> 1
+        tree.handleKey('down'); // -> 2 (Child B)
+        expect(tree.selectedIndex).toBe(2);
+
+        // Simulate external mutation and force a rebuild.
+        // No public API reproduces this scenario while preserving selection,
+        // so we call the private rebuild to simulate an external data change.
+        nodes[0].expanded = false;
+        (tree as any)._buildVisibleNodes();
+
+        // Observable behavior: selectedIndex must update to remain valid.
+        expect(tree.selectedIndex).toBe(1);
+    });
+
         describe('Virtualization', () => {
         it('updates scroll offset via keyboard navigation when moving past viewport', () => {
             // Generate many nodes

--- a/packages/widgets/src/display/Tree.ts
+++ b/packages/widgets/src/display/Tree.ts
@@ -273,6 +273,12 @@ export class Tree extends Widget {
     private _buildVisibleNodes(): void {
         this._visibleNodes = [];
         _collectVisible(this._nodes, 0, [], this._visibleNodes);
+        // If the visible set shrank (e.g. a parent collapsed elsewhere),
+        // ensure the selected index remains in-bounds.
+        if (this._selectedIndex >= this._visibleNodes.length) {
+            this._selectedIndex = Math.max(0, this._visibleNodes.length - 1);
+            this._clampScroll();
+        }
     }
 
     /** Ensure scroll keeps the selected index in view */


### PR DESCRIPTION
## Description

Fixes a bug where `Tree.selectedIndex` could become invalid when the visible node list shrinks after an external collapse and rebuild.

The fix clamps `selectedIndex` to the last valid visible node and adds a regression test covering the scenario.

## Related Issue

Closes #1767

## Which package(s)?

@termuijs/widgets

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)
* [x] 🧪 Tests (`type:testing`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

### Reproduction

1. Create a tree with an expanded parent containing multiple children.
2. Move selection to a child near the end of the visible node list.
3. Collapse the parent externally and rebuild visible nodes.
4. The visible node list shrinks, but `selectedIndex` can remain out of bounds.

### Before

* `selectedIndex` could point past the end of the visible node list after a rebuild.
* Selection state became invalid until another navigation action occurred.

### After

* `selectedIndex` is clamped to the last valid visible node whenever the visible set shrinks.
* Existing scroll clamping behavior is preserved.
* Added a regression test to prevent future regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tree widget now keeps selection valid when the visible node list shrinks after an external collapse, automatically clamping the selected item and maintaining consistent scroll position.

* **Tests**
  * Added coverage to verify the selected index is clamped during external node collapse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->