### PR TITLE
fix(ui): sanitize text in Toast screen reader announcement to prevent OSC escape injection

### DIFF
--- a/packages/ui/src/Toast.ts
+++ b/packages/ui/src/Toast.ts
@@ -1,6 +1,6 @@
 // Toast — auto-dismiss notification
 import { Widget } from '@termuijs/widgets';
-import { type Screen, mergeStyles, defaultStyle, styleToCellAttrs, caps } from '@termuijs/core';
+import { type Screen, stripAnsiControl, mergeStyles, defaultStyle, styleToCellAttrs, caps } from '@termuijs/core';
 
 export type ToastType = 'info' | 'success' | 'warning' | 'error';
 export interface ToastMessage { text: string; type: ToastType; expireAt: number; }
@@ -45,7 +45,8 @@ export class Toast extends Widget {
 
     private _announceToScreenReader(text: string, _type: ToastType): void {
         try {
-            const announcement = `[${text}]`;
+            const safeText = stripAnsiControl(text);
+            const announcement = `[${safeText}]`;
             const oscSequence = `\x1b]777;notify;TermUI;${announcement}\x07`;
             process.stderr.write(oscSequence);
         } catch {


### PR DESCRIPTION
## Description

Toast._announceToScreenReader() embeds notification text directly into an OSC 777 terminal sequence without sanitization. A text containing BEL (`\x07`), ESC (`\x1b`), or control characters terminates the OSC early and injects arbitrary escape codes into the terminal. The fix uses `stripAnsiControl()` (already exported from `@termuijs/core`) to strip dangerous characters before embedding.

## Related Issue

Closes #1842

## Which package(s)?

@termuijs/ui

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [x] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/vipul674`

## Notes for the Reviewer

Uses `stripAnsiControl()` which is already part of the exported public API from `@termuijs/core` (see `packages/core/src/index.ts:100`). No new dependencies introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved toast announcements for screen readers by removing formatting/control characters from message text before it’s read aloud.
  * Accessibility notifications now use cleaner, more reliable spoken text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->