### PR TITLE
feat(core): add ANSI escape injection sanitization (#2030)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -93,6 +93,7 @@ export { renderInlineToTerminal, createInlineViewport } from './inline-viewport.
 // ── Utilities ─────────────────────────────────────────
 export { stringWidth, truncate, stripAnsi, wordWrap } from './utils/unicode.js';
 export * as ansi from './utils/ansi.js';
+export { stripAnsiEscapes, hasAnsiEscapes, sanitizeForDisplay } from './terminal/sanitize.js';
 export { debounce } from './utils/debounce.js';
 export type { DebounceOptions } from './utils/debounce.js';
 export * from './session/Session.js';

--- a/packages/core/src/terminal/Screen.test.ts
+++ b/packages/core/src/terminal/Screen.test.ts
@@ -314,6 +314,43 @@ describe('Screen and Cell Hyperlink Support', () => {
         });
     });
 
+    describe('writeFormattedString', () => {
+        it('strips ANSI sequences like writeString', () => {
+            const screen = new Screen(30, 5);
+            screen.writeFormattedString(0, 0, '\x1b[31mred\x1b[0m');
+            const text = screen.back[0].map(c => c.char).join('').trimEnd();
+            expect(text).toBe('red');
+        });
+
+        it('strips cursor movement sequences but keeps text', () => {
+            const screen = new Screen(30, 5);
+            screen.writeFormattedString(0, 0, '\x1b[2Jclear\x1b[5B');
+            const text = screen.back[0].map(c => c.char).join('').trimEnd();
+            expect(text).toBe('clear');
+        });
+
+        it('strips OSC sequences', () => {
+            const screen = new Screen(30, 5);
+            screen.writeFormattedString(0, 0, '\x1b]0;title\x07text');
+            const text = screen.back[0].map(c => c.char).join('').trimEnd();
+            expect(text).toBe('text');
+        });
+
+        it('preserves normal text unchanged', () => {
+            const screen = new Screen(30, 5);
+            screen.writeFormattedString(0, 0, 'Hello, World!');
+            const text = screen.back[0].slice(0, 13).map(c => c.char).join('');
+            expect(text).toBe('Hello, World!');
+        });
+
+        it('preserves Unicode and emoji', () => {
+            const screen = new Screen(30, 5);
+            screen.writeFormattedString(0, 0, '你好 🌍');
+            const text = screen.back[0].map(c => c.char).join('').trimEnd();
+            expect(text).toBe('你好 🌍');
+        });
+    });
+
     describe('Backdrop Filters (Compositing)', () => {
         it('cells outside the modal rect are dimmed', () => {
             const screen = new Screen(10, 10);

--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -391,16 +391,14 @@ export class Screen {
     /**
      * Write a string to the back buffer.
      *
-     * Unlike `writeString`, this method preserves SGR formatting sequences
-     * (colors, bold, italic, etc.) while still stripping cursor movement,
-     * screen clears, OSC sequences (window title, clipboard, hyperlinks),
-     * and other non-formatting escape sequences.
-     *
-     * Note: TermUI's cell grid does not interpret inline ANSI codes — they
-     * would render as visible characters.  This method is provided for API
-     * completeness and forward compatibility; in practice it behaves the
-     * same as `writeString` for text content.  Use `writeString` for all
-     * user-supplied or untrusted text.
+     * TermUI's cell grid does not interpret inline ANSI codes — colors and
+     * attributes are applied via the `style` param / cell attrs, not via
+     * escape sequences embedded in `str`. Any escape sequences in `str`
+     * (including SGR) would only render as visible garbage characters, so
+     * this method currently delegates to `writeString`, which strips all of
+     * them — identical behavior to calling `writeString` directly. It exists
+     * as a distinct, forward-compatible entry point in case formatted-string
+     * support is added later; it does not currently preserve SGR.
      */
     writeFormattedString(
         col: number,

--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -5,6 +5,7 @@
 import type { Color } from '../style/Color.js';
 import { stringWidth, segmenter } from '../utils/unicode.js';
 import { stripAnsiControl } from '../utils/ansi.js';
+import { stripAnsiEscapes, sanitizeForDisplay } from './sanitize.js';
 import { caps } from './env-caps.js';
 
 const EMPTY_COLOR: Color = Object.freeze({ type: 'none' } as const);
@@ -343,7 +344,7 @@ export class Screen {
         if (!(row >= 0 && row < this._rows)) return;
 
         // Strip ANSI control sequences from user-supplied content to prevent escape injection
-        const safeStr = stripAnsiControl(str);
+        const safeStr = stripAnsiEscapes(str);
         let x = col;
         
         const segments = segmenter.segment(safeStr);
@@ -385,6 +386,31 @@ export class Screen {
 
             x += width;
         }
+    }
+
+    /**
+     * Write a string to the back buffer.
+     *
+     * Unlike `writeString`, this method preserves SGR formatting sequences
+     * (colors, bold, italic, etc.) while still stripping cursor movement,
+     * screen clears, OSC sequences (window title, clipboard, hyperlinks),
+     * and other non-formatting escape sequences.
+     *
+     * Note: TermUI's cell grid does not interpret inline ANSI codes — they
+     * would render as visible characters.  This method is provided for API
+     * completeness and forward compatibility; in practice it behaves the
+     * same as `writeString` for text content.  Use `writeString` for all
+     * user-supplied or untrusted text.
+     */
+    writeFormattedString(
+        col: number,
+        row: number,
+        str: string,
+        style: Partial<Omit<Cell, 'char' | 'width'>> = {},
+    ): void {
+        // Delegate to writeString — the cell grid cannot interpret inline
+        // ANSI codes, so all text paths must be sanitized.
+        this.writeString(col, row, str, style);
     }
 
     /**

--- a/packages/core/src/terminal/sanitize.test.ts
+++ b/packages/core/src/terminal/sanitize.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import { stripAnsiEscapes, hasAnsiEscapes, sanitizeForDisplay } from './sanitize.js';
+
+describe('stripAnsiEscapes', () => {
+    it('strips CSI SGR color sequences', () => {
+        expect(stripAnsiEscapes('\x1b[31mhello\x1b[0m')).toBe('hello');
+    });
+
+    it('strips CSI cursor movement', () => {
+        expect(stripAnsiEscapes('\x1b[2J')).toBe('');
+        expect(stripAnsiEscapes('\x1b[5B')).toBe('');
+        expect(stripAnsiEscapes('\x1b[?25l')).toBe('');
+    });
+
+    it('strips OSC sequences (window title)', () => {
+        expect(stripAnsiEscapes('\x1b]0;My App\x07')).toBe('');
+    });
+
+    it('strips OSC sequences with ST terminator', () => {
+        expect(stripAnsiEscapes('\x1b]8;;https://example.com\x1b\\')).toBe('');
+    });
+
+    it('strips OSC 52 clipboard sequences', () => {
+        expect(stripAnsiEscapes('\x1b]52;c;dGVzdA==\x07')).toBe('');
+    });
+
+    it('strips DCS sequences', () => {
+        expect(stripAnsiEscapes('\x1bPsome data\x1b\\')).toBe('');
+    });
+
+    it('strips bare C0 controls except TAB and LF', () => {
+        expect(stripAnsiEscapes('ab\x00\x01\x07cd')).toBe('abcd');
+    });
+
+    it('preserves TAB and LF', () => {
+        expect(stripAnsiEscapes('a\tb\nc')).toBe('a\tb\nc');
+    });
+
+    it('strips C1 controls and DEL', () => {
+        expect(stripAnsiEscapes('ab\x7f\x80\x9bcd')).toBe('abcd');
+    });
+
+    it('preserves normal text unchanged', () => {
+        expect(stripAnsiEscapes('Hello, World!')).toBe('Hello, World!');
+    });
+
+    it('preserves Unicode and emoji', () => {
+        expect(stripAnsiEscapes('你好，世界 🌍')).toBe('你好，世界 🌍');
+    });
+
+    it('handles empty strings', () => {
+        expect(stripAnsiEscapes('')).toBe('');
+    });
+
+    it('handles non-string input', () => {
+        expect(stripAnsiEscapes(undefined as unknown as string)).toBe('');
+        expect(stripAnsiEscapes(null as unknown as string)).toBe('');
+    });
+
+    it('strips mixed text and sequences', () => {
+        const input = 'Hello\x1b[1m World\x1b[0m\x1b[2J!';
+        expect(stripAnsiEscapes(input)).toBe('Hello World!');
+    });
+});
+
+describe('hasAnsiEscapes', () => {
+    it('returns true for CSI sequences', () => {
+        expect(hasAnsiEscapes('\x1b[31mtest')).toBe(true);
+    });
+
+    it('returns true for OSC sequences', () => {
+        expect(hasAnsiEscapes('\x1b]0;title\x07')).toBe(true);
+    });
+
+    it('returns true for bare C0 controls', () => {
+        expect(hasAnsiEscapes('ab\x00cd')).toBe(true);
+    });
+
+    it('returns false for clean text', () => {
+        expect(hasAnsiEscapes('Hello, World!')).toBe(false);
+    });
+
+    it('returns false for empty string', () => {
+        expect(hasAnsiEscapes('')).toBe(false);
+    });
+
+    it('returns false for Unicode without escapes', () => {
+        expect(hasAnsiEscapes('你好 🌍')).toBe(false);
+    });
+});
+
+describe('sanitizeForDisplay', () => {
+    describe('without formatting (default)', () => {
+        it('strips all ANSI escapes', () => {
+            expect(sanitizeForDisplay('\x1b[31mhello\x1b[0m')).toBe('hello');
+        });
+
+        it('strips cursor movement', () => {
+            expect(sanitizeForDisplay('\x1b[2Jclear')).toBe('clear');
+        });
+    });
+
+    describe('with formatting allowed', () => {
+        it('preserves SGR sequences', () => {
+            const result = sanitizeForDisplay('\x1b[31mred\x1b[0m', true);
+            expect(result).toBe('\x1b[31mred\x1b[0m');
+        });
+
+        it('preserves combined SGR parameters', () => {
+            const result = sanitizeForDisplay('\x1b[1;31mbold red\x1b[0m', true);
+            expect(result).toBe('\x1b[1;31mbold red\x1b[0m');
+        });
+
+        it('strips cursor movement while preserving SGR', () => {
+            const result = sanitizeForDisplay('\x1b[31mred\x1b[2Jclear\x1b[0m', true);
+            // Should keep SGR but strip cursor clear
+            expect(result).not.toContain('\x1b[2J');
+            expect(result).toContain('\x1b[31m');
+            expect(result).toContain('\x1b[0m');
+        });
+
+        it('strips OSC sequences', () => {
+            const result = sanitizeForDisplay('\x1b]0;title\x07\x1b[31mred\x1b[0m', true);
+            expect(result).toBe('\x1b[31mred\x1b[0m');
+        });
+
+        it('strips OSC 52 clipboard sequences', () => {
+            const result = sanitizeForDisplay('\x1b]52;c;dGVzdA==\x07\x1b[33myellow\x1b[0m', true);
+            expect(result).toBe('\x1b[33myellow\x1b[0m');
+        });
+
+        it('strips screen clear sequence', () => {
+            const result = sanitizeForDisplay('\x1b[2Jtext', true);
+            expect(result).toBe('text');
+        });
+
+        it('strips cursor up sequence', () => {
+            const result = sanitizeForDisplay('\x1b[3Atext', true);
+            expect(result).toBe('text');
+        });
+
+        it('strips scroll region sequence', () => {
+            const result = sanitizeForDisplay('\x1b[5;10rtext', true);
+            expect(result).toBe('text');
+        });
+
+        it('strips C0 controls but keeps TAB and LF', () => {
+            const result = sanitizeForDisplay('\x00\x01a\tb\nc\x7f', true);
+            expect(result).toBe('a\tb\nc');
+        });
+
+        it('handles empty string', () => {
+            expect(sanitizeForDisplay('', true)).toBe('');
+        });
+
+        it('handles non-string input', () => {
+            expect(sanitizeForDisplay(undefined as unknown as string, true)).toBe('');
+            expect(sanitizeForDisplay(null as unknown as string, true)).toBe('');
+        });
+    });
+});

--- a/packages/core/src/terminal/sanitize.ts
+++ b/packages/core/src/terminal/sanitize.ts
@@ -23,12 +23,14 @@ const ANSI_ESCAPE_RE =
     /\x1b(?:\[[0-9;<=>?]*[a-zA-Z]|\][^\x07\x1b]*(?:\x07|\x1b\\)|[PX^_][^\x1b]*\x1b\\|[@-Z\\-_]|.)/g;
 
 // Matches bare C0 control characters (0x00–0x1F) except TAB (0x09) and LF (0x0A),
-// plus DEL (0x7F) and C1 controls (0x80–0x9F).
-const CONTROL_CHAR_RE = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]/g;
+// plus DEL (0x7F) and C1 controls (0x80–0x9F). Includes CR (0x0D) — a bare CR
+// lets untrusted text overwrite the current line when written to a real
+// terminal, so it is not safe to let through.
+const CONTROL_CHAR_RE = /[\x00-\x08\x0b-\x1f\x7f-\x9f]/g;
 
 // Same as CONTROL_CHAR_RE but excludes ESC (0x1B) — used by sanitizeForDisplay
 // when formatting is allowed so that ESC in preserved SGR sequences is not stripped.
-const CONTROL_NO_ESC_RE = /[\x00-\x08\x0b\x0c\x0e-\x1a\x1c-\x1f\x7f-\x9f]/g;
+const CONTROL_NO_ESC_RE = /[\x00-\x08\x0b-\x1a\x1c-\x1f\x7f-\x9f]/g;
 
 // Matches only cursor-movement, screen-clear, and other non-SGR CSI sequences,
 // while allowing SGR (Select Graphic Rendition — ESC [ <params> m) through.

--- a/packages/core/src/terminal/sanitize.ts
+++ b/packages/core/src/terminal/sanitize.ts
@@ -1,0 +1,96 @@
+/**
+ * ANSI escape sequence sanitization utilities for terminal security.
+ *
+ * User-supplied text rendered to the terminal can contain ANSI escape
+ * sequences that allow escape injection attacks — cursor movement, screen
+ * clearing, arbitrary command execution (via certain terminal emulators),
+ * visual spoofing, clipboard exfiltration (OSC 52), and more.
+ *
+ * These utilities provide defense-in-depth for all text paths.
+ *
+ * @module
+ */
+
+// Matches ESC-introduced sequences (longer matches first to prevent
+// the single-char FE alternative from eating multi-char sequences):
+//   ESC [ <params> <letter>            — CSI (SGR, cursor, clear, etc.)
+//   ESC ] ... ST                        — OSC (title, clipboard, hyperlinks)
+//   ESC P ... ST / ESC X ... ST         — DCS / SOS
+//   ESC ^ ... ST / ESC _               — PM / APC
+//   ESC ( | ) | # | ; | ? <chars>      — FE escape sequences (single char)
+//   Bare ESC followed by any char      — catch-all for partial sequences
+const ANSI_ESCAPE_RE =
+    /\x1b(?:\[[0-9;<=>?]*[a-zA-Z]|\][^\x07\x1b]*(?:\x07|\x1b\\)|[PX^_][^\x1b]*\x1b\\|[@-Z\\-_]|.)/g;
+
+// Matches bare C0 control characters (0x00–0x1F) except TAB (0x09) and LF (0x0A),
+// plus DEL (0x7F) and C1 controls (0x80–0x9F).
+const CONTROL_CHAR_RE = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]/g;
+
+// Same as CONTROL_CHAR_RE but excludes ESC (0x1B) — used by sanitizeForDisplay
+// when formatting is allowed so that ESC in preserved SGR sequences is not stripped.
+const CONTROL_NO_ESC_RE = /[\x00-\x08\x0b\x0c\x0e-\x1a\x1c-\x1f\x7f-\x9f]/g;
+
+// Matches only cursor-movement, screen-clear, and other non-SGR CSI sequences,
+// while allowing SGR (Select Graphic Rendition — ESC [ <params> m) through.
+// CSI sequences ending in `m` are SGR — everything else is non-SGR.
+// Parameter bytes: 0x30–0x3F (digits, semicolon, <=>?)
+// Final bytes: 0x40–0x7E (all except `m` = 0x6D)
+const NON_SGR_CSI_RE = /\x1b\[[0-9;<=>?]*[A-LN-Za-ln-z@\[\\\]^_\x60{|}~-]/g;
+
+/**
+ * Strip all ANSI escape sequences and dangerous control characters from a string.
+ *
+ * Removes:
+ *  - All ESC-introduced sequences (CSI, OSC, DCS, SOS, PM, APC, etc.)
+ *  - Bare C0 controls (0x00–0x1F) except TAB (0x09) and LF (0x0A)
+ *  - DEL (0x7F) and C1 controls (0x80–0x9F)
+ *
+ * Safe for use on any user-supplied or file-read text before rendering.
+ */
+export function stripAnsiEscapes(text: string): string {
+    if (typeof text !== 'string') return '';
+    return text.replace(ANSI_ESCAPE_RE, '').replace(CONTROL_CHAR_RE, '');
+}
+
+/**
+ * Return `true` if the string contains any ANSI escape sequences or
+ * dangerous control characters.
+ */
+export function hasAnsiEscapes(text: string): boolean {
+    if (typeof text !== 'string') return false;
+    return ANSI_ESCAPE_RE.test(text) || CONTROL_CHAR_RE.test(text);
+}
+
+/**
+ * Sanitize text for terminal display.
+ *
+ * When `allowFormatting` is `false` (default), ALL ANSI escapes are stripped —
+ * identical to `stripAnsiEscapes`.
+ *
+ * When `allowFormatting` is `true`, SGR (Select Graphic Rendition) sequences
+ * (e.g. `\x1b[31m` for red text, `\x1b[1m` for bold) are preserved, but all
+ * other CSI commands (cursor movement, screen clear, scroll, etc.) and all
+ * OSC sequences (window title, clipboard, hyperlinks) are stripped.  This is
+ * suitable for display of trusted formatted text, such as log output from a
+ * program that uses colors.
+ */
+export function sanitizeForDisplay(text: string, allowFormatting = false): string {
+    if (typeof text !== 'string') return '';
+
+    if (!allowFormatting) {
+        return stripAnsiEscapes(text);
+    }
+
+    // Strip non-SGR CSI sequences (cursor movement, clear, scroll, etc.)
+    let out = text.replace(NON_SGR_CSI_RE, '');
+    // Strip all OSC, DCS, SOS, PM, APC sequences
+    out = out.replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '');
+    out = out.replace(/\x1b[PX^_][^\x1b]*\x1b\\/g, '');
+    // Strip bare C0 controls (keep TAB, LF) and C1/DEL — excludes ESC (0x1B)
+    // so that ESC in preserved SGR sequences is not stripped.
+    out = out.replace(CONTROL_NO_ESC_RE, '');
+    // Strip bare ESC that isn't followed by `[` (the start of an SGR sequence)
+    out = out.replace(/\x1b(?!\[)/g, '');
+
+    return out;
+}

--- a/packages/widgets/src/base/Widget.test.ts
+++ b/packages/widgets/src/base/Widget.test.ts
@@ -38,6 +38,19 @@ class RecoversWidget extends Widget {
     }
 }
 
+// Exposes the protected sanitize() so tests can exercise both the default
+// (sanitizeContent = true) and raw (sanitizeContent = false) code paths
+// directly, independent of any specific widget's render pipeline.
+class SanitizingWidget extends Widget {
+    protected _renderSelf(_screen: Screen): void {}
+    setRaw(raw: boolean): void {
+        this.sanitizeContent = !raw;
+    }
+    publicSanitize(text: string): string {
+        return this.sanitize(text);
+    }
+}
+
 describe('Widget', () => {
     it('generates unique IDs', () => {
         const a = new TestWidget();
@@ -312,6 +325,38 @@ async function advanceSpring(ms: number) {
         await Promise.resolve();
     }
 }
+
+describe('Widget.sanitize()', () => {
+    it('default mode (sanitizeContent = true) strips everything, including SGR', () => {
+        const w = new SanitizingWidget();
+        const out = w.publicSanitize('\x1b[31mred\x1b[0m\x1b[2Jcleared');
+        expect(out).toBe('redcleared');
+    });
+
+    it('raw mode (sanitizeContent = false) is no longer a no-op: it strips OSC-52 clipboard exfiltration', () => {
+        const w = new SanitizingWidget();
+        w.setRaw(true);
+        const out = w.publicSanitize('\x1b]52;c;ZXZpbA==\x07safe');
+        expect(out).not.toContain('\x1b]52');
+        expect(out).toBe('safe');
+    });
+
+    it('raw mode strips cursor movement and screen-clear sequences', () => {
+        const w = new SanitizingWidget();
+        w.setRaw(true);
+        const out = w.publicSanitize('\x1b[2Jhi\x1b[10;20H');
+        expect(out).not.toContain('\x1b[2J');
+        expect(out).not.toContain('\x1b[10;20H');
+        expect(out).toBe('hi');
+    });
+
+    it('raw mode still preserves SGR formatting sequences, matching the documented Text.raw behavior', () => {
+        const w = new SanitizingWidget();
+        w.setRaw(true);
+        const out = w.publicSanitize('\x1b[31mred\x1b[0m');
+        expect(out).toBe('\x1b[31mred\x1b[0m');
+    });
+});
 
 describe('Widget.layoutTransition', () => {
     beforeEach(() => {

--- a/packages/widgets/src/base/Widget.ts
+++ b/packages/widgets/src/base/Widget.ts
@@ -19,6 +19,7 @@ import {
     containsPoint,
     caps,
     stripAnsiEscapes,
+    sanitizeForDisplay,
     type A11yProps,
     emitA11y,
 } from '@termuijs/core';
@@ -456,14 +457,20 @@ export abstract class Widget {
 
     /**
      * Sanitize text content by stripping ANSI escape sequences.
-     * Subclasses can override to customize behavior or bypass sanitization
-     * for trusted content.
+     *
+     * When `sanitizeContent` is `true` (default), all ANSI escapes and
+     * control characters are stripped. When `false` (e.g. `Text` with
+     * `raw: true`), SGR formatting is preserved but cursor movement, screen
+     * clears, and OSC sequences (title, clipboard, hyperlinks) are still
+     * stripped — content is never passed through completely unsanitized.
+     *
+     * Subclasses can override to customize behavior.
      */
     protected sanitize(text: string): string {
         if (this.sanitizeContent) {
             return stripAnsiEscapes(text);
         }
-        return text;
+        return sanitizeForDisplay(text, /* allowFormatting */ true);
     }
 
     /**

--- a/packages/widgets/src/base/Widget.ts
+++ b/packages/widgets/src/base/Widget.ts
@@ -18,6 +18,7 @@ import {
     styleToCellAttrs,
     containsPoint,
     caps,
+    stripAnsiEscapes,
     type A11yProps,
     emitA11y,
 } from '@termuijs/core';
@@ -129,6 +130,13 @@ export abstract class Widget {
     public layoutTransition: Partial<SpringConfig> | SpringPresetName | boolean = false;
     private _layoutCancel: (() => void) | null = null;
     private _targetRect: Rect | null = null;
+
+    /**
+     * Whether to automatically strip ANSI escape sequences from text content
+     * before rendering.  Defaults to `true` for security — set to `false` only
+     * when the widget displays trusted, internally-generated formatted text.
+     */
+    protected sanitizeContent = true;
 
     constructor(style: Partial<Style> = {}) {
         this.id = `widget_${++_widgetIdCounter}`;
@@ -445,6 +453,18 @@ export abstract class Widget {
 
     /** Get the last render error, if any */
     get renderError(): Error | null { return this._renderError; }
+
+    /**
+     * Sanitize text content by stripping ANSI escape sequences.
+     * Subclasses can override to customize behavior or bypass sanitization
+     * for trusted content.
+     */
+    protected sanitize(text: string): string {
+        if (this.sanitizeContent) {
+            return stripAnsiEscapes(text);
+        }
+        return text;
+    }
 
     /**
      * Render the border around this widget, including focus ring if focused.

--- a/packages/widgets/src/display/Text.test.ts
+++ b/packages/widgets/src/display/Text.test.ts
@@ -67,6 +67,37 @@ describe('Text', () => {
     });
 });
 
+describe('Text – raw mode sanitization', () => {
+    it('strips OSC 52 clipboard exfiltration sequences even when raw', () => {
+        const { screen } = renderText(
+            '\x1b]52;c;ZXZpbA==\x07safe',
+            {},
+            { raw: true },
+        );
+        const text = screen.back[0].map(c => c.char).join('').trimEnd();
+        expect(text).not.toContain('\x1b]52');
+        expect(text).toBe('safe');
+    });
+
+    it('strips cursor movement and screen clear sequences even when raw', () => {
+        const { screen } = renderText(
+            '\x1b[2Jhi\x1b[10;20H',
+            {},
+            { raw: true },
+        );
+        const text = screen.back[0].map(c => c.char).join('').trimEnd();
+        expect(text).not.toContain('\x1b[2J');
+        expect(text).not.toContain('\x1b[10;20H');
+        expect(text).toContain('hi');
+    });
+
+    it('does not sanitize away plain content when raw is true', () => {
+        const { screen } = renderText('plain text', {}, { raw: true });
+        const text = screen.back[0].map(c => c.char).join('').trimEnd();
+        expect(text).toBe('plain text');
+    });
+});
+
 describe('Text – mutation regression tests', () => {
     it('does not mark dirty when content is unchanged', () => {
         const text = new Text('hello');

--- a/packages/widgets/src/display/Text.ts
+++ b/packages/widgets/src/display/Text.ts
@@ -13,6 +13,13 @@ export interface TextProps {
     scrollY?: number;
     /** Horizontal scroll offset (columns to skip from left). Default: 0. */
     scrollX?: number;
+    /**
+     * If true, ANSI escape sequences in content are rendered as-is.
+     * Only SGR formatting is preserved — cursor movement, screen clears,
+     * and OSC sequences are still stripped for safety.
+     * Use only for trusted formatted content (e.g., log output).
+     */
+    raw?: boolean;
 }
 
 /**
@@ -24,6 +31,7 @@ export class Text extends Widget {
     private _align: 'left' | 'center' | 'right';
     private _scrollY: number;
     private _scrollX: number;
+    private _raw: boolean;
 
     constructor(content: string, style: Partial<Style> = {}, props: Partial<TextProps> = {}) {
         super(style);
@@ -32,6 +40,9 @@ export class Text extends Widget {
         this._align = props.align ?? 'left';
         this._scrollY = props.scrollY ?? 0;
         this._scrollX = props.scrollX ?? 0;
+        this._raw = props.raw ?? false;
+        // When raw mode is enabled, bypass sanitization (trusted formatted content)
+        this.sanitizeContent = !this._raw;
     }
 
     /** Update the text content */
@@ -86,8 +97,11 @@ export class Text extends Widget {
 
         const attrs = styleToCellAttrs(this._style);
 
+        // Sanitize content to prevent ANSI escape injection
+        const content = this.sanitize(this._content);
+
         // Word-wrap if enabled
-        let text = this._wrap ? wordWrap(this._content, width) : this._content;
+        let text = this._wrap ? wordWrap(content, width) : content;
         const allLines = text.split('\n');
 
         // Apply vertical scroll

--- a/packages/widgets/src/input/TextInput.ts
+++ b/packages/widgets/src/input/TextInput.ts
@@ -9,7 +9,8 @@ import {
     stringWidth,
     truncate,
     type KeyEvent,
-    splitGraphemes
+    splitGraphemes,
+    stripAnsiEscapes,
 } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 import { type VimMode } from './vim.js';
@@ -34,6 +35,8 @@ export class TextInput extends Widget {
     private _onComplete?: (value: string) => void;
     public signal?: AbortSignal;
 
+    private _raw: boolean;
+
     constructor(
         style: Partial<Style> = {},
         options: {
@@ -44,6 +47,8 @@ export class TextInput extends Widget {
             onChange?: (value: string) => void;
             onSubmit?: (value: string) => void;
             signal?: AbortSignal;
+            /** If true, ANSI escape sequences in the input value are preserved. */
+            raw?: boolean;
         } = {},
     ) {
         super({ border: 'single', height: 3, ...style });
@@ -55,6 +60,7 @@ export class TextInput extends Widget {
         this._onSubmit = options.onSubmit;
         this._suggestions = options.suggestions ?? [];
         this.signal = options.signal;
+        this._raw = options.raw ?? false;
 
         this.focusable = true;
 
@@ -385,7 +391,8 @@ export class TextInput extends Widget {
         const attrs = styleToCellAttrs(this._style);
 
         if (this._value.length === 0 && !this.isFocused) {
-            screen.writeString(x, y, truncate(this._placeholder, width), { ...attrs, dim: true });
+            const placeholderText = this._raw ? this._placeholder : stripAnsiEscapes(this._placeholder);
+            screen.writeString(x, y, truncate(placeholderText, width), { ...attrs, dim: true });
             return;
         }
 
@@ -434,7 +441,8 @@ export class TextInput extends Widget {
 
         const visibleGraphemes = displayGraphemes.slice(scrollGraphemeIndex, endGraphemeIndex);
         const visibleText = visibleGraphemes.join('');
-        screen.writeString(x, y, visibleText, attrs);
+        const displayText = this._raw ? visibleText : stripAnsiEscapes(visibleText);
+        screen.writeString(x, y, displayText, attrs);
 
         if (this.isFocused) {
             const cursorOffset = prefixWidths[this._cursorPos] - prefixWidths[scrollGraphemeIndex];


### PR DESCRIPTION
## Summary

Adds a `sanitize.ts` module to strip or detect ANSI escape sequences in display text, preventing ANSI injection attacks where user-controlled content could inject escape codes to manipulate the terminal. Implements defense-in-depth at both the Screen and Widget levels.

## Changes

- `packages/core/src/terminal/sanitize.ts`: New file with `stripAnsiEscapes`, `hasAnsiEscapes`, `sanitizeForDisplay`
- `packages/core/src/terminal/Screen.ts`: `writeString` uses `stripAnsiEscapes`; added `writeFormattedString`
- `packages/core/src/index.ts`: Exports sanitize utilities
- `packages/widgets/src/base/Widget.ts`: Added `sanitizeContent` field + `sanitize()` method
- `packages/widgets/src/display/Text.ts`: Added `raw` prop; sanitizes content in `_renderSelf`
- `packages/widgets/src/input/TextInput.ts`: Sanitizes displayed text, placeholder, and suggestions
- `packages/core/src/terminal/sanitize.test.ts`: 33 tests
- `packages/core/src/terminal/Screen.test.ts`: 5 `writeFormattedString` tests

Closes #2030

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer text handling across terminal output and widgets.
  * Introduced an option to display text “raw” when ANSI styling should be preserved.
  * Exposed new sanitization helpers for broader use in the app.

* **Bug Fixes**
  * Improved protection against ANSI/control-sequence injection in displayed text.
  * Ensured normal text, Unicode, tabs, and line breaks still render correctly while unwanted escape sequences are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->