### PR TITLE
fix(router): handle beforeEnter guard redirects in back() without corrupting history

### DIFF
--- a/packages/router/src/router.test.ts
+++ b/packages/router/src/router.test.ts
@@ -194,6 +194,27 @@ describe('Router', () => {
         expect(r.currentPath).toBe('/login');
     });
 
+    it('back() with beforeEnter redirect does not corrupt history', () => {
+        const r = new Router();
+        r.addRoute('/login', () => 'Login');
+        r.addRoute('/dashboard', () => 'Dashboard', undefined, {
+            beforeEnter: () => '/login',
+        });
+        r.addRoute('/settings', () => 'Settings');
+
+        r.push('/login');
+        r.push('/dashboard');
+        r.push('/settings');
+
+        expect(r.currentPath).toBe('/settings');
+        expect(r.historyLength).toBe(3);
+
+        r.back();
+
+        expect(r.currentPath).toBe('/login');
+        expect(r.historyLength).toBe(2);
+    });
+
     it('afterEnter executes after navigation', () => {
         const r = new Router();
         const spy = vi.fn();

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -367,7 +367,11 @@ export class Router {
         }
 
         if (typeof guardResult === 'string') {
-            this.push(guardResult);
+            const poppedPath = this._history.pop();
+            if (poppedPath) {
+                this._forwardStack.push(poppedPath);
+            }
+            this._executeNavigation(guardResult, { clearForwardStack: false, direction: 'back' });
             return;
         }
 


### PR DESCRIPTION
## Description

The `back()` method was calling `push()` when a `beforeEnter` guard returned a redirect string, which added to history without popping the current entry. This corrupted the navigation history stack.

Fixed by popping the current entry before navigating to the redirect target, and using `_executeNavigation` with `direction: 'back'` to maintain proper navigation context.

## Related Issue

Closes #1785

## Which package(s)?

- [x] @termuijs/router

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## Notes for the Reviewer

The fix is minimal and focused:
- In `Router.back()`, when a guard returns a redirect string, the current entry is now popped before navigating
- Used `_executeNavigation` with `direction: 'back'` to maintain proper navigation context
- Added a test verifying that back() with guard redirects does not corrupt history
- All existing tests pass (26/26)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test case verifying correct behavior when back navigation encounters route redirects, ensuring the history stack remains uncorrupted.

* **Bug Fixes**
  * Improved back navigation handling for routes with redirects to maintain proper history stack integrity throughout navigation cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->