### PR TITLE
fix: use visual width for text widget horizontal scrolling (Closes #1834)

### DIFF
--- a/packages/widgets/src/display/Text.test.ts
+++ b/packages/widgets/src/display/Text.test.ts
@@ -42,4 +42,27 @@ describe('Text', () => {
         expect(screen.back[0][0].char).toBe('H');
         expect(screen.back[1][0].char).not.toBe(' ');
     });
+
+    it('handles horizontal scroll with wide characters at partial offset', () => {
+        // Test scrollX landing in the middle of a wide character
+        const { screen } = renderText('中a', {}, { scrollX: 1, wrap: false }, 10, 5);
+        // When scrollX=1 lands in the middle of '中' (2 columns), should show space + 'a'
+        expect(screen.back[0][0].char).toBe(' ');
+        expect(screen.back[0][1].char).toBe('a');
+    });
+
+    it('handles horizontal scroll with wide characters at full offset', () => {
+        // Test scrollX after a complete wide character
+        const { screen } = renderText('中a', {}, { scrollX: 2, wrap: false }, 10, 5);
+        // When scrollX=2 skips the entire '中', should show 'a'
+        expect(screen.back[0][0].char).toBe('a');
+    });
+
+    it('handles horizontal scroll with emoji at partial offset', () => {
+        // Test scrollX landing in the middle of an emoji
+        const { screen } = renderText('😀a', {}, { scrollX: 1, wrap: false }, 10, 5);
+        // When scrollX=1 lands in the middle of '😀' (2 columns), should show space + 'a'
+        expect(screen.back[0][0].char).toBe(' ');
+        expect(screen.back[0][1].char).toBe('a');
+    });
 });

--- a/packages/widgets/src/display/Text.ts
+++ b/packages/widgets/src/display/Text.ts
@@ -89,8 +89,17 @@ export class Text extends Widget {
                 let skipped = 0;
                 let charIndex = 0;
                 for (const ch of line) {
-                    if (skipped >= this._scrollX) break;
                     const charWidth = stringWidth(ch);
+                    if (skipped + charWidth > this._scrollX) {
+                        // scrollX lands in the middle of this character
+                        // For wide characters, we need to handle the partial column
+                        if (charWidth === 2 && skipped < this._scrollX) {
+                            // We're at the second column of a wide character
+                            // Add a placeholder for the remaining column and skip the character
+                            line = ' ' + line.slice(charIndex + ch.length);
+                        }
+                        break;
+                    }
                     skipped += charWidth;
                     charIndex += ch.length;
                 }

--- a/packages/widgets/src/display/Text.ts
+++ b/packages/widgets/src/display/Text.ts
@@ -88,6 +88,7 @@ export class Text extends Widget {
                 // Skip scrollX visual columns
                 let skipped = 0;
                 let charIndex = 0;
+                let lineRebuilt = false;
                 for (const ch of line) {
                     const charWidth = stringWidth(ch);
                     if (skipped + charWidth > this._scrollX) {
@@ -97,13 +98,16 @@ export class Text extends Widget {
                             // We're at the second column of a wide character
                             // Add a placeholder for the remaining column and skip the character
                             line = ' ' + line.slice(charIndex + ch.length);
+                            lineRebuilt = true;
                         }
                         break;
                     }
                     skipped += charWidth;
                     charIndex += ch.length;
                 }
-                line = line.slice(charIndex);
+                if (!lineRebuilt) {
+                    line = line.slice(charIndex);
+                }
             }
 
             const lineWidth = stringWidth(line);

--- a/packages/widgets/src/display/Text.ts
+++ b/packages/widgets/src/display/Text.ts
@@ -85,12 +85,13 @@ export class Text extends Widget {
 
             // Apply horizontal scroll
             if (this._scrollX > 0) {
-                // Skip scrollX characters
+                // Skip scrollX visual columns
                 let skipped = 0;
                 let charIndex = 0;
                 for (const ch of line) {
                     if (skipped >= this._scrollX) break;
-                    skipped++;
+                    const charWidth = stringWidth(ch);
+                    skipped += charWidth;
                     charIndex += ch.length;
                 }
                 line = line.slice(charIndex);


### PR DESCRIPTION
## Description

This PR fixes the horizontal scrolling behavior in the `Text` widget by using the visual display width of characters instead of their character count. This ensures that wide Unicode characters, such as CJK characters and emoji, scroll correctly in terminal output.

## Related Issue

Closes #1834 

## Which package(s)?

* `@termuijs/widgets`

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read `CONTRIBUTING.md`.
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if applicable).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] I am a GSSoC 2026 contributor.

## Notes for the Reviewer

This change focuses only on improving horizontal scrolling for Unicode text with variable display widths. The implementation is limited to the scrolling logic and does not introduce unrelated refactoring. I would appreciate any feedback or suggestions for improvement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved horizontal scrolling in text displays so clipping and alignment are based on visual character width, not character count—resulting in more accurate behavior with wide characters and emoji.
  * Added coverage for partial and full scroll offsets with wide glyphs and emoji.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->