### PR TITLE
fix(core): warn when grid auto-placement silently drops a child widget

### DIFF
--- a/packages/core/src/layout/LayoutEngine.ts
+++ b/packages/core/src/layout/LayoutEngine.ts
@@ -212,7 +212,7 @@ function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, p
         let currentAutoCol = 0;
         const maxAutoRow = Math.max(numCols * 100, 1000);
 
-        for (const child of autoChildren) {
+                for (const child of autoChildren) {
             const s = child.style;
             const colInfo = getSpan(s.gridColumnStart, s.gridColumnEnd);
             const rowInfo = getSpan(s.gridRowStart, s.gridRowEnd);
@@ -266,8 +266,8 @@ function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, p
                     }
                 }
             }
-            
-           if (!placed) {
+
+            if (!placed) {
                 console.warn(
                     `[LayoutEngine] Grid auto-placement exhausted (maxAutoRow=${maxAutoRow}, ` +
                     `numCols=${numCols}): child "${child.id}" was not placed and will be invisible. ` +
@@ -276,8 +276,7 @@ function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, p
             }
         }
 
-        }
-
+        
         let maxRowIndex = 0;
         for (const p of placements) {
             maxRowIndex = Math.max(maxRowIndex, p.row + p.rowSpan - 1);

--- a/packages/core/src/layout/LayoutEngine.ts
+++ b/packages/core/src/layout/LayoutEngine.ts
@@ -266,6 +266,16 @@ function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, p
                     }
                 }
             }
+            
+           if (!placed) {
+                console.warn(
+                    `[LayoutEngine] Grid auto-placement exhausted (maxAutoRow=${maxAutoRow}, ` +
+                    `numCols=${numCols}): child "${child.id}" was not placed and will be invisible. ` +
+                    `Check gridTemplateColumns or reduce colSpan values.`
+                );
+            }
+        }
+
         }
 
         let maxRowIndex = 0;


### PR DESCRIPTION
## Description

Adds a warning when a grid child cannot be auto-placed within the `maxAutoRow` limit in `@termuijs/core`.

Previously, if grid auto-placement exhausted the row search space without finding a valid slot, the child was silently skipped and ended up invisible with no indication of what went wrong. This PR surfaces that failure path with a `console.warn` so developers can identify invalid grid configurations such as oversized spans or fully occupied grids.

## Related Issue

Closes #1828

## Which package(s)?

`@termuijs/core`

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/944accbd-2283-4364-9c90-43bdbee0ecbf`

## Notes for the Reviewer

This PR adds a developer-facing warning for a silent grid auto-placement failure case in `packages/core/src/layout/LayoutEngine.ts`.

When the auto-placement loop reaches the `maxAutoRow` guard without finding a valid slot for a child, the child currently remains unplaced and becomes invisible with no warning or error. This change adds a `console.warn` immediately after the auto-placement loop when `placed === false`.

The warning includes:
- the fact that grid auto-placement was exhausted
- `maxAutoRow` and `numCols`
- the child id
- a short hint to check grid configuration or large `colSpan` values

This is a low-risk fix because it does **not** change any layout logic or placement behavior — it only surfaces an existing failure mode to make debugging easier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a warning when a grid item cannot be auto-placed within the configured placement limit.
  * The message now includes the item identifier and current placement settings, helping surface cases where content may not appear.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->