### PR TITLE
feat(core): implement True Color (24-bit RGB) support with graceful degradation #1872

### DIFF
--- a/packages/core/src/terminal/env-caps.test.ts
+++ b/packages/core/src/terminal/env-caps.test.ts
@@ -71,6 +71,24 @@ describe('env-caps', () => {
         vi.unstubAllEnvs();
         vi.resetModules();
     });
+
+    it('caps.colorDepth returns TrueColor when COLORTERM=truecolor', async () => {
+        vi.stubEnv('COLORTERM', 'truecolor');
+        vi.resetModules();
+        const { caps } = await import('./env-caps.js');
+        const { ColorDepth } = await import('../style/Color.js');
+        expect(caps.colorDepth).toBe(ColorDepth.TrueColor);
+        expect(caps.color).toBe(true);
+    });
+
+    it('caps.colorDepth returns None and caps.color is false when NO_COLOR=1', async () => {
+        vi.stubEnv('NO_COLOR', '1');
+        vi.resetModules();
+        const { caps } = await import('./env-caps.js');
+        const { ColorDepth } = await import('../style/Color.js');
+        expect(caps.colorDepth).toBe(ColorDepth.None);
+        expect(caps.color).toBe(false);
+    });
 });
 
 describe('prefersReducedMotion', () => {

--- a/packages/core/src/terminal/env-caps.ts
+++ b/packages/core/src/terminal/env-caps.ts
@@ -1,5 +1,14 @@
+import { ColorDepth, detectColorDepth } from '../style/Color.js';
+
 export const caps = {
-  color:   !process.env.NO_COLOR && process.env.TERM !== 'dumb',
+  get colorDepth(): ColorDepth {
+    return detectColorDepth();
+  },
+  get color(): boolean {
+    if (process.env.NO_COLOR !== undefined) return false;
+    if (process.env.TERM === 'dumb') return false;
+    return this.colorDepth !== ColorDepth.None;
+  },
   unicode: !process.env.NO_UNICODE && process.env.TERM !== 'dumb',
   motion:  !process.env.NO_MOTION && !process.env.CI,
   ci:      !!process.env.CI,


### PR DESCRIPTION
# Pull Request

## Description
Integrates the `detectColorDepth` check and terminal capability indicators directly into the global `caps` object of `@termuijs/core`. This completes the true-color detection loop, allowing widgets and render engines to dynamically identify 24-bit True Color support and fallback gracefully to 8-bit or basic ANSI colors.

Closes #1872

## Changes
- **`packages/core/src/terminal/env-caps.ts`**:
  - Integrated `detectColorDepth()` into the global `caps` object via a dynamic `colorDepth` getter.
  - Updated `caps.color` to verify that `colorDepth` is not `ColorDepth.None` (in addition to existing `NO_COLOR` and `TERM=dumb` checks).
- **`packages/core/src/terminal/env-caps.test.ts`**:
  - Added new unit test suites asserting that `caps.colorDepth` is dynamically loaded and outputs `ColorDepth.TrueColor` under `COLORTERM=truecolor` and fallback values under `NO_COLOR=1` configs.

## Verification
Ran all core unit tests, builds, and typechecks successfully:
```bash
bun run build && bun vitest run && bun run typecheck
```
All 496 tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal color support now detects a wider range of capabilities, including true color.
  * A new color-depth value is available for more accurate terminal behavior.

* **Bug Fixes**
  * Color output now correctly turns off when color is disabled by the environment.
  * Improved handling for terminals that report limited or no color support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->