### PR TITLE
feat(dev-server): implement inspect element cell hover mode

### DIFF
--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -58,7 +58,7 @@ export function emptyCell(): Cell {
         inverse: false,
         width: 1,
         link: undefined,
-         debugWidgetId: undefined,
+        debugWidgetId: undefined,
     };
 }
 

--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -90,7 +90,6 @@ export function cellsEqual(a: Cell, b: Cell): boolean {
         a.inverse === b.inverse &&
         a.width === b.width &&
         a.link === b.link &&
-        a.debugWidgetId === b.debugWidgetId &&
         colorsEqual(a.fg, b.fg) &&
         colorsEqual(a.bg, b.bg)
     );

--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -40,6 +40,8 @@ export interface Cell {
     width: number;
     /** Optional OSC 8 hyperlink target for this cell. */
     link?: string;
+    /** DevTools Widget ID for Inspector Mode */
+    debugWidgetId?: string;
 }
 
 /** Create a blank cell with default attributes */
@@ -56,6 +58,7 @@ export function emptyCell(): Cell {
         inverse: false,
         width: 1,
         link: undefined,
+         debugWidgetId: undefined,
     };
 }
 
@@ -72,6 +75,7 @@ export function resetCell(cell: Cell): void {
     cell.inverse = false;
     cell.width = 1;
     cell.link = undefined;
+    cell.debugWidgetId = undefined;
 }
 
 /** Check if two cells are visually identical */
@@ -86,6 +90,7 @@ export function cellsEqual(a: Cell, b: Cell): boolean {
         a.inverse === b.inverse &&
         a.width === b.width &&
         a.link === b.link &&
+        a.debugWidgetId === b.debugWidgetId &&
         colorsEqual(a.fg, b.fg) &&
         colorsEqual(a.bg, b.bg)
     );

--- a/packages/dev-server/src/devtools.test.ts
+++ b/packages/dev-server/src/devtools.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { DevTools } from './devtools.js';
+import { DevTools, renderDebugRect, handleDevToolsHover, type WidgetNode } from './devtools.js';
+import { Screen } from '@termuijs/core';
 
 describe('DevTools frame capture', () => {
     it('setFrame stores the frame rows', () => {
@@ -290,5 +291,45 @@ describe('DevTools filename stability', () => {
         for (const ts of timestamps) {
             expect(devtools.screenshotFilename(ts)).toBe(`termui-frame-${ts}.txt`);
         }
+    });
+});
+
+describe('DevTools Hover State', () => {
+    it('does not save duplicate corner cells during debug rect rendering', () => {
+        const screen = new Screen(20, 20);
+        const cells = renderDebugRect(screen, { x: 0, y: 0, width: 10, height: 10 });
+        // Perimeter of 10x10 is 4 * 10 - 4 = 36
+        expect(cells.length).toBe(36);
+        
+        const coords = new Set(cells.map(c => `${c.x},${c.y}`));
+        expect(coords.size).toBe(36);
+    });
+
+    it('clears hover state on recordRender to prevent restoring stale cells', () => {
+        const devtools = new DevTools();
+        devtools.lastHoverCells = [{ x: 1, y: 1, cell: { char: 'A' } as any }];
+        devtools.recordRender(10, 100);
+        expect(devtools.lastHoverCells.length).toBe(0);
+    });
+
+    it('saves and restores properly across hover events', () => {
+        const devtools = new DevTools();
+        const screen = new Screen(20, 20);
+        const widgetTree: WidgetNode = {
+            type: 'Box', id: 'box1', rect: { x: 1, y: 1, width: 2, height: 2 }, children: []
+        };
+        devtools.updateTree(widgetTree);
+        
+        screen.setCell(1, 1, { char: 'A', fg: { type: 'none' }, bg: { type: 'none' } });
+        screen.getCell(1, 1)!.debugWidgetId = 'box1';
+        
+        handleDevToolsHover(1, 1, screen, devtools);
+        expect(devtools.lastHoverWidgetId).toBe('box1');
+        expect(devtools.lastHoverCells.length).toBe(4); // 2x2 box has 4 corners
+        expect(screen.getCell(1, 1)!.char).toBe('┌'); // corner was drawn
+        
+        handleDevToolsHover(5, 5, screen, devtools);
+        expect(devtools.lastHoverWidgetId).toBeNull();
+        expect(screen.getCell(1, 1)!.char).toBe('A'); // old cell restored
     });
 });

--- a/packages/dev-server/src/devtools.ts
+++ b/packages/dev-server/src/devtools.ts
@@ -1,6 +1,8 @@
 // ─────────────────────────────────────────────────────
 // DevTools Panel — widget tree inspector, perf metrics
 // ─────────────────────────────────────────────────────
+import { type Screen } from '@termuijs/core';
+
 
 export interface WidgetNode {
     type: string;
@@ -179,6 +181,48 @@ export class DevTools {
             }
             default:
                 return '';
+        }
+    }
+}
+
+export function getWidgetRect(root: WidgetNode | null, id: string): { x: number; y: number; width: number; height: number; } | null {
+    if (!root) return null;
+    if (root.id === id) return root.rect;
+    for (const child of root.children) {
+        const found = getWidgetRect(child, id);
+        if (found) return found;
+    }
+    return null;
+}
+
+export function renderDebugRect(screen: Screen, rect: { x: number; y: number; width: number; height: number; }): void {
+    const color = { type: 'hex', hex: '#FF00FF' } as const;
+    const bg = { type: 'none' } as const;
+
+    // Draw top & bottom borders safely
+    for (let x = rect.x; x < rect.x + rect.width; x++) {
+        screen.setCell(x, rect.y, { char: '─', fg: color, bg });
+        screen.setCell(x, rect.y + rect.height - 1, { char: '─', fg: color, bg });
+    }
+    // Draw left & right borders safely
+    for (let y = rect.y; y < rect.y + rect.height; y++) {
+        screen.setCell(rect.x, y, { char: '│', fg: color, bg });
+        screen.setCell(rect.x + rect.width - 1, y, { char: '│', fg: color, bg });
+    }
+    
+    // Draw corners
+    screen.setCell(rect.x, rect.y, { char: '┌', fg: color, bg });
+    screen.setCell(rect.x + rect.width - 1, rect.y, { char: '┐', fg: color, bg });
+    screen.setCell(rect.x, rect.y + rect.height - 1, { char: '└', fg: color, bg });
+    screen.setCell(rect.x + rect.width - 1, rect.y + rect.height - 1, { char: '┘', fg: color, bg });
+}
+
+export function handleDevToolsHover(x: number, y: number, screen: Screen, widgetTree: WidgetNode | null): void {
+    const cell = screen.getCell(x, y);
+    if (cell && cell.debugWidgetId) {
+        const rect = getWidgetRect(widgetTree, cell.debugWidgetId);
+        if (rect) {
+            renderDebugRect(screen, rect);
         }
     }
 }

--- a/packages/dev-server/src/devtools.ts
+++ b/packages/dev-server/src/devtools.ts
@@ -1,7 +1,7 @@
 // ─────────────────────────────────────────────────────
 // DevTools Panel — widget tree inspector, perf metrics
 // ─────────────────────────────────────────────────────
-import { type Screen } from '@termuijs/core';
+import { type Screen, caps } from '@termuijs/core';
 
 
 export interface WidgetNode {
@@ -195,34 +195,73 @@ export function getWidgetRect(root: WidgetNode | null, id: string): { x: number;
     return null;
 }
 
-export function renderDebugRect(screen: Screen, rect: { x: number; y: number; width: number; height: number; }): void {
+let lastHoverWidgetId: string | null = null;
+let lastHoverCells: { x: number; y: number; cell: any }[] = [];
+
+export function renderDebugRect(screen: Screen, rect: { x: number; y: number; width: number; height: number; }): { x: number; y: number; cell: any }[] {
     const color = { type: 'hex', hex: '#FF00FF' } as const;
     const bg = { type: 'none' } as const;
+    const savedCells: { x: number; y: number; cell: any }[] = [];
+
+    const saveCell = (x: number, y: number) => {
+        const cell = screen.getCell(x, y);
+        if (cell) {
+            savedCells.push({ x, y, cell: { ...cell } });
+        }
+    };
+
+    const hBar = caps.unicode ? '─' : '-';
+    const vBar = caps.unicode ? '│' : '|';
+    const tl = caps.unicode ? '┌' : '+';
+    const tr = caps.unicode ? '┐' : '+';
+    const bl = caps.unicode ? '└' : '+';
+    const br = caps.unicode ? '┘' : '+';
 
     // Draw top & bottom borders safely
     for (let x = rect.x; x < rect.x + rect.width; x++) {
-        screen.setCell(x, rect.y, { char: '─', fg: color, bg });
-        screen.setCell(x, rect.y + rect.height - 1, { char: '─', fg: color, bg });
+        saveCell(x, rect.y);
+        screen.setCell(x, rect.y, { char: hBar, fg: color, bg });
+        saveCell(x, rect.y + rect.height - 1);
+        screen.setCell(x, rect.y + rect.height - 1, { char: hBar, fg: color, bg });
     }
     // Draw left & right borders safely
     for (let y = rect.y; y < rect.y + rect.height; y++) {
-        screen.setCell(rect.x, y, { char: '│', fg: color, bg });
-        screen.setCell(rect.x + rect.width - 1, y, { char: '│', fg: color, bg });
+        saveCell(rect.x, y);
+        screen.setCell(rect.x, y, { char: vBar, fg: color, bg });
+        saveCell(rect.x + rect.width - 1, y);
+        screen.setCell(rect.x + rect.width - 1, y, { char: vBar, fg: color, bg });
     }
     
     // Draw corners
-    screen.setCell(rect.x, rect.y, { char: '┌', fg: color, bg });
-    screen.setCell(rect.x + rect.width - 1, rect.y, { char: '┐', fg: color, bg });
-    screen.setCell(rect.x, rect.y + rect.height - 1, { char: '└', fg: color, bg });
-    screen.setCell(rect.x + rect.width - 1, rect.y + rect.height - 1, { char: '┘', fg: color, bg });
+    saveCell(rect.x, rect.y);
+    screen.setCell(rect.x, rect.y, { char: tl, fg: color, bg });
+    saveCell(rect.x + rect.width - 1, rect.y);
+    screen.setCell(rect.x + rect.width - 1, rect.y, { char: tr, fg: color, bg });
+    saveCell(rect.x, rect.y + rect.height - 1);
+    screen.setCell(rect.x, rect.y + rect.height - 1, { char: bl, fg: color, bg });
+    saveCell(rect.x + rect.width - 1, rect.y + rect.height - 1);
+    screen.setCell(rect.x + rect.width - 1, rect.y + rect.height - 1, { char: br, fg: color, bg });
+
+    return savedCells;
 }
 
 export function handleDevToolsHover(x: number, y: number, screen: Screen, widgetTree: WidgetNode | null): void {
     const cell = screen.getCell(x, y);
-    if (cell && cell.debugWidgetId) {
-        const rect = getWidgetRect(widgetTree, cell.debugWidgetId);
+    const newId = (cell && cell.debugWidgetId) ? cell.debugWidgetId : null;
+
+    if (newId === lastHoverWidgetId) return;
+
+    // Restore old cells
+    for (const saved of lastHoverCells) {
+        screen.setCell(saved.x, saved.y, saved.cell);
+    }
+    lastHoverCells = [];
+    lastHoverWidgetId = newId;
+
+    if (newId) {
+        const rect = getWidgetRect(widgetTree, newId);
         if (rect) {
-            renderDebugRect(screen, rect);
+            lastHoverCells = renderDebugRect(screen, rect);
         }
     }
 }

--- a/packages/dev-server/src/devtools.ts
+++ b/packages/dev-server/src/devtools.ts
@@ -1,7 +1,7 @@
 // ─────────────────────────────────────────────────────
 // DevTools Panel — widget tree inspector, perf metrics
 // ─────────────────────────────────────────────────────
-import { type Screen, caps } from '@termuijs/core';
+import { type Screen, type Cell, type Color, caps } from '@termuijs/core';
 
 
 export interface WidgetNode {
@@ -29,6 +29,9 @@ export class DevTools {
     private _maxEvents = 100;
     private _renderTimes: number[] = [];
     private _frameRows: string[] = [];
+    
+    public lastHoverWidgetId: string | null = null;
+    public lastHoverCells: { x: number; y: number; cell: Cell }[] = [];
 
     get visible(): boolean { return this._visible; }
     toggle(): void { this._visible = !this._visible; }
@@ -40,9 +43,11 @@ export class DevTools {
 
     /** Update widget tree snapshot */
     updateTree(root: WidgetNode): void { this._widgetTree = root; }
+    get widgetTree(): WidgetNode | null { return this._widgetTree; }
 
     /** Record a render cycle */
     recordRender(timeMs: number, widgetCount: number): void {
+        this.lastHoverCells = []; // Clear saved cells so they aren't restored over fresh screen content
         const now = Date.now();
         this._renderTimes.push(now);
         // Keep last 60 render timestamps for FPS calculation
@@ -195,15 +200,16 @@ export function getWidgetRect(root: WidgetNode | null, id: string): { x: number;
     return null;
 }
 
-let lastHoverWidgetId: string | null = null;
-let lastHoverCells: { x: number; y: number; cell: any }[] = [];
-
-export function renderDebugRect(screen: Screen, rect: { x: number; y: number; width: number; height: number; }): { x: number; y: number; cell: any }[] {
-    const color = { type: 'hex', hex: '#FF00FF' } as const;
-    const bg = { type: 'none' } as const;
-    const savedCells: { x: number; y: number; cell: any }[] = [];
+export function renderDebugRect(screen: Screen, rect: { x: number; y: number; width: number; height: number; }): { x: number; y: number; cell: Cell }[] {
+    const color: Color = { type: 'hex', hex: '#FF00FF' };
+    const bg: Color = { type: 'none' };
+    const savedCells: { x: number; y: number; cell: Cell }[] = [];
+    const savedMap = new Set<string>();
 
     const saveCell = (x: number, y: number) => {
+        const key = `${x},${y}`;
+        if (savedMap.has(key)) return;
+        savedMap.add(key);
         const cell = screen.getCell(x, y);
         if (cell) {
             savedCells.push({ x, y, cell: { ...cell } });
@@ -245,23 +251,23 @@ export function renderDebugRect(screen: Screen, rect: { x: number; y: number; wi
     return savedCells;
 }
 
-export function handleDevToolsHover(x: number, y: number, screen: Screen, widgetTree: WidgetNode | null): void {
+export function handleDevToolsHover(x: number, y: number, screen: Screen, devtools: DevTools): void {
     const cell = screen.getCell(x, y);
     const newId = (cell && cell.debugWidgetId) ? cell.debugWidgetId : null;
 
-    if (newId === lastHoverWidgetId) return;
+    if (newId === devtools.lastHoverWidgetId) return;
 
     // Restore old cells
-    for (const saved of lastHoverCells) {
+    for (const saved of devtools.lastHoverCells) {
         screen.setCell(saved.x, saved.y, saved.cell);
     }
-    lastHoverCells = [];
-    lastHoverWidgetId = newId;
+    devtools.lastHoverCells = [];
+    devtools.lastHoverWidgetId = newId;
 
-    if (newId) {
-        const rect = getWidgetRect(widgetTree, newId);
+    if (newId && devtools.widgetTree) {
+        const rect = getWidgetRect(devtools.widgetTree, newId);
         if (rect) {
-            lastHoverCells = renderDebugRect(screen, rect);
+            devtools.lastHoverCells = renderDebugRect(screen, rect);
         }
     }
 }


### PR DESCRIPTION
## Description

This PR implements the "Inspect Element" Cell Hover Mode for the Dev Server. It adds a `debugWidgetId` to the `Cell` interface in `@termuijs/core` and introduces hover handling logic (`handleDevToolsHover` and `renderDebugRect`) in `@termuijs/dev-server` to highlight the bounding box of a widget when its corresponding cell is hovered during development.

## Related Issue

Closes #1724

## Which package(s)?

`@termuijs/core`, `@termuijs/dev-server`

## Type of Change

- [x] ✨ Feature (`type:feature`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/f49aa65e-aab2-4e9f-99d6-2174f339ecfe`

## Screenshots / Recordings (UI changes)

*(If you have a screenshot of the pink highlighted border during hover, drag and drop it here)*

## Notes for the Reviewer

The implementation safely adds `debugWidgetId` to the core `Cell` interface and uses it to look up widget bounding boxes from the DevTools widget tree snapshot. The debug overlay draws a `#FF00FF` ANSI border over the targeted rect bounds. 
*(Note: If the CI complains about `install-theme-regression.test.ts` locally on Windows, it is an unrelated `\r\n` parser issue with Vitest/Oxc on Windows—it will pass cleanly on the Linux Ubuntu CI).*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced terminal devtools with hover-based widget highlighting, drawing an outlined rectangle around the hovered UI element (Unicode or ASCII depending on capabilities).
  * Added public devtools utilities to locate widget bounds, render debug rectangles, and manage hover inspection behavior.
* **Bug Fixes**
  * Terminal cells now clear the debug widget identifier when created/reset to prevent stale inspector overlays.
  * Hover overlay state is cleared on fresh renders to avoid restoring outdated hover cells.
* **Tests**
  * Added coverage for hover rendering, state clearing, and correct save/restore behavior across hover events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->