### PR TITLE
fix(jsx): clamp selectedIndex when itemCount shrinks in useKeyboardNa…

### DIFF
--- a/packages/jsx/src/hooks/useKeyboardNavigation.test.ts
+++ b/packages/jsx/src/hooks/useKeyboardNavigation.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { caps, createKeyEvent } from '@termuijs/core';
-import { createFiber, setCurrentFiber, clearCurrentFiber, setRequestRender } from '../hooks.js';
+import { createFiber, setCurrentFiber, clearCurrentFiber, setRequestRender, runEffects } from '../hooks.js';
 import { useKeyboardNavigation } from './useKeyboardNavigation.js';
 
 function mockKeyEvent(key: string, shift = false) {
@@ -34,8 +34,10 @@ describe('useKeyboardNavigation', () => {
         setCurrentFiber(fiber);
         const res = useKeyboardNavigation(opts);
         clearCurrentFiber();
+        runEffects(fiber);
         return res;
     };
+
 
     it('initializes with selectedIndex 0', () => {
         const result = renderHook({ itemCount: 5 });
@@ -171,5 +173,20 @@ describe('useKeyboardNavigation', () => {
         } finally {
             spy.mockRestore();
         }
+    });
+
+    it('clamps selectedIndex when itemCount shrinks', () => {
+        let result = renderHook({ itemCount: 5 });
+
+        // Select index 4
+        fiber.onInput?.(mockKeyEvent('end'));
+        result = renderHook({ itemCount: 5 });
+        expect(result.selectedIndex).toBe(4);
+
+        // Shrink itemCount to 2
+        result = renderHook({ itemCount: 2 });
+        // Trigger effects so the sync useEffect runs
+        result = renderHook({ itemCount: 2 });
+        expect(result.selectedIndex).toBe(1);
     });
 });

--- a/packages/jsx/src/hooks/useKeyboardNavigation.ts
+++ b/packages/jsx/src/hooks/useKeyboardNavigation.ts
@@ -14,7 +14,7 @@
 //   }
 // ─────────────────────────────────────────────────────
 
-import { useState, useInput } from '../hooks.js';
+import { useState, useInput, useEffect } from '../hooks.js';
 import { normalizeNavigationKey } from '@termuijs/core';
 
 export interface KeyboardNavigationOptions {
@@ -72,6 +72,11 @@ export function useKeyboardNavigation({
     onSelect,
 }: KeyboardNavigationOptions): KeyboardNavigationResult {
     const [selectedIndex, setSelectedIndex] = useState(0);
+
+    // If the list shrinks, ensure the selected index doesn't stay out of bounds
+    useEffect(() => {
+        setSelectedIndex((prev) => Math.max(0, Math.min(Math.max(0, itemCount - 1), prev)));
+    }, [itemCount]);
 
     useInput((key, event) => {
         if (itemCount === 0) return;


### PR DESCRIPTION
## Description

`useKeyboardNavigation` didn't clamp the `selectedIndex` when the underlying array shrunk (e.g. elements were removed from a list). If a user was at index 4 and the list shrunk to 2 elements, the index remained 4, causing out-of-bounds errors when trying to render the selected item. This adds a `useEffect` to safely clamp `selectedIndex` to `Math.max(0, itemCount - 1)` whenever `itemCount` changes.

## Related Issue

Closes #2045 

## Which package(s)?

`@termuijs/jsx`

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: https://gssoc.girlscript.org/profile/daed37c5-b1cd-491d-a0bf-f46a00e1c44c

## Screenshots / Recordings (UI changes)

N/A — hook logic fix.

## Notes for the Reviewer

**Root cause:** The `useState(0)` selected index in `useKeyboardNavigation.ts` was not bounded when the list size dynamically reduced.

**Fix**: Added a simple `useEffect`:
```ts
// If the list shrinks, ensure the selected index doesn't stay out of bounds
useEffect(() => {
    setSelectedIndex((prev) => Math.max(0, Math.min(Math.max(0, itemCount - 1), prev)));
}, [itemCount]);


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation so the current selection stays within valid bounds when the number of items changes.
  * Prevented out-of-range selection states when a list becomes smaller.
* **Tests**
  * Added coverage for shrinking item lists to confirm the selected item is adjusted correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->