### PR TITLE
fix(core): validate containerId in FocusManager.release() and restore…

### DIFF
--- a/packages/core/src/events/FocusManager.test.ts
+++ b/packages/core/src/events/FocusManager.test.ts
@@ -381,3 +381,113 @@ describe('FocusManager Re-entrancy', () => {
         expect(fm.currentId).toBe('b');
     });
 });
+
+describe('FocusManager Focus Trap', () => {
+    it('release() on empty stack warns and does not throw', () => {
+        const fm = new FocusManager();
+        fm.register(makeWidget('a'));
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        expect(() => fm.release('some-modal')).not.toThrow();
+        expect(warnSpy).toHaveBeenCalledOnce();
+        expect(warnSpy.mock.calls[0][0]).toContain('empty trap stack');
+
+        warnSpy.mockRestore();
+    });
+
+    it('release() with mismatched containerId warns and keeps trap active', () => {
+        const fm = new FocusManager();
+        fm.register(makeWidget('a'));
+        fm.register(makeWidget('b'));
+        fm.registerContainerMembers('modal-1', ['b']);
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        fm.trap('modal-1');
+        fm.release('modal-2'); // wrong ID
+
+        expect(warnSpy).toHaveBeenCalledOnce();
+        expect(warnSpy.mock.calls[0][0]).toContain('modal-2');
+        expect(fm.isTrapped).toBe(true);
+        expect(fm.currentTrapId).toBe('modal-1');
+
+        warnSpy.mockRestore();
+    });
+
+    it('release() with correct containerId removes the trap', () => {
+        const fm = new FocusManager();
+        fm.register(makeWidget('a'));
+        fm.register(makeWidget('b'));
+        fm.registerContainerMembers('modal-1', ['b']);
+
+        fm.trap('modal-1');
+        expect(fm.isTrapped).toBe(true);
+
+        fm.release('modal-1');
+        expect(fm.isTrapped).toBe(false);
+        expect(fm.currentTrapId).toBeNull();
+    });
+
+    it('release() restores focus to widget focused before trap() was called', () => {
+        const fm = new FocusManager();
+        fm.register(makeWidget('trigger-btn'));
+        fm.register(makeWidget('modal-input'));
+        fm.register(makeWidget('modal-confirm'));
+        fm.registerContainerMembers('dialog', ['modal-input', 'modal-confirm']);
+
+        fm.focusWidget('trigger-btn');
+        expect(fm.currentId).toBe('trigger-btn');
+
+        fm.trap('dialog');
+        expect(fm.currentId).toBe('modal-input');
+
+        fm.focusNext(); // move around inside modal
+        expect(fm.currentId).toBe('modal-confirm');
+
+        fm.release('dialog');
+        // Must go back to what had focus before trap, not stay inside modal
+        expect(fm.currentId).toBe('trigger-btn');
+    });
+
+    it('nested traps: each release restores to the correct prior focus', () => {
+        const fm = new FocusManager();
+        fm.register(makeWidget('main-btn'));
+        fm.register(makeWidget('outer-input'));
+        fm.register(makeWidget('inner-input'));
+        fm.registerContainerMembers('outer-modal', ['outer-input']);
+        fm.registerContainerMembers('inner-modal', ['inner-input']);
+
+        fm.focusWidget('main-btn');
+
+        fm.trap('outer-modal');
+        expect(fm.currentId).toBe('outer-input');
+
+        fm.trap('inner-modal');
+        expect(fm.currentId).toBe('inner-input');
+
+        fm.release('inner-modal');
+        expect(fm.currentId).toBe('outer-input'); // restored to pre-inner-trap focus
+        expect(fm.currentTrapId).toBe('outer-modal');
+
+        fm.release('outer-modal');
+        expect(fm.currentId).toBe('main-btn'); // restored to pre-outer-trap focus
+        expect(fm.isTrapped).toBe(false);
+    });
+
+    it('double release() warns on second call and leaves state clean', () => {
+        const fm = new FocusManager();
+        fm.register(makeWidget('a'));
+        fm.register(makeWidget('b'));
+        fm.registerContainerMembers('modal', ['b']);
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        fm.trap('modal');
+        fm.release('modal'); // correct
+        fm.release('modal'); // duplicate — stack now empty
+
+        expect(warnSpy).toHaveBeenCalledOnce();
+        expect(warnSpy.mock.calls[0][0]).toContain('empty trap stack');
+        expect(fm.isTrapped).toBe(false);
+
+        warnSpy.mockRestore();
+    });
+});

--- a/packages/core/src/events/FocusManager.ts
+++ b/packages/core/src/events/FocusManager.ts
@@ -34,6 +34,12 @@ export class FocusManager {
     private _trapStack: string[] = [];
 
     /**
+     * Parallel stack to _trapStack. Captures the focused widget ID
+     * before each trap() call so release() can restore it.
+     */
+    private _preTrapFocus: string[] = [];
+
+    /**
      * Map of container ID → child widget IDs that belong to it.
      * Used for trap membership lookup.
      */
@@ -244,6 +250,7 @@ export class FocusManager {
      * nested modals create nested traps.
      */
     trap(containerId: string): void {
+        this._preTrapFocus.push(this.currentId ?? '');
         this._trapStack.push(containerId);
 
         // Focus the first focusable inside the trap
@@ -257,11 +264,37 @@ export class FocusManager {
         }
     }
 
+    // REPLACE WITH:
     /**
-     * Release the current focus trap. Restores previous trap or free navigation.
+     * Release a focus trap by container ID.
+     *
+     * - Must be called with the same containerId passed to trap().
+     * - Must be called in LIFO order — innermost trap released first.
+     * - Emits console.warn and is a no-op if stack is empty or ID mismatches.
+     * - Restores focus to the widget that was focused before trap() was called.
      */
-    release(): void {
+    release(containerId: string): void {
+        if (this._trapStack.length === 0) {
+            console.warn('FocusManager.release(): called with empty trap stack — ignoring.');
+            return;
+        }
+
+        const top = this._trapStack[this._trapStack.length - 1];
+        if (top !== containerId) {
+            console.warn(
+                `FocusManager.release(): expected "${top}" but got "${containerId}" — ignoring. ` +
+                `Ensure nested modals are released in LIFO order.`
+            );
+            return;
+        }
+
         this._trapStack.pop();
+
+        // Restore focus to what was focused before this trap was activated
+        const previousFocusId = this._preTrapFocus.pop();
+        if (previousFocusId) {
+            this.focusWidget(previousFocusId);
+        }
     }
 
     /** Whether a focus trap is currently active */


### PR DESCRIPTION
## Description

`FocusManager.release()` had no validation — it unconditionally popped
the trap stack regardless of which container called it, and silently
did nothing when the stack was already empty. This PR adds a `containerId`
parameter with LIFO enforcement, an empty-stack guard, and restores focus
to the widget that was active before `trap()` was called.

## Related Issue

Closes #1744 

## Which package(s)?

`@termuijs/core`

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [x] 🧪 Tests (`type:testing`)

## Checklist

- [ ] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read `CONTRIBUTING.md`.
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (not applicable).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/048e6a97-baaf-4a03-b6e5-bdfc6c38e173`

## Notes for the Reviewer

**Two bugs fixed, one enhancement added:**

**Bug A — Empty stack silent no-op:** `release()` called `this._trapStack.pop()`
with zero checks. If a component's cleanup fired twice (hot-reload, error
boundary), the second call silently popped nothing and left no trace.
Fix: guard at the top of `release()` emits `console.warn` and returns early
when the stack is empty.

**Bug B — No containerId enforcement:** `release()` always popped the top of
the stack regardless of which container was releasing. With two nested modals
`['outer', 'inner']`, if outer cleaned up before inner, it destroyed inner's
trap entry — silent corruption, no error. Fix: `release(containerId)` now
compares `containerId` against the stack top and warns + no-ops on mismatch.

**Focus restore:** `trap()` now pushes `this.currentId` onto a parallel
`_preTrapFocus` stack before activating the trap. `release()` pops it and
calls `focusWidget()` to restore focus — matching standard modal accessibility
behaviour (ARIA APG: focus returns to the element that opened the dialog).

**Changes summary:**
- `FocusManager.ts`: add `_preTrapFocus: string[]` field, one line in `trap()`,
  full rewrite of `release()` (~15 lines net added)
- `FocusManager.test.ts`: new `describe('FocusManager Focus Trap')` block,
  6 tests covering both bugs and focus restore

No existing tests modified. All spatial navigation, re-entrancy, and
tab-cycling logic is completely untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus trap release behavior with proper focus restoration to previously focused widgets.
  * Added validation for focus trap operations with appropriate warnings.
  * Fixed nested focus trap handling to restore focus correctly at each level.

* **Tests**
  * Added comprehensive test coverage for focus trap functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->