### PR TITLE
fix(core): set wide-char continuation cells to width:0 in LayerManager.writeString()

### DIFF
--- a/packages/core/src/terminal/LayerManager.test.ts
+++ b/packages/core/src/terminal/LayerManager.test.ts
@@ -187,10 +187,35 @@ describe('LayerManager - Cell Writing', () => {
         // The emoji occupies column 0 (wide, width=2)
         expect(layer.cells[0][0].char).toBe('😀');
         expect(layer.cells[0][0].width).toBe(2);
-        // Column 1 is the placeholder for the wide char's second cell
-        expect(layer.cells[0][1].char).toBe(' ');
+        // Column 1 is the continuation cell for the wide char (width=0)
+        expect(layer.cells[0][1].char).toBe('');
+        expect(layer.cells[0][1].width).toBe(0);
         // 'A' must land at column 2, not column 1
         expect(layer.cells[0][2].char).toBe('A');
+    });
+
+    it('wide char continuation cell has width:0 and composites correctly', () => {
+        const lm = new LayerManager(20, 10);
+        const layer = lm.createLayer('base', 0);
+
+        // Write a wide CJK character
+        lm.writeString('base', 0, 0, '中A');
+
+        // The wide char occupies column 0 (width=2)
+        expect(layer.cells[0][0].char).toBe('中');
+        expect(layer.cells[0][0].width).toBe(2);
+        // Continuation cell must have width:0, not width:1
+        expect(layer.cells[0][1].width).toBe(0);
+        // 'A' must land at column 2
+        expect(layer.cells[0][2].char).toBe('A');
+
+        // Composite onto screen and verify no stray space
+        const screen = new Screen(20, 10);
+        lm.composite(screen);
+        expect(screen.back[0][0].char).toBe('中');
+        expect(screen.back[0][0].width).toBe(2);
+        expect(screen.back[0][1].width).toBe(0);
+        expect(screen.back[0][2].char).toBe('A');
     });
 });
 

--- a/packages/core/src/terminal/LayerManager.ts
+++ b/packages/core/src/terminal/LayerManager.ts
@@ -166,10 +166,11 @@ export class LayerManager {
             if (x < 0) { x += charWidth; continue; }
 
             this.setCell(layerId, x, row, { char, width: charWidth, ...style });
-            // For wide characters, fill the next cell with a placeholder space
-            // so the grid stays coherent (no stale character bleeds through).
+            // For wide characters, fill the continuation cell with width: 0
+            // to match Screen.writeString() behavior and prevent stray spaces
+            // during compositing.
             if (charWidth === 2 && x + 1 < this._cols) {
-                this.setCell(layerId, x + 1, row, { char: ' ', width: 1, ...style });
+                this.setCell(layerId, x + 1, row, { char: '', width: 0, ...style });
             }
             x += charWidth;
         }


### PR DESCRIPTION
## Description

The `writeString()` method was setting continuation cells for wide characters (CJK, emoji) to `width:1` instead of `width:0`. This caused the differential renderer to treat continuation cells as renderable characters, outputting stray spaces and corrupting terminal display when overlay layers rendered wide characters.

Fixed by changing the continuation cell to use `width:0`, matching the behavior of `Screen.writeString()`.

## Related Issue

Closes #1784

## Which package(s)?

- [x] @termuijs/core

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## Notes for the Reviewer

The fix is minimal and focused:
- Changed `width: 1` to `width: 0` for continuation cells in `LayerManager.writeString()`
- Added a test verifying wide-char continuation cells have width:0 and composite correctly
- Updated existing test to also verify width:0 for continuation cells
- All existing tests pass (21/21)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed wide character rendering (emoji, CJK characters) to properly handle continuation cells and ensure accurate character composition in terminal display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->