### PR TITLE
Detect package manager for create app add

### DIFF
--- a/packages/create-termui-app/src/commands/add.test.ts
+++ b/packages/create-termui-app/src/commands/add.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { mkdirSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 
 vi.mock("node:child_process", () => ({
     execFileSync: vi.fn(),
@@ -133,14 +133,46 @@ describe("runAddCommand", () => {
             'export const Badge = () => "badge";',
         );
         expect(execSpy).toHaveBeenCalledWith(
-            "bun",
-            ["add", "@termuijs/core", "@termuijs/widgets"],
+            "npm",
+            ["install", "@termuijs/core", "@termuijs/widgets"],
             {
                 stdio: "inherit",
             },
         );
         expect(logSpy).toHaveBeenCalledWith(
             expect.stringContaining("added successfully"),
+        );
+    });
+
+    it("uses bun when bun.lock is present", async () => {
+        setupFetchMock();
+        writeFileSync(join(tempDir, "bun.lock"), "");
+        const execSpy = vi.spyOn(childProcess, "execFileSync");
+
+        await runAddCommand({ component: "Badge" });
+
+        expect(execSpy).toHaveBeenCalledWith(
+            "bun",
+            ["add", "@termuijs/core", "@termuijs/widgets"],
+            {
+                stdio: "inherit",
+            },
+        );
+    });
+
+    it("uses pnpm when pnpm-lock.yaml is present", async () => {
+        setupFetchMock();
+        writeFileSync(join(tempDir, "pnpm-lock.yaml"), "");
+        const execSpy = vi.spyOn(childProcess, "execFileSync");
+
+        await runAddCommand({ component: "Badge" });
+
+        expect(execSpy).toHaveBeenCalledWith(
+            "pnpm",
+            ["add", "@termuijs/core", "@termuijs/widgets"],
+            {
+                stdio: "inherit",
+            },
         );
     });
 

--- a/packages/create-termui-app/src/commands/add.ts
+++ b/packages/create-termui-app/src/commands/add.ts
@@ -27,6 +27,8 @@ interface RegistrySchema {
     components: RegistryComponent[];
 }
 
+type PackageManager = "npm" | "yarn" | "pnpm" | "bun";
+
 export async function runAddCommand(options: AddCommandOptions): Promise<void> {
     const componentName = options.component.trim();
     if (!componentName) {
@@ -213,9 +215,22 @@ async function installPackages(entry: RegistryComponent): Promise<void> {
         return;
     }
 
-    execFileSync("bun", ["add", ...deps], {
+    const pm = detectPackageManager(process.cwd());
+    execFileSync(pm, installArgs(pm, deps), {
         stdio: "inherit",
     });
+}
+
+function detectPackageManager(cwd: string): PackageManager {
+    if (existsSync(join(cwd, "bun.lock"))) return "bun";
+    if (existsSync(join(cwd, "pnpm-lock.yaml"))) return "pnpm";
+    if (existsSync(join(cwd, "yarn.lock"))) return "yarn";
+    return "npm";
+}
+
+function installArgs(pm: PackageManager, deps: string[]): string[] {
+    if (pm === "npm") return ["install", ...deps];
+    return ["add", ...deps];
 }
 
 function pascalCase(value: string): string {


### PR DESCRIPTION
## Summary
- Detect the package manager for create-termui-app add from project lockfiles
- Use npm install by default instead of requiring bun
- Add coverage for npm fallback, bun.lock, and pnpm-lock.yaml flows

Fixes #1977

## Testing
- Not run: Bun is not installed in this environment
