### PR TITLE
feat(core): add configurable input size limits to InputParser (#2031)

### DIFF
--- a/packages/core/src/input/InputParser.test.ts
+++ b/packages/core/src/input/InputParser.test.ts
@@ -404,4 +404,81 @@ describe('InputParser', () => {
             expect(pasteHandler).toHaveBeenCalledWith('hello world');
         });
     });
+
+    describe('configurable size limits', () => {
+        it('limits escape sequence length with maxEscapeSequenceLength option', () => {
+            const stdin = createMockStdin();
+            const parser = new InputParser(stdin, { maxEscapeSequenceLength: 5 });
+            const handler = vi.fn();
+            parser.onKey(handler);
+            parser.start();
+            // Send a long escape sequence — exceeds max of 5
+            sendKey(stdin, '\x1b[1;2;3;4;5;6;7;8;9;0A');
+            // Should not emit any key (sequence discarded)
+            expect(handler).not.toHaveBeenCalled();
+        });
+
+        it('limits paste buffer size with maxPasteBufferSize option', () => {
+            const stdin = createMockStdin();
+            const parser = new InputParser(stdin, { maxPasteBufferSize: 10 });
+            const pasteHandler = vi.fn();
+            parser.onPaste(pasteHandler);
+            parser.start();
+            // Paste content larger than 10 bytes
+            stdin.emit('data', Buffer.from('\x1b[200~hello world, this is a long paste\x1b[201~', 'utf8'));
+            // Content should be truncated to last 10 bytes
+            expect(pasteHandler).toHaveBeenCalledWith(expect.stringMatching(/.{10}/));
+            expect(pasteHandler).toHaveBeenCalledTimes(1);
+        });
+
+        it('discards escape buffer when it exceeds maxEscapeSequenceLength', () => {
+            const stdin = createMockStdin();
+            const parser = new InputParser(stdin, { maxEscapeSequenceLength: 4 });
+            const handler = vi.fn();
+            parser.onKey(handler);
+            parser.start();
+            // Send a lone ESC, then enough bytes to exceed the limit (4)
+            stdin.emit('data', Buffer.from([0x1b]));
+            stdin.emit('data', Buffer.from('ABCD', 'utf8'));
+            vi.advanceTimersByTime(10);
+            // ESC + ABCD = 5 bytes > 4 limit — buffer was discarded
+            expect(handler).not.toHaveBeenCalled();
+        });
+
+        it('limits grapheme buffer size with maxGraphemeBufferSize option', () => {
+            const stdin = createMockStdin();
+            const parser = new InputParser(stdin, { maxGraphemeBufferSize: 5 });
+            const handler = vi.fn();
+            parser.onKey(handler);
+            parser.start();
+            // Send many characters at once (exceeds grapheme buffer limit of 5)
+            stdin.emit('data', Buffer.from('abcdefghijklmnop', 'utf8'));
+            vi.advanceTimersByTime(20);
+            // Buffer keeps only last 5 bytes → 'klmno' → 5 grapheme events
+            expect(handler).toHaveBeenCalledTimes(5);
+        });
+
+        it('limits key events per chunk with maxKeyEventsPerChunk option', () => {
+            const stdin = createMockStdin();
+            const parser = new InputParser(stdin, { maxKeyEventsPerChunk: 3 });
+            const handler = vi.fn();
+            parser.onKey(handler);
+            parser.start();
+            // Send many characters at once
+            stdin.emit('data', Buffer.from('abcdefghij', 'utf8'));
+            vi.advanceTimersByTime(20);
+            // Should only emit up to 3 events
+            expect(handler).toHaveBeenCalledTimes(3);
+        });
+
+        it('default options preserve backward compatibility', () => {
+            const stdin = createMockStdin();
+            const parser = new InputParser(stdin);
+            const handler = vi.fn();
+            parser.onKey(handler);
+            parser.start();
+            sendKey(stdin, 'hello');
+            expect(handler).toHaveBeenCalledTimes(5);
+        });
+    });
 });

--- a/packages/core/src/input/InputParser.test.ts
+++ b/packages/core/src/input/InputParser.test.ts
@@ -480,5 +480,22 @@ describe('InputParser', () => {
             sendKey(stdin, 'hello');
             expect(handler).toHaveBeenCalledTimes(5);
         });
+
+        it('does not drop bytes from a raw chunk larger than maxEscapeSequenceLength', () => {
+            // A single data event bigger than the (default 4096) escape-sequence
+            // limit must not be truncated before parsing — that limit only bounds
+            // escape-sequence buffering, not the whole incoming chunk.
+            const stdin = createMockStdin();
+            const parser = new InputParser(stdin);
+            const pasteHandler = vi.fn();
+            parser.onPaste(pasteHandler);
+            parser.start();
+
+            const content = 'x'.repeat(5000); // > DEFAULT_MAX_ESCAPE_SEQUENCE_LENGTH (4096), < paste buffer cap (1MB)
+            stdin.emit('data', Buffer.from(`\x1b[200~${content}\x1b[201~`, 'utf8'));
+
+            expect(pasteHandler).toHaveBeenCalledWith(content);
+            expect(pasteHandler.mock.calls[0][0]).toHaveLength(5000);
+        });
     });
 });

--- a/packages/core/src/input/InputParser.ts
+++ b/packages/core/src/input/InputParser.ts
@@ -166,10 +166,6 @@ export class InputParser {
      * Process a chunk of raw input bytes.
      */
     private _processInput(data: Buffer): void {
-        // Cap the data chunk size to prevent memory exhaustion
-        if (data.length > this._maxEscapeSequenceLength) {
-            data = data.slice(0, this._maxEscapeSequenceLength);
-        }
         const PASTE_START = '\x1b[200~';
         const PASTE_END = '\x1b[201~';
 

--- a/packages/core/src/input/InputParser.ts
+++ b/packages/core/src/input/InputParser.ts
@@ -12,10 +12,41 @@ import { EventEmitter } from '../events/EventEmitter.js';
 import { splitGraphemes } from './grapheme.js';
 
 const ESCAPE_TIMEOUT_MS = 500;
+const DEFAULT_MAX_ESCAPE_SEQUENCE_LENGTH = 4096;
+const DEFAULT_MAX_PASTE_BUFFER_SIZE = 1024 * 1024; // 1 MB
+const DEFAULT_MAX_GRAPHENE_BUFFER_SIZE = 4096;
+const DEFAULT_MAX_KEY_EVENTS_PER_CHUNK = 1000;
 
 export interface CursorPosition {
     row: number;
     col: number;
+}
+
+export interface InputParserOptions {
+    /**
+     * Maximum byte length for an escape sequence buffer.
+     * Sequences exceeding this are discarded to prevent memory exhaustion.
+     * Default: 4096
+     */
+    maxEscapeSequenceLength?: number;
+    /**
+     * Maximum byte length for the paste buffer.
+     * Paste content exceeding this is truncated.
+     * Default: 1,048,576 (1 MB)
+     */
+    maxPasteBufferSize?: number;
+    /**
+     * Maximum byte length for the grapheme buffer.
+     * Grapheme content exceeding this is discarded.
+     * Default: 4096
+     */
+    maxGraphemeBufferSize?: number;
+    /**
+     * Maximum number of key events to emit from a single _processInput call.
+     * Prevents event loop starvation from a flood of input data.
+     * Default: 1000
+     */
+    maxKeyEventsPerChunk?: number;
 }
 
 interface InputEvents {
@@ -46,9 +77,17 @@ export class InputParser {
         reject: (error: Error) => void;
         timeout: ReturnType<typeof setTimeout>;
     }> = [];
+    private _maxEscapeSequenceLength: number;
+    private _maxPasteBufferSize: number;
+    private _maxGraphemeBufferSize: number;
+    private _maxKeyEventsPerChunk: number;
 
-    constructor(stdin: NodeJS.ReadStream) {
+    constructor(stdin: NodeJS.ReadStream, options: InputParserOptions = {}) {
         this._stdin = stdin;
+        this._maxEscapeSequenceLength = options.maxEscapeSequenceLength ?? DEFAULT_MAX_ESCAPE_SEQUENCE_LENGTH;
+        this._maxPasteBufferSize = options.maxPasteBufferSize ?? DEFAULT_MAX_PASTE_BUFFER_SIZE;
+        this._maxGraphemeBufferSize = options.maxGraphemeBufferSize ?? DEFAULT_MAX_GRAPHENE_BUFFER_SIZE;
+        this._maxKeyEventsPerChunk = options.maxKeyEventsPerChunk ?? DEFAULT_MAX_KEY_EVENTS_PER_CHUNK;
     }
 
     /** Subscribe to key events */
@@ -127,6 +166,10 @@ export class InputParser {
      * Process a chunk of raw input bytes.
      */
     private _processInput(data: Buffer): void {
+        // Cap the data chunk size to prevent memory exhaustion
+        if (data.length > this._maxEscapeSequenceLength) {
+            data = data.slice(0, this._maxEscapeSequenceLength);
+        }
         const PASTE_START = '\x1b[200~';
         const PASTE_END = '\x1b[201~';
 
@@ -134,19 +177,36 @@ export class InputParser {
             const str = this._decoder.write(data);
             const endIdx = str.indexOf(PASTE_END);
             if (endIdx !== -1) {
-                this._pasteBuffer += str.substring(0, endIdx);
+                const chunk = str.substring(0, endIdx);
+                const newLen = this._pasteBuffer.length + chunk.length;
+                if (newLen > this._maxPasteBufferSize) {
+                    const excess = newLen - this._maxPasteBufferSize;
+                    this._pasteBuffer = this._pasteBuffer.slice(excess) + chunk;
+                    this._pasteBuffer = this._pasteBuffer.slice(-this._maxPasteBufferSize);
+                } else {
+                    this._pasteBuffer += chunk;
+                }
                 const pastedText = this._pasteBuffer;
                 this._isPasting = false;
                 this._pasteBuffer = '';
                 this._clearPasteTimeout();
                 this._events.emit('paste', pastedText);
-                
+
                 const remaining = str.substring(endIdx + PASTE_END.length);
                 if (remaining.length > 0) {
                     this._processInput(Buffer.from(remaining, 'utf8'));
                 }
             } else {
-                this._pasteBuffer += str;
+                const newLen = this._pasteBuffer.length + str.length;
+                if (newLen > this._maxPasteBufferSize) {
+                    const excess = newLen - this._maxPasteBufferSize;
+                    this._pasteBuffer = this._pasteBuffer.slice(excess) + str;
+                    if (this._pasteBuffer.length > this._maxPasteBufferSize) {
+                        this._pasteBuffer = this._pasteBuffer.slice(-this._maxPasteBufferSize);
+                    }
+                } else {
+                    this._pasteBuffer += str;
+                }
                 this._startPasteTimeout();
             }
             return;
@@ -154,7 +214,10 @@ export class InputParser {
 
         // If we are currently collecting an escape sequence, continue collecting it
         if (this._escapeBuffer.length > 0) {
-            this._escapeBuffer = Buffer.concat([this._escapeBuffer, data]);
+            const newBuf = Buffer.concat([this._escapeBuffer, data]);
+            this._escapeBuffer = newBuf.length > this._maxEscapeSequenceLength
+                ? newBuf.slice(0, this._maxEscapeSequenceLength)
+                : newBuf;
             if (this._escapeTimeout) {
                 clearTimeout(this._escapeTimeout);
                 this._escapeTimeout = null;
@@ -188,7 +251,9 @@ export class InputParser {
                 }
             } else {
                 this._isPasting = true;
-                this._pasteBuffer = afterStart;
+                this._pasteBuffer = afterStart.length > this._maxPasteBufferSize
+                    ? afterStart.slice(-this._maxPasteBufferSize)
+                    : afterStart;
                 this._startPasteTimeout();
             }
             return;
@@ -213,7 +278,16 @@ export class InputParser {
 
         // Decode input and append to grapheme buffer
         const decoded = this._decoder.write(data);
-        this._graphemeBuffer += decoded;
+        const newLen = this._graphemeBuffer.length + decoded.length;
+        if (newLen > this._maxGraphemeBufferSize) {
+            const excess = newLen - this._maxGraphemeBufferSize;
+            this._graphemeBuffer = this._graphemeBuffer.slice(excess) + decoded;
+            if (this._graphemeBuffer.length > this._maxGraphemeBufferSize) {
+                this._graphemeBuffer = this._graphemeBuffer.slice(-this._maxGraphemeBufferSize);
+            }
+        } else {
+            this._graphemeBuffer += decoded;
+        }
 
         if (this._graphemeTimeout) {
             clearTimeout(this._graphemeTimeout);
@@ -233,11 +307,11 @@ export class InputParser {
         const graphemes = splitGraphemes(this._graphemeBuffer);
         if (graphemes.length === 0) return;
 
-        let processCount = graphemes.length;
+        let processCount = Math.min(graphemes.length, this._maxKeyEventsPerChunk);
         // Check if the last grapheme is potentially incomplete
-        const lastGrapheme = graphemes[graphemes.length - 1];
-        if (this._isPossiblyIncompleteGrapheme(lastGrapheme)) {
-            processCount = graphemes.length - 1;
+        const lastGrapheme = graphemes[processCount - 1];
+        if (processCount > 0 && this._isPossiblyIncompleteGrapheme(lastGrapheme)) {
+            processCount = processCount - 1;
         }
 
         for (let i = 0; i < processCount; i++) {
@@ -388,7 +462,7 @@ export class InputParser {
                 return;
             }
             // Might be incomplete mouse sequence — wait for more data (no timeout, FSM handles via _escapeBuffer)
-            if (seq.length < 20) { // safety cap
+            if (seq.length < 20) {
                 return;
             }
         }
@@ -460,8 +534,8 @@ export class InputParser {
             return;
         }
 
-        // If the sequence is getting too long, give up
-        if (seq.length > 20) {
+        // If the sequence is at or over the limit, discard it
+        if (seq.length >= this._maxEscapeSequenceLength) {
             this._escapeBuffer = Buffer.alloc(0);
             return;
         }


### PR DESCRIPTION
## Summary

Adds configurable size limits to `InputParser` to prevent resource exhaustion from malformed or malicious input sequences. Caps escape sequence length, paste buffer size, grapheme buffer size, and key events per chunk.

## Changes

- `packages/core/src/input/InputParser.ts`: Added `InputParserOptions` interface; enforced limits in `_processInput`, `_processGraphemeBuffer`, `_tryParseEscape`
- `packages/core/src/input/InputParser.test.ts`: 6 new tests for size limit enforcement

Closes #2031

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable limits for input handling, including escape sequences, paste buffering, grapheme buffering, and key-event emission per chunk.

* **Bug Fixes**
  * Prevents excessive buffering during large or malformed input, improving stability under heavy terminal input.
  * Preserves normal behavior with default settings, continuing to emit expected key events for standard input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->