### PR TITLE
fix(store): add missing equalityFn parameter to UseStore interface

### DIFF
--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -611,7 +611,7 @@ export function createStore<T extends object>(
 
 export interface UseStore<T> {
     (): T;
-    <U>(selector: Selector<T, U>): U;
+    <U>(selector: Selector<T, U>, equalityFn?: EqualityFn<U>): U;
     getState: GetState<T>;
     setState: SetState<T>;
     mutate(recipe: (draft: T) => void): void;


### PR DESCRIPTION
The UseStore interface type was missing the optional equalityFn parameter on the selector call signature, even though the implementation already supports it. This caused a type mismatch when using useStore with an equality comparator like shallow.

Closes #488

<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow \	ype: short description\ (example: \ix: handle empty list in VirtualList\). -->

## Description

Added the optional \equalityFn\ parameter to the \UseStore\ interface selector call signature to match the already-existing implementation in the hook function.

## Related Issue

Closes #488

## Which package(s)?

@termuijs/store

## Type of Change

- [x] 🐛 Bug fix (\	ype:bug\)

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: \un vitest run\
- [x] Build passes: \un run build\
- [x] Typecheck passes: \un run typecheck\
- [x] You read [\CONTRIBUTING.md\](./CONTRIBUTING.md).
- [x] Your PR title follows \	ype: short description\.
- [x] No new \ny\ types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: https://gssoc.girlscript.org/profile/Shan7Usmani

## Notes for the Reviewer

This fixes a type gap from PR #1580 — the \UseStore\ interface was not updated to include the \equalityFn\ parameter that the implementation already accepts.