### PR TITLE
feat(widgets): support resizable columns in Table component

### DIFF
--- a/packages/widgets/src/data/Table.ts
+++ b/packages/widgets/src/data/Table.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets — Table widget
 // ─────────────────────────────────────────────────────
 
-import { type Screen, type Style, type Color, type KeyEvent, styleToCellAttrs, stringWidth, truncate, wordWrap, caps } from '@termuijs/core';
+import { type Screen, type Style, type Color, type KeyEvent, type MouseEvent, styleToCellAttrs, stringWidth, truncate, wordWrap, caps } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 import { type TableState } from './TableState.js';
 import { computeVariableRange } from '../input/virtual-scroll.js';
@@ -35,6 +35,8 @@ export interface TableOptions {
     separator?: string;
     /** Callback when a column header is activated to sort */
     onSort?: (colIndex: number, direction: 'asc' | 'desc') => void;
+    /** Whether columns can be resized by dragging separators */
+    resizable?: boolean;
 }
 
 export interface TableProps {
@@ -71,6 +73,12 @@ export class Table extends Widget {
     protected _stripe: boolean;
     protected _stripeColor: Color;
     protected _separator: string;
+    protected _resizable: boolean;
+    protected _columnWidths: number[] = [];
+    private _lastWidth = -1;
+    private _isDragging = false;
+    private _dragColIndex = -1;
+    
     private _state?: TableState;
     private _onStateChange?: (state: TableState) => void;
     private _selectedRow = 0;
@@ -110,9 +118,15 @@ export class Table extends Widget {
         this._stripe = options.stripe ?? true;
         this._stripeColor = options.stripeColor ?? { type: 'named', name: 'brightBlack' };
         this._separator = options.separator ?? ' │ ';
+        this._resizable = options.resizable ?? false;
         this._state = state;
         this._onStateChange = onStateChange;
         this._tableOnSort = options.onSort;
+
+        this.events.on('key', this.handleKey.bind(this));
+        if (this._resizable) {
+            this.events.on('mouse', this.handleMouse.bind(this));
+        }
     }
 
     // ── Public API ────────────────────────────────────
@@ -170,6 +184,48 @@ export class Table extends Widget {
         }
     }
 
+    handleMouse(event: MouseEvent): void {
+        if (!this._resizable) return;
+
+        // Ensure we have computed widths at least once
+        const rect = this._getContentRect();
+        const sepWidth = stringWidth(this._separator);
+        this._getColWidths(rect.width, sepWidth);
+
+        if (event.type === 'mousedown') {
+            const colIndex = this._findColumnBoundaryAt(event.x);
+            if (colIndex !== -1) {
+                this._isDragging = true;
+                this._dragColIndex = colIndex;
+            }
+        } else if (event.type === 'mouseup') {
+            this._isDragging = false;
+            this._dragColIndex = -1;
+        } else if (event.type === 'mousedrag' && this._isDragging) {
+            this._columnWidths[this._dragColIndex] = Math.max(1, this._columnWidths[this._dragColIndex] + event.dx);
+            
+            // To prevent table width from changing uncontrollably, we can subtract dx from the next column 
+            // if there's enough space, but a simpler free-resizing UX works better for terminal tables
+            this.markDirty();
+        }
+    }
+
+    private _findColumnBoundaryAt(screenX: number): number {
+        const rect = this._getContentRect();
+        let cx = rect.x;
+        const sepWidth = stringWidth(this._separator);
+        
+        for (let c = 0; c < this._columns.length - 1; c++) {
+            cx += this._columnWidths[c] ?? 0;
+            // The separator is from cx to cx + sepWidth
+            if (screenX >= cx && screenX < cx + sepWidth) {
+                return c;
+            }
+            cx += sepWidth;
+        }
+        return -1;
+    }
+
     handleKey(event: KeyEvent): void {
         const minRow = this._showHeader ? -1 : 0;
 
@@ -225,7 +281,7 @@ export class Table extends Widget {
         if (visibleHeight <= 0) { this._scrollOffset = 0; return; }
 
         const sepWidth = stringWidth(this._separator);
-        const colWidths = this._computeColumnWidths(Math.max(0, rect.width - (this._columns.length - 1) * sepWidth));
+        const colWidths = this._getColWidths(rect.width, sepWidth);
         const sizes = this._computeRowHeights(colWidths);
 
         let selectedTop = 0;
@@ -253,9 +309,7 @@ export class Table extends Widget {
         const sepWidth = stringWidth(this._separator);
 
         // Calculate column widths
-        const colWidths = this._computeColumnWidths(
-            width - (this._columns.length - 1) * sepWidth,
-        );
+        const colWidths = this._getColWidths(width, sepWidth);
 
         let headerOffset = 0;
 
@@ -365,6 +419,18 @@ export class Table extends Widget {
                 }
             }
         }
+    }
+
+    private _getColWidths(rectWidth: number, sepWidth: number): number[] {
+        if (!this._resizable) {
+            return this._computeColumnWidths(Math.max(0, rectWidth - (this._columns.length - 1) * sepWidth));
+        }
+        
+        if (this._columnWidths.length !== this._columns.length || this._lastWidth !== rectWidth) {
+            this._columnWidths = this._computeColumnWidths(Math.max(0, rectWidth - (this._columns.length - 1) * sepWidth));
+            this._lastWidth = rectWidth;
+        }
+        return this._columnWidths;
     }
 
     protected _computeColumnWidths(totalWidth: number): number[] {

--- a/packages/widgets/src/data/Table.ts
+++ b/packages/widgets/src/data/Table.ts
@@ -198,11 +198,17 @@ export class Table extends Widget {
                 this._isDragging = true;
                 this._dragColIndex = colIndex;
             }
-        } else if (event.type === 'mouseup') {
+        } else if (event.type === 'mouseup' || event.type === 'dragend') {
             this._isDragging = false;
             this._dragColIndex = -1;
-        } else if (event.type === 'mousedrag' && this._isDragging) {
-            this._columnWidths[this._dragColIndex] = Math.max(1, this._columnWidths[this._dragColIndex] + event.dx);
+        } else if (event.type === 'drag' && this._isDragging) {
+            let colStartX = rect.x;
+            for (let i = 0; i < this._dragColIndex; i++) {
+                colStartX += (this._columnWidths[i] ?? 0) + sepWidth;
+            }
+            
+            const newWidth = Math.max(1, event.x - colStartX);
+            this._columnWidths[this._dragColIndex] = newWidth;
             
             // To prevent table width from changing uncontrollably, we can subtract dx from the next column 
             // if there's enough space, but a simpler free-resizing UX works better for terminal tables


### PR DESCRIPTION
## Description

This PR implements interactive resizable columns for the `Table` widget. By passing `resizable: true` into `TableOptions`, users can now click and drag on column boundaries in the terminal to dynamically resize columns horizontally in data-heavy CLI applications.

## Related Issue

Closes #1719

## Which package(s)?

@termuijs/widgets

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [x] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/f49aa65e-aab2-4e9f-99d6-2174f339ecfe` 

## Screenshots / Recordings (UI changes)

*(Optional: Add a screenshot or GIF showing the drag-to-resize behavior here)*

## Notes for the Reviewer

Added dynamic state tracking for the `_columnWidths` array. When `mousedrag` events fire on a column boundary separator, the table immediately adjusts the respective width and re-renders dynamically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional interactive column resizing in tables via a new table option.
  * Users can resize columns by dragging column separators when resizing is enabled.
  * Column widths update dynamically during drag and remain consistent while scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->