### PR TITLE
fix(jsx): normalize emacs ctrl+p/ctrl+n navigation keys

### DIFF
--- a/packages/jsx/src/hooks/useKeyboardNavigation.test.ts
+++ b/packages/jsx/src/hooks/useKeyboardNavigation.test.ts
@@ -153,4 +153,23 @@ describe('useKeyboardNavigation', () => {
         result = renderHook({ itemCount: 0 });
         expect(result.selectedIndex).toBe(0);
     });
+
+    it('supports emacs ctrl+p / ctrl+n navigation when keybindingMode=emacs', () => {
+        const prev = process.env.TERMUI_KEYBINDINGS;
+        process.env.TERMUI_KEYBINDINGS = 'emacs';
+
+        let result = renderHook({ itemCount: 3, loop: true });
+
+        // Ctrl+P should behave like 'up' (wraps from 0 -> 2)
+        fiber.onInput?.(createKeyEvent({ key: 'p', raw: Buffer.alloc(0), ctrl: true, alt: false, shift: false }));
+        result = renderHook({ itemCount: 3, loop: true });
+        expect(result.selectedIndex).toBe(2);
+
+        // Ctrl+N should behave like 'down' (2 -> 0)
+        fiber.onInput?.(createKeyEvent({ key: 'n', raw: Buffer.alloc(0), ctrl: true, alt: false, shift: false }));
+        result = renderHook({ itemCount: 3, loop: true });
+        expect(result.selectedIndex).toBe(0);
+
+        if (prev === undefined) delete process.env.TERMUI_KEYBINDINGS; else process.env.TERMUI_KEYBINDINGS = prev;
+    });
 });

--- a/packages/jsx/src/hooks/useKeyboardNavigation.test.ts
+++ b/packages/jsx/src/hooks/useKeyboardNavigation.test.ts
@@ -3,7 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createKeyEvent } from '@termuijs/core';
+import { caps, createKeyEvent } from '@termuijs/core';
 import { createFiber, setCurrentFiber, clearCurrentFiber, setRequestRender } from '../hooks.js';
 import { useKeyboardNavigation } from './useKeyboardNavigation.js';
 
@@ -155,21 +155,21 @@ describe('useKeyboardNavigation', () => {
     });
 
     it('supports emacs ctrl+p / ctrl+n navigation when keybindingMode=emacs', () => {
-        const prev = process.env.TERMUI_KEYBINDINGS;
-        process.env.TERMUI_KEYBINDINGS = 'emacs';
+        const spy = vi.spyOn(caps, 'keybindingMode', 'get').mockReturnValue('emacs');
+        try {
+            let result = renderHook({ itemCount: 3, loop: true });
 
-        let result = renderHook({ itemCount: 3, loop: true });
+            // Ctrl+P should behave like 'up' (wraps from 0 -> 2)
+            fiber.onInput?.(createKeyEvent({ key: 'p', raw: Buffer.alloc(0), ctrl: true, alt: false, shift: false }));
+            result = renderHook({ itemCount: 3, loop: true });
+            expect(result.selectedIndex).toBe(2);
 
-        // Ctrl+P should behave like 'up' (wraps from 0 -> 2)
-        fiber.onInput?.(createKeyEvent({ key: 'p', raw: Buffer.alloc(0), ctrl: true, alt: false, shift: false }));
-        result = renderHook({ itemCount: 3, loop: true });
-        expect(result.selectedIndex).toBe(2);
-
-        // Ctrl+N should behave like 'down' (2 -> 0)
-        fiber.onInput?.(createKeyEvent({ key: 'n', raw: Buffer.alloc(0), ctrl: true, alt: false, shift: false }));
-        result = renderHook({ itemCount: 3, loop: true });
-        expect(result.selectedIndex).toBe(0);
-
-        if (prev === undefined) delete process.env.TERMUI_KEYBINDINGS; else process.env.TERMUI_KEYBINDINGS = prev;
+            // Ctrl+N should behave like 'down' (2 -> 0)
+            fiber.onInput?.(createKeyEvent({ key: 'n', raw: Buffer.alloc(0), ctrl: true, alt: false, shift: false }));
+            result = renderHook({ itemCount: 3, loop: true });
+            expect(result.selectedIndex).toBe(0);
+        } finally {
+            spy.mockRestore();
+        }
     });
 });

--- a/packages/jsx/src/hooks/useKeyboardNavigation.ts
+++ b/packages/jsx/src/hooks/useKeyboardNavigation.ts
@@ -73,7 +73,7 @@ export function useKeyboardNavigation({
 }: KeyboardNavigationOptions): KeyboardNavigationResult {
     const [selectedIndex, setSelectedIndex] = useState(0);
 
-    useInput((key) => {
+    useInput((key, event) => {
         if (itemCount === 0) return;
 
         const move = (delta: number) => {
@@ -87,7 +87,13 @@ export function useKeyboardNavigation({
             });
         };
 
-        switch (normalizeNavigationKey(key)) {
+        // Build a modifier-aware token when the KeyEvent is available so
+        // navigation modes like `emacs` (ctrl+n / ctrl+p) work as expected.
+        const token = event
+            ? `${event.ctrl ? 'ctrl+' : ''}${event.alt ? 'alt+' : ''}${event.shift ? 'shift+' : ''}${String(event.key).toLowerCase()}`
+            : String(key);
+
+        switch (normalizeNavigationKey(token)) {
             case 'up':
                 move(-1);
                 break;

--- a/packages/widgets/src/layout/ScrollView.ts
+++ b/packages/widgets/src/layout/ScrollView.ts
@@ -89,7 +89,8 @@ export class ScrollView extends Widget {
 }
     /** Handle keyboard navigation */
     handleKey(event: KeyEvent): void {
-        switch (normalizeNavigationKey(event.key)) {
+        const token = `${event.ctrl ? 'ctrl+' : ''}${event.alt ? 'alt+' : ''}${event.shift ? 'shift+' : ''}${String(event.key).toLowerCase()}`;
+        switch (normalizeNavigationKey(token)) {
             case 'up':       this.scrollBy(-this.getScrollDelta(1)); break;
             case 'down':     this.scrollBy(this.getScrollDelta(1)); break;
             case 'pageup':   this.scrollBy(-this.getScrollDelta(Math.max(1, this._rect.height - 1))); break;


### PR DESCRIPTION
## Description

This PR fixes an inconsistency in keyboard navigation when `TERMUI_KEYBINDINGS=emacs` is enabled. Components using `useKeyboardNavigation` and `ScrollView` now preserve modifier information when normalizing navigation keys, allowing `Ctrl+P` and `Ctrl+N` to behave as documented. A regression test has been added to cover the runtime behavior.

## Related Issue

Closes #1815

## Which package(s)?

* `@termuijs/jsx`
* `@termuijs/widgets`

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)
* [x] 🧪 Tests (`type:testing`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [ ] Build passes: `bun run build`
* [ ] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A (no UI changes)

## Notes for the Reviewer

* This change keeps the implementation localized without introducing new public APIs.
* A regression test has been added to verify `Ctrl+P` and `Ctrl+N` navigation in Emacs keybinding mode through the runtime input path.
* Existing default and Vim navigation behavior remains unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added modifier-aware keyboard navigation by recognizing combined keys (Ctrl/Alt/Shift), including emacs-style `Ctrl+N` and `Ctrl+P` behavior.
* **Bug Fixes**
  * Improved navigation consistency across interactive views by ensuring key handling is normalized with modifier states.
  * Strengthened list wrapping behavior for keyboard shortcuts when moving forward/backward.
* **Tests**
  * Added coverage for emacs-mode Ctrl key navigation, including wraparound from start to end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->