### PR TITLE
fix(widgets): evict VirtualList _renderCache entries outside visible window

### DIFF
--- a/packages/widgets/src/input/VirtualList.test.ts
+++ b/packages/widgets/src/input/VirtualList.test.ts
@@ -278,4 +278,34 @@ describe('VirtualList', () => {
         });
     });
 
+    describe('render cache eviction', () => {
+        it('evicts old entries outside visible range after scroll', () => {
+            const list = new VirtualList({
+                totalItems: 1000,
+                renderItem: (i) => `Item ${i}`,
+                style: { width: 40, height: 10 },
+                springScroll: false,
+            });
+            const node = list.getLayoutNode();
+            computeLayout(node, 40, 10);
+            list.syncLayout();
+            const screen = new Screen(80, 25);
+
+            list.scrollTo(0);
+            list.render(screen);
+            const cache = (list as any)._renderCache as Map<number, any>;
+            const initialSize = cache.size;
+
+            // Scroll through large range - cache should stay bounded
+            for (let i = 1; i <= 50; i++) {
+                list.scrollTo(i * 10);
+                list.render(screen);
+            }
+
+            // Cache should not have grown unbounded with 1000 items
+            expect(cache.size).toBeLessThanOrEqual(initialSize + 20);
+            expect(cache.size).toBeLessThan(100);
+        });
+    });
+
 });

--- a/packages/widgets/src/input/VirtualList.ts
+++ b/packages/widgets/src/input/VirtualList.ts
@@ -366,6 +366,13 @@ export class VirtualList extends Widget {
             }
         }
 
+        // Evict cache entries outside the visible+overscan window
+        for (const key of this._renderCache.keys()) {
+            if (key < startIdx || key >= endIdx) {
+                this._renderCache.delete(key);
+            }
+        }
+
         // Scrollbar
         if (this._showScrollbar && this._totalItems > visibleItemCount) {
             const scrollbarX = x + width - 1;


### PR DESCRIPTION
## Description

Fixes a memory leak in `VirtualList._renderSelf()` where the `_renderCache` Map grows unboundedly as the user scrolls through long lists. Each scroll position generates a new cache entry for every rendered row, but entries outside the current visible range are never evicted.

## Changes

- `packages/widgets/src/input/VirtualList.ts`: After the render loop in `_renderSelf()`, iterate `_renderCache` and delete entries whose index falls outside `[startIdx, endIdx)`. This keeps only the visible + overscan rows and drops stale entries.
- `packages/widgets/src/input/VirtualList.test.ts`: Added test that scrolls through 500 items and asserts cache size stays bounded at the visible window size (plus overscan margin).

Closes #1861

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling performance in virtualized lists by removing off-screen rendered rows from cache as you scroll.
  * Prevented internal render cache growth from becoming unbounded during repeated scrolling.
* **Tests**
  * Added coverage to verify the render cache stays within expected limits after multiple scroll positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->