### PR TITLE
fix(store): resolve symlinks in persist file path

### DIFF
--- a/packages/store/src/store.test.ts
+++ b/packages/store/src/store.test.ts
@@ -867,3 +867,57 @@ describe('useStore selector memoization', () => {
     })
 })
 
+describe('persist – symlink resolution', () => {
+    const testRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'termuijs-symtest-')));
+    const storeDir = path.join(testRoot, 'termuijs-stores');
+    const realDir = path.join(storeDir, 'real');
+    const linkDir = path.join(storeDir, 'link');
+
+    afterAll(() => {
+        try { fs.rmSync(storeDir, { recursive: true }); } catch { /* ok */ }
+        try { fs.rmdirSync(testRoot); } catch { /* ok */ }
+    });
+
+    const origAppData = process.env.APPDATA;
+    const origXdgConfig = process.env.XDG_CONFIG_HOME;
+    const symlinkType: any = process.platform === 'win32' ? 'junction' : 'dir';
+
+    beforeEach(() => {
+        process.env.APPDATA = testRoot;
+        process.env.XDG_CONFIG_HOME = testRoot;
+        fs.mkdirSync(realDir, { recursive: true });
+        try { fs.rmdirSync(linkDir); } catch { /* ok */ }
+        if (!fs.existsSync(linkDir)) {
+            fs.symlinkSync(realDir, linkDir, symlinkType);
+        }
+    });
+
+    afterEach(() => {
+        process.env.APPDATA = origAppData;
+        process.env.XDG_CONFIG_HOME = origXdgConfig;
+        vi.useRealTimers();
+        try { fs.rmSync(storeDir, { recursive: true }); } catch { /* ok */ }
+    });
+
+    it('resolves symlinks in persist path and writes to real directory', () => {
+        vi.useFakeTimers();
+        const useStore = createStore({ count: 0 }, {
+            persist: { file: path.join(linkDir, 'symtest.json') },
+        });
+        useStore.setState({ count: 42 });
+        vi.advanceTimersByTime(200);
+        const realFilePath = path.join(realDir, 'symtest.json');
+        expect(fs.existsSync(realFilePath)).toBe(true);
+        const content = JSON.parse(fs.readFileSync(realFilePath, 'utf8'));
+        expect(content.count).toBe(42);
+    });
+
+    it('rehydrates from the resolved real path on restart', () => {
+        fs.writeFileSync(path.join(realDir, 'symtest.json'), JSON.stringify({ count: 99 }));
+        const useStore = createStore({ count: 0 }, {
+            persist: { file: path.join(linkDir, 'symtest.json') },
+        });
+        expect(useStore.getState().count).toBe(99);
+    });
+})
+

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -323,6 +323,26 @@ export function createStore<T extends object>(
             }
             persistFilePath = path.join(persistDir, `${persistOpt.key}.json`);
         }
+        // Resolve symlinks in the persist directory to prevent writes through
+        // symlink targets (e.g., ~/.config or ~/AppData/Roaming being a symlink).
+        // Walk up from the file to find the first existing ancestor, resolve it,
+        // and reconstruct the remainder.
+        try {
+            const dir = path.dirname(persistFilePath);
+            if (fs.existsSync(dir)) {
+                persistFilePath = path.join(fs.realpathSync(dir), path.basename(persistFilePath));
+            } else {
+                const segments: string[] = [];
+                let current = dir;
+                while (!fs.existsSync(current)) {
+                    segments.unshift(path.basename(current));
+                    current = path.dirname(current);
+                }
+                persistFilePath = path.join(fs.realpathSync(current), ...segments, path.basename(persistFilePath));
+            }
+        } catch {
+            // If realpath fails (permissions, etc.), use the unresolved path
+        }
     }
 
     const persistState = () => {


### PR DESCRIPTION
## Summary

Resolves symlinks in the persist file path when writing store state to disk, preventing writes from accidentally going through a symlink target (e.g., if `~/.config` or `~/AppData/Roaming` is a symlink). Walks up the filesystem tree to find the first existing ancestor directory, resolves it with `fs.realpathSync`, and reconstructs the path.

## Changes

- `packages/store/src/store.ts`: Added symlink resolution block in persist path setup (wrapped in try/catch with fallback)
- `packages/store/src/store.test.ts`: 2 new tests for symlink resolution and rehydration

Closes #2032