### PR TITLE
Track total process count

### DIFF
--- a/packages/data/src/processes.test.ts
+++ b/packages/data/src/processes.test.ts
@@ -154,4 +154,20 @@ describe('processes provider', () => {
         expect(top2[0].pid).toBe(101);
         expect(top2[1].pid).toBe(102);
     });
+
+    it('reports total process count separately from the capped list', () => {
+        const rows = Array.from({ length: 75 }, (_, index) => {
+            const pid = 1000 + index;
+            return `pro       ${pid}  1.0  0.1   1000   100 ?        S    12:00   0:00 proc${index}`;
+        });
+        const mockOutput =
+            'USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND\n' +
+            rows.join('\n') +
+            '\n';
+
+        mockExecFileSync.mockReturnValue(mockOutput);
+
+        expect(processes.list).toHaveLength(50);
+        expect(processes.count).toBe(75);
+    });
 });

--- a/packages/data/src/processes.ts
+++ b/packages/data/src/processes.ts
@@ -12,11 +12,16 @@ export interface ProcessInfo {
     user: string;
 }
 
-let _cachedProcesses: ProcessInfo[] = [];
+interface ProcessSnapshot {
+    list: ProcessInfo[];
+    count: number;
+}
+
+let _cachedProcesses: ProcessSnapshot = { list: [], count: 0 };
 let _lastProcessCheck = 0;
 const PROCESS_CACHE_MS = 2000;
 
-function parsePs(): ProcessInfo[] {
+function parsePs(): ProcessSnapshot {
     try {
         // Linux supports --sort=-%cpu; macOS does not — fall back to -r (sort by CPU)
         let output: string;
@@ -27,27 +32,30 @@ function parsePs(): ProcessInfo[] {
         }
         const lines = output.trim().split('\n').slice(1); // skip header
 
-        return lines.slice(0, 50).map(line => {
-            const parts = line.trim().split(/\s+/);
-            if (parts.length < 11) {
-                return { pid: 0, name: 'unknown', cpu: 0, mem: 0, user: '' };
-            }
-            return {
-                user: parts[0],
-                pid: parseInt(parts[1], 10) || 0,
-                cpu: parseFloat(parts[2]) || 0,
-                mem: parseFloat(parts[3]) || 0,
-                name: parts.slice(10).join(' ').split('/').pop()?.split(' ')[0] ?? parts[10],
-            };
-        });
+        return {
+            list: lines.slice(0, 50).map(line => {
+                const parts = line.trim().split(/\s+/);
+                if (parts.length < 11) {
+                    return { pid: 0, name: 'unknown', cpu: 0, mem: 0, user: '' };
+                }
+                return {
+                    user: parts[0],
+                    pid: parseInt(parts[1], 10) || 0,
+                    cpu: parseFloat(parts[2]) || 0,
+                    mem: parseFloat(parts[3]) || 0,
+                    name: parts.slice(10).join(' ').split('/').pop()?.split(' ')[0] ?? parts[10],
+                };
+            }),
+            count: lines.length,
+        };
     } catch {
-        return [];
+        return { list: [], count: 0 };
     }
 }
 
-function getProcesses(): ProcessInfo[] {
+function getProcesses(): ProcessSnapshot {
     const now = Date.now();
-    if (now - _lastProcessCheck > PROCESS_CACHE_MS || _cachedProcesses.length === 0) {
+    if (now - _lastProcessCheck > PROCESS_CACHE_MS || _cachedProcesses.list.length === 0) {
         _cachedProcesses = parsePs();
         _lastProcessCheck = now;
     }
@@ -58,16 +66,16 @@ function getProcesses(): ProcessInfo[] {
 export const processes = {
     /** Top N processes sorted by CPU usage */
     top(n = 10): ProcessInfo[] {
-        return getProcesses().slice(0, n);
+        return getProcesses().list.slice(0, n);
     },
 
     /** Full process list (up to 50) */
     get list(): ProcessInfo[] {
-        return getProcesses();
+        return getProcesses().list;
     },
 
     /** Total number of running processes */
     get count(): number {
-        return getProcesses().length;
+        return getProcesses().count;
     },
 };


### PR DESCRIPTION
## Summary
- Cache the process list and total process count separately
- Keep the public list capped at 50 entries while count reports all process rows
- Add regression coverage for process output larger than the list cap

Fixes #1975

## Testing
- Not run: Bun is not installed in this environment
