### PR TITLE
fix(core): validate negative percentage values in resolveSize (closes #1836)

### DIFF
--- a/packages/core/src/layout/LayoutEngine.test.ts
+++ b/packages/core/src/layout/LayoutEngine.test.ts
@@ -73,6 +73,17 @@ describe('computeLayout', () => {
         expect(root.children[1].computed.width).toBe(40);
     });
 
+    it('rejects negative percentage values', () => {
+        const root = makeNode('root', { flexDirection: 'row' }, [
+            makeNode('a', { width: '-50%' }),
+            makeNode('b', { width: '-25%' }),
+        ]);
+        computeLayout(root, 80, 24);
+
+        expect(root.children[0].computed.width).toBe(0);
+        expect(root.children[1].computed.width).toBe(0);
+    });
+
     it('respects padding', () => {
         const root = makeNode('root', { padding: 2 }, [
             makeNode('child', { flexGrow: 1 }),

--- a/packages/core/src/layout/LayoutEngine.ts
+++ b/packages/core/src/layout/LayoutEngine.ts
@@ -383,7 +383,7 @@ function resolveSize(value: number | string | undefined | Dim, available: number
     }
     if (typeof value === 'string' && value.endsWith('%')) {
         const pct = parseFloat(value) / 100;
-        if (!Number.isFinite(pct)) return 0;
+        if (!Number.isFinite(pct) || pct < 0) return 0;
         return Math.floor(available * pct);
     }
     return undefined;


### PR DESCRIPTION
## Description

This PR fixes an issue in the `LayoutEngine` where negative percentage values in the `resolveSize` function were not properly validated. Previously, values like `"-50%"` could result in negative dimensions, which may cause incorrect or broken layout rendering.

With this update, negative percentage values are now treated as invalid input and safely return `0`, ensuring more stable and predictable layout behavior.

## Related Issue

Closes #1836

## Which package(s)?

@termuijs/core

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] I was a GSSoC 2026 contributor.

## Notes for the Reviewer

This is a small and focused fix that improves input validation in layout calculations. No architectural changes were made, and the behavior remains backward-compatible for valid percentage inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated percentage-based sizing to treat negative percentage values as `0`, preventing incorrect computed widths during layout.
  - Positive percentage sizing behavior remains unchanged.
- **Tests**
  - Added layout coverage to verify negative percentage widths (e.g., `-50%`, `-25%`) are rejected and compute to `0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->