### PR TITLE
fix(core): enforce maxSize constraint in CommandHistory.import()

### DIFF
--- a/packages/core/src/history/CommandHistory.test.ts
+++ b/packages/core/src/history/CommandHistory.test.ts
@@ -183,4 +183,20 @@ describe('CommandHistory', () => {
         ch.import(JSON.stringify(['cmd1', 'cmd2']));
         expect(ch.previous()).toBe('cmd2');
     });
+
+    it('import() trims to maxSize when imported data exceeds limit', () => {
+        const ch = new CommandHistory({ maxSize: 3 });
+        const largeHistory = Array.from({ length: 10 }, (_, i) => `cmd${i}`);
+        ch.import(JSON.stringify(largeHistory));
+        expect(ch.getAll()).toHaveLength(3);
+        expect(ch.getAll()).toEqual(['cmd7', 'cmd8', 'cmd9']);
+    });
+
+    it('import() keeps all entries when under maxSize', () => {
+        const ch = new CommandHistory({ maxSize: 10 });
+        const smallHistory = ['cmd1', 'cmd2', 'cmd3'];
+        ch.import(JSON.stringify(smallHistory));
+        expect(ch.getAll()).toHaveLength(3);
+        expect(ch.getAll()).toEqual(smallHistory);
+    });
 });

--- a/packages/core/src/history/CommandHistory.ts
+++ b/packages/core/src/history/CommandHistory.ts
@@ -71,7 +71,8 @@ export class CommandHistory {
     }
 
     import(data: string): void {
-        this.commands = JSON.parse(data);
+        const parsed: string[] = JSON.parse(data);
+        this.commands = parsed.slice(-this.maxSize);
         this.index = this.commands.length;
     }
 }


### PR DESCRIPTION
## Description

The `import()` method in `CommandHistory` was replacing the commands array without enforcing the `maxSize` constraint, allowing unbounded memory growth when importing large history files. This fix trims the imported array to the last `maxSize` entries, consistent with the `add()` method behavior.

## Related Issue

Closes #1786

## Which package(s)?

- [x] @termuijs/core

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## Notes for the Reviewer

The fix is minimal and focused:
- In `CommandHistory.import()`, parsed data is now sliced to keep only the last `maxSize` entries
- Two new tests added to verify the maxSize constraint is enforced on import
- All existing tests pass (25/25)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command history import functionality to properly enforce maximum size limits by truncating incoming data to the most recent entries when the imported dataset exceeds the configured limit.

* **Tests**
  * Enhanced test coverage for command history import, verifying that imported entries are correctly truncated to maximum size when necessary and fully retained when within limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->