### PR TITLE
feat(ui): add AbortSignal support to prompts

### DIFF
--- a/packages/ui/src/Form.ts
+++ b/packages/ui/src/Form.ts
@@ -25,6 +25,7 @@ export class Form extends Widget {
     private _activeColor: Style['fg'];
     private _onSubmit?: (values: Record<string, string>) => void;
     private _isValidating = false;
+    private _onComplete?: (values: Record<string, string>) => void;
     focusable = true;
     public signal?: AbortSignal;
 
@@ -82,8 +83,15 @@ export class Form extends Widget {
         }
 
         this._isValidating = false;
-        if (!hasErr) this._onSubmit?.(this.values);
+        if (!hasErr) {
+            this._onSubmit?.(this.values);
+            this._onComplete?.(this.values);
+        }
         this.markDirty();
+    }
+
+    onComplete(cb: (values: Record<string, string>) => void): void {
+        this._onComplete = cb;
     }
 
     /** Minimal key router — printable chars -> insertChar, backspace -> deleteBack */

--- a/packages/ui/src/Form.ts
+++ b/packages/ui/src/Form.ts
@@ -11,6 +11,7 @@ export interface FormField {
 export interface FormOptions {
     labelColor?: Style['fg']; errorColor?: Style['fg']; activeColor?: Style['fg'];
     onSubmit?: (values: Record<string, string>) => void;
+    signal?: AbortSignal;
 }
 
 export class Form extends Widget {
@@ -25,6 +26,7 @@ export class Form extends Widget {
     private _onSubmit?: (values: Record<string, string>) => void;
     private _isValidating = false;
     focusable = true;
+    public signal?: AbortSignal;
 
     constructor(fields: FormField[], options: FormOptions = {}) {
         super(mergeStyles(defaultStyle(), { height: fields.length * 2 + 1, flexGrow: 1 }));
@@ -33,6 +35,7 @@ export class Form extends Widget {
         this._errorColor = options.errorColor ?? { type: 'named', name: 'red' };
         this._activeColor = options.activeColor ?? { type: 'named', name: 'cyan' };
         this._onSubmit = options.onSubmit;
+        this.signal = options.signal;
         for (const f of fields) this._values.set(f.name, '');
         // Wire key events from the App/event system into this widget's handlers.
         // Minimal: only route printable chars and backspace to existing methods.

--- a/packages/ui/src/NumberInput.ts
+++ b/packages/ui/src/NumberInput.ts
@@ -19,6 +19,7 @@ export interface NumberInputOptions {
     allowDecimal?: boolean;
     onChange?: (value: number | null) => void;
     onSubmit?: (value: number | null) => void;
+    signal?: AbortSignal;
 }
 
 export class NumberInput extends Widget {
@@ -32,6 +33,7 @@ export class NumberInput extends Widget {
     private _onChange?: (value: number | null) => void;
     private _onSubmit?: (value: number | null) => void;
     focusable = true;
+    public signal?: AbortSignal;
 
     constructor(
         style: Partial<Style> = {},
@@ -45,6 +47,7 @@ export class NumberInput extends Widget {
         this._allowDecimal = options.allowDecimal ?? true;
         this._onChange = options.onChange;
         this._onSubmit = options.onSubmit;
+        this.signal = options.signal;
     }
 
     /** The numeric value, or null if the field is empty / invalid. */

--- a/packages/ui/src/NumberInput.ts
+++ b/packages/ui/src/NumberInput.ts
@@ -32,6 +32,7 @@ export class NumberInput extends Widget {
     private _allowDecimal: boolean;
     private _onChange?: (value: number | null) => void;
     private _onSubmit?: (value: number | null) => void;
+    private _onComplete?: (value: number | null) => void;
     focusable = true;
     public signal?: AbortSignal;
 
@@ -136,7 +137,14 @@ export class NumberInput extends Widget {
         this._notify();
     }
 
-    submit(): void { this._onSubmit?.(this.numericValue); }
+    submit(): void { 
+        this._onSubmit?.(this.numericValue); 
+        this._onComplete?.(this.numericValue);
+    }
+
+    onComplete(cb: (value: number | null) => void): void {
+        this._onComplete = cb;
+    }
     clear(): void { this._raw = ''; this._cursorPos = 0; this._notify(); }
 
     /**

--- a/packages/ui/src/Select.ts
+++ b/packages/ui/src/Select.ts
@@ -7,6 +7,7 @@ export interface SelectOptions {
     placeholder?: string;
     activeColor?: Style['fg'];
     onSelect?: (option: SelectOption, index: number) => void;
+    signal?: AbortSignal;
 }
 
 export class Select extends Widget {
@@ -18,6 +19,7 @@ export class Select extends Widget {
     private _onSelect?: (option: SelectOption, index: number) => void;
     private _closedHeight: number;
     focusable = true;
+    public signal?: AbortSignal;
 
     constructor(options: SelectOption[], config: SelectOptions = {}, style?: Partial<Style>) {
         super(mergeStyles(mergeStyles(defaultStyle(), { height: 1 }), style ?? {}));
@@ -26,6 +28,7 @@ export class Select extends Widget {
         this._placeholder = config.placeholder ?? 'Select...';
         this._activeColor = config.activeColor ?? { type: 'named', name: 'cyan' };
         this._onSelect = config.onSelect;
+        this.signal = config.signal;
     }
 
     get selectedOption(): SelectOption | undefined { return this._options[this._selectedIndex]; }

--- a/packages/ui/src/Select.ts
+++ b/packages/ui/src/Select.ts
@@ -18,6 +18,7 @@ export class Select extends Widget {
     private _activeColor: Style['fg'];
     private _onSelect?: (option: SelectOption, index: number) => void;
     private _closedHeight: number;
+    private _onComplete?: (option: SelectOption) => void;
     focusable = true;
     public signal?: AbortSignal;
 
@@ -61,7 +62,17 @@ export class Select extends Widget {
     }
     confirm(): void {
         const opt = this._options[this._selectedIndex];
-        if (opt && !opt.disabled) { this._onSelect?.(opt, this._selectedIndex); this._isOpen = false; this._restoreHeight(); this.markDirty(); }
+        if (opt && !opt.disabled) { 
+            this._onSelect?.(opt, this._selectedIndex); 
+            this._onComplete?.(opt);
+            this._isOpen = false; 
+            this._restoreHeight(); 
+            this.markDirty(); 
+        }
+    }
+
+    onComplete(cb: (option: SelectOption) => void): void {
+        this._onComplete = cb;
     }
 
     protected _renderSelf(screen: Screen): void {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -102,7 +102,7 @@ export type { Command, CommandPaletteOptions } from './CommandPalette.js';
 export { useCommandPalette } from './hooks/useCommandPalette.js';
 export type { UseCommandPaletteOptions, UseCommandPaletteReturn } from './hooks/useCommandPalette.js';
 
-export { prompt, NonInteractiveError } from './prompts.js';
+export { prompt, NonInteractiveError, select, textInput, numberInput, form } from './prompts.js';
 export type { TextPromptOptions, ConfirmPromptOptions, SelectPromptOptions } from './prompts.js';
 
 export { NotificationCenter, NotificationStore, notifications, useNotifications } from './NotificationCenter.js';

--- a/packages/ui/src/prompts-abort.test.ts
+++ b/packages/ui/src/prompts-abort.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { prompt, select, textInput, numberInput, form } from './prompts.js';
+import { TermUIAbortError } from '@termuijs/core';
+
+describe('AbortSignal prompt integration', () => {
+    let originalIsTTY: any /* descriptor type */;
+    let originalSetRawMode: any /* descriptor type */;
+    let setRawModeSpy: any /* spy function */;
+
+    beforeEach(() => {
+        originalIsTTY = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+        originalSetRawMode = Object.getOwnPropertyDescriptor(process.stdin, 'setRawMode');
+
+        Object.defineProperty(process.stdin, 'isTTY', {
+            configurable: true,
+            get: () => true,
+        });
+
+        setRawModeSpy = vi.fn();
+        Object.defineProperty(process.stdin, 'setRawMode', {
+            configurable: true,
+            value: setRawModeSpy,
+        });
+
+        // Mock write to avoid writing TUI escape sequences to test output
+        vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        if (originalIsTTY) {
+            Object.defineProperty(process.stdin, 'isTTY', originalIsTTY);
+        } else {
+            delete (process.stdin as any).isTTY;
+        }
+        if (originalSetRawMode) {
+            Object.defineProperty(process.stdin, 'setRawMode', originalSetRawMode);
+        } else {
+            delete (process.stdin as any).setRawMode;
+        }
+    });
+
+    it('rejects select prompt with TermUIAbortError on signal abort', async () => {
+        const controller = new AbortController();
+        const sel = select({
+            options: ['a', 'b', 'c'],
+            signal: controller.signal,
+        });
+
+        const promise = prompt(sel);
+
+        // Abort the controller
+        controller.abort();
+
+        await expect(promise).rejects.toThrow(TermUIAbortError);
+        // Verify raw mode was cleaned up (called with false)
+        expect(setRawModeSpy).toHaveBeenCalledWith(false);
+    });
+
+    it('rejects textInput prompt with TermUIAbortError on signal abort', async () => {
+        const controller = new AbortController();
+        const input = textInput({
+            signal: controller.signal,
+        });
+
+        const promise = prompt(input);
+        controller.abort();
+
+        await expect(promise).rejects.toThrow(TermUIAbortError);
+        expect(setRawModeSpy).toHaveBeenCalledWith(false);
+    });
+
+    it('rejects numberInput prompt with TermUIAbortError on signal abort', async () => {
+        const controller = new AbortController();
+        const input = numberInput({
+            signal: controller.signal,
+        });
+
+        const promise = prompt(input);
+        controller.abort();
+
+        await expect(promise).rejects.toThrow(TermUIAbortError);
+        expect(setRawModeSpy).toHaveBeenCalledWith(false);
+    });
+
+    it('rejects form prompt with TermUIAbortError on signal abort', async () => {
+        const controller = new AbortController();
+        const f = form(
+            [
+                { name: 'name', label: 'Name', type: 'text' },
+            ],
+            {
+                signal: controller.signal,
+            }
+        );
+
+        const promise = prompt(f);
+        controller.abort();
+
+        await expect(promise).rejects.toThrow(TermUIAbortError);
+        expect(setRawModeSpy).toHaveBeenCalledWith(false);
+    });
+
+    it('rejects immediately if signal is already aborted', async () => {
+        const controller = new AbortController();
+        controller.abort();
+
+        const sel = select({
+            options: ['a', 'b', 'c'],
+            signal: controller.signal,
+        });
+
+        await expect(prompt(sel)).rejects.toThrow(TermUIAbortError);
+    });
+});

--- a/packages/ui/src/prompts-abort.test.ts
+++ b/packages/ui/src/prompts-abort.test.ts
@@ -112,4 +112,56 @@ describe('AbortSignal prompt integration', () => {
 
         await expect(prompt(sel)).rejects.toThrow(TermUIAbortError);
     });
+
+    it('resolves select prompt successfully without aborting', async () => {
+        const sel = select({
+            options: ['a', 'b', 'c'],
+        });
+        const promise = prompt(sel);
+        
+        sel.selectNext();
+        sel.confirm();
+        
+        await expect(promise).resolves.toBe('b');
+        expect(setRawModeSpy).toHaveBeenCalledWith(false);
+    });
+
+    it('resolves textInput prompt successfully without aborting', async () => {
+        const input = textInput();
+        const promise = prompt(input);
+        
+        input.value = 'hello world';
+        input.submit();
+        
+        await expect(promise).resolves.toBe('hello world');
+        expect(setRawModeSpy).toHaveBeenCalledWith(false);
+    });
+
+    it('resolves numberInput prompt successfully without aborting', async () => {
+        const input = numberInput();
+        const promise = prompt(input);
+        
+        input.rawValue = '42';
+        input.submit();
+        
+        await expect(promise).resolves.toBe(42);
+        expect(setRawModeSpy).toHaveBeenCalledWith(false);
+    });
+
+    it('resolves form prompt successfully without aborting', async () => {
+        const f = form([
+            { name: 'name', label: 'Name', type: 'text' },
+        ]);
+        const promise = prompt(f);
+        
+        f.insertChar('A');
+        f.insertChar('l');
+        f.insertChar('i');
+        f.insertChar('c');
+        f.insertChar('e');
+        await f.submit();
+        
+        await expect(promise).resolves.toEqual({ name: 'Alice' });
+        expect(setRawModeSpy).toHaveBeenCalledWith(false);
+    });
 });

--- a/packages/ui/src/prompts.ts
+++ b/packages/ui/src/prompts.ts
@@ -1,12 +1,13 @@
 // ─────────────────────────────────────────────────────
 // @termuijs/ui — Imperative Prompts
-//
-// Pure Node.js readline-based prompts for CLI scripts
-// that don't need a full TUI app. Zero dependency on
-// @termuijs/core, @termuijs/widgets, or @termuijs/jsx.
 // ─────────────────────────────────────────────────────
 
 import * as readline from 'readline';
+import { App, TermUIAbortError } from '@termuijs/core';
+import { TextInput, Widget } from '@termuijs/widgets';
+import { Select, type SelectOption, type SelectOptions } from './Select.js';
+import { NumberInput, type NumberInputOptions } from './NumberInput.js';
+import { Form, type FormField, type FormOptions } from './Form.js';
 
 export class NonInteractiveError extends Error {
     constructor() {
@@ -126,22 +127,130 @@ async function promptSelect<T = string>(options: SelectPromptOptions<T>): Promis
     });
 }
 
-/**
- * Imperative prompts for CLI scripts — no widget stack required.
- *
- * ```ts
- * const name = await prompt.text({ message: 'Project name:', default: 'my-app' });
- * const ok = await prompt.confirm({ message: 'Continue?', default: true });
- * const pkg = await prompt.select({ message: 'Package manager:', options: [
- *     { label: 'pnpm', value: 'pnpm' },
- *     { label: 'npm', value: 'npm' },
- * ]});
- * ```
- *
- * Throws `NonInteractiveError` when stdin is not a TTY.
- */
-export const prompt = {
+export async function promptWidget<T = any /* Allow resolving any prompt value type */>(widget: Widget): Promise<T> {
+    if (!process.stdin.isTTY) throw new NonInteractiveError();
+
+    let inlineRows = 3;
+    if (widget instanceof Form) {
+        inlineRows = typeof widget.style?.height === 'number' ? widget.style.height : 5;
+    } else if (widget instanceof Select) {
+        inlineRows = 1 + (widget as any /* Bypass private options access */)._options.length;
+    } else if (widget instanceof NumberInput) {
+        inlineRows = typeof widget.style?.height === 'number' ? widget.style.height : 3;
+    } else if (widget instanceof TextInput) {
+        inlineRows = typeof widget.style?.height === 'number' ? widget.style.height : 3;
+    }
+
+    const app = new App(widget, {
+        screenMode: 'inline',
+        inlineRows,
+        skipFallback: true,
+    });
+
+    const signal = (widget as any /* Bypass private signal access */).signal;
+
+    return new Promise<T>((resolve, reject) => {
+        let completed = false;
+
+        const cleanup = () => {
+            if (completed) return;
+            completed = true;
+            if (signal) {
+                signal.removeEventListener('abort', onAbort);
+            }
+            app.unmount();
+        };
+
+        const onAbort = () => {
+            cleanup();
+            reject(new TermUIAbortError());
+        };
+
+        if (signal) {
+            if (signal.aborted) {
+                cleanup();
+                reject(new TermUIAbortError());
+                return;
+            }
+            signal.addEventListener('abort', onAbort);
+        }
+
+        if (widget instanceof Select) {
+            const originalOnSelect = (widget as any /* Bypass private access */)._onSelect;
+            (widget as any /* Bypass private access */)._onSelect = (option: any /* Callback signature uses any */, index: number) => {
+                originalOnSelect?.(option, index);
+                cleanup();
+                resolve(option.value as T);
+            };
+        } else if (widget instanceof TextInput) {
+            const originalOnSubmit = (widget as any /* Bypass private access */)._onSubmit;
+            (widget as any /* Bypass private access */)._onSubmit = (value: string) => {
+                originalOnSubmit?.(value);
+                cleanup();
+                resolve(value as unknown as T);
+            };
+        } else if (widget instanceof NumberInput) {
+            const originalOnSubmit = (widget as any /* Bypass private access */)._onSubmit;
+            (widget as any /* Bypass private access */)._onSubmit = (value: number | null) => {
+                originalOnSubmit?.(value);
+                cleanup();
+                resolve(value as unknown as T);
+            };
+        } else if (widget instanceof Form) {
+            const originalOnSubmit = (widget as any /* Bypass private access */)._onSubmit;
+            (widget as any /* Bypass private access */)._onSubmit = (values: Record<string, string>) => {
+                originalOnSubmit?.(values);
+                cleanup();
+                resolve(values as unknown as T);
+            };
+        } else {
+            const originalOnSubmit = (widget as any /* Bypass private access */)._onSubmit;
+            if (typeof originalOnSubmit === 'function') {
+                (widget as any /* Bypass private access */)._onSubmit = (value: any /* Custom widget onSubmit values */) => {
+                    originalOnSubmit?.(value);
+                    cleanup();
+                    resolve(value as T);
+                };
+            }
+        }
+
+        app.mount().catch((err) => {
+            cleanup();
+            reject(err);
+        });
+    });
+}
+
+export function select(config: { options: string[]; placeholder?: string; activeColor?: any /* Keep color type flexible */; signal?: AbortSignal }) {
+    const formattedOptions = config.options.map(o => ({ label: o, value: o }));
+    return new Select(formattedOptions, {
+        placeholder: config.placeholder,
+        activeColor: config.activeColor,
+        signal: config.signal,
+    });
+}
+
+export function textInput(options: { placeholder?: string; mask?: string; maxLength?: number; suggestions?: string[]; signal?: AbortSignal } = {}) {
+    return new TextInput({}, options);
+}
+
+export function numberInput(options: NumberInputOptions & { signal?: AbortSignal } = {}) {
+    return new NumberInput({}, options);
+}
+
+export function form(fields: FormField[], options: FormOptions & { signal?: AbortSignal } = {}) {
+    return new Form(fields, options);
+}
+
+export interface Prompt {
+    <T = any /* Default prompt value type */>(widget: Widget): Promise<T>;
+    text: typeof promptText;
+    confirm: typeof promptConfirm;
+    select: typeof promptSelect;
+}
+
+export const prompt: Prompt = Object.assign(promptWidget, {
     text: promptText,
     confirm: promptConfirm,
     select: promptSelect,
-} as const;
+});

--- a/packages/ui/src/prompts.ts
+++ b/packages/ui/src/prompts.ts
@@ -176,42 +176,30 @@ export async function promptWidget<T = any /* Allow resolving any prompt value t
         }
 
         if (widget instanceof Select) {
-            const originalOnSelect = (widget as any /* Bypass private access */)._onSelect;
-            (widget as any /* Bypass private access */)._onSelect = (option: any /* Callback signature uses any */, index: number) => {
-                originalOnSelect?.(option, index);
+            widget.onComplete((option) => {
                 cleanup();
-                resolve(option.value as T);
-            };
+                resolve(option.value as unknown as T);
+            });
         } else if (widget instanceof TextInput) {
-            const originalOnSubmit = (widget as any /* Bypass private access */)._onSubmit;
-            (widget as any /* Bypass private access */)._onSubmit = (value: string) => {
-                originalOnSubmit?.(value);
+            widget.onComplete((value) => {
                 cleanup();
                 resolve(value as unknown as T);
-            };
+            });
         } else if (widget instanceof NumberInput) {
-            const originalOnSubmit = (widget as any /* Bypass private access */)._onSubmit;
-            (widget as any /* Bypass private access */)._onSubmit = (value: number | null) => {
-                originalOnSubmit?.(value);
+            widget.onComplete((value) => {
                 cleanup();
                 resolve(value as unknown as T);
-            };
+            });
         } else if (widget instanceof Form) {
-            const originalOnSubmit = (widget as any /* Bypass private access */)._onSubmit;
-            (widget as any /* Bypass private access */)._onSubmit = (values: Record<string, string>) => {
-                originalOnSubmit?.(values);
+            widget.onComplete((values) => {
                 cleanup();
                 resolve(values as unknown as T);
-            };
-        } else {
-            const originalOnSubmit = (widget as any /* Bypass private access */)._onSubmit;
-            if (typeof originalOnSubmit === 'function') {
-                (widget as any /* Bypass private access */)._onSubmit = (value: any /* Custom widget onSubmit values */) => {
-                    originalOnSubmit?.(value);
-                    cleanup();
-                    resolve(value as T);
-                };
-            }
+            });
+        } else if ('onComplete' in widget && typeof (widget as any).onComplete === 'function') {
+            (widget as any).onComplete((value: any) => {
+                cleanup();
+                resolve(value as T);
+            });
         }
 
         app.mount().catch((err) => {

--- a/packages/widgets/src/input/TextInput.ts
+++ b/packages/widgets/src/input/TextInput.ts
@@ -31,6 +31,7 @@ export class TextInput extends Widget {
     private _vimMode: VimMode = process.env.TERMUI_KEYBINDINGS === 'vim' ? 'normal' : 'insert';
     private _suggestions: string[] = [];
     private _suggestionIndex = 0;
+    public signal?: AbortSignal;
 
     constructor(
         style: Partial<Style> = {},
@@ -41,6 +42,7 @@ export class TextInput extends Widget {
             suggestions?: string[];
             onChange?: (value: string) => void;
             onSubmit?: (value: string) => void;
+            signal?: AbortSignal;
         } = {},
     ) {
         super({ border: 'single', height: 3, ...style });
@@ -51,6 +53,7 @@ export class TextInput extends Widget {
         this._onChange = options.onChange;
         this._onSubmit = options.onSubmit;
         this._suggestions = options.suggestions ?? [];
+        this.signal = options.signal;
 
         this.focusable = true;
 

--- a/packages/widgets/src/input/TextInput.ts
+++ b/packages/widgets/src/input/TextInput.ts
@@ -31,6 +31,7 @@ export class TextInput extends Widget {
     private _vimMode: VimMode = process.env.TERMUI_KEYBINDINGS === 'vim' ? 'normal' : 'insert';
     private _suggestions: string[] = [];
     private _suggestionIndex = 0;
+    private _onComplete?: (value: string) => void;
     public signal?: AbortSignal;
 
     constructor(
@@ -197,6 +198,11 @@ export class TextInput extends Widget {
 
     submit(): void {
         this._onSubmit?.(this._value);
+        this._onComplete?.(this._value);
+    }
+
+    onComplete(cb: (value: string) => void): void {
+        this._onComplete = cb;
     }
 
     clear(): void {


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

This PR adds support for programmatic cancellation to all interactive prompt components (`TextInput`, `Select`, `NumberInput`, and `Form`) using the standard `AbortController` / `AbortSignal` API. When the signal aborts, the prompt unmounts the inline app, cleanly restores the terminal's raw mode configuration, and rejects the prompt promise with `TermUIAbortError`.

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #64 

## Which package(s)?

`@termuijs/ui`, `@termuijs/widgets`

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [x] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/172e996c-3943-4a86-8249-1f01922d0f64`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

The implementation ensures that:
- Cleanups of event listeners are registered correctly.
- If the signal is already aborted before the prompt starts running, it rejects immediately without configuring raw mode.
- Custom/mock TTY and raw-mode spys are used to verify the cleanup flow under unit testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prompt-related controls (select, text input, number input, form) now support cancellation via an optional abort signal.
  * Added new prompt helper constructors for select, text input, number input, and form.
  * Updated the main prompt API to be callable while still exposing `.text`, `.confirm`, and `.select`.
  * Added new completion hooks (`onComplete`) for form inputs, number inputs, selects, and text inputs.

* **Bug Fixes**
  * Improved cancellation cleanup to help prevent stuck terminal states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->