### PR TITLE
fix(store): add missing equalityFn parameter to UseStore interface (#488)

### DIFF
--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -611,7 +611,7 @@ export function createStore<T extends object>(
 
 export interface UseStore<T> {
     (): T;
-    <U>(selector: Selector<T, U>): U;
+    <U>(selector: Selector<T, U>, equalityFn?: EqualityFn<U>): U;
     getState: GetState<T>;
     setState: SetState<T>;
     mutate(recipe: (draft: T) => void): void;


### PR DESCRIPTION
## Description

The \UseStore\ interface type was missing the optional \equalityFn\ parameter on the selector call signature. The implementation already supports it (PR #1580), but the exported type interface wasn't updated to match.

**Before:**
\\\	ypescript
export interface UseStore<T> {
    (): T;
    <U>(selector: Selector<T, U>): U;  // missing equalityFn
    ...
}
\\\

**After:**
\\\	ypescript
export interface UseStore<T> {
    (): T;
    <U>(selector: Selector<T, U>, equalityFn?: EqualityFn<U>): U;
    ...
}
\\\

## Verification
- \un vitest run packages/store\ — 66/66 tests pass
- \un run typecheck\ — 30/30 tasks pass
- Change is confined to \packages/store\

Closes #488

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Selector-based store subscriptions now support an optional equality function, giving you more control over when updates trigger.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->