### PR TITLE
fix: include actual color values in the style fingerprint to prevent renderer from skipping color-only changes

### DIFF
--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -102,13 +102,27 @@ function colorsEqual(a: Color, b: Color): boolean {
     }
 }
 
+/** ASCII hex digit char code -> 0-15, branch-free-ish (no string allocation). */
+function hexDigit(code: number): number {
+    // '0'-'9' = 48-57, 'A'-'F' = 65-70, 'a'-'f' = 97-102
+    return code >= 97 ? code - 87 : code >= 65 ? code - 55 : code - 48;
+}
+
 function hashColor(color: Color, hash: number): number {
     switch (color.type) {
         case 'none':    return ((hash << 3) - hash) | 0;
         case 'named':   return ((hash << 5) - hash + color.name.charCodeAt(0) * 256 + color.name.charCodeAt(color.name.length - 1)) | 0;
         case 'ansi256': return ((hash << 7) - hash + color.code) | 0;
         case 'rgb':     return ((hash << 9) - hash + color.r * 65536 + color.g * 256 + color.b) | 0;
-        case 'hex':     { let h = hash; for (let i = 0; i < color.hex.length; i++) h = ((h << 5) - h + color.hex.charCodeAt(i)) | 0; return h; }
+        case 'hex':     {
+            // '#rrggbb' — decode the 3 byte pairs directly via charCodeAt instead of
+            // looping over the string (this runs per-cell in the render hot path).
+            const s = color.hex;
+            const r = (hexDigit(s.charCodeAt(1)) << 4) | hexDigit(s.charCodeAt(2));
+            const g = (hexDigit(s.charCodeAt(3)) << 4) | hexDigit(s.charCodeAt(4));
+            const b = (hexDigit(s.charCodeAt(5)) << 4) | hexDigit(s.charCodeAt(6));
+            return ((hash << 9) - hash + r * 65536 + g * 256 + b) | 0;
+        }
     }
 }
 

--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -102,6 +102,16 @@ function colorsEqual(a: Color, b: Color): boolean {
     }
 }
 
+function hashColor(color: Color, hash: number): number {
+    switch (color.type) {
+        case 'none':    return ((hash << 3) - hash) | 0;
+        case 'named':   return ((hash << 5) - hash + color.name.charCodeAt(0) * 256 + color.name.charCodeAt(color.name.length - 1)) | 0;
+        case 'ansi256': return ((hash << 7) - hash + color.code) | 0;
+        case 'rgb':     return ((hash << 9) - hash + color.r * 65536 + color.g * 256 + color.b) | 0;
+        case 'hex':     { let h = hash; for (let i = 0; i < color.hex.length; i++) h = ((h << 5) - h + color.hex.charCodeAt(i)) | 0; return h; }
+    }
+}
+
 /**
  * Double-buffered 2D cell grid for the terminal.
  *
@@ -194,8 +204,10 @@ export class Screen {
         let hash = 0;
         for (const cell of this.back[row]) {
             if (cell.width === 0) continue;
-            const fg = cell.fg.type;
-            const bg = cell.bg.type;
+            
+            hash = hashColor(cell.fg, hash);
+            hash = hashColor(cell.bg, hash);
+            
             const bits =
                 (cell.bold ? 1 : 0) |
                 (cell.italic ? 2 : 0) |
@@ -203,8 +215,9 @@ export class Screen {
                 (cell.dim ? 8 : 0) |
                 (cell.strikethrough ? 16 : 0) |
                 (cell.inverse ? 32 : 0);
-            const seed = fg.charCodeAt(0) * 65536 + bg.charCodeAt(0) * 4096 + bits;
-            hash = ((hash << 7) - hash + seed) | 0;
+                
+            hash = ((hash << 7) - hash + bits) | 0;
+            
             if (cell.link) {
                 for (let i = 0; i < cell.link.length; i++)
                     hash = ((hash << 5) - hash + cell.link.charCodeAt(i)) | 0;


### PR DESCRIPTION
## Description

This PR fixes the issue where the renderer skips color-only changes because the `getStyleLine()` fingerprint ignored actual color values and only hashed the color's type string. A new `hashColor()` function is introduced to incorporate the specific color values (named name, ansi code, rgb values, or hex code) into the line hash so that foreground or background color changes trigger a re-render.

## Related Issue

Closes #1773

## Which package(s)?

@termuijs/core

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] 🚀 Performance (`type:performance`)
- [ ] 👷 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/anshika1179`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

Added `hashColor` function to handle hashing for `none`, `named`, `ansi256`, `rgb`, and `hex` color types, properly shifting and merging the actual color definition fields with the rolling row hash.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how row styling is fingerprinted, making style comparison more consistent across different color types.
  * Preserved existing text-style handling and link detection while refining the underlying style hashing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->