### PR TITLE
Parse macOS disk capacity usage

### DIFF
--- a/packages/data/src/disk.test.ts
+++ b/packages/data/src/disk.test.ts
@@ -41,11 +41,11 @@ describe('disk provider', () => {
             size: '932Gi',
             used: '12Gi',
             available: '634Gi',
-            percent: 5,
+            percent: 2,
             mountpoint: '/',
         });
 
-        expect(disk.percent).toBe(5);
+        expect(disk.percent).toBe(2);
         expect(disk.main).toEqual(parts[0]);
     });
 

--- a/packages/data/src/disk.ts
+++ b/packages/data/src/disk.ts
@@ -23,10 +23,6 @@ function parseDf(): DiskPartition[] {
         const lines = output.trim().split('\n');
         if (lines.length < 2) return [];
 
-        // Detect column layout from header
-        const header = lines[0];
-        const isMac = header.includes('iused') || header.includes('Capacity');
-
         return lines.slice(1) // skip header
             .map(line => {
                 const parts = line.split(/\s+/);
@@ -34,7 +30,7 @@ function parseDf(): DiskPartition[] {
 
                 // macOS: Filesystem Size Used Avail Capacity iused ifree %iused Mounted on
                 // Linux:  Filesystem Size Used Avail Use%   Mounted on
-                const percentIdx = isMac ? 7 : 4;
+                const percentIdx = 4;
                 const percentStr = parts[percentIdx]?.replace('%', '');
                 // Mountpoint is always the last field
                 const mountpoint = parts[parts.length - 1];


### PR DESCRIPTION
## Summary
- Parse macOS disk usage from the Capacity column instead of %iused
- Update the macOS df fixture expectation

Fixes #1974

## Testing
- Not run: Bun is not installed in this environment
