### PR TITLE
fix(core): invalidate overlay layers and reset screen state on resize

### DIFF
--- a/packages/core/src/terminal/LayerManager.test.ts
+++ b/packages/core/src/terminal/LayerManager.test.ts
@@ -313,19 +313,36 @@ describe('LayerManager - Resize', () => {
         expect(layer.cells[0].length).toBe(20);
     });
 
-    it('clears dirty regions on resize', () => {
+    it('marks entire layer as dirty on resize so it is recomposited', () => {
         const lm = new LayerManager(10, 10);
 
         const layer = lm.createLayer('base', 0);
 
-        lm.setCell('base', 1, 1, {
-            char: 'A',
-        });
-
-        expect(layer.dirtyRegion).not.toBeNull();
-
         lm.resize(20, 15);
 
-        expect(layer.dirtyRegion).toBeNull();
+        expect(layer.dirtyRegion).toEqual({
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 15,
+        });
+    });
+
+    it('composites layer content after resize', () => {
+        const lm = new LayerManager(10, 10);
+        const layer = lm.createLayer('overlay', 100);
+        lm.setCell('overlay', 1, 1, { char: 'X' });
+
+        // Resize should set dirtyRegion to full area
+        lm.resize(20, 15);
+
+        // Write to the new size
+        lm.setCell('overlay', 10, 5, { char: 'Y' });
+
+        const screen = new (require('./Screen.js').Screen)(20, 15);
+        lm.composite(screen);
+
+        // Content written after resize should appear
+        expect(screen.back[5][10].char).toBe('Y');
     });
 });

--- a/packages/core/src/terminal/LayerManager.test.ts
+++ b/packages/core/src/terminal/LayerManager.test.ts
@@ -339,7 +339,7 @@ describe('LayerManager - Resize', () => {
         // Write to the new size
         lm.setCell('overlay', 10, 5, { char: 'Y' });
 
-        const screen = new (require('./Screen.js').Screen)(20, 15);
+        const screen = new Screen(20, 15);
         lm.composite(screen);
 
         // Content written after resize should appear

--- a/packages/core/src/terminal/LayerManager.ts
+++ b/packages/core/src/terminal/LayerManager.ts
@@ -257,7 +257,7 @@ export class LayerManager {
 
         for (const layer of this._layers.values()) {
             layer.cells = this._createGrid();
-            layer.dirtyRegion = null;
+            layer.dirtyRegion = { x: 0, y: 0, width: cols, height: rows };
         }
 
         this._allocateHitGrids();

--- a/packages/core/src/terminal/Screen.test.ts
+++ b/packages/core/src/terminal/Screen.test.ts
@@ -70,6 +70,28 @@ describe('Screen', () => {
         expect(screen.front[0][0].char).toBe('\0');
     });
 
+    it('resize resets all ancillary state', () => {
+        const screen = new Screen(10, 5);
+
+        // Set up some state
+        screen.pushClip({ x: 0, y: 0, width: 5, height: 3 });
+        screen.pushTranslateY(2);
+        screen.writeAnsi('\x1b[31m');
+        screen.applyBackdropFilter({ x: 0, y: 0, width: 3, height: 3 });
+
+        // Resize
+        screen.resize(20, 10);
+
+        expect(screen.cols).toBe(20);
+        expect(screen.rows).toBe(10);
+        expect(screen.activeClip).toBeNull();
+        expect(screen.drainAnsiQueue()).toBe('');
+        expect(screen.getPreviousLine(0)).toBe('');
+        // Write after resize and verify it lands correctly (no stale clip/translate)
+        screen.setCell(15, 8, { char: 'Z' });
+        expect(screen.back[8][15].char).toBe('Z');
+    });
+
     it('writeString applies style attributes (bold, fg)', () => {
         const screen = new Screen(10, 5);
         screen.writeString(0, 0, 'Hi', { bold: true, fg: { type: 'named', name: 'red' } });

--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -440,6 +440,14 @@ export class Screen {
         this.front = this._createGrid(cols, rows);
         this.back = this._createGrid(cols, rows);
         this._previousLines = [];
+        this._previousStyleLines = [];
+        this._clipStack = [];
+        this._translateYStack = [];
+        this._translateY = 0;
+        this._ansiQueue = [];
+        this._flushEpoch = -1;
+        this._swapping = false;
+        this._backdropFilters = [];
     }
 
     /**


### PR DESCRIPTION
## Description

Two coordinated bugs caused overlay content (modals, dropdowns, toasts) to permanently disappear after terminal resize:

### Fix 1: `LayerManager.resize()` — Invalidate all layers

Changed `dirtyRegion = null` to `dirtyRegion = { x: 0, y: 0, width: cols, height: rows }` so every layer is fully recomposited after resize (`LayerManager.ts:258-261`).

### Fix 2: `Screen.resize()` — Reset all ancillary state

Added reset of `_previousStyleLines`, `_clipStack`, `_translateYStack`, `_translateY`, `_ansiQueue`, `_flushEpoch`, `_swapping`, and `_backdropFilters` to prevent stale state from causing clipping/translation/swap errors after resize (`Screen.ts:433-446`).

### Tests

- Updated `LayerManager.test.ts` to verify `dirtyRegion` covers the full new dimensions after resize and that compositing works post-resize.
- Added `Screen.test.ts` test verifying all ancillary state is reset after resize.

Closes #1911

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resizing now fully refreshes terminal layers so content is redrawn correctly after a size change.
  * Resizing the screen now clears leftover rendering state, preventing clipping, translation, or queued output from affecting new content.
  * Content entered after a resize now renders properly using the updated terminal dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->