### PR TITLE
test(core): add createKeyEvent unit tests

### DIFF
--- a/packages/core/src/events/types.test.ts
+++ b/packages/core/src/events/types.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { createKeyEvent } from './types.js';
+
+describe('createKeyEvent', () => {
+    it('constructs a KeyEvent with correct base properties', () => {
+        const rawBuffer = Buffer.from('a');
+        const event = createKeyEvent({
+            key: 'a',
+            raw: rawBuffer,
+            ctrl: false,
+            alt: true,
+            shift: false,
+            targetId: 'my-widget'
+        });
+
+        expect(event.key).toBe('a');
+        expect(event.raw).toBe(rawBuffer);
+        expect(event.ctrl).toBe(false);
+        expect(event.alt).toBe(true);
+        expect(event.shift).toBe(false);
+        expect(event.targetId).toBe('my-widget');
+        expect(event._propagationStopped).toBe(false);
+        expect(event._defaultPrevented).toBe(false);
+    });
+
+    it('sets _propagationStopped to true when stopPropagation is called', () => {
+        const event = createKeyEvent({
+            key: 'enter',
+            raw: Buffer.alloc(0),
+            ctrl: false,
+            alt: false,
+            shift: false
+        });
+
+        event.stopPropagation();
+        expect(event._propagationStopped).toBe(true);
+    });
+
+    it('sets _defaultPrevented to true when preventDefault is called', () => {
+        const event = createKeyEvent({
+            key: 'escape',
+            raw: Buffer.alloc(0),
+            ctrl: false,
+            alt: false,
+            shift: false
+        });
+
+        event.preventDefault();
+        expect(event._defaultPrevented).toBe(true);
+    });
+});


### PR DESCRIPTION
## Description

This PR adds comprehensive unit tests for `createKeyEvent` helper function in `packages/core/src/events/types.ts` to verify its functional correctness and prevent regressions.

## Related Issue

Closes #1920

## Which package(s)?

@termuijs/core

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read `CONTRIBUTING.md`.
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/Harshithk951`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for keyboard event creation behavior.
  * Verified that key events include the expected base properties and modifier flags.
  * Confirmed that stopping propagation and preventing default correctly update the event’s internal state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->