### PR TITLE
fix(jsx): sync startValue in useCountdown to fix stale reset()

### DIFF
--- a/packages/jsx/src/hooks/useCountdown.test.ts
+++ b/packages/jsx/src/hooks/useCountdown.test.ts
@@ -107,4 +107,39 @@ describe('useCountdown', () => {
 
         destroyFiber(fiber);
     });
+
+    it('reset() restores to the latest startValue, not the mount-time value', () => {
+        const fiber = createFiber();
+
+        // Mount with startValue=10
+        renderWithFiber(fiber, () => useCountdown(10));
+
+        // Re-render with a new startValue=20 (countdown is idle, not running)
+        renderWithFiber(fiber, () => useCountdown(20));
+
+        // Trigger effects so the sync useEffect runs
+        const [, controls] = renderWithFiber(fiber, () => useCountdown(20));
+        controls.reset();
+
+        // Re-render to pick up the new count
+        const [count] = renderWithFiber(fiber, () => useCountdown(20));
+        expect(count).toBe(20);
+
+        destroyFiber(fiber);
+    });
+
+    it('count syncs to new startValue when not running', () => {
+        const fiber = createFiber();
+
+        // Mount with startValue=5
+        renderWithFiber(fiber, () => useCountdown(5));
+
+        // Re-render with startValue=15 while idle
+        renderWithFiber(fiber, () => useCountdown(15));
+        const [count] = renderWithFiber(fiber, () => useCountdown(15));
+
+        expect(count).toBe(15);
+
+        destroyFiber(fiber);
+    });
 });

--- a/packages/jsx/src/hooks/useCountdown.ts
+++ b/packages/jsx/src/hooks/useCountdown.ts
@@ -33,6 +33,16 @@ export function useCountdown(
     const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
     const startValueRef = useRef(startValue);
 
+    // Sync startValueRef and count whenever startValue changes between renders.
+    // Without this, reset() always restores the mount-time value and start()
+    // cannot restart after the countdown finishes if the caller updates startValue.
+    useEffect(() => {
+        startValueRef.current = startValue;
+        if (!isRunning) {
+            setCount(startValue);
+        }
+    }, [startValue]);
+
     useEffect(() => {
         if (isRunning) {
             intervalRef.current = setInterval(() => {


### PR DESCRIPTION
## Description

`useCountdown` stored `startValue` in a `useRef` once at mount and never synced it on subsequent renders. This caused `reset()` to always restore the original mount-time value instead of the latest `startValue`, and prevented `start()` from re-arming after the countdown reached zero when the parent passed a new `startValue`. This PR adds a `useEffect` to sync `startValueRef` and `count` whenever `startValue` changes while the countdown is idle.

## Related Issue

Closes #2041 

## Which package(s)?

`@termuijs/jsx`

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____](https://gssoc.girlscript.org/profile/daed37c5-b1cd-491d-a0bf-f46a00e1c44c`

## Screenshots / Recordings (UI changes)

N/A — this is a hook logic fix with no visual output.

## Notes for the Reviewer

**Root cause:** `const startValueRef = useRef(startValue)` on line 34 of `useCountdown.ts` was never updated after mount. The fix adds:

```ts
useEffect(() => {
    startValueRef.current = startValue;
    if (!isRunning) {
        setCount(startValue);
    }
}, [startValue]);


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Countdown values now stay in sync with the latest starting value after the component updates.
  * Resetting a paused or idle countdown now returns to the most recently provided start value.
  * When the countdown is not running, updating the starting value is reflected immediately in the displayed count.
* **Tests**
  * Added coverage for updated reset behavior and idle re-render handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->