### PR TITLE
Validate CLI dir option values

### DIFF
--- a/packages/cli/src/args.test.ts
+++ b/packages/cli/src/args.test.ts
@@ -19,4 +19,10 @@ describe('parseArgs', () => {
     it('parses list', () => {
         expect(parseArgs(['list']).command).toBe('list');
     });
+    it('rejects --dir without a value', () => {
+        expect(() => parseArgs(['add', 'spinner', '--dir'])).toThrow('--dir requires a path value');
+    });
+    it('rejects --dir followed by another flag', () => {
+        expect(() => parseArgs(['add', 'spinner', '--dir', '--dry-run'])).toThrow('--dir requires a path value');
+    });
 });

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -18,7 +18,13 @@ export function parseArgs(argv: string[]): CliArgs {
 
     for (let i = 0; i < rest.length; i++) {
         const a = rest[i]!;
-        if (a === '--dir') { dir = rest[++i]; }
+        if (a === '--dir') {
+            const value = rest[++i];
+            if (!value || value.startsWith('-')) {
+                throw new Error('--dir requires a path value');
+            }
+            dir = value;
+        }
         else if (a === '--dry-run') { dryRun = true; }
         else if (a === '--yes' || a === '-y') { yes = true; }
         else if (!a.startsWith('-')) { components.push(a); }


### PR DESCRIPTION
## Summary
- Require --dir to be followed by a path value
- Reject --dir when it is missing a value or followed by another flag
- Add parser regression coverage

Fixes #1976

## Testing
- Not run: Bun is not installed in this environment
