### PR TITLE
feat(widgets): add mouse click selection support for List

### DIFF
--- a/packages/core/src/app/App.ts
+++ b/packages/core/src/app/App.ts
@@ -10,7 +10,7 @@ import { InputParser } from '../input/InputParser.js';
 import { FocusManager } from '../events/FocusManager.js';
 import { EventEmitter } from '../events/EventEmitter.js';
 import { computeLayout, type LayoutNode } from '../layout/LayoutEngine.js';
-import type { EventMap, FocusEvent } from '../events/types.js';
+import type { EventMap, FocusEvent, MouseEvent } from '../events/types.js';
 import { createKeyEvent } from '../events/types.js';
 import { renderFallback, shouldUseFallback } from './Fallback.js';
 import { mergeBorders } from '../renderer/border-merge.js';
@@ -219,6 +219,13 @@ export class App {
         // Forward mouse events
         this._unsubMouse = this.input.onMouse((event) => {
             this.events.emit('mouse', event);
+
+            if (event.type === 'mousedown' || event.type === 'mouseup') {
+                const hitWidget = this._findWidgetAt(event.x, event.y);
+                if (hitWidget) {
+                    hitWidget.events.emit('mouse', event);
+                }
+            }
 
             if (event.type === 'mousemove') {
                 const hitWidget = this._findWidgetAt(event.x, event.y);

--- a/packages/widgets/src/input/List.test.ts
+++ b/packages/widgets/src/input/List.test.ts
@@ -69,6 +69,19 @@ describe('List', () => {
         expect(handler).toHaveBeenCalledWith(items[1], 1);
     });
 
+    it('mousedown on one item and mouseup on another confirms the originally selected item', () => {
+        const handler = vi.fn();
+        const list = new List(items, {}, handler);
+        list.updateRect({ x: 0, y: 0, width: 20, height: 5 });
+
+        list.events.emit('mouse', { x: 1, y: 2, type: 'mousedown', button: 'left' });
+        expect(list.selectedIndex).toBe(1);
+
+        list.events.emit('mouse', { x: 1, y: 3, type: 'mouseup', button: 'left' });
+        expect(list.selectedIndex).toBe(1);
+        expect(handler).toHaveBeenCalledWith(items[1], 1);
+    });
+
     it('mouse clicks on disabled items do not select or confirm', () => {
         const handler = vi.fn();
         const disabledItems: ListItem[] = [

--- a/packages/widgets/src/input/List.test.ts
+++ b/packages/widgets/src/input/List.test.ts
@@ -57,6 +57,36 @@ describe('List', () => {
         expect(handler).not.toHaveBeenCalled();
     });
 
+    it('mouse events emitted on the widget trigger List selection and confirmation', () => {
+        const handler = vi.fn();
+        const list = new List(items, {}, handler);
+        list.updateRect({ x: 0, y: 0, width: 20, height: 5 });
+
+        list.events.emit('mouse', { x: 1, y: 2, type: 'mousedown', button: 'left' });
+        expect(list.selectedIndex).toBe(1);
+
+        list.events.emit('mouse', { x: 1, y: 2, type: 'mouseup', button: 'left' });
+        expect(handler).toHaveBeenCalledWith(items[1], 1);
+    });
+
+    it('mouse clicks on disabled items do not select or confirm', () => {
+        const handler = vi.fn();
+        const disabledItems: ListItem[] = [
+            { label: 'A', value: 'a' },
+            { label: 'B', value: 'b', disabled: true },
+            { label: 'C', value: 'c' },
+        ];
+        const list = new List(disabledItems, {}, handler);
+        list.updateRect({ x: 0, y: 0, width: 20, height: 5 });
+
+        // y=2 hits the second visible item inside the bordered content area.
+        list.events.emit('mouse', { x: 1, y: 2, type: 'mousedown', button: 'left' });
+        expect(list.selectedIndex).toBe(0);
+
+        list.events.emit('mouse', { x: 1, y: 2, type: 'mouseup', button: 'left' });
+        expect(handler).not.toHaveBeenCalled();
+    });
+
     it('setItems() marks widget as dirty', () => {
         const list = new List(items);
         (list as any)._dirty = false;

--- a/packages/widgets/src/input/List.ts
+++ b/packages/widgets/src/input/List.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets — List widget (selectable)
 // ─────────────────────────────────────────────────────
 
-import { type Screen, type Style, styleToCellAttrs, stringWidth, truncate, caps } from '@termuijs/core';
+import { type Screen, type Style, type MouseEvent, styleToCellAttrs, stringWidth, truncate, caps } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 import { type ListState } from '../data/ListState.js';
 
@@ -74,6 +74,7 @@ export class List extends Widget {
         }
 
         this.focusable = true;
+        this.events.on('mouse', (event) => this.handleMouse(event));
     }
 
     // ── Getters ───────────────────────────────────────
@@ -220,6 +221,30 @@ export class List extends Widget {
         }
         if (this._selectedIndex >= this._scrollOffset + visibleHeight) {
             this._scrollOffset = this._selectedIndex - visibleHeight + 1;
+        }
+    }
+
+    handleMouse(event: MouseEvent): void {
+        if (event.button !== 'left') return;
+        if (event.type !== 'mousedown' && event.type !== 'mouseup') return;
+
+        const rect = this._getContentRect();
+        if (event.x < rect.x || event.x >= rect.x + rect.width) return;
+        if (event.y < rect.y || event.y >= rect.y + rect.height) return;
+
+        const clickedIndex = this._scrollOffset + (event.y - rect.y);
+        const item = this._items[clickedIndex];
+        if (!item || item.disabled) return;
+
+        if (this._selectedIndex !== clickedIndex) {
+            this._selectedIndex = clickedIndex;
+            this._clampScroll();
+            this.markDirty();
+            this._pushState();
+        }
+
+        if (event.type === 'mouseup') {
+            this.confirm();
         }
     }
 }

--- a/packages/widgets/src/input/List.ts
+++ b/packages/widgets/src/input/List.ts
@@ -41,6 +41,7 @@ export class List extends Widget {
     private _items: ListItem[];
     private _selectedIndex = 0;
     private _scrollOffset = 0;
+    private _mouseDownValid = false;
     private _onSelect?: (item: ListItem, index: number) => void;
     private _state?: ListState;
     private _onStateChange?: (state: ListState) => void;
@@ -228,23 +229,39 @@ export class List extends Widget {
         if (event.button !== 'left') return;
         if (event.type !== 'mousedown' && event.type !== 'mouseup') return;
 
-        const rect = this._getContentRect();
-        if (event.x < rect.x || event.x >= rect.x + rect.width) return;
-        if (event.y < rect.y || event.y >= rect.y + rect.height) return;
+        if (event.type === 'mousedown') {
+            const rect = this._getContentRect();
+            if (event.x < rect.x || event.x >= rect.x + rect.width) {
+                this._mouseDownValid = false;
+                return;
+            }
+            if (event.y < rect.y || event.y >= rect.y + rect.height) {
+                this._mouseDownValid = false;
+                return;
+            }
 
-        const clickedIndex = this._scrollOffset + (event.y - rect.y);
-        const item = this._items[clickedIndex];
-        if (!item || item.disabled) return;
+            const clickedIndex = this._scrollOffset + (event.y - rect.y);
+            const item = this._items[clickedIndex];
+            if (!item || item.disabled) {
+                this._mouseDownValid = false;
+                return;
+            }
 
-        if (this._selectedIndex !== clickedIndex) {
-            this._selectedIndex = clickedIndex;
-            this._clampScroll();
-            this.markDirty();
-            this._pushState();
+            this._mouseDownValid = true;
+            if (this._selectedIndex !== clickedIndex) {
+                this._selectedIndex = clickedIndex;
+                this._clampScroll();
+                this.markDirty();
+                this._pushState();
+            }
+            return;
         }
 
         if (event.type === 'mouseup') {
-            this.confirm();
+            if (this._mouseDownValid) {
+                this.confirm();
+            }
+            this._mouseDownValid = false;
         }
     }
 }


### PR DESCRIPTION
## Description

This PR adds mouse click selection support to the `List` widget. When mouse support is enabled, users can select an enabled list item with a left mouse click and confirm the selection on mouse release, while preserving all existing keyboard navigation behavior.

## Related Issue

Closes #1840

## Which package(s)?

* `@termuijs/core`
* `@termuijs/widgets`

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [x] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [ ] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [ ] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A (interaction change only; no visual UI changes).

## Notes for the Reviewer

### Summary

* Forward `mousedown` and `mouseup` events from `App` to the hit-tested widget.
* Add mouse event handling to `List` using the existing widget event emitter.
* Support selecting enabled items with a left mouse click.
* Confirm selection on mouse release to match existing keyboard behavior.
* Ignore clicks outside the list content and on disabled items.
* Added tests covering mouse selection, confirmation, and disabled-item behavior while preserving existing keyboard functionality.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * List items now support mouse selection: press selects, and release confirms the currently selected item.
  * Improved pointer routing ensures mouse press/release events reach the widget under the cursor.

* **Bug Fixes**
  * Clicking disabled items no longer changes selection or triggers confirmation.
  * If press and release occur on different items, confirmation uses the item originally selected on press.

* **Tests**
  * Added coverage for mouse press/release selection and disabled-item behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->