### PR TITLE
fix(widgets): prevent Pty output drop on early completion

### DIFF
--- a/packages/widgets/src/base/Widget.ts
+++ b/packages/widgets/src/base/Widget.ts
@@ -175,6 +175,11 @@ export abstract class Widget {
     addChild(child: Widget): void {
         child.parent = this;
         this._children.push(child);
+        // Propagate any dirty state the child accumulated before being added
+        // to the tree (e.g., Pty output that arrived before mount).
+        if (child._dirty) {
+            this.markDirty();
+        }
     }
 
     /** Remove a child widget */


### PR DESCRIPTION
## Fix: Pty output drop on early completion

### Changes

**`packages/widgets/src/base/Widget.ts`**
- Added dirty state propagation in `addChild`: when a child widget has `_dirty = true` (accumulated before being added to the tree), the parent's `markDirty()` is called to propagate the dirty signal up to the root.

### Fixes
- Pty widget spawned its process in the constructor; output received before the widget was added to the widget tree called `markDirty()` with `parent = null`, silently dropping the dirty signal
- Root widget never learned about dirty children that accumulated state before tree attachment
- Output from fast-exiting processes was completely lost

Closes #1959