### PR TITLE
fix(core): prevent TCP chunk escape sequence breakage in InputParser

### DIFF
--- a/packages/core/src/input/InputParser.test.ts
+++ b/packages/core/src/input/InputParser.test.ts
@@ -353,13 +353,13 @@ describe('InputParser', () => {
     });
 
     describe('FSM escape sequence handling', () => {
-        it('emits standalone Escape key after 200ms timeout', () => {
+        it('emits standalone Escape key after 500ms timeout', () => {
             const { stdin, handler } = createParser();
             // Lone ESC byte
             originalSendKey(stdin, Buffer.from([0x1b]));
             expect(handler).not.toHaveBeenCalled();
-            // Advance past the 200ms timeout
-            vi.advanceTimersByTime(250);
+            // Advance past the 500ms timeout
+            vi.advanceTimersByTime(550);
             expect(handler).toHaveBeenCalledTimes(1);
             expect(handler).toHaveBeenCalledWith(expect.objectContaining({ key: 'escape' }));
         });
@@ -380,9 +380,9 @@ describe('InputParser', () => {
             const { stdin, handler } = createParser();
             // Simulate ESC arriving alone (as if it was the start of an escape sequence)
             originalSendKey(stdin, Buffer.from([0x1b]));
-            // Advance time past 200ms timeout - should NOT emit yet if buffer was appended
+            // Advance time past 500ms timeout - should NOT emit yet if buffer was appended
             // But in this test, no continuation arrives, so after timeout Escape fires
-            vi.advanceTimersByTime(250);
+            vi.advanceTimersByTime(550);
             expect(handler).toHaveBeenCalledTimes(1);
             expect(handler).toHaveBeenCalledWith(expect.objectContaining({ key: 'escape' }));
         });

--- a/packages/core/src/input/InputParser.ts
+++ b/packages/core/src/input/InputParser.ts
@@ -11,6 +11,8 @@ import { parseMouseEvent, isMouseSequence } from './MouseParser.js';
 import { EventEmitter } from '../events/EventEmitter.js';
 import { splitGraphemes } from './grapheme.js';
 
+const ESCAPE_TIMEOUT_MS = 500;
+
 export interface CursorPosition {
     row: number;
     col: number;
@@ -203,6 +205,9 @@ export class InputParser {
         if (str.startsWith('\x1b')) {
             this._escapeBuffer = data;
             this._tryParseEscape();
+            if (this._escapeBuffer.length > 0) {
+                this._startEscapeTimeout();
+            }
             return;
         }
 
@@ -331,7 +336,7 @@ export class InputParser {
                 alt: false,
                 shift: false,
             }));
-        }, 500);
+        }, ESCAPE_TIMEOUT_MS);
     }
 
     /**

--- a/packages/core/src/input/InputParser.ts
+++ b/packages/core/src/input/InputParser.ts
@@ -158,6 +158,11 @@ export class InputParser {
                 this._escapeTimeout = null;
             }
             this._tryParseEscape();
+            // If the sequence is still incomplete, restart the timeout
+            // so fragmented TCP chunks won't trigger a false standalone ESC.
+            if (this._escapeBuffer.length > 0) {
+                this._startEscapeTimeout();
+            }
             return;
         }
 
@@ -189,21 +194,9 @@ export class InputParser {
 
         // Check if this starts an escape sequence
         if (str.startsWith('\x1b') && str.length === 1) {
-            // Lone ESC — wait for more bytes (FSM via _escapeBuffer handles continuation)
+            // Lone ESC — wait for more bytes
             this._escapeBuffer = data;
-            this._escapeTimeout = setTimeout(() => {
-                // Timeout — it was a standalone Escape key
-                const remained = this._escapeBuffer;
-                this._escapeBuffer = Buffer.alloc(0);
-                this._escapeTimeout = null;
-                this._events.emit('key', createKeyEvent({
-                    key: 'escape',
-                    raw: remained,
-                    ctrl: false,
-                    alt: false,
-                    shift: false,
-                }));
-            }, 200); // 200ms debounce (increased from 50ms to avoid race with render)
+            this._startEscapeTimeout();
             return;
         }
 
@@ -316,6 +309,29 @@ export class InputParser {
             }
         }
         return false;
+    }
+
+    /**
+     * Start or restart the escape sequence timeout.
+     * Fires when no additional bytes arrive within the window,
+     * treating the buffered bytes as a standalone Escape key.
+     */
+    private _startEscapeTimeout(): void {
+        if (this._escapeTimeout) {
+            clearTimeout(this._escapeTimeout);
+        }
+        this._escapeTimeout = setTimeout(() => {
+            const remained = this._escapeBuffer;
+            this._escapeBuffer = Buffer.alloc(0);
+            this._escapeTimeout = null;
+            this._events.emit('key', createKeyEvent({
+                key: 'escape',
+                raw: remained,
+                ctrl: false,
+                alt: false,
+                shift: false,
+            }));
+        }, 500);
     }
 
     /**


### PR DESCRIPTION
## Fix: InputParser TCP chunk escape sequence breakage

### Changes

**`packages/core/src/input/InputParser.ts`**
- Replaced the fixed 200ms timeout for lone ESC bytes with a new `_startEscapeTimeout()` method that uses a 500ms timeout.
- Added timeout restart in the escape buffer concatenation handler: each partial chunk resets the timer, preventing false standalone ESC emission.
- Cleaned up the lone ESC code path by extracting timeout logic into its own method.

### Fixes
- Escape sequences fragmented across TCP chunks (SSH, serial connections) with >200ms gaps were incorrectly parsed as standalone Escape keypresses followed by garbage characters
- After the initial ESC timeout fired, subsequent sequence bytes were processed as regular input, corrupting the input stream
- 200ms window was too aggressive for high-latency network connections

Closes #1957

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the Escape key so incomplete or delayed key sequences are buffered more reliably.
  * Restarts the Escape timeout when more input arrives, reducing misread key events.
  * Lone Escape presses now emit consistently after a short delay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->