### PR TITLE
fix: restore router notFound history navigation

### DIFF
--- a/packages/router/src/not-found.test.ts
+++ b/packages/router/src/not-found.test.ts
@@ -94,4 +94,59 @@ describe('Router notFound', () => {
         expect(router.currentPath).toBe('/');
         expect(router.historyLength).toBe(0);
     });
+
+    it('back() navigates between consecutive notFound history entries', () => {
+        const router = new Router({ notFound });
+        const back = vi.fn();
+        const error = vi.fn();
+        router.events.on('back', back);
+        router.events.on('error', error);
+
+        router.push('/missing-a');
+        router.push('/missing-b');
+
+        router.back();
+
+        expect(error).not.toHaveBeenCalled();
+        expect(back).toHaveBeenCalledOnce();
+        expect(router.currentPath).toBe('/missing-a');
+        expect(router.historyLength).toBe(1);
+
+        const event = back.mock.calls[0][0];
+        expect(event.match.route.path).toBe('/missing-a');
+        expect(event.direction).toBe('back');
+
+        rendered = render(event.screen);
+        expect(rendered.getByText('404 /missing-a')).not.toBeNull();
+    });
+
+    it('forward() restores a notFound entry from the forward stack', () => {
+        const router = new Router({ notFound });
+        const navigate = vi.fn();
+        const error = vi.fn();
+        router.events.on('navigate', navigate);
+        router.events.on('error', error);
+        router.addRoute('/home', () => 'Home');
+
+        router.push('/home');
+        router.push('/missing');
+        router.back();
+
+        navigate.mockClear();
+        error.mockClear();
+
+        router.forward();
+
+        expect(error).not.toHaveBeenCalled();
+        expect(navigate).toHaveBeenCalledOnce();
+        expect(router.currentPath).toBe('/missing');
+        expect(router.historyLength).toBe(2);
+
+        const event = navigate.mock.calls[0][0];
+        expect(event.match.route.path).toBe('/missing');
+        expect(event.direction).toBe('forward');
+
+        rendered = render(event.screen);
+        expect(rendered.getByText('404 /missing')).not.toBeNull();
+    });
 });

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -353,6 +353,19 @@ export class Router {
         const match = prevPath ? matchRoute(prevPath, this._routes) : null;
 
         if (!match) {
+            if (this._notFound && prevPath) {
+                const poppedPath = this._history.pop();
+                if (poppedPath) {
+                    this._forwardStack.push(poppedPath);
+                }
+                this._executeNavigation(prevPath, {
+                    modifyHistory: 'none',
+                    clearForwardStack: false,
+                    direction: 'back',
+                });
+                return;
+            }
+
             this.events.emit('back', null);
             return;
         }
@@ -394,6 +407,16 @@ export class Router {
 
         const match = matchRoute(nextPath, this._routes);
         if (!match) {
+            if (this._notFound) {
+                this._forwardStack.pop();
+                this._executeNavigation(nextPath, {
+                    modifyHistory: 'push',
+                    clearForwardStack: false,
+                    direction: 'forward',
+                });
+                return;
+            }
+
             this.events.emit('error', new Error(`No route found for forward path: ${nextPath}`));
             return;
         }


### PR DESCRIPTION
## Description

Fixes router history navigation for configurable `notFound` routes. Unmatched paths that were already recorded in history can now be revisited with `back()` and restored with `forward()` using the same wrapped notFound screen behavior as `push()`.

## Related Issue

Closes #1929

## Which package(s)?

`@termuijs/router`

## Type of Change

- [x] Bug fix (`type:bug`)
- [ ] Feature (`type:feature`)
- [ ] Docs (`type:docs`)
- [ ] Tests (`type:testing`)
- [ ] Refactor (`type:refactor`)
- [ ] Design / UX (`type:design`)
- [ ] Accessibility (`type:accessibility`)
- [ ] Performance (`type:performance`)
- [ ] DevOps / CI (`type:devops`)
- [ ] Security (`type:security`)

## Checklist

- [x] Starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] Read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [ ] GSSoC 2026 contributor.
- Your GSSoC profile: `not provided`

## Screenshots / Recordings (UI changes)

Not applicable.

## Notes for the Reviewer

Focused verification passes:

- `bun vitest run packages/router` passes: 8 files, 86 tests.
- `bun run build` passes.
- `bun run typecheck` passes.

Full `bun vitest run` does not pass in this local environment. After running with normal terminal capability environment and elevated access for existing filesystem/system tests, the remaining failures are outside `@termuijs/router`: `packages/dev-server/src/server.test.ts` attempts to assign readonly `globalThis.Bun`, zod adapter/validation tests see `z` as undefined, two conf adapter tests fail around temp config persistence, and `env-caps.test.ts` still reports color depth as `0` despite `COLORTERM=truecolor`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved back/forward browser history behavior for pages shown with a custom 404 screen.
  * Back navigation now properly steps through consecutive 404 history entries.
  * Forward navigation now restores missing-page views from the forward stack without stopping with an error.
  * Navigation events now reflect the attempted path, and 404 screens render consistently.
* **Tests**
  * Added router tests covering back/forward behavior with the configurable not-found view, including assertions for emitted events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->