### PR TITLE
fix(core): extend mergeBorders() to support all border styles

### DIFF
--- a/packages/core/src/renderer/border-merge.test.ts
+++ b/packages/core/src/renderer/border-merge.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import { Screen } from '../terminal/Screen.js';
-import { mergeBorders, ASCII_JUNCTIONS, } from './border-merge.js';
+import { mergeBorders, ASCII_JUNCTIONS, SINGLE_JUNCTIONS, DOUBLE_JUNCTIONS, HEAVY_JUNCTIONS } from './border-merge.js';
+import { caps } from '../terminal/env-caps.js';
 
 describe('border merge', () => {
-        
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
 
     it('merges a cross intersection into ┼', () => {
         const screen = new Screen(7, 7);
@@ -161,16 +164,242 @@ it('merges a bottom-right corner into ┘', () => {
     mergeBorders(screen);
 
     expect(screen.back[3][2].char).toBe('│');
-  }  );
+  });
+    
    
-  
  it('provides ASCII fallback junction mappings', () => {
     expect(ASCII_JUNCTIONS.LRTB).toBe('+');
     expect(ASCII_JUNCTIONS.TB).toBe('|');
     expect(ASCII_JUNCTIONS.LR).toBe('-');
   });
-    
 
-  
+  // ── Double border style tests ──────────────────────
 
+  it('merges double border cross into ╬', () => {
+    const screen = new Screen(7, 7);
+
+    screen.setCell(3, 2, { char: '║' });
+    screen.setCell(3, 4, { char: '║' });
+    screen.setCell(2, 3, { char: '═' });
+    screen.setCell(4, 3, { char: '═' });
+
+    mergeBorders(screen);
+
+    expect(screen.back[3][3].char).toBe('╬');
+  });
+
+  it('merges double border tees correctly', () => {
+    const screen = new Screen(7, 7);
+
+    screen.setCell(3, 2, { char: '║' });
+    screen.setCell(3, 4, { char: '║' });
+    screen.setCell(4, 3, { char: '═' });
+
+    mergeBorders(screen);
+
+    expect(screen.back[3][3].char).toBe('╟');
+  });
+
+  // ── Heavy border style tests ───────────────────────
+
+  it('merges heavy border cross into ┿', () => {
+    const screen = new Screen(7, 7);
+
+    screen.setCell(3, 2, { char: '┃' });
+    screen.setCell(3, 4, { char: '┃' });
+    screen.setCell(2, 3, { char: '━' });
+    screen.setCell(4, 3, { char: '━' });
+
+    mergeBorders(screen);
+
+    expect(screen.back[3][3].char).toBe('┿');
+  });
+
+  it('merges heavy border tees correctly', () => {
+    const screen = new Screen(7, 7);
+
+    screen.setCell(3, 2, { char: '┃' });
+    screen.setCell(3, 4, { char: '┃' });
+    screen.setCell(4, 3, { char: '━' });
+
+    mergeBorders(screen);
+
+    expect(screen.back[3][3].char).toBe('┠');
+  });
+
+  // ── Mixed border style tests ───────────────────────
+
+  it('merges mixed single-vertical double-horizontal cross using heavier double junctions', () => {
+    const screen = new Screen(7, 7);
+
+    screen.setCell(3, 2, { char: '│' });
+    screen.setCell(3, 4, { char: '│' });
+    screen.setCell(2, 3, { char: '═' });
+    screen.setCell(4, 3, { char: '═' });
+
+    mergeBorders(screen);
+
+    expect(screen.back[3][3].char).toBe('╬');
+  });
+
+  it('merges mixed double-vertical single-horizontal cross using heavier double junctions', () => {
+    const screen = new Screen(7, 7);
+
+    screen.setCell(3, 2, { char: '║' });
+    screen.setCell(3, 4, { char: '║' });
+    screen.setCell(2, 3, { char: '─' });
+    screen.setCell(4, 3, { char: '─' });
+
+    mergeBorders(screen);
+
+    expect(screen.back[3][3].char).toBe('╬');
+  });
+
+  it('merges mixed light-heavy cross using heavier heavy junctions', () => {
+    const screen = new Screen(7, 7);
+
+    screen.setCell(3, 2, { char: '┃' });
+    screen.setCell(3, 4, { char: '┃' });
+    screen.setCell(2, 3, { char: '─' });
+    screen.setCell(4, 3, { char: '─' });
+
+    mergeBorders(screen);
+
+    expect(screen.back[3][3].char).toBe('┿');
+  });
+
+  // ── Dashed border recognition ──────────────────────
+
+  it('recognizes dashed border characters', () => {
+    const screen = new Screen(7, 7);
+
+    screen.setCell(3, 2, { char: '┆' });
+    screen.setCell(3, 4, { char: '┆' });
+    screen.setCell(2, 3, { char: '┄' });
+    screen.setCell(4, 3, { char: '┄' });
+
+    mergeBorders(screen);
+
+    expect(screen.back[3][3].char).toBe('┼');
+  });
+
+  // ── Round corner recognition ───────────────────────
+
+  it('recognizes round corner characters as borders', () => {
+    const screen = new Screen(7, 7);
+
+    screen.setCell(4, 3, { char: '─' });
+    screen.setCell(3, 4, { char: '╭' });
+
+    mergeBorders(screen);
+
+    expect(screen.back[3][3].char).toBe('┌');
+  });
+
+  // ── Content preservation ───────────────────────────
+
+  it('does not overwrite non-border character at intersection', () => {
+    const screen = new Screen(7, 7);
+
+    screen.setCell(3, 2, { char: '│' });
+    screen.setCell(3, 4, { char: '│' });
+    screen.setCell(2, 3, { char: '─' });
+    screen.setCell(4, 3, { char: '─' });
+    // Intersection contains a text character, not a border char
+    screen.setCell(3, 3, { char: 'X' });
+
+    mergeBorders(screen);
+
+    expect(screen.back[3][3].char).toBe('X');
+  });
+
+  it('overwrites empty space at intersection', () => {
+    const screen = new Screen(7, 7);
+
+    screen.setCell(3, 2, { char: '│' });
+    screen.setCell(3, 4, { char: '│' });
+    screen.setCell(2, 3, { char: '─' });
+    screen.setCell(4, 3, { char: '─' });
+    // Intersection is a space (default)
+
+    mergeBorders(screen);
+
+    expect(screen.back[3][3].char).toBe('┼');
+  });
+
+  it('does not overwrite text content adjacent to borders', () => {
+    const screen = new Screen(10, 5);
+
+    screen.setCell(3, 2, { char: '│' });
+    screen.setCell(3, 4, { char: '│' });
+    screen.setCell(2, 3, { char: '─' });
+    screen.setCell(4, 3, { char: '─' });
+    // Intersection has a letter — should not be replaced
+    screen.setCell(3, 3, { char: 'A' });
+
+    mergeBorders(screen);
+
+    expect(screen.back[3][3].char).toBe('A');
+  });
+
+  // ── Junction map completeness ──────────────────────
+
+  it('SINGLE_JUNCTIONS has all expected keys', () => {
+    expect(SINGLE_JUNCTIONS.LRTB).toBe('┼');
+    expect(SINGLE_JUNCTIONS.RTB).toBe('├');
+    expect(SINGLE_JUNCTIONS.LTB).toBe('┤');
+    expect(SINGLE_JUNCTIONS.LRB).toBe('┬');
+    expect(SINGLE_JUNCTIONS.LRT).toBe('┴');
+    expect(SINGLE_JUNCTIONS.RB).toBe('┌');
+    expect(SINGLE_JUNCTIONS.LB).toBe('┐');
+    expect(SINGLE_JUNCTIONS.RT).toBe('└');
+    expect(SINGLE_JUNCTIONS.LT).toBe('┘');
+    expect(SINGLE_JUNCTIONS.TB).toBe('│');
+    expect(SINGLE_JUNCTIONS.LR).toBe('─');
+  });
+
+  it('DOUBLE_JUNCTIONS has all expected keys', () => {
+    expect(DOUBLE_JUNCTIONS.LRTB).toBe('╬');
+    expect(DOUBLE_JUNCTIONS.RTB).toBe('╟');
+    expect(DOUBLE_JUNCTIONS.LTB).toBe('╢');
+    expect(DOUBLE_JUNCTIONS.LRB).toBe('╦');
+    expect(DOUBLE_JUNCTIONS.LRT).toBe('╩');
+    expect(DOUBLE_JUNCTIONS.RB).toBe('╔');
+    expect(DOUBLE_JUNCTIONS.LB).toBe('╗');
+    expect(DOUBLE_JUNCTIONS.RT).toBe('╚');
+    expect(DOUBLE_JUNCTIONS.LT).toBe('╝');
+    expect(DOUBLE_JUNCTIONS.TB).toBe('║');
+    expect(DOUBLE_JUNCTIONS.LR).toBe('═');
+  });
+
+  it('HEAVY_JUNCTIONS has all expected keys', () => {
+    expect(HEAVY_JUNCTIONS.LRTB).toBe('┿');
+    expect(HEAVY_JUNCTIONS.RTB).toBe('┠');
+    expect(HEAVY_JUNCTIONS.LTB).toBe('┨');
+    expect(HEAVY_JUNCTIONS.LRB).toBe('┰');
+    expect(HEAVY_JUNCTIONS.LRT).toBe('┸');
+    expect(HEAVY_JUNCTIONS.RB).toBe('┏');
+    expect(HEAVY_JUNCTIONS.LB).toBe('┓');
+    expect(HEAVY_JUNCTIONS.RT).toBe('┗');
+    expect(HEAVY_JUNCTIONS.LT).toBe('┛');
+    expect(HEAVY_JUNCTIONS.TB).toBe('┃');
+    expect(HEAVY_JUNCTIONS.LR).toBe('━');
+  });
+
+  // ── Re-merging already-merged junctions ────────────
+
+  it('re-merges existing single junctions correctly', () => {
+    const screen = new Screen(7, 7);
+
+    // Set up already-merged junctions
+    screen.setCell(3, 2, { char: '│' });
+    screen.setCell(3, 4, { char: '│' });
+    screen.setCell(2, 3, { char: '─' });
+    screen.setCell(4, 3, { char: '─' });
+    screen.setCell(3, 3, { char: '┼' });
+
+    mergeBorders(screen);
+
+    expect(screen.back[3][3].char).toBe('┼');
+  });
 });

--- a/packages/core/src/renderer/border-merge.ts
+++ b/packages/core/src/renderer/border-merge.ts
@@ -1,108 +1,217 @@
 import type { Screen } from '../terminal/Screen.js';
 import { caps } from '../terminal/env-caps.js';
 
-const VERTICAL = new Set(['│', '|']);
-const HORIZONTAL = new Set(['─', '-']);
+// ── Comprehensive box-drawing character detection ──────
+
+// All characters with a vertical stroke (raw segments, corners, junctions, round)
+const VERTICAL_CHARS = new Set([
+  '│', '║', '┃', '┆', '|',
+  '┌', '┐', '└', '┘', '├', '┤', '┬', '┴', '┼',
+  '╔', '╗', '╚', '╝', '╟', '╢', '╤', '╧', '╥', '╨', '╞', '╡', '╪', '╫', '╬',
+  '┏', '┓', '┗', '┛', '┠', '┨', '┰', '┸', '┝', '┥', '┞', '┦', '┱', '┹', '┲', '┺', '┽', '┾', '┿',
+  '+', '╭', '╮', '╰', '╯',
+]);
+
+// All characters with a horizontal stroke
+const HORIZONTAL_CHARS = new Set([
+  '─', '═', '━', '┄', '-',
+  '┌', '┐', '└', '┘', '├', '┤', '┬', '┴', '┼',
+  '╔', '╗', '╚', '╝', '╟', '╢', '╤', '╧', '╥', '╨', '╞', '╡', '╪', '╫', '╬',
+  '┏', '┓', '┗', '┛', '┠', '┨', '┰', '┸', '┝', '┥', '┞', '┦', '┱', '┹', '┲', '┺', '┽', '┾', '┿',
+  '+', '╭', '╮', '╰', '╯',
+]);
 
 function isVertical(char: string): boolean {
-    return VERTICAL.has(char);
+  return VERTICAL_CHARS.has(char);
 }
 
 function isHorizontal(char: string): boolean {
-    return HORIZONTAL.has(char);
+  return HORIZONTAL_CHARS.has(char);
 }
 
- export const  UNICODE_JUNCTIONS =
-     {
-        LRTB: '┼',
-        RTB: '├',
-        LTB: '┤',
-        LRB: '┬',
-        LRT: '┴',
+// ── Border character weight classification ────────────
 
-        RB: '┌',
-        LB: '┐',
-        RT: '└',
-        LT: '┘',
+type BorderWeight = 'single' | 'double' | 'heavy';
 
-        TB: '│',
-        LR: '─',
+// Map specific chars to their visual weight
+const WEIGHT_MAP: Record<string, BorderWeight> = {
+  '│': 'single', '─': 'single',
+  '┌': 'single', '┐': 'single', '└': 'single', '┘': 'single',
+  '├': 'single', '┤': 'single', '┬': 'single', '┴': 'single', '┼': 'single',
+  '╭': 'single', '╮': 'single', '╰': 'single', '╯': 'single',
+  '║': 'double', '═': 'double',
+  '╔': 'double', '╗': 'double', '╚': 'double', '╝': 'double',
+  '╟': 'double', '╢': 'double', '╤': 'double', '╧': 'double',
+  '╥': 'double', '╨': 'double', '╞': 'double', '╡': 'double',
+  '╪': 'double', '╫': 'double', '╬': 'double',
+  '┃': 'heavy', '━': 'heavy',
+  '┏': 'heavy', '┓': 'heavy', '┗': 'heavy', '┛': 'heavy',
+  '┠': 'heavy', '┨': 'heavy', '┰': 'heavy', '┸': 'heavy',
+  '┝': 'heavy', '┥': 'heavy', '┞': 'heavy', '┦': 'heavy',
+  '┱': 'heavy', '┹': 'heavy', '┲': 'heavy', '┺': 'heavy',
+  '┽': 'heavy', '┾': 'heavy', '┿': 'heavy',
+};
 
-        R: '─',
-        L: '─',
-        T: '│',
-        B: '│',
-    };
-    export const ASCII_JUNCTIONS = {
-        LRTB: '+',
-        RTB: '+',
-        LTB: '+',
-        LRB: '+',
-        LRT: '+',
+// Dashed and ASCII chars are treated as light-weight for merge purposes
+const DASHED_CHARS = new Set(['┆', '┄']);
+const ASCII_CHARS = new Set(['|', '-', '+']);
 
-        RB: '+',
-        LB: '+',
-        RT: '+',
-        LT: '+',
+function charWeight(char: string): BorderWeight | null {
+  return WEIGHT_MAP[char] ?? null;
+}
 
-        TB: '|',
-        LR: '-',
+// Returns the heavier of two weights, used for mixed-style junctions.
+function heavierWeight(a: BorderWeight | null, b: BorderWeight | null): BorderWeight {
+  if (a === 'heavy' || b === 'heavy') return 'heavy';
+  if (a === 'double' || b === 'double') return 'double';
+  return 'single';
+}
 
-        R: '-',
-        L: '-',
-        T: '|',
-        B: '|',
-    };
+function isBorderChar(char: string): boolean {
+  return VERTICAL_CHARS.has(char) || HORIZONTAL_CHARS.has(char) ||
+         DASHED_CHARS.has(char) || ASCII_CHARS.has(char);
+}
 
-    // Choose junction set based on terminal capabilities
-    function getJunctions() {
-    return caps.unicode
-        ? UNICODE_JUNCTIONS
-        : ASCII_JUNCTIONS;
-     }
+// ── Style-specific junction maps ──────────────────────
+
+export const SINGLE_JUNCTIONS: Record<string, string> = {
+  LRTB: '┼', RTB: '├', LTB: '┤', LRB: '┬', LRT: '┴',
+  RB: '┌', LB: '┐', RT: '└', LT: '┘',
+  TB: '│', LR: '─',
+  R: '─', L: '─', T: '│', B: '│',
+};
+
+export const DOUBLE_JUNCTIONS: Record<string, string> = {
+  LRTB: '╬', RTB: '╟', LTB: '╢', LRB: '╦', LRT: '╩',
+  RB: '╔', LB: '╗', RT: '╚', LT: '╝',
+  TB: '║', LR: '═',
+  R: '═', L: '═', T: '║', B: '║',
+};
+
+export const HEAVY_JUNCTIONS: Record<string, string> = {
+  LRTB: '┿', RTB: '┠', LTB: '┨', LRB: '┰', LRT: '┸',
+  RB: '┏', LB: '┓', RT: '┗', LT: '┛',
+  TB: '┃', LR: '━',
+  R: '━', L: '━', T: '┃', B: '┃',
+};
+
+// Mixed: vertical weight is used when both axes are present but differ.
+// For corners and tees the heavier style takes precedence.
+const MIXED_LIGHT_VERTICAL: Record<string, string> = {
+  LRTB: '│', RTB: '│', LTB: '│', LRB: '┬', LRT: '┴',
+  RB: '┌', LB: '┐', RT: '└', LT: '┘',
+};
+
+export const ASCII_JUNCTIONS: Record<string, string> = {
+  LRTB: '+', RTB: '+', LTB: '+', LRB: '+', LRT: '+',
+  RB: '+', LB: '+', RT: '+', LT: '+',
+  TB: '|', LR: '-',
+  R: '-', L: '-', T: '|', B: '|',
+};
+
+// Determine the effective junction map to use based on surrounding characters.
+function selectJunctions(
+  hasLeft: boolean, hasRight: boolean,
+  hasTop: boolean, hasBottom: boolean,
+  left: string, right: string, top: string, bottom: string,
+): Record<string, string> {
+  // Collect horizontal chars (left/right) and vertical chars (top/bottom)
+  const hChars: string[] = [];
+  if (hasLeft) hChars.push(left);
+  if (hasRight) hChars.push(right);
+  const vChars: string[] = [];
+  if (hasTop) vChars.push(top);
+  if (hasBottom) vChars.push(bottom);
+
+  // Determine horizontal and vertical weights independently
+  let hWeight: BorderWeight = 'single';
+  for (const c of hChars) {
+    const w = charWeight(c);
+    if (w === 'heavy') hWeight = 'heavy';
+    else if (w === 'double' && hWeight !== 'heavy') hWeight = 'double';
+  }
+
+  let vWeight: BorderWeight = 'single';
+  for (const c of vChars) {
+    const w = charWeight(c);
+    if (w === 'heavy') vWeight = 'heavy';
+    else if (w === 'double' && vWeight !== 'heavy') vWeight = 'double';
+  }
+
+  // If both axes have the same weight, use that weight's junction set
+  if (hWeight === vWeight) {
+    if (hWeight === 'heavy') return HEAVY_JUNCTIONS;
+    if (hWeight === 'double') return DOUBLE_JUNCTIONS;
+    return SINGLE_JUNCTIONS;
+  }
+
+  // Mixed: use the heavier of the two
+  const overall = heavierWeight(hWeight, vWeight);
+  if (overall === 'heavy') return HEAVY_JUNCTIONS;
+  if (overall === 'double') return DOUBLE_JUNCTIONS;
+  return SINGLE_JUNCTIONS;
+}
+
+function getJunctions(): Record<string, string> {
+  return caps.unicode ? SINGLE_JUNCTIONS : ASCII_JUNCTIONS;
+}
+
+// ── Public API ────────────────────────────────────────
 
 export function mergeBorders(screen: Screen): void {
-    const grid = screen.back;
-    const junctions = getJunctions();
+  const grid = screen.back;
+  const asciiJunctions = ASCII_JUNCTIONS;
 
-    const updates: Array<{
-        row: number;
-        col: number;
-        char: string;
-    }> = [];
+  const updates: Array<{
+    row: number;
+    col: number;
+    char: string;
+  }> = [];
 
-    for (let row = 0; row < screen.rows; row++) {
-        for (let col = 0; col < screen.cols; col++) {
-            const cell = grid[row][col];
+  for (let row = 0; row < screen.rows; row++) {
+    for (let col = 0; col < screen.cols; col++) {
+      const cell = grid[row][col];
 
-            const top = row > 0 ? grid[row - 1][col].char : '';
-            const bottom = row < screen.rows - 1 ? grid[row + 1][col].char : '';
-            const left = col > 0 ? grid[row][col - 1].char : '';
-            const right = col < screen.cols - 1 ? grid[row][col + 1].char : '';
+      // Content-preservation guard: only overwrite border chars or spaces
+      const currentChar = cell.char;
+      if (currentChar !== ' ' && !isBorderChar(currentChar)) continue;
 
-            const hasTop = isVertical(top);
-            const hasBottom = isVertical(bottom);
-            const hasLeft = isHorizontal(left);
-            const hasRight = isHorizontal(right);
+      const top = row > 0 ? grid[row - 1][col].char : '';
+      const bottom = row < screen.rows - 1 ? grid[row + 1][col].char : '';
+      const left = col > 0 ? grid[row][col - 1].char : '';
+      const right = col < screen.cols - 1 ? grid[row][col + 1].char : '';
 
-            const key =
-                (hasLeft ? 'L' : '') +
-                (hasRight ? 'R' : '') +
-                (hasTop ? 'T' : '') +
-                (hasBottom ? 'B' : '');
+      const hasTop = isVertical(top);
+      const hasBottom = isVertical(bottom);
+      const hasLeft = isHorizontal(left);
+      const hasRight = isHorizontal(right);
 
-            const merged = junctions[key as keyof typeof junctions];
+      const key =
+        (hasLeft ? 'L' : '') +
+        (hasRight ? 'R' : '') +
+        (hasTop ? 'T' : '') +
+        (hasBottom ? 'B' : '');
 
-            if (merged) {
-           updates.push({
-          row,
-          col,
-          char: merged,
-              }); 
-       }   
+      if (!key) continue;
+
+      if (!caps.unicode) {
+        const merged = asciiJunctions[key];
+        if (merged) {
+          updates.push({ row, col, char: merged });
+        }
+        continue;
+      }
+
+      // Unicode path: select style-appropriate junction
+      const junctions = selectJunctions(hasLeft, hasRight, hasTop, hasBottom, left, right, top, bottom);
+      const merged = junctions[key];
+      if (merged) {
+        updates.push({ row, col, char: merged });
       }
     }
-     for (const update of updates) {
-        grid[update.row][update.col].char = update.char;
-        }
+  }
+
+  for (const update of updates) {
+    grid[update.row][update.col].char = update.char;
+  }
 }


### PR DESCRIPTION
## Description

`mergeBorders()` only recognized single-line box-drawing characters (`│`, `─`), silently ignoring all other border styles (double `║═`, heavy `┃━`, dashed `┆┄`, round `╭╮╰╯`). This caused broken or missing junctions when widgets used `borderStyle: 'double'`, `'heavy'`, or `'dashed'`.

### Fix

Complete refactoring of `border-merge.ts` (from 108 → ~200 lines):

1. **Comprehensive character classification** — `VERTICAL_CHARS`/`HORIZONTAL_CHARS` sets now include all box-drawing characters from all border styles, including junctions and round corners.

2. **Style-aware junction selection** — Added `SINGLE_JUNCTIONS`, `DOUBLE_JUNCTIONS`, `HEAVY_JUNCTIONS` maps with proper weight-appropriate junction characters. A `selectJunctions()` function determines the effective weight from surrounding characters and picks the correct junction set. Mixed styles use the heavier weight.

3. **Content-preservation guard** — Before replacing a cell, `mergeBorders` now checks if it's a border character or space. Non-border content (text, icons, etc.) is never overwritten.

4. **ASCII fallback** — When `caps.unicode` is `false`, all border styles merge to ASCII equivalents (`+`, `-`, `|`).

### Tests

Added comprehensive coverage:
- Single/double/heavy border cross and tee junctions
- Mixed-style merges (single×double, light×heavy)
- Dashed border character recognition
- Round corner recognition
- Content preservation (non-border chars at intersections are not overwritten)
- Empty space at intersection gets merged
- Re-merging already-merged junctions
- Junction map completeness assertions

Closes #1912