### PR TITLE
feat(widgets): add scrollToIndex API to VirtualList

### DIFF
--- a/packages/widgets/src/input/VirtualList.test.ts
+++ b/packages/widgets/src/input/VirtualList.test.ts
@@ -87,6 +87,43 @@ describe('VirtualList', () => {
             list.scrollTo(200);
             expect(list.selectedIndex).toBe(99);
         });
+
+        it('scrollToIndex jumps instantly to specified index with alignment', () => {
+            const list = new VirtualList({
+                totalItems: 100,
+                renderItem: (i) => `Item ${i}`,
+                springScroll: true,
+                style: { width: 40, height: 10 },
+            });
+            const node = list.getLayoutNode();
+            computeLayout(node, 40, 10);
+            list.syncLayout();
+            
+            // test start alignment
+            list.scrollToIndex(50, 'start');
+            expect(list.scrollOffset).toBe(50);
+            expect(list.selectedIndex).toBe(50);
+            
+            // test center alignment (content height is 8)
+            list.scrollToIndex(50, 'center');
+            // offset = 50 - floor(8/2) = 46
+            expect(list.scrollOffset).toBe(46);
+            expect(list.selectedIndex).toBe(50);
+            
+            // test end alignment
+            list.scrollToIndex(50, 'end');
+            // offset = 50 - 8 + 1 = 43
+            expect(list.scrollOffset).toBe(43);
+            expect(list.selectedIndex).toBe(50);
+            
+            // test out of bounds clamping (returns early)
+            const previousOffset = list.scrollOffset;
+            list.scrollToIndex(-10);
+            expect(list.scrollOffset).toBe(previousOffset);
+            
+            list.scrollToIndex(200);
+            expect(list.scrollOffset).toBe(previousOffset);
+        });
     });
 
     describe('pageUp/pageDown with viewport smaller than itemHeight', () => {

--- a/packages/widgets/src/input/VirtualList.ts
+++ b/packages/widgets/src/input/VirtualList.ts
@@ -192,6 +192,43 @@ export class VirtualList extends Widget {
         });
     }
 
+    /** Scroll directly to an index with the specified alignment */
+    scrollToIndex(index: number, alignment: 'start' | 'center' | 'end' = 'start'): void {
+        this._runScrollAction(() => {
+            if (index < 0 || index >= this._totalItems) return;
+            
+            const rect = this._getContentRect();
+            const visibleItems = Math.floor(rect.height / this._itemHeight);
+            
+            if (visibleItems <= 0) return;
+
+            let targetOffset = index;
+            if (alignment === 'center') {
+                targetOffset -= Math.floor(visibleItems / 2);
+            } else if (alignment === 'end') {
+                targetOffset -= visibleItems - 1;
+            }
+
+            // Clamp offset
+            const maxOffset = Math.max(0, this._totalItems - visibleItems);
+            this._targetScrollOffset = Math.max(0, Math.min(targetOffset, maxOffset));
+
+            // Adjust instantly
+            this._scrollOffset = this._targetScrollOffset;
+            this._spring.position = this._targetScrollOffset;
+            this._spring.velocity = 0;
+            
+            // Keep selected index within the new viewport bounds
+            if (this._selectedIndex < this._targetScrollOffset) {
+                this._selectedIndex = this._targetScrollOffset;
+            } else if (this._selectedIndex >= this._targetScrollOffset + visibleItems) {
+                this._selectedIndex = Math.min(this._totalItems - 1, this._targetScrollOffset + visibleItems - 1);
+            }
+
+            this.markDirty();
+        });
+    }
+
     /** Confirm the current selection */
     confirm(): void {
         if (this._totalItems > 0) {


### PR DESCRIPTION
## Description

This PR adds the `scrollToIndex` API to the `VirtualList` widget, allowing developers to programmatically jump to a specific item. It properly manages `scrollOffset`, respects alignment arguments ('start', 'center', or 'end'), forces an instant update, and safely aligns the `selectedIndex` so it stays within the new viewport. Full Vitest coverage has been added.

## Related Issue

Closes #1726

## Which package(s)?

@termuijs/widgets

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/f49aa65e-aab2-4e9f-99d6-2174f339ecfe`

## Screenshots / Recordings (UI changes)

*No visual regressions, purely an API enhancement.*

## Notes for the Reviewer

Added `scrollToIndex` to instantly snap the list's viewport to the target index, bypassing the spring animation to adhere to the expected behavior outlined in the issue ("instantly adjust the internal scroll offset"). It includes full Vitest test suites for out-of-bounds behavior and `start`/`center`/`end` alignments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a way to jump the virtual list directly to a specific item.
  * Supports alignment options for positioning the item at the start, center, or end of the view.

* **Bug Fixes**
  * Out-of-range item indexes now safely do nothing instead of changing the list position.
  * Selection stays in sync with the visible range after scrolling to an item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->