### PR TITLE
fix(core): reset style fingerprint at each row boundary in diff renderer

### DIFF
--- a/packages/core/src/terminal/Renderer.test.ts
+++ b/packages/core/src/terminal/Renderer.test.ts
@@ -236,4 +236,30 @@ describe('Renderer profiling hooks', () => {
         const output = fakeStdout.writes;
         expect(output).toBeTruthy();
     });
+
+    it('resets style fingerprint at each row boundary in diff renderer', () => {
+        const narrowScreen = new Screen(5, 2);
+        const renderer = new Renderer(terminal, narrowScreen);
+
+        // Row 0: bold red cell at col 0
+        narrowScreen.setCell(0, 0, { char: 'A', bold: true, fg: { type: 'named', name: 'red' } });
+
+        // Row 1: same style at col 0 — after moveTo, must re-emit ANSI style even though
+        // the fingerprint matches the last cell of row 0
+        narrowScreen.setCell(0, 1, { char: 'B', bold: true, fg: { type: 'named', name: 'red' } });
+
+        // Capture output
+        const initialWrites = fakeStdout.writes.length;
+        renderer.renderNow();
+        const output = fakeStdout.writes.slice(initialWrites);
+
+        // The output must contain at least one ANSI reset sequence with style re-application
+        // for row 1 (the moveTo + reset + bold + color + char sequence).
+        // The key assertion: the diff renderer should emit \x1b[0m (reset) after the moveTo
+        // for row 1 to force the terminal into the correct style state.
+        expect(output).toContain('\x1b[0m');
+        // Verify reset appears at least twice (once for row 0 first cell, once for row 1)
+        const resetCount = (output.match(/\x1b\[0m/g) || []).length;
+        expect(resetCount).toBeGreaterThanOrEqual(2);
+    });
 });

--- a/packages/core/src/terminal/Renderer.ts
+++ b/packages/core/src/terminal/Renderer.ts
@@ -137,8 +137,8 @@ export class Renderer {
             let output = beginSyncUpdate;
 
             if (this._diffRenderer) {
-                this._lastStyleFingerprint = null;
                 for (let r = 0; r < rows; r++) {
+                    this._lastStyleFingerprint = null;
                     output += this._renderDiffLine(r, front, back, cols);
                 }
 


### PR DESCRIPTION
## Description

The differential renderer's style optimization (`_lastStyleFingerprint`) was only reset once per frame flush, not once per row. When `_renderDiffLine` renders spans on multiple rows, the style state bled across row boundaries because `moveTo` positions the cursor at a new row where the terminal has no memory of the previous cell's style. This caused sporadic missing ANSI style sequences, leading to visible color/bold/italic corruption on all rows after the first one.

### Fix

Moved `this._lastStyleFingerprint = null;` inside the `for (let r = 0; r < rows; r++)` loop in `_flush()` (`Renderer.ts:139-143`) so the fingerprint is reset before each row is processed. This ensures the first cell on every row always emits the full ANSI reset+style sequence.

### Test

Added `'resets style fingerprint at each row boundary in diff renderer'` test that creates two rows with identical boundary styles and asserts the ANSI output contains at least two reset sequences (one per row).

Closes #1910

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal diff rendering so style resets are correctly emitted at row boundaries.
  * Improved consistency when consecutive rows reuse the same styling, reducing missing or suppressed ANSI reset sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->