### PR TITLE
fix(router): prevent RouterView unmount leak

### DIFF
--- a/packages/router/src/RouterView.tsx
+++ b/packages/router/src/RouterView.tsx
@@ -32,8 +32,10 @@ export function RouterView({ router }: RouterViewProps) {
     useEffect(() => {
         router.autoUnmount = false;
         let cancelTransition: (() => void) | null = null;
+        let alive = true;
 
         const handleNavigate = (e: NavigateEvent) => {
+            if (!alive) return;
             if (cancelTransition) {
                 cancelTransition();
                 cancelTransition = null;
@@ -53,9 +55,11 @@ export function RouterView({ router }: RouterViewProps) {
             cancelTransition = transition({
                 durationMs: 350,
                 onFrame: (p) => {
+                    if (!alive) return;
                     setScreens(prev => ({ ...prev, progress: p }));
                 },
                 onComplete: () => {
+                    if (!alive) return;
                     setScreens(prev => ({ ...prev, previous: null, progress: 1 }));
                     cancelTransition = null;
                 }
@@ -71,8 +75,12 @@ export function RouterView({ router }: RouterViewProps) {
         router.events.on('back', onBack);
         
         return () => {
+            alive = false;
             router.autoUnmount = true;
-            if (cancelTransition) cancelTransition();
+            if (cancelTransition) {
+                cancelTransition();
+                cancelTransition = null;
+            }
             router.events.off('navigate', onNav);
             router.events.off('back', onBack);
         };


### PR DESCRIPTION
## Fix: RouterView unmount leak

### Changes

**`packages/router/src/RouterView.tsx`**
- Added `alive` guard variable in the effect that prevents `handleNavigate`, transition `onFrame`, and `onComplete` callbacks from executing after the component has been cleaned up.
- Properly nullify `cancelTransition` reference after calling it in cleanup to release the closure.
- Set `alive = false` at the start of the cleanup function before cancelling transitions and unsubscribing events.

### Fixes
- Transition `onComplete` callback could fire after component unmount, calling `setScreens` on a dead component
- `cancelTransition` reference was held after cancellation, preventing GC of the transition closure
- VNode references leaked when RouterView was permanently removed without further navigation

Closes #1960