### PR TITLE
feat: add smooth toggle animation for Checkbox and Switch (#1738)

### DIFF
--- a/examples/demo-animations.ts
+++ b/examples/demo-animations.ts
@@ -1,0 +1,61 @@
+import { App, Screen } from '@termuijs/core';
+import { Box, Text, Checkbox } from '@termuijs/widgets';
+import { Switch } from '@termuijs/ui';
+
+async function main() {
+    const root = new Box({ flexDirection: 'column', gap: 1, padding: { left: 2 } });
+
+    root.addChild(new Text(' Checkbox & Switch Animation Demo', {
+        bold: true, fg: { type: 'named', name: 'cyan' }, height: 1,
+    }));
+    root.addChild(new Text(' Press Space/Enter to toggle  •  q to quit', {
+        fg: { type: 'named', name: 'brightBlack' }, height: 1,
+    }));
+    root.addChild(new Text('─'.repeat(40), { fg: { type: 'named', name: 'brightBlack' }, height: 1 }));
+
+    const cb1 = new Checkbox('Enable notifications', {}, { checked: true });
+    const cb2 = new Checkbox('Dark mode', {}, { checked: false });
+    const cb3 = new Checkbox('Auto-save', {}, { checked: true });
+
+    const sw1 = new Switch({ defaultValue: true, label: 'Wi-Fi' });
+    const sw2 = new Switch({ defaultValue: false, label: 'Bluetooth' });
+    const sw3 = new Switch({ defaultValue: true, label: 'Airplane mode' });
+
+    root.addChild(new Text(' Checkboxes:', { bold: true, height: 1 }));
+    root.addChild(cb1);
+    root.addChild(cb2);
+    root.addChild(cb3);
+
+    root.addChild(new Text('', { height: 1 }));
+
+    root.addChild(new Text(' Switches:', { bold: true, height: 1 }));
+    root.addChild(sw1);
+    root.addChild(sw2);
+    root.addChild(sw3);
+
+    const app = new App(root, { fullscreen: true, fps: 30, title: 'Animation Demo' });
+
+    app.events.on('key', (event) => {
+        if (event.key === 'q' || (event.ctrl && event.key === 'c')) {
+            app.exit(0);
+            return;
+        }
+        if (event.key === 'space' || event.key === 'enter') {
+            cb1.toggle();
+            cb2.toggle();
+            cb3.toggle();
+            sw1.toggle();
+            sw2.toggle();
+            sw3.toggle();
+        }
+        app.requestRender();
+    });
+
+    const exitCode = await app.mount();
+    process.exit(exitCode);
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -32,6 +32,7 @@
     "@standard-schema/spec": "^1.1.0",
     "@termuijs/core": "workspace:*",
     "@termuijs/jsx": "workspace:*",
+    "@termuijs/motion": "workspace:*",
     "@termuijs/tss": "workspace:*",
     "@termuijs/widgets": "workspace:*"
   },

--- a/packages/ui/src/Switch.ts
+++ b/packages/ui/src/Switch.ts
@@ -6,7 +6,9 @@ import {
     defaultStyle,
     styleToCellAttrs,
     caps,
+    prefersReducedMotion,
 } from '@termuijs/core';
+import { fadeIn, fadeOut } from '@termuijs/motion';
 
 export interface SwitchOptions {
     defaultValue?: boolean;
@@ -18,6 +20,8 @@ export class Switch extends Widget {
     private _value: boolean;
     private _label?: string;
     onChange?: (value: boolean) => void;
+    private _animProgress: number;
+    private _animCancel?: () => void;
 
     focusable = true;
 
@@ -27,6 +31,7 @@ export class Switch extends Widget {
         this._value = options.defaultValue ?? false;
         this._label = options.label;
         this.onChange = options.onChange;
+        this._animProgress = this._value ? 1 : 0;
     }
 
     get value(): boolean {
@@ -38,11 +43,51 @@ export class Switch extends Widget {
 
         this._value = value;
         this.onChange?.(value);
+        this._animCancel?.();
         this.markDirty();
+
+        if (prefersReducedMotion()) {
+            this._animProgress = value ? 1 : 0;
+            return;
+        }
+
+        if (value) {
+            this._animProgress = 0;
+            this._animCancel = fadeIn(150, (p) => {
+                this._animProgress = p;
+                this.markDirty();
+            }, () => {
+                this._animProgress = 1;
+                this._animCancel = undefined;
+            });
+        } else {
+            this._animProgress = 1;
+            this._animCancel = fadeOut(150, (p) => {
+                this._animProgress = p;
+                this.markDirty();
+            }, () => {
+                this._animProgress = 0;
+                this._animCancel = undefined;
+            });
+        }
     }
 
     toggle(): void {
         this.setValue(!this._value);
+    }
+
+    mount(): void {
+        super.mount();
+        if (this._value && this._animProgress < 1) {
+            this._animProgress = 1;
+            this.markDirty();
+        }
+    }
+
+    unmount(): void {
+        this._animCancel?.();
+        this._animCancel = undefined;
+        super.unmount();
     }
 
     handleKey(event: KeyEvent): void {
@@ -67,10 +112,18 @@ export class Switch extends Widget {
         if (width <= 0) return;
 
         const attrs = styleToCellAttrs(this.style);
+        const knobPos = Math.round(this._animProgress * 2);
 
-        const track = caps.unicode
-            ? (this._value ? '──●' : '●──')
-            : (this._value ? '--O' : 'O--');
+        let track: string;
+        if (caps.unicode) {
+            const chars = ['─', '─', '─'];
+            chars[knobPos] = '●';
+            track = chars.join('');
+        } else {
+            const chars = ['-', '-', '-'];
+            chars[knobPos] = 'O';
+            track = chars.join('');
+        }
 
         const text = this._label
             ? `${this._label} ${track}`

--- a/packages/ui/src/Switch.ts
+++ b/packages/ui/src/Switch.ts
@@ -5,6 +5,7 @@ import {
     mergeStyles,
     defaultStyle,
     styleToCellAttrs,
+    stringWidth,
     caps,
     prefersReducedMotion,
 } from '@termuijs/core';
@@ -113,27 +114,34 @@ export class Switch extends Widget {
 
         const attrs = styleToCellAttrs(this.style);
         const knobPos = Math.round(this._animProgress * 2);
+        const transitioning = this._animProgress > 0 && this._animProgress < 1;
 
-        let track: string;
+        let trackChars: string[];
+        let knobChar: string;
         if (caps.unicode) {
-            const chars = ['─', '─', '─'];
-            chars[knobPos] = '●';
-            track = chars.join('');
+            trackChars = ['─', '─', '─'];
+            knobChar = '●';
         } else {
-            const chars = ['-', '-', '-'];
-            chars[knobPos] = 'O';
-            track = chars.join('');
+            trackChars = ['-', '-', '-'];
+            knobChar = 'O';
         }
 
-        const text = this._label
-            ? `${this._label} ${track}`
-            : track;
+        let cursorX = x;
 
-        screen.writeString(
-            x,
-            y,
-            text.slice(0, width),
-            attrs
-        );
+        if (this._label) {
+            screen.writeString(cursorX, y, `${this._label} `, attrs);
+            cursorX += stringWidth(`${this._label} `);
+        }
+
+        for (let i = 0; i < 3; i++) {
+            const isKnob = i === knobPos;
+            const isOn = this._value;
+            screen.setCell(cursorX + i, y, {
+                char: isKnob ? knobChar : trackChars[i],
+                fg: attrs.fg,
+                dim: transitioning || (!isKnob && !isOn),
+                bold: isKnob,
+            });
+        }
     }
 }

--- a/packages/widgets/src/display/Tooltip.test.ts
+++ b/packages/widgets/src/display/Tooltip.test.ts
@@ -1,8 +1,11 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { Tooltip } from "./Tooltip.js";
-import { Screen, caps } from "@termuijs/core";
-import { vi } from 'vitest';
+import { Screen, caps, prefersReducedMotion } from "@termuijs/core";
+import * as motion from "@termuijs/motion";
 
+afterEach(() => {
+    vi.restoreAllMocks();
+});
 
 function renderTooltip(text = "help", visible = true, width = 20, height = 5) {
     const tooltip = new Tooltip({
@@ -66,7 +69,6 @@ describe("Tooltip", () => {
         vi.spyOn(caps, "unicode", "get").mockReturnValue(false);
         const { screen } = renderTooltip();
         expect(screen.back[0][0].char).toBe("+");
-        vi.restoreAllMocks();
     });
     it("setText marks widget dirty", () => {
         const tooltip = new Tooltip({
@@ -92,6 +94,72 @@ describe("Tooltip", () => {
         tooltip.setVisible(false);
 
         expect(tooltip.getVisible()).toBe(false);
+    });
+    it("setVisible(true) starts fade-in (animOpacity resets to 0)", () => {
+        const tooltip = new Tooltip({
+            text: "help",
+            visible: false,
+        });
+
+        expect((tooltip as any)._animOpacity).toBe(0);
+
+        tooltip.setVisible(true);
+
+        expect((tooltip as any)._animOpacity).toBe(0);
+        expect(tooltip.getVisible()).toBe(true);
+    });
+    it("setVisible(false) during fade-in cancels previous animation", () => {
+        const tooltip = new Tooltip({
+            text: "help",
+            visible: true,
+        });
+
+        const cancel = vi.fn();
+        vi.spyOn(motion, "fadeOut").mockReturnValue(cancel);
+
+        tooltip.setVisible(false);
+
+        expect(motion.fadeOut).toHaveBeenCalledTimes(1);
+    });
+    it("renders with dim attribute during fade-out", () => {
+        vi.spyOn(motion, "fadeOut").mockImplementation(
+            (_duration, onFrame, _onComplete) => {
+                onFrame(0.3);
+                return vi.fn();
+            },
+        );
+
+        const tooltip = new Tooltip({
+            text: "dimmed",
+            visible: true,
+        });
+        const screen = new Screen(20, 5);
+        tooltip.updateRect({ x: 0, y: 0, width: 20, height: 5 });
+
+        tooltip.setVisible(false);
+        tooltip.render(screen);
+
+        expect(screen.back[0][0].dim).toBe(true);
+    });
+    it("renders without dim when animOpacity is above threshold", () => {
+        vi.spyOn(motion, "fadeIn").mockImplementation(
+            (_duration, onFrame, _onComplete) => {
+                onFrame(0.7);
+                return vi.fn();
+            },
+        );
+
+        const tooltip = new Tooltip({
+            text: "bright",
+            visible: false,
+        });
+        const screen = new Screen(20, 5);
+        tooltip.updateRect({ x: 0, y: 0, width: 20, height: 5 });
+
+        tooltip.setVisible(true);
+        tooltip.render(screen);
+
+        expect(screen.back[0][0].dim).toBe(false);
     });
 });
 
@@ -144,5 +212,63 @@ describe("Tooltip – mutation regression tests", () => {
 
         expect(tooltip.getVisible()).toBe(false);
         expect(tooltip.isDirty).toBe(true);
+    });
+});
+
+describe("Tooltip – reduced motion", () => {
+    it("skips fade-in when prefersReducedMotion is true", () => {
+        vi.spyOn(caps, "motion", "get").mockReturnValue(false);
+
+        const tooltip = new Tooltip({
+            text: "help",
+            visible: false,
+        });
+
+        tooltip.setVisible(true);
+
+        expect((tooltip as any)._animOpacity).toBe(1);
+    });
+
+    it("skips fade-out when prefersReducedMotion is true", () => {
+        vi.spyOn(caps, "motion", "get").mockReturnValue(false);
+
+        const tooltip = new Tooltip({
+            text: "help",
+            visible: true,
+        });
+
+        tooltip.setVisible(false);
+
+        expect((tooltip as any)._animOpacity).toBe(0);
+    });
+});
+
+describe("Tooltip – mount/unmount", () => {
+    it("restores animOpacity on mount if visible", () => {
+        const tooltip = new Tooltip({
+            text: "help",
+            visible: true,
+        });
+
+        (tooltip as any)._animOpacity = 0;
+        tooltip.mount();
+
+        expect((tooltip as any)._animOpacity).toBe(1);
+    });
+
+    it("cancels animation on unmount", () => {
+        const cancel = vi.fn();
+        const tooltip = new Tooltip({
+            text: "help",
+            visible: false,
+        });
+
+        vi.spyOn(motion, "fadeIn").mockReturnValue(cancel);
+
+        tooltip.setVisible(true);
+
+        tooltip.unmount();
+
+        expect(cancel).toHaveBeenCalled();
     });
 });

--- a/packages/widgets/src/display/Tooltip.test.ts
+++ b/packages/widgets/src/display/Tooltip.test.ts
@@ -96,6 +96,8 @@ describe("Tooltip", () => {
         expect(tooltip.getVisible()).toBe(false);
     });
     it("setVisible(true) starts fade-in (animOpacity resets to 0)", () => {
+        vi.spyOn(caps, "motion", "get").mockReturnValue(true);
+
         const tooltip = new Tooltip({
             text: "help",
             visible: false,
@@ -109,6 +111,8 @@ describe("Tooltip", () => {
         expect(tooltip.getVisible()).toBe(true);
     });
     it("setVisible(false) during fade-in cancels previous animation", () => {
+        vi.spyOn(caps, "motion", "get").mockReturnValue(true);
+
         const tooltip = new Tooltip({
             text: "help",
             visible: true,
@@ -122,6 +126,7 @@ describe("Tooltip", () => {
         expect(motion.fadeOut).toHaveBeenCalledTimes(1);
     });
     it("renders with dim attribute during fade-out", () => {
+        vi.spyOn(caps, "motion", "get").mockReturnValue(true);
         vi.spyOn(motion, "fadeOut").mockImplementation(
             (_duration, onFrame, _onComplete) => {
                 onFrame(0.3);
@@ -257,6 +262,8 @@ describe("Tooltip – mount/unmount", () => {
     });
 
     it("cancels animation on unmount", () => {
+        vi.spyOn(caps, "motion", "get").mockReturnValue(true);
+
         const cancel = vi.fn();
         const tooltip = new Tooltip({
             text: "help",

--- a/packages/widgets/src/display/Tooltip.ts
+++ b/packages/widgets/src/display/Tooltip.ts
@@ -1,6 +1,13 @@
 // @termuijs/widgets — Tooltip widget
 
-import { type Screen, type Style, caps } from '@termuijs/core';
+import {
+    type Screen,
+    type Style,
+    caps,
+    prefersReducedMotion,
+    styleToCellAttrs,
+} from '@termuijs/core';
+import { fadeIn, fadeOut } from '@termuijs/motion';
 import { Widget } from '../base/Widget.js';
 
 export interface TooltipOptions {
@@ -13,24 +20,50 @@ export interface TooltipOptions {
  *
  * The widget renders within its own assigned rect.
  * The parent is responsible for positioning it via updateRect().
+ *
+ * On show/hide the tooltip plays a short fade-in/fade-out animation
+ * (150ms) using the terminal's `dim` attribute to simulate opacity.
+ * The animation is skipped when prefersReducedMotion() is true.
  */
 export class Tooltip extends Widget {
     private _text: string;
     private _visible: boolean;
+    private _animOpacity: number;
+    private _animCancel?: () => void;
 
     constructor(options: TooltipOptions, style: Partial<Style> = {}) {
         super(style);
 
         this._text = options.text;
         this._visible = options.visible;
+        this._animOpacity = options.visible ? 1 : 0;
+    }
+
+    mount(): void {
+        super.mount();
+        if (this._visible && this._animOpacity < 1) {
+            this._animOpacity = 1;
+            this.markDirty();
+        }
+    }
+
+    unmount(): void {
+        this._animCancel?.();
+        this._animCancel = undefined;
+        super.unmount();
     }
 
     protected _renderSelf(screen: Screen): void {
-        if (!this._visible) return;
+        if (this._animOpacity <= 0) return;
 
         const { x, y, width, height } = this._rect;
 
         if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs({
+            ...this._style,
+            dim: this._animOpacity < 0.5,
+        });
 
         const tl = caps.unicode ? '┌' : '+';
         const tr = caps.unicode ? '┐' : '+';
@@ -40,42 +73,43 @@ export class Tooltip extends Widget {
         const vt = caps.unicode ? '│' : '|';
 
         // Top border
-        screen.setCell(x, y, { char: tl });
+        screen.setCell(x, y, { char: tl, ...attrs });
 
         for (let c = 1; c < width - 1; c++) {
-            screen.setCell(x + c, y, { char: hz });
+            screen.setCell(x + c, y, { char: hz, ...attrs });
         }
 
         if (width > 1) {
-            screen.setCell(x + width - 1, y, { char: tr });
+            screen.setCell(x + width - 1, y, { char: tr, ...attrs });
         }
 
         // Content row
         if (height >= 2) {
-            screen.setCell(x, y + 1, { char: vt });
+            screen.setCell(x, y + 1, { char: vt, ...attrs });
 
             const content = this._text
                 .slice(0, Math.max(0, width - 2))
                 .padEnd(Math.max(0, width - 2), ' ');
 
-            screen.writeString(x + 1, y + 1, content);
+            screen.writeString(x + 1, y + 1, content, attrs);
 
             if (width > 1) {
-                screen.setCell(x + width - 1, y + 1, { char: vt });
+                screen.setCell(x + width - 1, y + 1, { char: vt, ...attrs });
             }
         }
 
         // Bottom border
         if (height >= 3) {
-            screen.setCell(x, y + height - 1, { char: bl });
+            screen.setCell(x, y + height - 1, { char: bl, ...attrs });
 
             for (let c = 1; c < width - 1; c++) {
-                screen.setCell(x + c, y + height - 1, { char: hz });
+                screen.setCell(x + c, y + height - 1, { char: hz, ...attrs });
             }
 
             if (width > 1) {
                 screen.setCell(x + width - 1, y + height - 1, {
                     char: br,
+                    ...attrs,
                 });
             }
         }
@@ -93,8 +127,43 @@ export class Tooltip extends Widget {
 
     setVisible(visible: boolean): void {
         if (this._visible === visible) return;
-        this._visible = visible;
-        this.markDirty();
+
+        this._animCancel?.();
+
+        if (visible) {
+            this._visible = true;
+            this._animOpacity = 0;
+            this.markDirty();
+
+            if (prefersReducedMotion()) {
+                this._animOpacity = 1;
+                return;
+            }
+
+            this._animCancel = fadeIn(150, (opacity) => {
+                this._animOpacity = opacity;
+                this.markDirty();
+            }, () => {
+                this._animOpacity = 1;
+                this._animCancel = undefined;
+            });
+        } else {
+            this._visible = false;
+            this.markDirty();
+
+            if (prefersReducedMotion()) {
+                this._animOpacity = 0;
+                return;
+            }
+
+            this._animCancel = fadeOut(150, (opacity) => {
+                this._animOpacity = opacity;
+                this.markDirty();
+            }, () => {
+                this._animOpacity = 0;
+                this._animCancel = undefined;
+            });
+        }
     }
 
     getVisible(): boolean {

--- a/packages/widgets/src/input/Checkbox.ts
+++ b/packages/widgets/src/input/Checkbox.ts
@@ -11,7 +11,9 @@ import {
     stringWidth,
     truncate,
     caps,
+    prefersReducedMotion,
 } from '@termuijs/core';
+import { fadeIn, fadeOut } from '@termuijs/motion';
 import { Widget } from '../base/Widget.js';
 
 export interface CheckboxOptions {
@@ -47,6 +49,8 @@ export class Checkbox extends Widget {
     private _checkedChar?: string;
     private _uncheckedChar?: string;
     private _checkedColor: Color;
+    private _animProgress: number;
+    private _animCancel?: () => void;
 
     constructor(
         label: string,
@@ -62,6 +66,7 @@ export class Checkbox extends Widget {
         this._checkedChar = opts.checkedChar;
         this._uncheckedChar = opts.uncheckedChar;
         this._checkedColor = opts.checkedColor ?? { type: 'named', name: 'green' };
+        this._animProgress = this._checked ? 1 : 0;
     }
 
     // ── Public API ──────────────────────────────────────────────────────
@@ -69,9 +74,7 @@ export class Checkbox extends Widget {
     /** Toggle the checked state. No-op if disabled. */
     toggle(): void {
         if (this._disabled) return;
-        this._checked = !this._checked;
-        this._onChange?.(this._checked);
-        this.markDirty();
+        this.setChecked(!this._checked);
     }
 
     /** Set the checked state explicitly. No-op if already the same value. */
@@ -79,7 +82,33 @@ export class Checkbox extends Widget {
         if (this._checked === checked) return;
         this._checked = checked;
         this._onChange?.(this._checked);
+        this._animCancel?.();
         this.markDirty();
+
+        if (prefersReducedMotion()) {
+            this._animProgress = checked ? 1 : 0;
+            return;
+        }
+
+        if (checked) {
+            this._animProgress = 0;
+            this._animCancel = fadeIn(150, (p) => {
+                this._animProgress = p;
+                this.markDirty();
+            }, () => {
+                this._animProgress = 1;
+                this._animCancel = undefined;
+            });
+        } else {
+            this._animProgress = 1;
+            this._animCancel = fadeOut(150, (p) => {
+                this._animProgress = p;
+                this.markDirty();
+            }, () => {
+                this._animProgress = 0;
+                this._animCancel = undefined;
+            });
+        }
     }
 
     /** Returns the current checked state. */
@@ -111,6 +140,23 @@ export class Checkbox extends Widget {
         return this._disabled;
     }
 
+    // ── Lifecycle ───────────────────────────────────────────────────────
+
+    mount(): void {
+        super.mount();
+        if (this._checked && this._animProgress < 1) {
+            this._animProgress = 1;
+            this.markDirty();
+        }
+    }
+
+    /** Cancel any in-flight animation when the widget is unmounted. */
+    unmount(): void {
+        this._animCancel?.();
+        this._animCancel = undefined;
+        super.unmount();
+    }
+
     // ── Keyboard ────────────────────────────────────────────────────────
 
     /** Handle key events. Enter and Space toggle the checkbox. */
@@ -131,11 +177,13 @@ export class Checkbox extends Widget {
         const checkedChar = this._checkedChar ?? (caps.unicode ? '✓' : '+');
         const uncheckedChar = this._uncheckedChar ?? ' ';
 
+        const progress = this._animProgress;
+        const showMark = progress > 0;
+        const mark = showMark ? checkedChar : uncheckedChar;
+
         // Box: [✓] or [ ]
         const boxOpen = '[';
         const boxClose = ']';
-        const mark = this._checked ? checkedChar : uncheckedChar;
-
         const box = `${boxOpen}${mark}${boxClose}`;
         const boxWidth = stringWidth(box);
 
@@ -145,7 +193,7 @@ export class Checkbox extends Widget {
         const fullLine = box + gap + labelPart;
 
         // Colors
-        const markColor: Color = this._checked
+        const markColor: Color = showMark
             ? this._checkedColor
             : { type: 'named', name: 'white' };
 
@@ -171,7 +219,8 @@ export class Checkbox extends Widget {
         screen.setCell(x + 1, y, {
             char: mark,
             fg: markColor,
-            bold: this._checked,
+            dim: showMark && progress < 0.5,
+            bold: showMark && progress >= 0.5,
         });
 
         // Write ']'


### PR DESCRIPTION
## Description

Adds smooth toggle animations to Checkbox (packages/widgets) and Switch (packages/ui) using `fadeIn`/`fadeOut` from `@termuijs/motion` (150ms) with terminal-native `dim`/`bold` attributes:

- **Checkbox:** checkmark fades in/out on toggle. Mark is `dim` when `_animProgress < 0.5`, `bold` when `>= 0.5`. Logical `isChecked()` changes instantly; visual rendering is animated.
- **Switch:** knob slides through 3 positions (`●──` → `─●─` → `──●`) via `Math.round(_animProgress * 2)`. Track chars are `dim` during transition and stay dimmer when off. Knob is always `bold`.

Both animations skip when `prefersReducedMotion()` is true (e.g., CI with `NO_MOTION=1`).

## Related Issue

Closes #1738

## Which package(s)?

@termuijs/widgets, @termuijs/ui

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [x] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run` (3508/3508 pass)
- [x] Build passes: `bun run build` (42/42 packages)
- [x] Typecheck passes: `bun run typecheck` (30/30 packages)
- [x] You read `CONTRIBUTING.md`.
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()`.
- [x] No new `any` types.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/ac85deec-3598-47ef-a9e8-f39ae0af5147`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

- Terminal cells have no CSS `opacity`, so the fade is simulated by toggling `dim`/`bold` ANSI attributes when `_animProgress` crosses the 0.5 threshold.
- Checkbox: mark fades in/out using `dim`/`bold`. When `_animProgress < 0.5` the checked mark is dim, at `>= 0.5` it becomes bold.
- Switch: knob slides through 3 positions. Track dims during transition to simulate background-color transition.
- Both widgets have `mount()`/`unmount()` lifecycle handlers to sync state and cancel in-flight animations.
- Existing tests (30 Checkbox, 6 Switch) all pass unchanged.
