### PR TITLE
Add getting-started examples for beginners (closes #1682)

### DIFF
--- a/examples/01-hello-world/README.md
+++ b/examples/01-hello-world/README.md
@@ -1,0 +1,27 @@
+# 01 · Hello World
+
+The smallest possible TermUI app — renders "Hello, World!" centered in a bordered box.
+
+## What you'll learn
+- How to create an `App` and mount it
+- How `Box`, `Text`, and `Center` widgets work together
+- How to listen for a key event to quit
+
+## Run it
+\`\`\`bash
+cd examples/01-hello-world
+bun install
+bun run start
+\`\`\`
+
+## Expected output
+\`\`\`
+┌────────────────────────────────────┐
+│                                      │
+│           Hello, World!             │
+│           Press 'q' to quit         │
+│                                      │
+└────────────────────────────────────┘
+\`\`\`
+
+Press `q` or `Ctrl+C` to exit.

--- a/examples/01-hello-world/package.json
+++ b/examples/01-hello-world/package.json
@@ -1,0 +1,25 @@
+{
+    "name": "@termuijs/example-hello-world",
+    "version": "0.1.0",
+    "private": true,
+    "description": "Beginner example: basic text display",
+    "type": "module",
+    "scripts": {
+        "start": "bun src/index.tsx",
+        "dev": "bun --watch src/index.tsx",
+        "build": "echo 'no build needed'",
+        "typecheck": "tsc --noEmit"
+    },
+    "dependencies": {
+        "@termuijs/core": "workspace:*",
+        "@termuijs/widgets": "workspace:*",
+        "@termuijs/ui": "workspace:*",
+        "@termuijs/jsx": "workspace:*"
+    },
+    "devDependencies": {
+        "typescript": "^5.9.3"
+    },
+    "engines": {
+        "bun": ">=1.3.0"
+    }
+}

--- a/examples/01-hello-world/src/index.tsx
+++ b/examples/01-hello-world/src/index.tsx
@@ -1,0 +1,56 @@
+// 01-hello-world
+// The simplest possible TermUI app: mount a Box, put a Text widget in it,
+// center it on screen, and render.
+
+import { App } from "@termuijs/core";
+import { Box, Text, Center } from "@termuijs/widgets";
+
+async function main() {
+    // A bordered box holding our greeting
+    const helloBox = new Box({
+        flexDirection: "column",
+        width: 40,
+        height: 7,
+        border: "single",
+        borderColor: { type: "named", name: "cyan" },
+        padding: { left: 2, right: 2, top: 1, bottom: 1 },
+    });
+
+    const greeting = new Text("Hello, World!", {
+        bold: true,
+        height: 1,
+        fg: { type: "named", name: "cyan" },
+    }, { align: "center" });
+
+    const hint = new Text("Press 'q' to quit", {
+        height: 1,
+        fg: { type: "named", name: "brightBlack" },
+    }, { align: "center" });
+
+    helloBox.addChild(greeting);
+    helloBox.addChild(hint);
+
+    // Center the box in the terminal
+    const centerLayout = new Center({}, { horizontal: true, vertical: true });
+    centerLayout.addChild(helloBox);
+
+    const app = new App(centerLayout, {
+        fullscreen: true,
+        title: "Hello World Example",
+        fps: 30,
+    });
+
+    app.events.on("key", (event) => {
+        if (event.key === "q" || (event.ctrl && event.key === "c")) {
+            app.exit(0);
+        }
+    });
+
+    const exitCode = await app.mount();
+    process.exit(exitCode);
+}
+
+main().catch((err) => {
+    console.error("Hello World application error:", err);
+    process.exit(1);
+});

--- a/examples/01-hello-world/tsconfig.json
+++ b/examples/01-hello-world/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "dist",
+        "rootDir": "src",
+        "jsx": "react-jsx",
+        "jsxImportSource": "@termuijs/jsx"
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/examples/02-simple-button/README.md
+++ b/examples/02-simple-button/README.md
@@ -1,0 +1,30 @@
+# 02 · Simple Button
+
+A focusable, clickable button that increments a counter — your first
+interactive TermUI widget.
+
+## What you'll learn
+- Creating a custom `Widget` subclass (`Button`) with its own `_renderSelf`
+- Handling focus state and highlighting the focused element
+- Responding to Enter/Space key presses to trigger a click
+
+## Run it
+```bash
+cd examples/02-simple-button
+bun install
+bun run start
+```
+
+## Expected output
++----------------------------------------+
+|                                        |
+|          Clicked: 0 times             |
+|                                        |
+|  +--------------------------------+   |
+|  |          Click Me!             |   |
+|  +--------------------------------+   |
+|                                        |
+|  Enter/Space = click . q = quit       |
+|                                        |
++----------------------------------------+
+Press `Enter` or `Space` to click. Press `q` or `Ctrl+C` to exit.

--- a/examples/02-simple-button/package.json
+++ b/examples/02-simple-button/package.json
@@ -1,0 +1,25 @@
+{
+    "name": "@termuijs/example-simple-button",
+    "version": "0.1.0",
+    "private": true,
+    "description": "Beginner example: button with click",
+    "type": "module",
+    "scripts": {
+        "start": "bun src/index.tsx",
+        "dev": "bun --watch src/index.tsx",
+        "build": "echo 'no build needed'",
+        "typecheck": "tsc --noEmit"
+    },
+    "dependencies": {
+        "@termuijs/core": "workspace:*",
+        "@termuijs/widgets": "workspace:*",
+        "@termuijs/ui": "workspace:*",
+        "@termuijs/jsx": "workspace:*"
+    },
+    "devDependencies": {
+        "typescript": "^5.9.3"
+    },
+    "engines": {
+        "bun": ">=1.3.0"
+    }
+}

--- a/examples/02-simple-button/src/index.tsx
+++ b/examples/02-simple-button/src/index.tsx
@@ -1,0 +1,122 @@
+// 02-simple-button
+// Demonstrates a clickable/focusable Button widget that updates a counter
+// on click, using the same Widget subclass pattern as the calculator example.
+
+import { App, type KeyEvent, type Screen, type Style, styleToCellAttrs, stringWidth, truncate } from "@termuijs/core";
+import { Widget, Box, Text, Center } from "@termuijs/widgets";
+
+class Button extends Widget {
+    private label: string;
+    private onClick: () => void;
+
+    constructor(label: string, onClick: () => void, style: Partial<Style> = {}) {
+        super({ border: "single", height: 3, ...style });
+        this.label = label;
+        this.onClick = onClick;
+        this.focusable = true;
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width, height } = this._getContentRect();
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this._style);
+        const cellStyle = {
+            ...attrs,
+            fg: this.isFocused ? { type: "named" as const, name: "cyan" as const } : attrs.fg,
+            bold: this.isFocused,
+            inverse: this.isFocused,
+        };
+
+        for (let r = 0; r < height; r++) {
+            screen.writeString(x, y + r, " ".repeat(width), cellStyle);
+        }
+
+        const paddingLeft = Math.max(0, Math.floor((width - stringWidth(this.label)) / 2));
+        const visibleText = truncate(" ".repeat(paddingLeft) + this.label, width);
+        screen.writeString(x, y + Math.floor(height / 2), visibleText, cellStyle);
+    }
+
+    click(): void {
+        this.onClick();
+    }
+}
+
+class SimpleButtonApp extends Widget {
+    private counter = 0;
+    private counterDisplay: Text;
+    private button: Button;
+
+    constructor() {
+        super({
+            flexDirection: "column",
+            width: 40,
+            height: 14,
+            border: "double",
+            borderColor: { type: "named", name: "cyan" },
+            padding: { left: 2, right: 2, top: 1, bottom: 1 },
+        });
+
+        this.counterDisplay = new Text("Clicked: 0 times", {
+            height: 1,
+            fg: { type: "named", name: "green" },
+        }, { align: "center" });
+
+        this.button = new Button("Click Me!", () => this.handleClick(), {
+            fg: { type: "named", name: "white" },
+        });
+
+        const hint = new Text("Enter/Space = click · q = quit", {
+            height: 1,
+            fg: { type: "named", name: "brightBlack" },
+        }, { align: "center" });
+
+        this.addChild(this.counterDisplay);
+        this.addChild(this.button);
+        this.addChild(hint);
+
+        this.button.isFocused = true;
+    }
+
+    private handleClick() {
+        this.counter++;
+        this.counterDisplay.setContent(`Clicked: ${this.counter} times`);
+        this.markDirty();
+    }
+
+    handleKey(event: KeyEvent): boolean {
+        if (event.key === "q" || (event.ctrl && event.key === "c")) return false;
+        if (event.key === "enter" || event.key === "return" || event.key === "space") {
+            this.button.click();
+        }
+        return true;
+    }
+
+    protected _renderSelf(_screen: Screen): void {}
+}
+
+async function main() {
+    const buttonApp = new SimpleButtonApp();
+    const centerLayout = new Center({}, { horizontal: true, vertical: true });
+    centerLayout.addChild(buttonApp);
+
+    const app = new App(centerLayout, {
+        fullscreen: true,
+        title: "Simple Button Example",
+        fps: 30,
+    });
+
+    app.events.on("key", (event) => {
+        const shouldContinue = buttonApp.handleKey(event);
+        if (!shouldContinue) app.exit(0);
+        app.requestRender();
+    });
+
+    const exitCode = await app.mount();
+    process.exit(exitCode);
+}
+
+main().catch((err) => {
+    console.error("Simple Button application error:", err);
+    process.exit(1);
+});

--- a/examples/02-simple-button/tsconfig.json
+++ b/examples/02-simple-button/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "dist",
+        "rootDir": "src",
+        "jsx": "react-jsx",
+        "jsxImportSource": "@termuijs/jsx"
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/examples/03-form-inputs/README.md
+++ b/examples/03-form-inputs/README.md
@@ -1,0 +1,33 @@
+# 02 · Simple Button
+
+A focusable, clickable button that increments a counter — your first
+interactive TermUI widget.
+
+## What you'll learn
+- Creating a custom `Widget` subclass (`Button`) with its own `_renderSelf`
+- Handling focus state and highlighting the focused element
+- Responding to Enter/Space key presses to trigger a click
+
+## Run it
+\`\`\`bash
+cd examples/02-simple-button
+bun install
+bun run start
+\`\`\`
+
+## Expected output
+\`\`\`
+┌──────────────────────────────────────┐
+│                                        │
+│          Clicked: 0 times             │
+│                                        │
+│  ┌──────────────────────────────┐    │
+│  │          Click Me!            │    │
+│  └──────────────────────────────┘    │
+│                                        │
+│  Enter/Space = click · q = quit       │
+│                                        │
+└──────────────────────────────────────┘
+\`\`\`
+
+Press `Enter` or `Space` to click. Press `q` or `Ctrl+C` to exit.

--- a/examples/03-form-inputs/README.md
+++ b/examples/03-form-inputs/README.md
@@ -1,33 +1,32 @@
-# 02 · Simple Button
+# 03 · Form Inputs
 
-A focusable, clickable button that increments a counter — your first
-interactive TermUI widget.
+Type your name into a text field and see it echoed back — your first
+interactive input example.
 
 ## What you'll learn
-- Creating a custom `Widget` subclass (`Button`) with its own `_renderSelf`
-- Handling focus state and highlighting the focused element
-- Responding to Enter/Space key presses to trigger a click
+- Using the `TextInput` widget from `@termuijs/widgets`
+- Forwarding keyboard events into a focused input with `handleKey`
+- Reacting to submission via the `onSubmit` callback
 
 ## Run it
-\`\`\`bash
-cd examples/02-simple-button
+```bash
+cd examples/03-form-inputs
 bun install
 bun run start
-\`\`\`
+```
 
 ## Expected output
-\`\`\`
-┌──────────────────────────────────────┐
-│                                        │
-│          Clicked: 0 times             │
-│                                        │
-│  ┌──────────────────────────────┐    │
-│  │          Click Me!            │    │
-│  └──────────────────────────────┘    │
-│                                        │
-│  Enter/Space = click · q = quit       │
-│                                        │
-└──────────────────────────────────────┘
-\`\`\`
+```
+┌────────────────────────────────────────┐
+│ What's your name?                       │
+│ ┌──────────────────────────────────┐   │
+│ │ sam_                              │   │
+│ └──────────────────────────────────┘   │
+│                                          │
+│ Hello, sam! Nice to meet you.           │
+│                                          │
+│ Type your name, press Enter · Esc = quit│
+└────────────────────────────────────────┘
+```
 
-Press `Enter` or `Space` to click. Press `q` or `Ctrl+C` to exit.
+Press `Esc` or `Ctrl+C` to exit.

--- a/examples/03-form-inputs/package.json
+++ b/examples/03-form-inputs/package.json
@@ -1,0 +1,25 @@
+{
+    "name": "@termuijs/example-form-inputs",
+    "version": "0.1.0",
+    "private": true,
+    "description": "Beginner example: text input with live display",
+    "type": "module",
+    "scripts": {
+        "start": "bun src/index.tsx",
+        "dev": "bun --watch src/index.tsx",
+        "build": "echo 'no build needed'",
+        "typecheck": "tsc --noEmit"
+    },
+    "dependencies": {
+        "@termuijs/core": "workspace:*",
+        "@termuijs/widgets": "workspace:*",
+        "@termuijs/ui": "workspace:*",
+        "@termuijs/jsx": "workspace:*"
+    },
+    "devDependencies": {
+        "typescript": "^5.9.3"
+    },
+    "engines": {
+        "bun": ">=1.3.0"
+    }
+}

--- a/examples/03-form-inputs/src/index.tsx
+++ b/examples/03-form-inputs/src/index.tsx
@@ -1,0 +1,96 @@
+// 03-form-inputs
+// Demonstrates a TextInput widget that echoes what you typed back to
+// the screen once submitted. Builds on 01 and 02 by adding real
+// keyboard-driven text input.
+
+import { App, type KeyEvent } from "@termuijs/core";
+import { Text, TextInput, Widget } from "@termuijs/widgets";
+
+class FormInputsApp extends Widget {
+    private input: TextInput;
+    private display: Text;
+
+    constructor() {
+        super({
+            flexDirection: "column",
+            width: 44,
+            height: 12,
+            border: "single",
+            borderColor: { type: "named", name: "cyan" },
+            padding: { left: 2, right: 2, top: 1, bottom: 1 },
+            gap: 1,
+        });
+
+        const title = new Text("What's your name?", {
+            bold: true,
+            height: 1,
+            fg: { type: "named", name: "cyan" },
+        });
+
+        this.input = new TextInput(
+            { border: "single", height: 3, width: 36 },
+            {
+                placeholder: "Type here...",
+                onSubmit: (value) => this.showGreeting(value),
+            },
+        );
+        this.input.isFocused = true;
+
+        this.display = new Text("", {
+            height: 1,
+            fg: { type: "named", name: "green" },
+        });
+
+        const hint = new Text("Type your name, press Enter · q = quit", {
+            height: 1,
+            fg: { type: "named", name: "brightBlack" },
+        });
+
+        this.addChild(title);
+        this.addChild(this.input);
+        this.addChild(this.display);
+        this.addChild(hint);
+    }
+
+    private showGreeting(name: string) {
+        if (name.trim().length > 0) {
+            this.display.setContent(`Hello, ${name}! Nice to meet you.`);
+            this.display.setStyle({ fg: { type: "named", name: "green" } });
+        }
+        this.markDirty();
+    }
+
+    handleKey(event: KeyEvent): boolean {
+        if (event.key === "q" || (event.ctrl && event.key === "c")) {
+            return false;
+        }
+        this.input.handleKey(event);
+        return true;
+    }
+
+    protected _renderSelf(): void {}
+}
+
+async function main() {
+    const formApp = new FormInputsApp();
+
+    const app = new App(formApp, {
+        fullscreen: true,
+        title: "Form Inputs Example",
+        fps: 30,
+    });
+
+    app.events.on("key", (event) => {
+        const shouldContinue = formApp.handleKey(event);
+        if (!shouldContinue) app.exit(0);
+        app.requestRender();
+    });
+
+    const exitCode = await app.mount();
+    process.exit(exitCode);
+}
+
+main().catch((err) => {
+    console.error("Form Inputs application error:", err);
+    process.exit(1);
+});

--- a/examples/03-form-inputs/src/index.tsx
+++ b/examples/03-form-inputs/src/index.tsx
@@ -13,7 +13,7 @@ class FormInputsApp extends Widget {
     constructor() {
         super({
             flexDirection: "column",
-            width: 44,
+            width: 50,
             height: 12,
             border: "single",
             borderColor: { type: "named", name: "cyan" },
@@ -41,7 +41,7 @@ class FormInputsApp extends Widget {
             fg: { type: "named", name: "green" },
         });
 
-        const hint = new Text("Type your name, press Enter · q = quit", {
+        const hint = new Text("Type your name, press Enter · Esc = quit", {
             height: 1,
             fg: { type: "named", name: "brightBlack" },
         });
@@ -61,7 +61,7 @@ class FormInputsApp extends Widget {
     }
 
     handleKey(event: KeyEvent): boolean {
-        if (event.key === "q" || (event.ctrl && event.key === "c")) {
+        if (event.key === "escape" || (event.ctrl && event.key === "c")) {
             return false;
         }
         this.input.handleKey(event);

--- a/examples/03-form-inputs/tsconfig.json
+++ b/examples/03-form-inputs/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "dist",
+        "rootDir": "src",
+        "jsx": "react-jsx",
+        "jsxImportSource": "@termuijs/jsx"
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Description
Adds three beginner-friendly examples (`01-hello-world`, `02-simple-button`, `03-form-inputs`) to help new users get started with TermUI, each with clear code comments and a README covering run instructions and expected output.

## Related Issue
Closes #1682

## Which package(s)?
examples

## Type of Change
- [x] ✨ Feature (`type:feature`)
- [x] 📝 Docs (`type:docs`)

## Checklist
- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation
- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/af55953f-7e8d-4063-8c29-45dee3e6247b`

## Screenshots / Recordings (UI changes)
\<img width="488" height="156" alt="image" src="https://github.com/user-attachments/assets/0f2f8c71-89d7-4f48-a32d-71262a5fd16a" />
<img width="652" height="515" alt="image" src="https://github.com/user-attachments/assets/975dbe2a-f7fc-46bc-8256-cbcfa07942e3" />
<img width="742" height="227" alt="image" src="https://github.com/user-attachments/assets/6dbae846-a78e-49cf-bdc9-e71260326292" />


## Notes for the Reviewer
While building `examples/03-form-inputs`, I found that the `Form` widget (`@termuijs/ui`) has a rendering bug where field labels and typed text get clipped — this is reproducible in the existing `forms-and-validation` example too, so it's a pre-existing issue, not something introduced here. To keep this example clean for beginners, I used `TextInput` from `@termuijs/widgets` instead, which renders correctly. Happy to file a separate issue for the `Form` clipping bug if that's useful — let me know.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new terminal UI examples: a hello world screen, a simple button with click and keyboard support, and a basic text input form.
  * Each example includes runnable setup and project configuration for easy local use.
* **Documentation**
  * Added README files for the new examples, including run steps, expected output, and exit instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->