### PR TITLE
fix(#1794): resolve useStore hook re-renders on new object reference

### DIFF
--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -44,6 +44,20 @@ const filter = useAppStore((s) => s.filter)  // only filter
 const all    = useCounter()                   // everything
 ```
 
+### Shallow Equality
+
+If your selector returns a new object or array (e.g. `(state) => ({ x: state.x, y: state.y })`), strict equality (`===`) will fail and your component will re-render on *every* store change. To prevent this, pass the `shallow` equality function as the second argument:
+
+```typescript
+import { shallow } from '@termuijs/store'
+
+// Component only re-renders when user.name or user.age actually change
+const user = useCounter(
+    (state) => ({ name: state.user.name, age: state.user.age }),
+    shallow
+)
+```
+
 ## batch()
 
 Group multiple `setState` calls into one reconciler pass. Use this in event handlers or timer callbacks where you update several fields at once.


### PR DESCRIPTION
## Description

This PR fixes a performance issue where the `useStore` hook re-renders on unrelated state changes when a selector returns a new object reference. The `@termuijs/store` package already implemented the `shallow` equality function and supported it in the `useStore` hook signature. This PR finalizes the fix by officially documenting the `shallow` equality solution in the README so developers know how to optimize their components.

## Related Issue

Closes #1794

## Which package(s)?

@termuijs/store

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [x] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/knoxiboy`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

The `shallow` implementation and tests were already present in `store.test.ts`/`shallow.test.ts`. This PR adds the necessary documentation to `README.md` to guide developers on how to prevent performance issues with object selectors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Shallow Equality” section to explain why selectors that return new object or array values can trigger unnecessary re-renders.
  * Included guidance on using shallow equality with store selectors, plus a typed example selecting multiple fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->