### PR TITLE
test(jsx): add runtime unit tests

### DIFF
--- a/packages/jsx/src/runtime.test.ts
+++ b/packages/jsx/src/runtime.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { getCurrentApp, setCurrentApp } from './runtime.js';
+import type { App } from '@termuijs/core';
+
+describe('JSX runtime app context', () => {
+    it('defaults current app to null', () => {
+        expect(getCurrentApp()).toBeNull();
+    });
+
+    it('sets and retrieves the current app instance', () => {
+        const dummyApp = { name: 'DummyApp' } as unknown as App;
+        setCurrentApp(dummyApp);
+        expect(getCurrentApp()).toBe(dummyApp);
+
+        // Reset back to null
+        setCurrentApp(null);
+        expect(getCurrentApp()).toBeNull();
+    });
+});


### PR DESCRIPTION
## Description

This PR adds comprehensive unit tests for `packages/jsx/src/runtime.ts` to verify its functional correctness and prevent regressions.

## Related Issue

Closes #1803

## Which package(s)?

@termuijs/jsx

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read `CONTRIBUTING.md`.
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/Harshithk951`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for the JSX runtime app context.
  * Verified the current app starts as `null`, can be set to an app instance, and can be reset back to `null`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->