### PR TITLE
fix(core): prevent Terminal writeSync interleaving with render queue

### DIFF
--- a/packages/core/src/terminal/Terminal.ts
+++ b/packages/core/src/terminal/Terminal.ts
@@ -217,9 +217,17 @@ export class Terminal {
      * Writes data to stdout synchronously, bypassing the write queue.
      * Used by the renderer during frame flush to avoid races with the
      * async queue lifecycle. Only use for render-path output.
+     *
+     * Drains any pending queue items first so that ordering is preserved
+     * between async queued writes and synchronous render output.
      */
     writeSync(data: string): void {
         if (!data) return;
+        while (this._writeQueue.length > 0) {
+            const chunk = this._writeQueue.shift()!;
+            this.stdout.write(chunk);
+        }
+        this._isWriting = false;
         this.stdout.write(data);
     }
 


### PR DESCRIPTION
## Fix: Terminal writeSync interleaving with render queue

### Changes

**`packages/core/src/terminal/Terminal.ts`**
- `writeSync` now drains the pending `_writeQueue` synchronously before writing, ensuring ordering is preserved between async queued writes and synchronous render output.
- Added `_isWriting = false` after draining to reset the queue lock state.

### Fixes
- Render output (via `writeSync`) could interleave with queued ANSI sequences (via `write`) when the event loop yielded between `setImmediate`-scheduled queue processing steps
- Interleaved output caused corrupted terminal rendering and flickering
- No ordering guarantee between render-path writes and application-path writes

Closes #1958