### PR TITLE
fix(#1792): sanitize persist file path to prevent arbitrary file writes

### DIFF
--- a/packages/store/src/store.test.ts
+++ b/packages/store/src/store.test.ts
@@ -3,6 +3,7 @@ import { createStore, batch } from './store.js'
 import { logger } from './logger.js'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
+import * as os from 'node:os'
 
 describe('createStore', () => {
     it('initializes state from creator function', () => {
@@ -553,7 +554,11 @@ describe('middleware', () => {
 })
 
 describe('persistence', () => {
-    const testDir = path.join(__dirname, 'temp-test-store-dir')
+    let appConfig = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
+    if (process.platform === 'win32') appConfig = process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming');
+    if (process.platform === 'darwin') appConfig = path.join(os.homedir(), 'Library', 'Application Support');
+    
+    const testDir = path.join(appConfig, 'termuijs-stores', 'temp-test-store-dir')
     const testFile = path.join(testDir, 'test-store.json')
 
     afterEach(() => {
@@ -638,6 +643,26 @@ describe('persistence', () => {
 
         vi.advanceTimersByTime(100)
         expect(fs.existsSync(testFile)).toBe(false)
+    })
+
+    it('throws error on path traversal in file option', () => {
+        expect(() => {
+            createStore({ count: 0 }, {
+                persist: {
+                    file: '../../etc/passwd',
+                }
+            })
+        }).toThrow(/Persist file path must be within/)
+    })
+
+    it('throws error on path traversal in key option', () => {
+        expect(() => {
+            createStore({ count: 0 }, {
+                persist: {
+                    key: '../evil',
+                }
+            })
+        }).toThrow(/Persist key must contain only alphanumeric characters/)
     })
 })
 

--- a/packages/store/src/store.test.ts
+++ b/packages/store/src/store.test.ts
@@ -655,6 +655,17 @@ describe('persistence', () => {
         }).toThrow(/Persist file path must be within/)
     })
 
+    it('rejects a sibling dir that shares the persist-dir prefix', () => {
+        // `${persistDir}-evil/...` passes a naive startsWith() check but is outside persistDir.
+        expect(() => {
+            createStore({ count: 0 }, {
+                persist: {
+                    file: '../termuijs-stores-evil/x.json',
+                }
+            })
+        }).toThrow(/Persist file path must be within/)
+    })
+
     it('throws error on path traversal in key option', () => {
         expect(() => {
             createStore({ count: 0 }, {

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -247,12 +247,21 @@ export function createStore<T extends object>(
     let persistFilePath = '';
     if (options?.persist) {
         const persistOpt = options.persist;
+        const persistDir = path.join(getAppConfigDir(), 'termuijs-stores');
         if (persistOpt.file) {
             persistFilePath = path.isAbsolute(persistOpt.file)
                 ? persistOpt.file
-                : path.join(getAppConfigDir(), persistOpt.file);
+                : path.join(persistDir, persistOpt.file);
+            const resolvedPath = path.resolve(persistFilePath);
+            if (!resolvedPath.startsWith(path.resolve(persistDir))) {
+                throw new Error(`Persist file path must be within ${persistDir}`);
+            }
+            persistFilePath = resolvedPath;
         } else if (persistOpt.key) {
-            persistFilePath = path.join(getAppConfigDir(), `${persistOpt.key}.json`);
+            if (!/^[a-zA-Z0-9._-]+$/.test(persistOpt.key)) {
+                throw new Error('Persist key must contain only alphanumeric characters, hyphens, underscores, and dots.');
+            }
+            persistFilePath = path.join(persistDir, `${persistOpt.key}.json`);
         }
     }
 

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -253,7 +253,10 @@ export function createStore<T extends object>(
                 ? persistOpt.file
                 : path.join(persistDir, persistOpt.file);
             const resolvedPath = path.resolve(persistFilePath);
-            if (!resolvedPath.startsWith(path.resolve(persistDir))) {
+            // Use path.relative for containment: startsWith() is bypassable by a
+            // sibling dir sharing the prefix (e.g. `${persistDir}-evil/x.json`).
+            const rel = path.relative(path.resolve(persistDir), resolvedPath);
+            if (rel.startsWith('..') || path.isAbsolute(rel)) {
                 throw new Error(`Persist file path must be within ${persistDir}`);
             }
             persistFilePath = resolvedPath;


### PR DESCRIPTION
## Description

This PR fixes a critical security vulnerability where the `persist` module could allow arbitrary file writes via path traversal in the `file` and `key` options. It strictly sanitizes the file path to ensure the destination file is resolved inside the application's configuration directory.

## Related Issue

Closes #1792

## Which package(s)?

@termuijs/store

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [x] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/knoxiboy`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

Added explicit path traversal security checks for both `file` and `key` configurations using `path.resolve` and strict prefix checking. Also updated unit tests to cover path traversal scenarios.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened persistence path handling by enforcing that persistence files stay within a dedicated app config subfolder.
  * Added persistence key validation to only allow safe characters, and improved how keys map to stored filenames.
* **Tests**
  * Expanded persistence tests to cover platform-specific config directory resolution.
  * Added new cases to verify rejection of path traversal and traversal-like persistence inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->