### PR TITLE
fix(cli): normalize path separators in scanDirectory for Windows #2003

### DIFF
--- a/scripts/build-registry.ts
+++ b/scripts/build-registry.ts
@@ -368,7 +368,7 @@ function scanDirectory(dir: string, entries: { path: string; content: string }[]
         scanDirectory(full, entries);
       }
     } else if (file.endsWith('.ts') && !file.endsWith('.test.ts') && !file.endsWith('.d.ts')) {
-      entries.push({ path: full.replace(ROOT + '/', ''), content: readFileSync(full, 'utf-8') });
+      entries.push({ path: full.replace(ROOT, '').replace(/\\/g, '/').replace(/^\//, ''), content: readFileSync(full, 'utf-8') });
     }
   }
 }


### PR DESCRIPTION

  ### Description
  Normalizes path separators in `scanDirectory` to forward slashes before pushing them to the registry files array. This guarantees that checks like `filePath.includes('/hooks/')` or `filePath.includes('packages/widgets/')` behave identically on POSIX and Windows.

  ### Changes
  * Replaced `full.replace(ROOT + '/', '')` with `full.replace(ROOT, '').replace(/\\/g, '/').replace(/^\//, '')` in `scanDirectory()`.

  Closes #2003