### PR TITLE
feat(data): add LRU eviction to response cache

### DIFF
--- a/packages/data/src/cache.test.ts
+++ b/packages/data/src/cache.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
     getCache,
     setCache,
+    setCacheMaxSize,
     isFresh,
     invalidate,
     clearCache,
@@ -78,6 +79,64 @@ describe('Response Cache Provider', () => {
             clearCache();
             expect(getCache('key1')).toBeUndefined();
             expect(getCache('key2')).toBeUndefined();
+        });
+    });
+
+    describe('LRU eviction', () => {
+        afterEach(() => {
+            setCacheMaxSize(100);
+        });
+
+        it('evicts the oldest entry when cache exceeds maxSize on set', () => {
+            setCacheMaxSize(3);
+            setCache('a', 1, 5000);
+            setCache('b', 2, 5000);
+            setCache('c', 3, 5000);
+            // Adding a 4th entry should evict 'a' (oldest)
+            setCache('d', 4, 5000);
+            expect(getCache('a')).toBeUndefined();
+            expect(getCache('b')).toBeDefined();
+            expect(getCache('c')).toBeDefined();
+            expect(getCache('d')).toBeDefined();
+        });
+
+        it('promotes an entry on getCache, preventing its eviction', () => {
+            setCacheMaxSize(3);
+            setCache('a', 1, 5000);
+            setCache('b', 2, 5000);
+            setCache('c', 3, 5000);
+            getCache('a'); // promotes to MRU — order is now b, c, a
+            setCache('d', 4, 5000); // evicts b
+            expect(getCache('a')).toBeDefined();
+            expect(getCache('b')).toBeUndefined();
+            expect(getCache('c')).toBeDefined();
+            expect(getCache('d')).toBeDefined();
+        });
+
+        it('promotes an entry on isFresh, preventing its eviction', () => {
+            setCacheMaxSize(3);
+            setCache('a', 1, 5000);
+            setCache('b', 2, 5000);
+            setCache('c', 3, 5000);
+            isFresh('a'); // promotes to MRU — order is now b, c, a
+            setCache('d', 4, 5000); // evicts b
+            expect(getCache('a')).toBeDefined();
+            expect(getCache('b')).toBeUndefined();
+            expect(getCache('c')).toBeDefined();
+            expect(getCache('d')).toBeDefined();
+        });
+
+        it('re-setting an existing key promotes it', () => {
+            setCacheMaxSize(3);
+            setCache('a', 1, 5000);
+            setCache('b', 2, 5000);
+            setCache('c', 3, 5000);
+            setCache('a', 10, 5000); // re-set promotes to MRU — order is b, c, a
+            setCache('d', 4, 5000); // evicts b
+            expect(getCache('a')).toBeDefined();
+            expect(getCache('b')).toBeUndefined();
+            expect(getCache('c')).toBeDefined();
+            expect(getCache('d')).toBeDefined();
         });
     });
 

--- a/packages/data/src/cache.test.ts
+++ b/packages/data/src/cache.test.ts
@@ -138,6 +138,22 @@ describe('Response Cache Provider', () => {
             expect(getCache('c')).toBeDefined();
             expect(getCache('d')).toBeDefined();
         });
+
+        it('converges to the new limit when maxSize is shrunk below current size', () => {
+            setCacheMaxSize(5);
+            setCache('a', 1, 5000);
+            setCache('b', 2, 5000);
+            setCache('c', 3, 5000);
+            setCache('d', 4, 5000);
+            setCache('e', 5, 5000); // 5 entries, at limit
+            setCacheMaxSize(2);
+            setCache('f', 6, 5000); // one set must drain down to the new limit of 2
+            expect(getCache('e')).toBeDefined();
+            expect(getCache('f')).toBeDefined();
+            for (const k of ['a', 'b', 'c', 'd']) {
+                expect(getCache(k)).toBeUndefined();
+            }
+        });
     });
 
     describe('fetchShared', () => {

--- a/packages/data/src/cache.ts
+++ b/packages/data/src/cache.ts
@@ -50,12 +50,12 @@ export function setCache<T = any>(key: string, data: T, staleTime: number): void
         timestamp: Date.now(),
         staleTime,
     });
-    // Evict the least recently used entry (first in insertion order)
-    if (cacheStore.size > maxSize) {
+    // Evict least-recently-used entries (first in insertion order) until within limit.
+    // while, not if: converges when setCacheMaxSize() shrinks the limit below current size.
+    while (cacheStore.size > maxSize) {
         const oldestKey = cacheStore.keys().next().value;
-        if (oldestKey !== undefined) {
-            cacheStore.delete(oldestKey);
-        }
+        if (oldestKey === undefined) break;
+        cacheStore.delete(oldestKey);
     }
 }
 

--- a/packages/data/src/cache.ts
+++ b/packages/data/src/cache.ts
@@ -11,29 +11,60 @@ export interface CacheEntry<T = any> {
 const cacheStore = new Map<string, CacheEntry>();
 const inFlight = new Map<string, Promise<any>>(); // any: fetch promises resolve to heterogeneous shapes per endpoint
 
+/** Maximum number of entries before the LRU evictor kicks in */
+let maxSize = 100;
+
 /**
- * Get a cache entry by key (URL).
+ * Set the maximum cache size. When the cache exceeds this limit,
+ * the least recently used entry is evicted on the next write.
  */
-export function getCache<T = any>(key: string): CacheEntry<T> | undefined {
-    return cacheStore.get(key) as CacheEntry<T> | undefined;
+export function setCacheMaxSize(size: number): void {
+    maxSize = size;
 }
 
 /**
- * Set a cache entry.
+ * Get a cache entry by key (URL).
+ * On access the entry is promoted to most recently used.
+ */
+export function getCache<T = any>(key: string): CacheEntry<T> | undefined {
+    const entry = cacheStore.get(key);
+    if (entry) {
+        // Move entry to end (most recently used)
+        cacheStore.delete(key);
+        cacheStore.set(key, entry);
+    }
+    return entry as CacheEntry<T> | undefined;
+}
+
+/**
+ * Set a cache entry. If the key already exists it is promoted
+ * to most recently used. If the cache exceeds maxSize the least
+ * recently used entry is evicted.
  */
 export function setCache<T = any>(key: string, data: T, staleTime: number): void {
+    if (cacheStore.has(key)) {
+        cacheStore.delete(key);
+    }
     cacheStore.set(key, {
         data,
         timestamp: Date.now(),
         staleTime,
     });
+    // Evict the least recently used entry (first in insertion order)
+    if (cacheStore.size > maxSize) {
+        const oldestKey = cacheStore.keys().next().value;
+        if (oldestKey !== undefined) {
+            cacheStore.delete(oldestKey);
+        }
+    }
 }
 
 /**
  * Check if a cache entry exists and is still fresh.
+ * Also promotes the entry to most recently used.
  */
 export function isFresh(key: string): boolean {
-    const entry = cacheStore.get(key);
+    const entry = getCache(key);
     if (!entry) return false;
     return (Date.now() - entry.timestamp) < entry.staleTime;
 }

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -15,7 +15,7 @@ export { tail } from './tail.js';
 export type { TailOptions, TailStream } from './tail.js';
 export { http } from './http.js';
 export type { HealthResult, Endpoint } from './http.js';
-export { invalidate } from './cache.js';
+export { invalidate, setCacheMaxSize, getCache, setCache, isFresh, clearCache, fetchShared } from './cache.js';
 
 
 // ── Reactive hooks ────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds LRU (Least Recently Used) eviction to the in-memory response cache. When a new entry is set and the cache exceeds the maximum size (default 100), the least recently used entry is evicted. `getCache` and `isFresh` both promote the accessed entry to most-recently-used, preventing its eviction.

## Changes

- `packages/data/src/cache.ts`: Added `maxSize`, `setCacheMaxSize()`, LRU eviction in `setCache`, promotion in `getCache`
- `packages/data/src/cache.test.ts`: 4 new tests for eviction, promotion via get/isFresh, and re-set promotion
- `packages/data/src/index.ts`: Exported `setCacheMaxSize` and other cache functions

Closes #2034

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable cache size limits with automatic least-recently-used eviction.
  * Cache access now keeps recently used entries from being removed too early.

* **Bug Fixes**
  * Reading cache entries now refreshes their usage so active data stays available longer.
  * Updating an existing cache entry now correctly counts as recent activity.
  * Reducing the cache limit now trims entries down to the new size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->