### PR TITLE
Clamp NumberInput numeric values

### DIFF
--- a/packages/ui/src/NumberInput.test.ts
+++ b/packages/ui/src/NumberInput.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render } from '@termuijs/testing';
 import { createElement, useRef } from '@termuijs/jsx';
 import { NumberInput } from './NumberInput.js';
@@ -66,5 +66,20 @@ describe('NumberInput', () => {
         expect(screen.lastFrame().join('\n')).toContain('0');
 
         screen.unmount();
+    });
+
+    it('clamps typed values exposed through numericValue and submit', () => {
+        const onChange = vi.fn();
+        const onSubmit = vi.fn();
+        const input = new NumberInput({}, { min: 0, max: 10, onChange, onSubmit });
+
+        input.insertChar('9');
+        input.insertChar('9');
+        input.submit();
+
+        expect(input.rawValue).toBe('99');
+        expect(input.numericValue).toBe(10);
+        expect(onChange).toHaveBeenLastCalledWith(10);
+        expect(onSubmit).toHaveBeenCalledWith(10);
     });
 });

--- a/packages/ui/src/NumberInput.ts
+++ b/packages/ui/src/NumberInput.ts
@@ -51,7 +51,7 @@ export class NumberInput extends Widget {
     get numericValue(): number | null {
         if (this._raw === '' || this._raw === '-') return null;
         const n = parseFloat(this._raw);
-        return isNaN(n) ? null : n;
+        return isNaN(n) ? null : this._clamp(n);
     }
 
     /** Raw text string (what the user typed). */


### PR DESCRIPTION
## Summary
- Clamp NumberInput numericValue through the configured min/max range
- Cover typed input so callbacks and submit receive bounded values

Fixes #1968

## Testing
- Not run: Bun is not installed in this environment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Number inputs now consistently clamp typed values to the configured minimum and maximum.
  * Change and submit actions now return the corrected in-range value instead of an out-of-range number.
  * Improved keyboard interaction handling so input behavior remains stable during key presses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->