### PR TITLE
feat(widgets): support multiple node selection via checkboxes in Tree…

### DIFF
--- a/packages/widgets/src/display/Tree.ts
+++ b/packages/widgets/src/display/Tree.ts
@@ -25,6 +25,7 @@ export interface TreeOptions {
     nodes: TreeNode[];
     onSelect?: (node: TreeNode, path: number[]) => void;
     indent?: number;    // spaces per level, default 2
+    selectable?: boolean;
 }
 
 interface VisibleEntry {
@@ -52,19 +53,28 @@ export class Tree extends Widget {
     protected _selectedIndex = 0;
     protected _scrollOffset = 0;
     protected _visibleNodes: VisibleEntry[] = [];
+    private _selectable: boolean;
+    private _checkedNodes: Set<string> = new Set();
+
 
     constructor(options: TreeOptions, style: Partial<Style> = {}) {
         super(style);
         this._nodes = options.nodes;
         this._onSelect = options.onSelect;
         this._indent = options.indent ?? 2;
+        this._selectable = options.selectable ?? false;
         this.focusable = true;
         this._buildVisibleNodes();
     }
 
+
     // ── Public API ─────────────────────────────────────
 
     get selectedIndex(): number { return this._selectedIndex; }
+    get checkedNodes(): string[] {
+        return Array.from(this._checkedNodes);
+    }
+
 
     get selectedNode(): TreeNode | undefined {
         return this._visibleNodes[this._selectedIndex]?.node;
@@ -173,6 +183,23 @@ export class Tree extends Widget {
      */
     handleKey(key: string): void {
         const normalized = normalizeNavigationKey(key.toLowerCase());
+
+        // Handle selection via spacebar
+        if ((normalized === ' ' || normalized === 'space') && this._selectable) {
+            const entry = this._visibleNodes[this._selectedIndex];
+            if (entry) {
+                // Use structural path (e.g. '0.1.2') as unique ID
+                const id = entry.path.join('.');
+                if (this._checkedNodes.has(id)) {
+                    this._checkedNodes.delete(id);
+                } else {
+                    this._checkedNodes.add(id);
+                }
+                this.markDirty();
+            }
+            return;
+        }
+
         switch (normalized) {
             case 'arrowup':
             case 'up':
@@ -204,6 +231,7 @@ export class Tree extends Widget {
         }
     }
 
+
     // ── Rendering ──────────────────────────────────────
 
     protected _renderSelf(screen: Screen): void {
@@ -215,8 +243,8 @@ export class Tree extends Widget {
         const useUnicode = caps.unicode;
 
         const collapsedChevron = useUnicode ? '▶ ' : '> ';
-        const expandedChevron  = useUnicode ? '▼ ' : 'v ';
-        const leafPrefix       = useUnicode ? '• ' : '* ';
+        const expandedChevron = useUnicode ? '▼ ' : 'v ';
+        const leafPrefix = useUnicode ? '• ' : '* ';
 
         // Use the virtualization engine
         const range = computeRange(this._scrollOffset, height, this._visibleNodes.length, 0);
@@ -230,6 +258,7 @@ export class Tree extends Widget {
             if (screenY < y || screenY >= y + height) continue;
 
             // Build line text
+            // Build line text
             const indentStr = ' '.repeat(this._indent * depth);
             let chevron: string;
             if (_isParent(node)) {
@@ -237,8 +266,16 @@ export class Tree extends Widget {
             } else {
                 chevron = leafPrefix;
             }
-            let line = indentStr + chevron + node.label;
+
+            let checkbox = '';
+            if (this._selectable) {
+                const id = entry.path.join('.');
+                checkbox = this._checkedNodes.has(id) ? '[x] ' : '[ ] ';
+            }
+
+            let line = indentStr + chevron + checkbox + node.label;
             line = truncate(line, width);
+
 
             // Cell style for selected row
             const cellStyle = isSelected && this.isFocused


### PR DESCRIPTION
## Description

This PR implements multiple node selection via checkboxes in the `Tree` component. It adds a `selectable` flag to the `TreeOptions` interface and maintains a `_checkedNodes` `Set` to persist selected nodes. 

To ensure uniqueness across nodes without requiring users to pass custom IDs, this uses the structural path (e.g. `0.1.2`) as the unique identifier for each checked node. When `selectable` is true, a spacebar press intercepts the default toggle behavior and instead checks/unchecks the active node, rendering a `[x]` or `[ ]` next to the tree label. This allows for robust multi-selection patterns in CLI file managers.

## Related Issue

Closes #1721

## Which package(s)?

`@termuijs/widgets`

## Type of Change

- [x] ✨ Feature (`type:feature`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/f49aa65e-aab2-4e9f-99d6-2174f339ecfe`

## Notes for the Reviewer

The implementation uses `entry.path.join('.')` to uniquely track the checked state, bypassing the need to enforce unique `id`s on all `TreeNode` objects. Spacebar selection is fully integrated into the existing `handleKey` flow, rendering out conditionally in `_renderSelf`. All virtualization logic and existing tests remain completely intact and pass successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tree items can now be made selectable with a checkbox-style state.
  * Pressing Space toggles the checked state for the currently highlighted visible item.
  * Checked items are now exposed through a new list of checked node IDs.
  * Visible rows show `[x]` / `[ ]` markers when selection is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->