### PR TITLE
fix(router): make wrapScreen public for RouterView compatibility (Closes #1928)

### DIFF
--- a/packages/router/src/RouterView.tsx
+++ b/packages/router/src/RouterView.tsx
@@ -24,7 +24,7 @@ export function RouterView({ router }: RouterViewProps) {
         progress: number;
     }>({
         previous: null,
-        current: router.current ? router._wrapScreen(router.current) : null,
+        current: router.current ? router.wrapScreen(router.current) : null,
         direction: 'push',
         progress: 1,
     });

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -177,7 +177,8 @@ export class Router {
         }
     }
 
-    _wrapScreen(match: RouteMatch): VNode {
+    /** Wrap a route match into a VNode with layout chain and providers */
+    wrapScreen(match: RouteMatch): VNode {
         let screen = createElement(match.route.component, match.params);
 
         for (let i = match.chain.length - 2; i >= 0; i--) {
@@ -267,7 +268,7 @@ export class Router {
                 const notFoundMatch = this._createNotFoundMatch(resolvedPath);
                 this._currentMatch = notFoundMatch;
                 if (this.autoUnmount) unmountAll();
-                const screen = this._wrapScreen(notFoundMatch);
+                const screen = this.wrapScreen(notFoundMatch);
                 const emitEvent = direction === 'back' ? 'back' : 'navigate';
                 this.events.emit(emitEvent, { match: notFoundMatch, screen, direction });
                 return;
@@ -310,7 +311,7 @@ export class Router {
 
         this._currentMatch = match;
         if (this.autoUnmount) unmountAll();
-        const screen = this._wrapScreen(match);
+        const screen = this.wrapScreen(match);
 
         const emitEvent = direction === 'back' ? 'back' : 'navigate';
         this.events.emit(emitEvent, { match, screen, direction });
@@ -379,7 +380,7 @@ export class Router {
 
         this._currentMatch = match;
         if (this.autoUnmount) unmountAll();
-        const screen = this._wrapScreen(match);
+        const screen = this.wrapScreen(match);
 
         this.events.emit('back', { match, screen, direction: 'back' });
 
@@ -414,7 +415,7 @@ export class Router {
         this._history.push(nextPath);
         this._currentMatch = match;
         if (this.autoUnmount) unmountAll();
-        const screen = this._wrapScreen(match);
+        const screen = this.wrapScreen(match);
         this.events.emit('navigate', { match, screen, direction: 'forward' });
 
         match.route.afterEnter?.(nextPath);


### PR DESCRIPTION
## Description

This PR resolves the remaining API mismatch between `Router` and `RouterView` by exposing `wrapScreen()` as a public Router API.

Previously, `RouterView` relied on the private `_wrapScreen()` method, which caused TypeScript build failures due to access of a private member. This change introduces a public `wrapScreen()` method and updates internal references to use the public API.

## Related Issue

Closes #1928

## Which package(s)?

* @termuijs/router

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)

## Checklist

* [x] ⭐ You starred the repo.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read `CONTRIBUTING.md`.
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if applicable).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] Yes, I am a GSSoC 2026 contributor.

## Notes for the Reviewer

The `autoUnmount` property and `direction` field on `NavigateEvent` are already present in the current `main` branch. This PR focuses only on exposing `wrapScreen()` as a public API and updating all internal usages accordingly, providing a minimal, backward-compatible fix for the remaining API mismatch reported in Issue #1928.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved router screen rendering consistency across route changes, including back/forward navigation and not-found handling.
  * Updated route view behavior to use the shared screen-wrapping flow, helping keep navigation transitions consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->