### PR TITLE
feat(widgets): add FileExplorer sorting by date and size

### DIFF
--- a/packages/widgets/src/FileExplorer.ts
+++ b/packages/widgets/src/FileExplorer.ts
@@ -2,16 +2,23 @@
 // @termuijs/widgets — Interactive File Explorer Widget
 // ─────────────────────────────────────────────────────
 
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
 export interface FileItem {
     name: string;
     path: string;
     isDirectory: boolean;
+    size?: number;
+    date?: number;
 }
 
 export interface FileExplorerOptions {
     root?: string;
     multiSelect?: boolean;
     onSelect?: (path: string) => void;
+    sortBy?: 'name' | 'size' | 'date';
+    sortOrder?: 'asc' | 'desc';
 }
 
 export class FileExplorer {
@@ -21,10 +28,56 @@ export class FileExplorer {
     private _selectedFiles: Set<string> = new Set();
     private _filter = "";
     private _onSelect?: (path: string) => void;
+    private _sortBy: 'name' | 'size' | 'date';
+    private _sortOrder: 'asc' | 'desc';
 
     constructor(options: FileExplorerOptions = {}) {
         this._root = options.root ?? "./";
         this._onSelect = options.onSelect;
+        this._sortBy = options.sortBy ?? 'name';
+        this._sortOrder = options.sortOrder ?? 'asc';
+    }
+
+    /**
+     * Read directory and load files into the explorer based on OS file metadata.
+     */
+    reload(): void {
+        let files: string[] = [];
+        try {
+            files = readdirSync(this._root);
+        } catch {
+            files = [];
+        }
+
+        const mappedFiles: FileItem[] = files.map(file => {
+            const filePath = join(this._root, file);
+            let size = 0;
+            let date = 0;
+            let isDirectory = false;
+            try {
+                const stats = statSync(filePath);
+                size = stats.size;
+                date = stats.mtimeMs;
+                isDirectory = stats.isDirectory();
+            } catch {
+                // Ignore stat errors for broken symlinks/permissions
+            }
+            return { name: file, path: filePath, isDirectory, size, date };
+        });
+
+        mappedFiles.sort((a, b) => {
+            let diff = 0;
+            if (this._sortBy === 'size') {
+                diff = (a.size || 0) - (b.size || 0);
+            } else if (this._sortBy === 'date') {
+                diff = (a.date || 0) - (b.date || 0);
+            } else {
+                diff = a.name.localeCompare(b.name);
+            }
+            return this._sortOrder === 'desc' ? -diff : diff;
+        });
+
+        this.setFiles(mappedFiles);
     }
 
     /**


### PR DESCRIPTION
## Description

This PR enhances the `FileExplorer` widget by adding the ability to sort files by modified date and size. It introduces `sortBy` and `sortOrder` options to `FileExplorerOptions` and implements a `reload()` method that uses `node:fs` `statSync` to fetch OS file metadata (`mtimeMs` and `size`) during the directory read phase, dynamically recalculating the list order.

## Related Issue

Closes #1723

## Which package(s)?

`@termuijs/widgets`

## Type of Change

- [x] ✨ Feature (`type:feature`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/f49aa65e-aab2-4e9f-99d6-2174f339ecfe`

## Notes for the Reviewer

The dynamic sorting logic matches the requested pseudo-code in the issue. When `reload()` is called, it correctly catches and ignores any stat errors (such as broken symlinks or missing permissions) to ensure the file explorer doesn't crash during normal traversal. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File browsing now shows additional item details like size and date when available.
  * Files can now be sorted by name, size, or date, in ascending or descending order.
  * Directory listings now refresh with updated file information and sorting applied automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->