### PR TITLE
docs: add local environment troubleshooting section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,8 @@ examples/
 
 ## Development
 > **Note:** This project uses [Bun](https://bun.sh) as its package manager. Install Bun first: https://bun.sh/docs/installation
+> **Note:** If you encounter execution policy or permission errors during setup, open your terminal as an Administrator (Windows) or use `sudo` before running commands (Mac/Linux).
+
 
 ```bash
 bun install


### PR DESCRIPTION
## Description
This pull request introduces a dedicated workspace local troubleshooting layout guide to the primary framework documentation overview.

## Related Issue
Closes #1851

## Which package(s)?
website

## Type of Change
- [x] Documentation ('type:docs')
