### PR TITLE
fix(widgets): call super.destroy in Pty widget #1997

### DIFF
--- a/packages/widgets/src/display/Pty.ts
+++ b/packages/widgets/src/display/Pty.ts
@@ -102,10 +102,11 @@ export class Pty extends Widget {
     /**
      * Terminate the spawned process
      */
-    public destroy(): void {
+    override destroy(): void {
         if (this._process) {
             this._process.kill();
             this._process = null;
         }
+        super.destroy();
     }
 }


### PR DESCRIPTION


  ### Description
  Updates `Pty.ts` to add the `override` keyword to its `destroy()` method and invoke `super.destroy()` at the end, ensuring correct lifecycle cleanup (such as calling `unmount()` and cleaning parent/child references).

  ### Changes
  * Added `override` keyword to `destroy()` in `Pty.ts`.
  * Added `super.destroy()` call to `Pty.destroy()`.

  Closes #1997

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->
