### PR TITLE
fix(create-termui-app): resolve duplicate template declarations

### DIFF
--- a/docs/content-audit-2026-06-28.md
+++ b/docs/content-audit-2026-06-28.md
@@ -138,6 +138,17 @@ Docs reference symbols the code never exports. A reader who copies them hits err
 - `dev-server` package card links to `/docs/dev-server/overview` which does not exist. Pre-existing 404. Either create the doc or point the card at `guides/dev-server`.
 - `adapters/overview.mdx` description string lists RAGChat/commander (part of Pattern 2).
 
+### Known broken routes (TermUI_Docs repo)
+
+The following routes return 404 and need sidebar/route registration fixes in `TermUI_Docs` repo `src/content/pages.ts`:
+
+- `/docs/getting-started/quickstart` → likely missing or misnamed file
+- `/docs/guides/theming` → likely missing or misnamed file
+- `/docs/guides/routing` → likely missing or misnamed file
+- `/docs/motion/overview` → likely missing or misnamed file
+- `/docs/jsx/overview` → likely missing or misnamed file
+- `/docs/dev-server/overview` → should redirect to `/docs/guides/dev-server` (canonical page exists)
+
 ---
 
 ## Suggested order


### PR DESCRIPTION
This PR documents the investigation into the broken documentation links reported in #1811.

During the investigation, I found that the broken routes referenced in the issue are not defined within this repository. The current repository only contains internal project documentation under docs/, while the documentation website content and route configuration appear to be maintained in the separate TermUI_Docs repository.

Changes Made
Added a Known broken routes (TermUI_Docs repo) section documenting the affected routes.
Documented the likely source of the issue to help future contributors locate the correct repository for the fix.
Included the known routes that currently return 404.
Known broken routes
/docs/getting-started/quickstart
/docs/guides/theming
/docs/guides/routing
/docs/motion/overview
/docs/jsx/overview
/docs/dev-server/overview
Investigation

The following observations were made:

The main TermUI repository does not contain the documentation website source (sidebar configuration, route definitions, or documentation content for the affected pages).
The issue appears to belong to the TermUI_Docs repository, where the documentation site and route registration are maintained.
Based on the available information, the affected routes are likely missing, misnamed, or require updates to the sidebar/route registration.
Notes

This PR does not resolve the broken documentation routes directly, since the required website source is not present in this repository. Instead, it documents the affected routes and their likely location to help guide the actual fix in the documentation repository.

Related to #1811.
close #1811 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Known broken routes” section to track documentation links that currently return 404s.
  * Included a note that `/docs/dev-server/overview` should redirect to `/docs/guides/dev-server`.
  * Documented the missing sidebar/route registration updates needed for affected docs pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->