### PR TITLE
fix(core): safely handle ANSI escape sequences in wordWrap and truncate

### DIFF
--- a/packages/core/src/utils/unicode.test.ts
+++ b/packages/core/src/utils/unicode.test.ts
@@ -53,6 +53,11 @@ describe('truncate', () => {
         const result = truncate('\x1b[31mhello world\x1b[0m', 8);
         expect(result).toContain('\x1b[31m');
     });
+
+    it('appends ANSI reset when truncating text with ANSI styling', () => {
+        const result = truncate('\x1b[31mhello world\x1b[0m', 8);
+        expect(result.endsWith('\x1b[0m')).toBe(true);
+    });
 });
 
 describe('stripAnsi', () => {
@@ -85,5 +90,15 @@ describe('wordWrap', () => {
     it('breaks very long words', () => {
         const result = wordWrap('abcdefghij', 5);
         expect(result.split('\n').every(l => stringWidth(l) <= 5)).toBe(true);
+    });
+
+    it('safely breaks long words containing ANSI escape sequences without premature wrapping', () => {
+        const styledWord = '\x1b[31mabcdefghij\x1b[0m';
+        const result = wordWrap(styledWord, 5);
+        const lines = result.split('\n');
+        expect(lines.length).toBe(2);
+        expect(stringWidth(lines[0]!)).toBe(5);
+        expect(stringWidth(lines[1]!)).toBe(5);
+        expect(lines[0]!).toContain('\x1b[31m');
     });
 });

--- a/packages/core/src/utils/unicode.ts
+++ b/packages/core/src/utils/unicode.ts
@@ -148,7 +148,10 @@ export function truncate(str: string, maxWidth: number, ellipsis = '…'): strin
     if (strW <= maxWidth) return str;
     const ellipsisW = stringWidth(ellipsis);
     const targetW = maxWidth - ellipsisW;
-    if (targetW <= 0) return ellipsis.slice(0, maxWidth);
+    const hasAnsi = str.includes('\x1b');
+    const resetSeq = hasAnsi ? '\x1b[0m' : '';
+
+    if (targetW <= 0) return ellipsis.slice(0, maxWidth) + resetSeq;
     let width = 0;
     let result = '';
     let inEscape = false;
@@ -175,7 +178,7 @@ export function truncate(str: string, maxWidth: number, ellipsis = '…'): strin
         width += charW;
         result += segment;
     }
-    return result + ellipsis;
+    return result + ellipsis + resetSeq;
 }
 
 /**
@@ -187,8 +190,8 @@ export function stripAnsi(str: string): string {
 }
 
 /**
- * Word‑wrap text to a given width, respecting existing newlines.
- * Does not handle ANSI codes within words (wraps at the character level).
+ * Word-wrap text to a given width, respecting existing newlines.
+ * Safely handles ANSI escape sequences without breaking formatting.
  */
 export function wordWrap(str: string, width: number): string {
     if (width <= 0) return str;
@@ -215,7 +218,21 @@ export function wordWrap(str: string, width: number): string {
                     currentWidth = 0;
                 }
                 const wordSegments = segmenter.segment(word);
+                let inEscape = false;
                 for (const { segment } of wordSegments) {
+                    const cp = segment.codePointAt(0)!;
+                    if (cp === 0x1B) {
+                        inEscape = true;
+                        currentLine += segment;
+                        continue;
+                    }
+                    if (inEscape) {
+                        currentLine += segment;
+                        if ((cp >= 0x40 && cp <= 0x7E) && cp !== 0x5B) {
+                            inEscape = false;
+                        }
+                        continue;
+                    }
                     const charW = segmentWidth(segment);
                     if (currentWidth + charW > width) {
                         if (currentLine) result.push(currentLine);


### PR DESCRIPTION
## What this PR does / why we need it
In `@termuijs/core`, `wordWrap` and `truncate` did not safely handle strings containing ANSI styling sequences:
- `wordWrap` broke words character-by-character without parsing escape codes, treating zero-width styling sequences as visible characters and causing premature wraps or split escape sequences.
- `truncate` shorted styled strings without checking for open ANSI codes or appending `\x1b[0m`, resulting in color bleeding across trailing terminal cells and widgets.

This PR:
1. Implements ANSI escape code parsing in `wordWrap` (`inEscape` tracking) so escape sequences contribute `0` visual width and are never split mid-sequence.
2. Updates `truncate` to append `\x1b[0m` when shorting strings with active ANSI formatting to prevent color bleed.
3. Adds Vitest unit tests asserting clean visual wrapping and color reset preservation.

## Which issue(s) this PR fixes
Closes #123

## Special notes for your reviewer
- Confined strictly to `packages/core`.
- Verified with `bun run build && bun vitest run packages/core && bun run typecheck` (all passed cleanly).
- Contributing under GSSoC 2026.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text truncation so ANSI-styled content now ends with a proper reset, preventing formatting from bleeding into following text.
  * Fixed wrapping behavior for long ANSI-styled words so line width stays accurate while preserving styling.

* **Tests**
  * Added coverage for ANSI-aware truncation and word wrapping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->