### PR TITLE
fix(store): eliminate double-microtask window in async batch()

### DIFF
--- a/packages/store/src/store.test.ts
+++ b/packages/store/src/store.test.ts
@@ -292,6 +292,31 @@ describe('batch', () => {
     })
 })
 
+    it('async batch does not overwrite concurrent non-batched setState calls', async () => {
+        const useStore = createStore((set) => ({
+            a: 0,
+            b: 0,
+        }))
+        const spy = vi.fn()
+        useStore.subscribe(spy)
+
+        // Start an async batch that modifies key 'a'
+        const batchPromise = batch(async () => {
+            useStore.setState({ a: 1 })
+            // Yield to allow interleaving
+            await Promise.resolve()
+        })
+
+        // Non-batched setState on key 'b' between async batch microtasks
+        useStore.setState({ b: 2 })
+
+        await batchPromise
+        await new Promise(resolve => queueMicrotask(resolve))
+
+        // Both changes should be preserved
+        expect(useStore.getState()).toEqual({ a: 1, b: 2 })
+    })
+
 describe('middleware', () => {
     it('middleware is called during setState', () => {
         const spy = vi.fn((prev, update, next) => next(update))

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -80,12 +80,12 @@ export function batch<T>(fn: () => T): T {
         return (res as Promise<any>).then(
             (val) => {
                 _batchDepth--;
-                if (_batchDepth === 0) flushBatch(false);
+                if (_batchDepth === 0) flushBatch(false, true);
                 return val;
             },
             (err) => {
                 _batchDepth--;
-                if (_batchDepth === 0) flushBatch(true);
+                if (_batchDepth === 0) flushBatch(true, true);
                 throw err;
             }
         ) as T;
@@ -98,7 +98,7 @@ export function batch<T>(fn: () => T): T {
     }
 }
 
-function flushBatch(threw: boolean) {
+function flushBatch(threw: boolean, immediate = false) {
     if (threw) {
         for (const [, { prevState, rollback }] of _batchStores) {
             rollback();
@@ -106,7 +106,7 @@ function flushBatch(threw: boolean) {
         _batchStores.clear(); // Don't notify listeners with partial state
     } else {
         if (_batchStores.size === 0) return;
-        queueMicrotask(() => {
+        const notify = () => {
             const stores = Array.from(_batchStores.entries());
             _batchStores.clear();
             for (const [listeners, { prevState, commit }] of stores) {
@@ -115,7 +115,12 @@ function flushBatch(threw: boolean) {
                     listener(newState, prevState);
                 }
             }
-        });
+        };
+        if (immediate) {
+            notify();
+        } else {
+            queueMicrotask(notify);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

When `batch()` wraps an async function, `flushBatch` queues a microtask for notification,
but the `.then()` callback of the async function is already running inside a microtask.
The extra `queueMicrotask` creates a window where a concurrent non-batched `setState` call
can be overwritten by the batch's stale snapshot.

## Changes

### `packages/store/src/store.ts`
- Added an `immediate` parameter to `flushBatch(threw, immediate = false)`
- The async path (`batch(fn)` where `fn` returns a promise) now calls
  `flushBatch(false, true)`, which notifies listeners synchronously inside the `.then()`
  callback instead of scheduling another microtask
- The sync path preserves the existing `queueMicrotask` behavior

### `packages/store/src/store.test.ts`
- Added test: "async batch does not overwrite concurrent non-batched setState calls"

Closes #1779 