### PR TITLE
docs: add comprehensive Button widget documentation (closes #1681)

### DIFF
--- a/packages/widgets/README.md
+++ b/packages/widgets/README.md
@@ -110,7 +110,7 @@ list.scrollTo(500)
 ```
 ## Button
 
-A pressable button with a label, four visual variants, and built-in disabled/loading states. Handles `enter` and `space` key activation automatically when focused.
+A pressable button with a label, four visual variants, and built-in disabled/loading states. Handles `enter` and `space` key activation when focused, provided your app forwards keyboard events to it via `handleKey()`.
 
 ### Purpose
 
@@ -173,8 +173,11 @@ const submitBtn = new Button('Submit', {}, {
     onPress: async () => {
         submitBtn.setLoading(true)
         submitBtn.setLoadingText('Submitting...')
-        await submitForm()
-        submitBtn.setLoading(false)
+        try {
+            await submitForm()
+        } finally {
+            submitBtn.setLoading(false)
+        }
     },
 })
 ```
@@ -200,7 +203,7 @@ const submitBtn = new Button('Submit', {}, {
 | `onPress` fires even while `loading` is `true` | You're calling `onPress` directly instead of routing through `handleKey` | Only `handleKey` respects the `loading`/`disabled` guard; don't call `onPress` directly |
 | Label or disabled state doesn't visually update | You're mutating internal state directly | Always use `setLabel()` / `setDisabled()` / `setLoading()` — these call `markDirty()` for you |
 | Spinner doesn't animate | `NO_MOTION=1` is set, or `prefersReducedMotion()` returns true | This is expected behavior — motion is intentionally disabled; the spinner shows a static first frame instead |
-| Box-drawing characters render as `?` or garbled | Terminal doesn't support Unicode | Set `NO_UNICODE=1` to force the ASCII fallback (`+`, `-`, `|`) |
+| Box-drawing characters render as `?` or garbled | Terminal doesn't support Unicode | Set `NO_UNICODE=1` to force the ASCII fallback (`+`, `-`, `\|`) |
 
 ## AI widgets
 

--- a/packages/widgets/README.md
+++ b/packages/widgets/README.md
@@ -69,6 +69,7 @@ Requires `@termuijs/core` as a peer dependency.
 
 | Widget | What it does |
 |--------|-------------|
+| `Button` | Pressable button with variants, disabled/loading states, and keyboard activation |
 | `TextInput` | Single-line text input with cursor, placeholder, and change callback |
 | `List` | Scrollable list with keyboard selection. Good for small datasets |
 | `VirtualList` | Scroll-virtualized list. Renders only visible rows; 1M items costs the same as 10 |
@@ -107,6 +108,99 @@ list.selectFirst()
 list.selectLast()
 list.scrollTo(500)
 ```
+## Button
+
+A pressable button with a label, four visual variants, and built-in disabled/loading states. Handles `enter` and `space` key activation automatically when focused.
+
+### Purpose
+
+`Button` renders a bordered, centered-label button that responds to keyboard activation. It's the standard way to trigger an action (submit, confirm, cancel, retry) in a TermUI app. It manages its own focus-aware border color, supports a busy/loading spinner state, and falls back to ASCII box-drawing characters when `NO_UNICODE=1`.
+
+### Props
+
+**Constructor:** `new Button(label: string, style?: Partial<Style>, opts?: ButtonOptions)`
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `variant` | `'default' \| 'primary' \| 'danger' \| 'ghost'` | `'default'` | Controls background/foreground color scheme |
+| `disabled` | `boolean` | `false` | When `true`, ignores `enter`/`space` key activation |
+| `onPress` | `() => void` | `undefined` | Called when the button is activated via keyboard |
+| `color` | `Color` | variant default | Overrides the variant's background color |
+| `loading` | `boolean` | `false` | Shows an animated spinner and suppresses activation while `true` |
+| `loadingText` | `string` | falls back to `label` | Text shown next to the spinner while `loading` is `true` |
+
+### Methods
+
+- `setLabel(label: string): void` — update the displayed label (no-op + no re-render if unchanged)
+- `setDisabled(disabled: boolean): void` — toggle disabled state (no-op + no re-render if unchanged)
+- `setLoading(loading: boolean): void` — toggle loading state; starts/stops the spinner timer
+- `setLoadingText(loadingText: string | undefined): void` — update the text shown while loading
+- `handleKey(event: KeyEvent): void` — call this from your app's key handler to route `enter`/`space` to the button
+
+### Examples
+
+**1. Basic button with a click handler**
+```typescript
+import { Button } from '@termuijs/widgets'
+
+const button = new Button('Click Me!', {}, {
+    onPress: () => console.log('Button pressed!'),
+})
+```
+
+**2. Variants**
+```typescript
+const submitBtn = new Button('Submit', {}, { variant: 'primary', onPress: submit })
+const deleteBtn = new Button('Delete', {}, { variant: 'danger', onPress: remove })
+const cancelBtn = new Button('Cancel', {}, { variant: 'ghost', onPress: cancel })
+```
+
+**3. Disabled button**
+```typescript
+const saveBtn = new Button('Save', {}, {
+    disabled: !formIsValid,
+    onPress: save,
+})
+
+// Toggle later, e.g. once validation passes
+saveBtn.setDisabled(false)
+```
+
+**4. Loading state during an async action**
+```typescript
+const submitBtn = new Button('Submit', {}, {
+    variant: 'primary',
+    onPress: async () => {
+        submitBtn.setLoading(true)
+        submitBtn.setLoadingText('Submitting...')
+        await submitForm()
+        submitBtn.setLoading(false)
+    },
+})
+```
+
+### Common patterns
+
+- **Routing keys to the button:** `Button` doesn't listen for input on its own — forward key events from your app's key handler:
+```typescript
+  app.events.on('key', (event) => {
+      if (button.isFocused) button.handleKey(event)
+  })
+```
+- **Focus indication:** the button's border automatically turns cyan when `isFocused` is `true`. Set `button.isFocused = true` when it should be the active element.
+- **Disable during async work:** prefer `loading` over `disabled` for actions that take time — it gives the user visual feedback (spinner) instead of a button that silently does nothing.
+- **Only `'enter'` and `'space'` (lowercase) trigger `onPress`.** Uppercase `'Enter'` or a raw `' '` character will not activate the button — this matches how `KeyEvent.key` is normalized elsewhere in TermUI.
+
+### Troubleshooting
+
+| Problem | Likely cause | Fix |
+|---------|--------------|-----|
+| Button doesn't respond to Enter/Space | Key events aren't being forwarded to `button.handleKey()` | Call `button.handleKey(event)` from your app's `'key'` event handler |
+| Button looks unfocused even though it's the active element | `isFocused` was never set | Set `button.isFocused = true` manually — `Button` doesn't manage focus state itself |
+| `onPress` fires even while `loading` is `true` | You're calling `onPress` directly instead of routing through `handleKey` | Only `handleKey` respects the `loading`/`disabled` guard; don't call `onPress` directly |
+| Label or disabled state doesn't visually update | You're mutating internal state directly | Always use `setLabel()` / `setDisabled()` / `setLoading()` — these call `markDirty()` for you |
+| Spinner doesn't animate | `NO_MOTION=1` is set, or `prefersReducedMotion()` returns true | This is expected behavior — motion is intentionally disabled; the spinner shows a static first frame instead |
+| Box-drawing characters render as `?` or garbled | Terminal doesn't support Unicode | Set `NO_UNICODE=1` to force the ASCII fallback (`+`, `-`, `|`) |
 
 ## AI widgets
 


### PR DESCRIPTION
## Description
Adds comprehensive documentation for the `Button` widget to `packages/widgets/README.md`, covering its purpose, all props, real-world examples, common patterns, and troubleshooting.

## Related Issue
Closes #1681

## Which package(s)?
@termuijs/widgets

## Type of Change
- [x] 📝 Docs (`type:docs`)

## Checklist
- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation
- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/af55953f-7e8d-4063-8c29-45dee3e6247b`

## Notes for the Reviewer
Per `CONTRIBUTING.md`, I noticed the full API docs site actually lives in the separate `TermUI_Docs` repo. Since this repo's `packages/widgets/README.md` didn't previously mention `Button` at all despite it being a core exported widget, I documented it here instead, following the issue's requirements (purpose, all props, real examples, common patterns, troubleshooting). Happy to also open a companion PR in `TermUI_Docs` if the maintainer wants it mirrored there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the widget documentation with a dedicated button section and added it to the widget index.
  * Documented button variants, keyboard activation, disabled/loading behavior, and ASCII fallback behavior.
  * Added constructor/options details, usage examples, common patterns, and a troubleshooting guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->