### PR TITLE
fix(core): restore pre-trap focus when FocusManager.release() is called

### DIFF
--- a/packages/core/src/events/FocusManager.test.ts
+++ b/packages/core/src/events/FocusManager.test.ts
@@ -381,3 +381,76 @@ describe('FocusManager Re-entrancy', () => {
         expect(fm.currentId).toBe('b');
     });
 });
+describe('FocusManager Focus Trap — focus restore', () => {
+    it('release() restores focus to widget focused before trap() was called', () => {
+        const fm = new FocusManager();
+        fm.register(makeWidget('trigger-btn'));
+        fm.register(makeWidget('modal-input'));
+        fm.register(makeWidget('modal-confirm'));
+        fm.registerContainerMembers('dialog', ['modal-input', 'modal-confirm']);
+
+        fm.focusWidget('trigger-btn');
+        expect(fm.currentId).toBe('trigger-btn');
+
+        fm.trap('dialog');
+        expect(fm.currentId).toBe('modal-input'); // focus moved into modal
+
+        fm.focusNext(); // navigate inside modal
+        expect(fm.currentId).toBe('modal-confirm');
+
+        fm.release();
+        // Must return to trigger-btn, not stay inside the closed modal
+        expect(fm.currentId).toBe('trigger-btn');
+    });
+
+    it('nested traps: each release restores to the correct prior focus', () => {
+        const fm = new FocusManager();
+        fm.register(makeWidget('main-btn'));
+        fm.register(makeWidget('outer-input'));
+        fm.register(makeWidget('inner-input'));
+        fm.registerContainerMembers('outer-modal', ['outer-input']);
+        fm.registerContainerMembers('inner-modal', ['inner-input']);
+
+        fm.focusWidget('main-btn');
+
+        fm.trap('outer-modal');
+        expect(fm.currentId).toBe('outer-input');
+
+        fm.trap('inner-modal');
+        expect(fm.currentId).toBe('inner-input');
+
+        fm.release(); // release inner
+        expect(fm.currentId).toBe('outer-input'); // restored to pre-inner-trap focus
+        expect(fm.currentTrapId).toBe('outer-modal');
+
+        fm.release(); // release outer
+        expect(fm.currentId).toBe('main-btn'); // restored to pre-outer-trap focus
+        expect(fm.isTrapped).toBe(false);
+    });
+
+    it('release() with no prior focus does not throw', () => {
+        const fm = new FocusManager();
+        fm.register(makeWidget('modal-btn'));
+        fm.registerContainerMembers('dialog', ['modal-btn']);
+
+        // trap() called before any explicit focusWidget — currentId is auto-focused
+        fm.trap('dialog');
+
+        // Should not throw even if previousFocusId resolves to empty string
+        expect(() => fm.release()).not.toThrow();
+    });
+
+    it('focus does not leak outside the modal after release when no trigger was focused', () => {
+        const fm = new FocusManager();
+        fm.register(makeWidget('a'));
+        fm.register(makeWidget('modal-x'));
+        fm.registerContainerMembers('m', ['modal-x']);
+
+        fm.focusWidget('a');
+        fm.trap('m');
+        fm.release();
+
+        // 'a' had focus before the trap — it should be restored
+        expect(fm.currentId).toBe('a');
+    });
+});

--- a/packages/core/src/events/FocusManager.ts
+++ b/packages/core/src/events/FocusManager.ts
@@ -32,6 +32,11 @@ export class FocusManager {
      * that belong to the topmost trap container are reachable via Tab.
      */
     private _trapStack: string[] = [];
+    /**
+     * Parallel stack to _trapStack. Captures the focused widget ID
+     * before each trap() call so release() can restore it on dismiss.
+     */
+    private _preTrapFocus: string[] = [];
 
     /**
      * Map of container ID → child widget IDs that belong to it.
@@ -244,6 +249,7 @@ export class FocusManager {
      * nested modals create nested traps.
      */
     trap(containerId: string): void {
+        this._preTrapFocus.push(this.currentId ?? '');
         this._trapStack.push(containerId);
 
         // Focus the first focusable inside the trap
@@ -261,7 +267,11 @@ export class FocusManager {
      * Release the current focus trap. Restores previous trap or free navigation.
      */
     release(): void {
-        this._trapStack.pop();
+        this._trapStack.pop();\
+        const previousFocusId = this._preTrapFocus.pop();
+        if (previousFocusId) {
+            this.focusWidget(previousFocusId);
+        }
     }
 
     /** Whether a focus trap is currently active */


### PR DESCRIPTION
## Description

`FocusManager.trap()` moved focus to the first widget inside the trap
container but never saved which widget had focus before activation.
`release()` only popped the `_trapStack` — focus stayed stranded inside
the now-invisible modal. This PR adds a `_preTrapFocus` parallel stack
so focus is correctly restored to the triggering widget on dismiss.

## Related Issue

Closes #1745 

## Which package(s)?

`@termuijs/core`

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [x] 🧪 Tests (`type:testing`)

## Checklist

- [ ] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read `CONTRIBUTING.md`.
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (not applicable).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/048e6a97-baaf-4a03-b6e5-bdfc6c38e173`

## Notes for the Reviewer

**Root cause:** `trap()` pushed `containerId` onto `_trapStack` and
immediately moved focus into the container — but the ID of the previously
focused widget was never stored anywhere. `release()` popped the stack
with no restoration logic, leaving focus inside a widget that belongs to
a modal that no longer exists on screen.

**Fix — 3 lines of production code changed:**
1. New private field `_preTrapFocus: string[]` — parallel stack to `_trapStack`
2. `trap()` — one line added: `this._preTrapFocus.push(this.currentId ?? '')`
3. `release()` — two lines added: pop `_preTrapFocus`, call `focusWidget()` if non-empty

**Nested modal behaviour is correct:** since both stacks are pushed and
popped in lockstep, `release()` at any nesting depth restores exactly the
focus that `trap()` captured at that same depth.

**No breaking changes** — `release()` signature is unchanged, all existing
spatial navigation, re-entrancy, and tab-cycling tests pass without modification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced focus trap release behavior to restore focus to the previously focused element
  * Proper handling of nested focus traps with correct focus restoration per nesting level
  * Focus returns to the widget that had focus before trap activation, preventing focus leaks

* **Tests**
  * Added test coverage for focus restoration semantics including nested trap scenarios and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->