### PR TITLE
fix(widgets): call super.destroy in Stopwatch widget #1995

### DIFF
--- a/packages/widgets/src/display/Stopwatch.ts
+++ b/packages/widgets/src/display/Stopwatch.ts
@@ -87,9 +87,10 @@ export class Stopwatch extends Widget {
      * Release all resources held by this widget.
      * Call this when the widget is no longer needed to avoid timer leaks.
      */
-    destroy(): void {
+    override destroy(): void {
         this.stop();
         this._clearInterval();
+        super.destroy();
     }
 
     // ── Lifecycle ───────────────────────────────────────────────────────


### PR DESCRIPTION


  ### Description
  Ensures that `Stopwatch.destroy()` invokes `super.destroy()` to correctly unmount the widget and clean up parent/child nodes in the tree structure.

  ### Changes
  * Added `override` keyword to `destroy()` in `Stopwatch.ts`.
  * Appended `super.destroy()` in `Stopwatch.destroy()`.

  Closes #1995

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stopwatch cleanup when it is closed or removed, ensuring it stops correctly and performs the expected parent cleanup.
  * Updated the component’s destruction behavior for more reliable resource handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->