### PR TITLE
fix: add timeout and cleanup to readClipboard to prevent permanent stdin handler leak

### DIFF
--- a/packages/core/src/utils/ansi.ts
+++ b/packages/core/src/utils/ansi.ts
@@ -180,17 +180,18 @@ export function writeClipboard(text: string, stdout: NodeJS.WriteStream = proces
 }
 export function readClipboard(
     stdin: NodeJS.ReadStream = process.stdin,
-    stdout: NodeJS.WriteStream = process.stdout
+    stdout: NodeJS.WriteStream = process.stdout,
+    timeoutMs = 1000,
 ): Promise<string> {
     return new Promise((resolve, reject) => {
+        let settled = false;
         const handler = (data: Buffer) => {
             const str = data.toString('utf8');
-
             const match = str.match(/\x1b\]52;c;([^\x07]+)\x07/);
 
             if (!match) return;
-
-            stdin.off('data', handler);
+            
+            cleanup();
 
             try {
                 resolve(
@@ -199,6 +200,18 @@ export function readClipboard(
             } catch (err) {
                 reject(err);
             }
+        };
+
+        const timer = setTimeout(() => {
+            cleanup();
+            reject(new Error('Clipboard read timed out'));
+        }, timeoutMs);
+
+        const cleanup = () => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            stdin.off('data', handler);
         };
 
         stdin.on('data', handler);


### PR DESCRIPTION
## Description

This PR fixes the issue where `readClipboard()` permanently leaked a `stdin` data handler if the terminal didn't respond to OSC 52 queries. By adding a configurable timeout (default 1000ms) and a cleanup mechanism, it prevents unbounded memory growth, CPU waste from regex matching on every stdin event, and interference with the `InputParser`.

## Related Issue

Closes #1772

## Which package(s)?

@termuijs/core

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] 🚀 Performance (`type:performance`)
- [ ] 👷 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/anshika1179`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

Added `timeoutMs` parameter to `readClipboard` which defaults to 1000ms. It properly clears its `stdin.on('data')` listener either upon successful parsing or a timeout rejection, preventing handler buildup across multiple calls.
