### PR TITLE
Feat/2043 typing indicator

### DIFF
--- a/packages/widgets/src/display/TypingIndicator.test.ts
+++ b/packages/widgets/src/display/TypingIndicator.test.ts
@@ -20,8 +20,8 @@ describe('TypingIndicator', () => {
         indicator.updateRect({ x: 0, y: 0, width: 10, height: 1 });
         indicator.render(screen);
 
-        const row = screen.back[0].map(c => c.char).join('');
-        expect(row).toContain('          '); // Empty
+        const row = screen.back[0].map(c => c.char).join('').slice(0, 10);
+        expect(row).toBe('          '); // Empty
     });
 
     it('animates frames when started', () => {
@@ -56,30 +56,32 @@ describe('TypingIndicator', () => {
         // Stop it
         indicator.stop();
         expect(indicator.isRunning()).toBe(false);
-        screen = new Screen(20, 5);
         indicator.render(screen);
-        row = screen.back[0].map(c => c.char).join('').trim();
-        expect(row).toBe(''); // Should clear text when stopped
+        row = screen.back[0].map(c => c.char).join('').slice(0, 10);
+        expect(row).toBe('          '); // Should clear text when stopped
     });
 
     it('respects caps.motion (reduced motion)', () => {
-        // Mock caps.motion to be false
-        vi.spyOn(caps, 'motion', 'get').mockReturnValue(false);
+        const originalMotion = caps.motion;
+        Object.defineProperty(caps, 'motion', { value: false, configurable: true });
+        try {
+            const indicator = new TypingIndicator({}, { fallbackText: 'Typing...' });
+            indicator.updateRect({ x: 0, y: 0, width: 15, height: 1 });
+            
+            indicator.start();
+            indicator.render(screen);
 
-        const indicator = new TypingIndicator({}, { fallbackText: 'Typing...' });
-        indicator.updateRect({ x: 0, y: 0, width: 15, height: 1 });
-        
-        indicator.start();
-        indicator.render(screen);
+            let row = screen.back[0].map(c => c.char).join('').trim();
+            expect(row).toBe('Typing...');
 
-        let row = screen.back[0].map(c => c.char).join('').trim();
-        expect(row).toBe('Typing...');
-
-        // Advancing time should not change anything when motion is disabled
-        vi.advanceTimersByTime(500);
-        indicator.render(screen);
-        row = screen.back[0].map(c => c.char).join('').trim();
-        expect(row).toBe('Typing...');
+            // Advancing time should not change anything when motion is disabled
+            vi.advanceTimersByTime(500);
+            indicator.render(screen);
+            row = screen.back[0].map(c => c.char).join('').trim();
+            expect(row).toBe('Typing...');
+        } finally {
+            Object.defineProperty(caps, 'motion', { value: originalMotion, configurable: true });
+        }
     });
 
     it('clears interval on unmount', () => {

--- a/packages/widgets/src/display/TypingIndicator.test.ts
+++ b/packages/widgets/src/display/TypingIndicator.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { Screen, caps } from '@termuijs/core';
+import { TypingIndicator } from './TypingIndicator.js';
+
+describe('TypingIndicator', () => {
+    let screen: Screen;
+
+    beforeEach(() => {
+        screen = new Screen(20, 5);
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it('renders empty when stopped', () => {
+        const indicator = new TypingIndicator();
+        indicator.updateRect({ x: 0, y: 0, width: 10, height: 1 });
+        indicator.render(screen);
+
+        const row = screen.back[0].map(c => c.char).join('');
+        expect(row).toContain('          '); // Empty
+    });
+
+    it('animates frames when started', () => {
+        const indicator = new TypingIndicator({ speedMs: 100 });
+        indicator.updateRect({ x: 0, y: 0, width: 10, height: 1 });
+        
+        indicator.start();
+        expect(indicator.isRunning()).toBe(true);
+        indicator.render(screen);
+
+        let row = screen.back[0].map(c => c.char).join('').trim();
+        expect(row).toBe(''); // Initial frame is empty
+
+        // Advance 100ms
+        vi.advanceTimersToNextTimer();
+        indicator.render(screen);
+        row = screen.back[0].map(c => c.char).join('').trim();
+        expect(row).toBe('.');
+
+        // Advance 100ms
+        vi.advanceTimersToNextTimer();
+        indicator.render(screen);
+        row = screen.back[0].map(c => c.char).join('').trim();
+        expect(row).toBe('..');
+
+        // Advance 100ms
+        vi.advanceTimersToNextTimer();
+        indicator.render(screen);
+        row = screen.back[0].map(c => c.char).join('').trim();
+        expect(row).toBe('...');
+
+        // Stop it
+        indicator.stop();
+        expect(indicator.isRunning()).toBe(false);
+        screen = new Screen(20, 5);
+        indicator.render(screen);
+        row = screen.back[0].map(c => c.char).join('').trim();
+        expect(row).toBe(''); // Should clear text when stopped
+    });
+
+    it('respects caps.motion (reduced motion)', () => {
+        // Mock caps.motion to be false
+        vi.spyOn(caps, 'motion', 'get').mockReturnValue(false);
+
+        const indicator = new TypingIndicator({ fallbackText: 'Typing...' });
+        indicator.updateRect({ x: 0, y: 0, width: 15, height: 1 });
+        
+        indicator.start();
+        indicator.render(screen);
+
+        let row = screen.back[0].map(c => c.char).join('').trim();
+        expect(row).toBe('Typing...');
+
+        // Advancing time should not change anything when motion is disabled
+        vi.advanceTimersByTime(500);
+        indicator.render(screen);
+        row = screen.back[0].map(c => c.char).join('').trim();
+        expect(row).toBe('Typing...');
+    });
+
+    it('clears interval on unmount', () => {
+        const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+        const indicator = new TypingIndicator();
+        indicator.start();
+        
+        indicator.unmount();
+        
+        expect(clearIntervalSpy).toHaveBeenCalled();
+    });
+});

--- a/packages/widgets/src/display/TypingIndicator.test.ts
+++ b/packages/widgets/src/display/TypingIndicator.test.ts
@@ -25,7 +25,7 @@ describe('TypingIndicator', () => {
     });
 
     it('animates frames when started', () => {
-        const indicator = new TypingIndicator({ speedMs: 100 });
+        const indicator = new TypingIndicator({}, { speedMs: 100 });
         indicator.updateRect({ x: 0, y: 0, width: 10, height: 1 });
         
         indicator.start();
@@ -66,7 +66,7 @@ describe('TypingIndicator', () => {
         // Mock caps.motion to be false
         vi.spyOn(caps, 'motion', 'get').mockReturnValue(false);
 
-        const indicator = new TypingIndicator({ fallbackText: 'Typing...' });
+        const indicator = new TypingIndicator({}, { fallbackText: 'Typing...' });
         indicator.updateRect({ x: 0, y: 0, width: 15, height: 1 });
         
         indicator.start();

--- a/packages/widgets/src/display/TypingIndicator.test.ts
+++ b/packages/widgets/src/display/TypingIndicator.test.ts
@@ -5,12 +5,17 @@ import { TypingIndicator } from './TypingIndicator.js';
 describe('TypingIndicator', () => {
     let screen: Screen;
 
+    let originalMotion: boolean;
+
     beforeEach(() => {
         screen = new Screen(20, 5);
         vi.useFakeTimers();
+        originalMotion = caps.motion;
+        Object.defineProperty(caps, 'motion', { value: true, configurable: true });
     });
 
     afterEach(() => {
+        Object.defineProperty(caps, 'motion', { value: originalMotion, configurable: true });
         vi.useRealTimers();
         vi.restoreAllMocks();
     });
@@ -62,26 +67,22 @@ describe('TypingIndicator', () => {
     });
 
     it('respects caps.motion (reduced motion)', () => {
-        const originalMotion = caps.motion;
         Object.defineProperty(caps, 'motion', { value: false, configurable: true });
-        try {
-            const indicator = new TypingIndicator({}, { fallbackText: 'Typing...' });
-            indicator.updateRect({ x: 0, y: 0, width: 15, height: 1 });
-            
-            indicator.start();
-            indicator.render(screen);
+        
+        const indicator = new TypingIndicator({}, { fallbackText: 'Typing...' });
+        indicator.updateRect({ x: 0, y: 0, width: 15, height: 1 });
+        
+        indicator.start();
+        indicator.render(screen);
 
-            let row = screen.back[0].map(c => c.char).join('').trim();
-            expect(row).toBe('Typing...');
+        let row = screen.back[0].map(c => c.char).join('').trim();
+        expect(row).toBe('Typing...');
 
-            // Advancing time should not change anything when motion is disabled
-            vi.advanceTimersByTime(500);
-            indicator.render(screen);
-            row = screen.back[0].map(c => c.char).join('').trim();
-            expect(row).toBe('Typing...');
-        } finally {
-            Object.defineProperty(caps, 'motion', { value: originalMotion, configurable: true });
-        }
+        // Advancing time should not change anything when motion is disabled
+        vi.advanceTimersByTime(500);
+        indicator.render(screen);
+        row = screen.back[0].map(c => c.char).join('').trim();
+        expect(row).toBe('Typing...');
     });
 
     it('clears interval on unmount', () => {

--- a/packages/widgets/src/display/TypingIndicator.ts
+++ b/packages/widgets/src/display/TypingIndicator.ts
@@ -1,0 +1,112 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — TypingIndicator widget
+// ─────────────────────────────────────────────────────
+
+import { type Screen, type Style, type Color, styleToCellAttrs, stringWidth, caps } from '@termuijs/core';
+import { Widget } from '../base/Widget.js';
+
+export interface TypingIndicatorOptions {
+    /** Speed of the animation in milliseconds. Default: 300. */
+    speedMs?: number;
+    /** Text to display when motion is disabled. Default: "Typing..." */
+    fallbackText?: string;
+    /** Color of the indicator dots/text. Default: brightBlack. */
+    color?: Color;
+}
+
+const FRAMES = ['', '.', '..', '...'];
+
+/**
+ * TypingIndicator — an animated indicator typically used in chat UIs.
+ * 
+ * - Cycles through an animation (e.g., `.`, `..`, `...`) on a timer.
+ * - Respects `caps.motion`. If disabled, displays static `fallbackText`.
+ */
+export class TypingIndicator extends Widget {
+    private _speedMs: number;
+    private _fallbackText: string;
+    private _color: Color;
+    
+    private _frameIndex = 0;
+    private _running = false;
+    private _intervalId: ReturnType<typeof setInterval> | undefined;
+
+    constructor(style: Partial<Style> = {}, opts: TypingIndicatorOptions = {}) {
+        super(style);
+        this._speedMs = opts.speedMs ?? 300;
+        this._fallbackText = opts.fallbackText ?? 'Typing...';
+        this._color = opts.color ?? { type: 'named', name: 'brightBlack' };
+    }
+
+    /** Start the typing animation. */
+    start(): void {
+        if (this._running) return;
+        this._running = true;
+
+        if (!caps.motion) {
+            this.markDirty();
+            return;
+        }
+
+        this._intervalId = setInterval(() => this._tick(), this._speedMs);
+        this.markDirty();
+    }
+
+    /** Stop the typing animation. */
+    stop(): void {
+        if (!this._running) return;
+        this._running = false;
+        this._clearInterval();
+        this.markDirty();
+    }
+
+    /** Return true if currently running. */
+    isRunning(): boolean {
+        return this._running;
+    }
+
+    destroy(): void {
+        this.stop();
+    }
+
+    unmount(): void {
+        this._clearInterval();
+        super.unmount();
+    }
+
+    private _tick(): void {
+        this._frameIndex = (this._frameIndex + 1) % FRAMES.length;
+        this.markDirty();
+    }
+
+    private _clearInterval(): void {
+        if (this._intervalId !== undefined) {
+            clearInterval(this._intervalId);
+            this._intervalId = undefined;
+        }
+    }
+
+    protected _renderSelf(screen: Screen): void {
+        const { x, y, width, height } = this._getContentRect();
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = { ...styleToCellAttrs(this._style), fg: this._color };
+
+        if (!caps.motion) {
+            // Render fallback if reduced motion is preferred
+            const display = this._running ? this._fallbackText : '';
+            if (display) {
+                const len = Math.min(stringWidth(display), width);
+                screen.writeString(x, y, display.slice(0, len), attrs);
+            }
+            return;
+        }
+
+        if (this._running) {
+            const frame = FRAMES[this._frameIndex];
+            const padded = frame.padEnd(3, ' ');
+            const len = Math.min(stringWidth(padded), width);
+            screen.writeString(x, y, padded.slice(0, len), attrs);
+        }
+    }
+}

--- a/packages/widgets/src/display/TypingIndicator.ts
+++ b/packages/widgets/src/display/TypingIndicator.ts
@@ -67,6 +67,7 @@ export class TypingIndicator extends Widget {
 
     destroy(): void {
         this.stop();
+        super.destroy();
     }
 
     unmount(): void {
@@ -95,18 +96,15 @@ export class TypingIndicator extends Widget {
         if (!caps.motion) {
             // Render fallback if reduced motion is preferred
             const display = this._running ? this._fallbackText : '';
-            if (display) {
-                const len = Math.min(stringWidth(display), width);
-                screen.writeString(x, y, display.slice(0, len), attrs);
-            }
+            const padded = display.padEnd(width, ' ');
+            const len = Math.min(stringWidth(padded), width);
+            screen.writeString(x, y, padded.slice(0, len), attrs);
             return;
         }
 
-        if (this._running) {
-            const frame = FRAMES[this._frameIndex];
-            const padded = frame.padEnd(3, ' ');
-            const len = Math.min(stringWidth(padded), width);
-            screen.writeString(x, y, padded.slice(0, len), attrs);
-        }
+        const frame = this._running ? FRAMES[this._frameIndex] : '';
+        const padded = frame.padEnd(3, ' ');
+        const len = Math.min(stringWidth(padded), width);
+        screen.writeString(x, y, padded.slice(0, len), attrs);
     }
 }

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -25,6 +25,8 @@ export { ChatMessage } from './display/ChatMessage.js';
 export type { ChatMessageOptions, MessageRole } from './display/ChatMessage.js';
 export { ChatThread } from './display/ChatThread.js';
 export type { ThreadMessage } from './display/ChatThread.js';
+export { TypingIndicator } from './display/TypingIndicator.js';
+export type { TypingIndicatorOptions } from './display/TypingIndicator.js';
 export { ToolCall, ToolApproval } from './display/ToolCall.js';
 export type { ToolCallOptions, ToolApprovalOptions, ToolCallStatus } from './display/ToolCall.js';
 export { Canvas } from './display/Canvas.js';


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

This PR adds the `TypingIndicator` widget to `@termuijs/widgets` to provide an animated, conversational CLI component. It cycles through frames (`.`, `..`, `...`) using an internal timer, correctly cleans up its rendering artifacts on the screen buffer, and falls back to a static string when reduced motion is requested.

## Related Issue

Closes #2043

## Which package(s)?

`@termuijs/widgets`

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [x] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/Unnati1007` 


## Notes for the Reviewer

- **Accessibility Handled:** Added a strict check against `caps.motion` to disable the `setInterval` completely and gracefully fall back to a static `"Typing..."` text when reduced motion is preferred by the terminal environment.
- **Rendering Artifacts Handled:** The `...` dots properly wipe previous ticks out by using `String.padEnd(3, ' ')` to avoid ghost characters in the terminal cell grid loop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new TypingIndicator widget with animated “typing” frames and configurable speed, fallback text, and color.
  * Respects reduced-motion settings by switching to a static fallback instead of animating.
  * Constrains output to the widget’s available width and manages its timer lifecycle (start/stop, unmount, destroy).
* **Tests**
  * Added a Vitest suite covering initial empty state, frame animation over time, reduced-motion rendering, and cleanup on unmount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->