### PR TITLE
feat(create-termui-app): add Vitest starter template

### DIFF
--- a/packages/create-termui-app/src/templates.test.ts
+++ b/packages/create-termui-app/src/templates.test.ts
@@ -183,4 +183,23 @@ it('cli-tool template generates a minimal entry under 15 source lines', () => {
         const tsconfig = files.find((f) => f.path === 'tsconfig.json')!
         expect(tsconfig.content).toContain('jsx')
     })
+
+    it('generates a Vitest starter with config and test dependencies', () => {
+        const files = generateProject(baseConfig)
+
+        const pkg = files.find((f) => f.path === 'package.json')!
+        const parsed = JSON.parse(pkg.content)
+        expect(parsed.scripts.test).toBe('vitest run')
+        expect(parsed.devDependencies.vitest).toBeDefined()
+        expect(parsed.devDependencies['@termuijs/testing']).toBe('latest')
+
+        const vitestConfig = files.find((f) => f.path === 'vitest.config.ts')
+        expect(vitestConfig).toBeDefined()
+        expect(vitestConfig?.content).toContain('defineConfig')
+
+        const starterTest = files.find((f) => f.path === 'src/index.test.tsx')
+        expect(starterTest).toBeDefined()
+        expect(starterTest?.content).toContain('@termuijs/testing')
+        expect(starterTest?.content).toContain('describe(')
+    })
 })

--- a/packages/create-termui-app/src/templates.ts
+++ b/packages/create-termui-app/src/templates.ts
@@ -58,8 +58,42 @@ export function generateProject(config: ProjectConfig): GeneratedFile[] {
                 outDir: 'dist',
                 rootDir: 'src',
             },
-            include: ['src'],
+            include: ['src', 'vitest.config.ts'],
         }, null, 2) + '\n',
+    });
+
+    files.push({
+        path: 'vitest.config.ts',
+        content: `import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    },
+});
+`,
+    });
+
+    files.push({
+        path: 'src/index.test.tsx',
+        content: `/** @jsxImportSource @termuijs/jsx */
+import { describe, expect, it } from 'vitest';
+import { render } from '@termuijs/testing';
+import { Text } from '@termuijs/widgets';
+
+function StarterApp() {
+    return <Text>Starter test passed</Text>;
+}
+
+describe('starter app', () => {
+    it('renders the starter text', () => {
+        const testInstance = render(<StarterApp />);
+        expect(testInstance.renderToString()).toContain('Starter test passed');
+        testInstance.unmount();
+    });
+});
+`,
     });
 
     // ── termui.config.ts ──
@@ -126,6 +160,7 @@ function createPackageJson(config: ProjectConfig): string {
             dev: 'bun --watch src/index.tsx',
             build: 'tsup src/index.tsx --format esm',
             start: 'bun dist/index.js',
+            test: 'vitest run',
         },
         dependencies: isAiAssistant
             ? {
@@ -157,8 +192,10 @@ function createPackageJson(config: ProjectConfig): string {
             },
         devDependencies: {
             '@types/bun': 'latest',
+            '@termuijs/testing': 'latest',
             tsup: '^8.0.0',
             typescript: '^5.3.0',
+            vitest: '^2.1.9',
         },
         engines: {
             bun: '>=1.3.0',


### PR DESCRIPTION
## Summary

Adds a minimal Vitest starter setup to projects generated by `create-termui-app`, allowing new applications to begin writing and running tests immediately after scaffolding.

Closes #2024 

## Changes Made

- Added Vitest support to generated project templates.
- Added `@termuijs/testing` to generated project dependencies.
- Added a minimal `vitest.config.ts` following the repository's Bun-first conventions.
- Added a simple starter test demonstrating the default testing workflow.
- Kept the implementation confined to the scaffolding package.

## Generated Project Improvements

Newly scaffolded applications now include:

- ✅ Vitest configuration
- ✅ `@termuijs/testing` integration
- ✅ A starter test file
- ✅ Ready-to-run testing setup with minimal configuration

## Why This Change

The project scaffolder advertises support for Vitest and `@termuijs/testing`, but previously required users to manually configure the testing environment before writing their first test.

Providing a working starter setup improves the onboarding experience and allows contributors to start testing immediately after creating a new project.

## Validation

Verified with:

```bash
bun run build
bun vitest run packages/create-termui-app
bun run typecheck

Close #2024 