### PR TITLE
fix(core): reset bracketed paste state in InputParser.stop() to prevent paste mode leak

### DIFF
--- a/packages/core/src/input/InputParser.ts
+++ b/packages/core/src/input/InputParser.ts
@@ -113,6 +113,8 @@ export class InputParser {
         }
         this._escapeBuffer = Buffer.alloc(0);
         this._graphemeBuffer = '';
+        this._isPasting = false;
+        this._pasteBuffer = '';
         this._decoder.end();
         for (const req of this._cursorRequests) {
             clearTimeout(req.timeout);


### PR DESCRIPTION
## Description

InputParser.stop() clears escape buffers, grapheme buffers, and paste timeouts, but does not reset `_isPasting` or `_pasteBuffer`. If stop() is called while a bracketed paste operation is in progress, the parser remains in paste mode permanently. On restart, all subsequent input is treated as paste content until a paste-end marker (`\x1b[201~`) arrives — which may never come if the paste was already interrupted.

The fix adds `this._isPasting = false; this._pasteBuffer = "";` to the stop() method.

## Related Issue

Closes #1843

## Which package(s)?

@termuijs/core

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/vipul674`

## Notes for the Reviewer

Two-line fix. The paste timeout already exists as a safety net (500ms), but resetting flags in stop() is the correct fix for explicit lifecycle transitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stopping input now fully clears any in-progress paste state, preventing stale pasted content from carrying over into the next session.
  * Improved input shutdown cleanup so canceled paste actions no longer leave the interface in an inconsistent state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->