### PR TITLE
refactor(jsx): create globals.ts, replace globalThis usage

### DIFF
--- a/packages/jsx/src/createPortal.test.tsx
+++ b/packages/jsx/src/createPortal.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { Box, Text } from '@termuijs/widgets';
+import { instanceMap } from './globals.js';
 import { createPortal } from './createPortal.js';
 import { useState, setRequestRender } from './hooks.js';
 import { createElement as h } from './createElement.js';
@@ -48,8 +49,7 @@ describe('createPortal', () => {
         }
 
         const rootWidget = reconcile(h(App, {}));
-        const instances: Map<Widget, any> = (globalThis as any).__termuijs_instances;
-        const rootInstance = instances?.get(rootWidget);
+        const rootInstance = instanceMap.get(rootWidget);
 
         // Mock requestRender so state updates trigger a re-render in our manual test
         setRequestRender(() => {

--- a/packages/jsx/src/globals.ts
+++ b/packages/jsx/src/globals.ts
@@ -1,0 +1,14 @@
+import type { Widget } from '@termuijs/widgets';
+import type { Fiber } from './hooks.js';
+
+export const instanceMap = new Map<Widget, any>();
+export const fiberToWidgetMap = new Map<Fiber, Widget>();
+export const suspendedFibers = new Map<number, { promise: Promise<any>; fiber: Fiber }>();
+export const activeApps: any[] = [];
+
+// Backward-compatible globalThis aliases so @termuijs/testing and external
+// consumers that read from globalThis continue to work.
+(globalThis as any).__termuijs_instances = instanceMap;
+(globalThis as any).__termuijs_fiberToWidget = fiberToWidgetMap;
+(globalThis as any).__termuijs_suspendedFibers = suspendedFibers;
+(globalThis as any).__termuijs_apps = activeApps;

--- a/packages/jsx/src/hooks.ts
+++ b/packages/jsx/src/hooks.ts
@@ -11,6 +11,7 @@ import { caps } from '@termuijs/core';
 import { timerPoolSubscribe } from '@termuijs/motion';
 import type { Widget } from '@termuijs/widgets';
 import type { FC } from './vnode.js';
+import { suspendedFibers, fiberToWidgetMap, instanceMap } from './globals.js';
 
 // ── Fiber — per-component-instance state ──
 
@@ -652,22 +653,13 @@ export function destroyFiber(fiber: Fiber): void {
         fiber.portalChildren = undefined;
     }
     // Clean up suspended promises (SuspenseBoundary tracking)
-    const _suspendedFibers: Map<number, any> | undefined = (globalThis as any).__termuijs_suspendedFibers;
-    if (_suspendedFibers instanceof Map) {
-        _suspendedFibers.delete(fiber.id);
-    }
+    suspendedFibers.delete(fiber.id);
 
-    // Clean up global _instanceMap via reverse fiber→widget mapping (O(1))
-    const _fiberToWidget: Map<any, any> | undefined = (globalThis as any).__termuijs_fiberToWidget;
-    if (_fiberToWidget instanceof Map) {
-        const widget = _fiberToWidget.get(fiber);
-        if (widget) {
-            const termuiInstances: Map<any, any> | undefined = (globalThis as any).__termuijs_instances;
-            if (termuiInstances instanceof Map) {
-                termuiInstances.delete(widget);
-            }
-            _fiberToWidget.delete(fiber);
-        }
+    // Clean up global instanceMap via reverse fiber→widget mapping (O(1))
+    const widget = fiberToWidgetMap.get(fiber);
+    if (widget) {
+        instanceMap.delete(widget);
+        fiberToWidgetMap.delete(fiber);
     }
     fiber.hooks = [];
     fiber.effects = [];
@@ -702,15 +694,9 @@ export function resetHooksGlobals(): void {
     }
     
     // Clear global instance map
-    const termuiInstances: Map<any, any> | undefined = (globalThis as any).__termuijs_instances;
-    if (termuiInstances instanceof Map) {
-        termuiInstances.clear();
-    }
+    instanceMap.clear();
     // Clear reverse fiber→widget map
-    const _fiberToWidget: Map<any, any> | undefined = (globalThis as any).__termuijs_fiberToWidget;
-    if (_fiberToWidget instanceof Map) {
-        _fiberToWidget.clear();
-    }
+    fiberToWidgetMap.clear();
 }
 
 /**

--- a/packages/jsx/src/reconciler.test.ts
+++ b/packages/jsx/src/reconciler.test.ts
@@ -4,6 +4,7 @@ import { Screen } from '@termuijs/core';
 import type { VNode } from './vnode.js';
 import { reconcile, reRenderComponent, unmountAll, _pruneInstancesForWidget } from './reconciler.js';
 import { destroyFiber } from './hooks.js';
+import { instanceMap } from './globals.js';
 
 // ── Helper: make a functional component VNode ──
 
@@ -36,7 +37,7 @@ function ReturnsTextVNode(): VNode {
 }
 
 function getInstanceMap(): Map<any, any> {
-    return (globalThis as any).__termuijs_instances;
+    return instanceMap;
 }
 
 describe('_instanceMap leak prevention', () => {

--- a/packages/jsx/src/reconciler.ts
+++ b/packages/jsx/src/reconciler.ts
@@ -23,6 +23,7 @@ import {
 import { ErrorBoundary } from './error-boundary.js';
 import { Suspense } from './Suspense.js';
 import { scheduleRender, currentFiber } from './hooks.js';
+import { instanceMap, fiberToWidgetMap, suspendedFibers } from './globals.js';
 // ── Component instance tracking ──
 
 interface ComponentInstance {
@@ -34,16 +35,6 @@ interface ComponentInstance {
     childInstances: ComponentInstance[];
     lastVNode: VNode | Widget;
 }
-
-const _instanceMap = new Map<Widget, ComponentInstance>();
-/** Reverse map: Fiber → Widget for O(1) cleanup in destroyFiber */
-const _fiberToWidgetMap = new Map<Fiber, Widget>();
-/** Track thrown Promises per fiber so SuspenseBoundary can re-render on resolution */
-const _suspendedFibers = new Map<number, { promise: Promise<any>; fiber: Fiber }>();
-// Expose globally so render() and @termuijs/testing can dispatch to useInput handlers and destroyFiber
-(globalThis as any).__termuijs_instances = _instanceMap;
-(globalThis as any).__termuijs_fiberToWidget = _fiberToWidgetMap;
-(globalThis as any).__termuijs_suspendedFibers = _suspendedFibers;
 
 // ── Parent fiber tracking ──
 // Tracks the currently-rendering fiber so child components
@@ -378,11 +369,11 @@ function SuspenseBoundary(props: Record<string, any>): any {
         return reconcile(child);
     } catch (err) {
         if (err instanceof Promise) {
-            _suspendedFibers.set(thisFiber.id, { promise: err, fiber: thisFiber });
+            suspendedFibers.set(thisFiber.id, { promise: err, fiber: thisFiber });
             err.then(() => {
-                const entry = _suspendedFibers.get(thisFiber.id);
+                const entry = suspendedFibers.get(thisFiber.id);
                 if (entry && entry.promise === err) {
-                    _suspendedFibers.delete(thisFiber.id);
+                    suspendedFibers.delete(thisFiber.id);
                     scheduleRender(thisFiber);
                 }
             });
@@ -498,7 +489,7 @@ function renderComponent(
         runLayoutEffects(fiber);
         runEffects(fiber);
 
-        _instanceMap.set(vnode, {
+        instanceMap.set(vnode, {
             fiber,
             component,
             props,
@@ -507,7 +498,7 @@ function renderComponent(
             childInstances: [],
             lastVNode: vnode,
         });
-        _fiberToWidgetMap.set(fiber, vnode);
+        fiberToWidgetMap.set(fiber, vnode);
 
         return vnode;
     }
@@ -526,7 +517,7 @@ function renderComponent(
     runEffects(fiber);
 
     // Store instance for cleanup and re-renders
-    _instanceMap.set(widget, {
+    instanceMap.set(widget, {
         fiber,
         component,
         props,
@@ -535,23 +526,23 @@ function renderComponent(
         childInstances: [],
         lastVNode: vnode,
     });
-    _fiberToWidgetMap.set(fiber, widget);
+    fiberToWidgetMap.set(fiber, widget);
 
     return widget;
 }
 
 /**
- * Recursively remove stale _instanceMap entries for a widget and all its
+ * Recursively remove stale instanceMap entries for a widget and all its
  * descendants. Fiber destruction is handled separately by
  * cleanupStaleChildFibers for stale subtrees after each reconcile pass.
  */
 /** @internal exposed for testing */
 export function _pruneInstancesForWidget(widget: Widget): void {
-    const inst = _instanceMap.get(widget);
-    if (inst && _fiberToWidgetMap.get(inst.fiber) === widget) {
-        _fiberToWidgetMap.delete(inst.fiber);
+    const inst = instanceMap.get(widget);
+    if (inst && fiberToWidgetMap.get(inst.fiber) === widget) {
+        fiberToWidgetMap.delete(inst.fiber);
     }
-    _instanceMap.delete(widget);
+    instanceMap.delete(widget);
 
     // Recursively clean up portal children registered on the fiber
     // so they are removed from their target widgets when the portal owner is destroyed.
@@ -630,8 +621,8 @@ export function reRenderComponent(instance: ComponentInstance): Widget {
 
         instance.widget = vnode;
         instance.lastVNode = vnode;
-        _instanceMap.set(vnode, instance);
-        _fiberToWidgetMap.set(fiber, vnode);
+        instanceMap.set(vnode, instance);
+        fiberToWidgetMap.set(fiber, vnode);
 
         return vnode;
     }
@@ -668,8 +659,8 @@ export function reRenderComponent(instance: ComponentInstance): Widget {
     instance.lastVNode = vnode;
 
     // Re-register with new widget
-    _instanceMap.set(newWidget, instance);
-    _fiberToWidgetMap.set(fiber, newWidget);
+    instanceMap.set(newWidget, instance);
+    fiberToWidgetMap.set(fiber, newWidget);
 
     return newWidget;
 }
@@ -678,9 +669,9 @@ export function reRenderComponent(instance: ComponentInstance): Widget {
  * Unmount all component instances — run cleanups.
  */
 export function unmountAll(): void {
-    for (const [, instance] of _instanceMap) {
+    for (const [, instance] of instanceMap) {
         destroyFiber(instance.fiber);
     }
-    _instanceMap.clear();
-    _fiberToWidgetMap.clear();
+    instanceMap.clear();
+    fiberToWidgetMap.clear();
 }

--- a/packages/jsx/src/render.ts
+++ b/packages/jsx/src/render.ts
@@ -13,6 +13,7 @@ import { reconcile, unmountAll, reRenderComponent } from './reconciler.js';
 import { setRequestRender, setInsertBefore, collectInputHandlers } from './hooks.js';
 import { createElement } from './createElement.js';
 import { setCurrentApp } from './runtime.js';
+import { instanceMap, activeApps } from './globals.js';
 
 /**
  * Unmount a list of apps. Swallow any errors thrown by `unmount()` but log
@@ -90,8 +91,7 @@ export async function render(
     setRequestRender(() => {
         // Re-render from the root component instance to preserve fiber state (useState, useRef, etc.)
         // Falling back to a full reconcile only when the root instance is not found.
-        const instances: Map<Widget, any> = (globalThis as any).__termuijs_instances;
-        const rootInstance = instances?.get(rootWidget);
+        const rootInstance = instanceMap.get(rootWidget);
 
         let newRoot: Widget;
         if (rootInstance) {
@@ -135,8 +135,7 @@ export async function render(
         // instanceMap dispatch is unreliable for pass-through components (ancestors
         // overwrite descendants' instanceMap entries). Traversing the root fiber's
         // childFibers tree finds every onInput handler regardless of nesting.
-        const instances: Map<Widget, any> = (globalThis as any).__termuijs_instances;
-        const rootInstance = instances?.get(rootWidget);
+        const rootInstance = instanceMap.get(rootWidget);
         if (rootInstance?.fiber) {
             for (const handler of collectInputHandlers(rootInstance.fiber)) {
                 handler(event);
@@ -144,12 +143,8 @@ export async function render(
         }
     });
 
-    // Register the app instance globally for HMR cleanups
-    // globalThis lacks a typed declaration for this property — cast needed to attach runtime state
-    if (!(globalThis as any).__termuijs_apps) {
-        (globalThis as any).__termuijs_apps = [];
-    }
-    (globalThis as any).__termuijs_apps.push(appInstance);
+    // Register the app instance for HMR cleanups
+    activeApps.push(appInstance);
 
     if ((import.meta as any).hot) {
         (import.meta as any).hot.accept();
@@ -158,16 +153,15 @@ export async function render(
             const devServerPkg = '@termuijs/dev-server';
             import(devServerPkg)
                 .then(({ cleanupActiveInstances }) => {
-                    // globalThis.__termuijs_apps is a runtime-only property without a type declaration
-                    cleanupActiveInstances((globalThis as any).__termuijs_apps || []);
-                    (globalThis as any).__termuijs_apps = [];
+                    cleanupActiveInstances(activeApps);
+                    activeApps.length = 0;
                 })
                 .catch(() => {
                     // dev-server unavailable — use local helper for cleanup
-                    const apps = (globalThis as any).__termuijs_apps;
+                    const apps = activeApps;
                     if (Array.isArray(apps)) {
                         unmountApps(apps);
-                        (globalThis as any).__termuijs_apps = [];
+                        activeApps.length = 0;
                     }
                 });
         });


### PR DESCRIPTION
## Summary

Creates `packages/jsx/src/globals.ts` to centralize shared state (`instanceMap`, `fiberToWidgetMap`, `suspendedFibers`, `activeApps`) that was previously scattered across the codebase via `globalThis` assignments. Refactors the reconciler, hooks engine, and renderer to import from `globals.ts` directly.

## Changes

- `packages/jsx/src/globals.ts`: New file exporting typed maps + backward-compatible globalThis aliases
- `packages/jsx/src/reconciler.ts`: Removed local map declarations and globalThis assignments; imports from globals
- `packages/jsx/src/hooks.ts`: Replaced 5 globalThis reads with direct map imports
- `packages/jsx/src/render.ts`: Replaced 11 globalThis references with `instanceMap` and `activeApps`
- `packages/jsx/src/reconciler.test.ts`: Updated to import `instanceMap` from globals
- `packages/jsx/src/createPortal.test.tsx`: Updated to import `instanceMap` from globals

Closes #2033