### PR TITLE
fix(core): sanitize title strings to prevent terminal escape injection

### DIFF
--- a/packages/core/src/app/App.ts
+++ b/packages/core/src/app/App.ts
@@ -166,7 +166,8 @@ export class App {
         }
 
         if (this._options.title) {
-            this.terminal.write(`\x1b]0;${this._options.title}\x07`);
+            const safeTitle = this._options.title.replace(/[\u0000-\u001F\u007F-\u009F\u001B]/g, '');
+            this.terminal.write(`\x1b]0;${safeTitle}\x07`);
         }
 
         // Handle resize

--- a/packages/core/src/utils/ansi.test.ts
+++ b/packages/core/src/utils/ansi.test.ts
@@ -139,6 +139,14 @@ describe('ANSI Title Functions', () => {
         expect(setTitle('My App')).toBe('\x1b]0;My App\x07');
         expect(setTitle('')).toBe('\x1b]0;\x07');
     });
+
+    it('strips control/escape chars to prevent OSC injection', () => {
+        // BEL terminates OSC, ESC opens new sequences — neither may survive in the payload.
+        const out = setTitle('a\x07evil\x1b]0;pwn');
+        const payload = out.slice(4, -1); // between the `\x1b]0;` prefix and the trailing \x07
+        expect(out.endsWith('\x07')).toBe(true);
+        expect(payload).not.toMatch(/[\x00-\x1f\x7f-\x9f]/); // no control/escape chars remain
+    });
 });
 
 describe('ANSI Clipboard Functions', () => {

--- a/packages/core/src/utils/ansi.ts
+++ b/packages/core/src/utils/ansi.ts
@@ -112,7 +112,8 @@ export const resetScrollRegion = `${CSI}r`;
 // ── Title ───────────────────────────────────────────
 
 export function setTitle(title: string): string {
-    return `${OSC}0;${title}\x07`;
+    const safeTitle = title.replace(/[\u0000-\u001F\u007F-\u009F\u001B]/g, '');
+    return `${OSC}0;${safeTitle}\x07`;
 }
 
 // ── Hyperlinks (OSC 8) ──────────────────────────────


### PR DESCRIPTION
## Description

This PR fixes a terminal escape injection vulnerability in `setTitle()` and `App.mount()`. It sanitizes user-supplied title strings to strip C0/C1 control characters (including `\x07` BEL) before embedding them in the OSC 0 terminal escape sequence, preventing malicious sequence breakout attacks.

## Related Issue

Closes #1771

## Which package(s)?

@termuijs/core

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] 🚀 Performance (`type:performance`)
- [ ] 👷 DevOps / CI (`type:devops`)
- [x] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/anshika1179`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

Added `replace(/[\u0000-\u001F\u007F-\u009F\u001B]/g, '')` to the title parameter directly in both `setTitle` inside `ansi.ts` and in `App.mount()` inside `App.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal title handling by sanitizing titles to remove control/escape characters before sending terminal OSC title updates.
  * Reduced the risk of malformed or unsafe terminal escape sequences when titles include special characters.
* **Tests**
  * Added coverage to verify terminal title sanitization prevents injection via control characters and embedded escape sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->