### PR TITLE
fix: handle large bracketed pastes split across chunks

### DIFF
--- a/packages/core/src/input/InputParser.ts
+++ b/packages/core/src/input/InputParser.ts
@@ -125,6 +125,31 @@ export class InputParser {
      * Process a chunk of raw input bytes.
      */
     private _processInput(data: Buffer): void {
+        const PASTE_START = '\x1b[200~';
+        const PASTE_END = '\x1b[201~';
+
+        if (this._isPasting) {
+            const str = this._decoder.write(data);
+            const endIdx = str.indexOf(PASTE_END);
+            if (endIdx !== -1) {
+                this._pasteBuffer += str.substring(0, endIdx);
+                const pastedText = this._pasteBuffer;
+                this._isPasting = false;
+                this._pasteBuffer = '';
+                this._clearPasteTimeout();
+                this._events.emit('paste', pastedText);
+                
+                const remaining = str.substring(endIdx + PASTE_END.length);
+                if (remaining.length > 0) {
+                    this._processInput(Buffer.from(remaining, 'utf8'));
+                }
+            } else {
+                this._pasteBuffer += str;
+                this._startPasteTimeout();
+            }
+            return;
+        }
+
         // If we are currently collecting an escape sequence, continue collecting it
         if (this._escapeBuffer.length > 0) {
             this._escapeBuffer = Buffer.concat([this._escapeBuffer, data]);
@@ -137,39 +162,26 @@ export class InputParser {
         }
 
         const str = data.toString('utf8');
-        const PASTE_START = '\x1b[200~';
-        const PASTE_END = '\x1b[201~';
-
-        // ── Multi-chunk bracketed paste handling ──
-
-        // Check if this chunk contains the paste-start marker
-        if (!this._isPasting && str.includes(PASTE_START)) {
-            this._isPasting = true;
-            this._pasteBuffer = str.slice(str.indexOf(PASTE_START) + PASTE_START.length);
-            this._startPasteTimeout();
-
-            // Check if paste-end is also in this same chunk
-            if (this._pasteBuffer.includes(PASTE_END)) {
-                const pastedText = this._pasteBuffer.slice(0, this._pasteBuffer.indexOf(PASTE_END));
-                this._isPasting = false;
-                this._pasteBuffer = '';
-                this._clearPasteTimeout();
-                this._events.emit('paste', pastedText);
+        
+        const startIdx = str.indexOf(PASTE_START);
+        if (startIdx !== -1) {
+            if (startIdx > 0) {
+                const before = str.substring(0, startIdx);
+                this._processInput(Buffer.from(before, 'utf8'));
             }
-            return;
-        }
 
-        // If we are inside a paste, accumulate content
-        if (this._isPasting) {
-            if (str.includes(PASTE_END)) {
-                this._pasteBuffer += str.slice(0, str.indexOf(PASTE_END));
-                const pastedText = this._pasteBuffer;
-                this._isPasting = false;
-                this._pasteBuffer = '';
-                this._clearPasteTimeout();
-                this._events.emit('paste', pastedText);
+            const afterStart = str.substring(startIdx + PASTE_START.length);
+            const endIdx = afterStart.indexOf(PASTE_END);
+            
+            if (endIdx !== -1) {
+                this._events.emit('paste', afterStart.substring(0, endIdx));
+                const remaining = afterStart.substring(endIdx + PASTE_END.length);
+                if (remaining.length > 0) {
+                    this._processInput(Buffer.from(remaining, 'utf8'));
+                }
             } else {
-                this._pasteBuffer += str;
+                this._isPasting = true;
+                this._pasteBuffer = afterStart;
                 this._startPasteTimeout();
             }
             return;
@@ -331,6 +343,19 @@ export class InputParser {
      */
     private _tryParseEscape(): void {
         const seq = this._escapeBuffer.toString('utf8');
+
+        const PASTE_START = '\x1b[200~';
+        const pasteStartIdx = seq.indexOf(PASTE_START);
+        if (pasteStartIdx !== -1) {
+            this._escapeBuffer = Buffer.alloc(0);
+            if (pasteStartIdx > 0) {
+                const before = seq.substring(0, pasteStartIdx);
+                this._processInput(Buffer.from(before, 'utf8'));
+            }
+            const after = seq.substring(pasteStartIdx);
+            this._processInput(Buffer.from(after, 'utf8'));
+            return;
+        }
 
         // Check for mouse event first
         if (isMouseSequence(seq)) {


### PR DESCRIPTION
## Description

This PR fixes the issue where bracketed pastes larger than a few characters are dropped when they are split across multiple data chunks in the Node.js stream.

## Related Issue

Closes #1774

## Which package(s)?

@termuijs/core

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] 🚀 Performance (`type:performance`)
- [ ] 👷 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/anshika1179`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

Replaced the logic in `_processInput` and `_tryParseEscape` to handle split paste chunks properly, intercept paste sequences incorrectly buffered in `_escapeBuffer`, and used `_decoder.write(data)` earlier to gracefully handle multibyte utf-8 sequences chunked mid-character.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of bracketed paste input so pasted content is recognized more reliably, even when paste markers arrive in the same input chunk.
  * Fixed cases where pasted text could be split across buffered input, ensuring the full paste is captured and emitted correctly.
  * Better preserves and processes any normal typing that appears before or after a paste sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->