### PR TITLE
fix(widgets): prevent non-plain objects from being traversed in JSONView #2047

### DIFF
--- a/packages/widgets/src/display/JSONView.test.ts
+++ b/packages/widgets/src/display/JSONView.test.ts
@@ -243,4 +243,13 @@ describe('jsonToTree() helper', () => {
         expect(labels).toContain('foo: 1');
         expect(labels).toContain('bar: 2');
     });
+
+    it('handles non-plain objects (e.g. Date) as string fallback', () => {
+        const date = new Date('2026-07-05T08:00:00.000Z');
+        const node = jsonToTree(date, 'created');
+        const data = node.data as JSONNodeData;
+        expect(data.type).toBe('unknown');
+        expect(node.label).toContain('created:');
+        expect(node.label).toContain(date.toString());
+    });
 });

--- a/packages/widgets/src/display/JSONView.ts
+++ b/packages/widgets/src/display/JSONView.ts
@@ -90,7 +90,7 @@ export function jsonToTree(value: unknown, key?: string): TreeNode {
         };
     }
 
-    if (typeof value === 'object') {
+    if (value && typeof value === 'object' && (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null)) {
         const obj = value as Record<string, unknown>;
         const children = Object.keys(obj).map(k => jsonToTree(obj[k], k));
         return {


### PR DESCRIPTION

  ### Description
  Restricts the object traversal check in `jsonToTree` to plain objects (objects whose prototype is `Object.prototype` or `null`). This allows structured non-plain objects like `Date` to correctly fall through to their string representations.

  ### Changes
  * Added prototype validation `(Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null)` to the object type check in `JSONView.ts`.
  * Added unit test in `JSONView.test.ts` verifying `Date` is formatted as string fallback.

  Closes #2047

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how complex values are displayed in JSON views, so non-plain objects like dates now appear as readable text instead of being treated as expandable containers.
  * Ensured object entries with custom prototypes are shown consistently with their key and string value.
* **Tests**
  * Added coverage for non-plain object handling in JSON view rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->