### PR TITLE
fix(widgets): clamp top border language label length in Code widget #2049

### DIFF
--- a/packages/widgets/src/display/Code.test.ts
+++ b/packages/widgets/src/display/Code.test.ts
@@ -62,4 +62,15 @@ describe('Code', () => {
         expect(screen.back[1][4].char).toBe('w');
         expect(screen.back[1][8].char).toBe('d');
     });
+
+    it('clamps language label when width is narrow', () => {
+        const code = new Code('hello', {}, { language: 'typescript' });
+        // Width of 5 only allows a 2-character label "[t"
+        code.updateRect({ x: 0, y: 0, width: 5, height: 4 });
+        const screen = new Screen(5, 4);
+        code.render(screen);
+        expect(screen.back[0][2].char).toBe('[');
+        expect(screen.back[0][3].char).toBe('t');
+        expect(screen.back[0][4].char).toBe('╮'); // topRight corner (width-1 index)
+    });
 });

--- a/packages/widgets/src/display/Code.ts
+++ b/packages/widgets/src/display/Code.ts
@@ -77,7 +77,10 @@ export class Code extends Widget {
         const cellStyle = { fg: borderFg };
 
         // Top edge with language label
-        const label = this._language ? `[${this._language}]` : '';
+        const availableLabelWidth = width - 3;
+        const label = this._language && availableLabelWidth > 0
+            ? `[${this._language}]`.slice(0, availableLabelWidth)
+            : '';
 
         screen.setCell(x, y, { char: chars.topLeft, ...cellStyle });
 


### PR DESCRIPTION


  ### Description
  Introduces boundary checking for the language label in the `Code` widget. Clamps the label length to the maximum available width (`width - 3`) and completely disables label drawing if the widget is too narrow.

  ### Changes
  * Added `availableLabelWidth` calculation and sliced `_language` to it in `Code.ts`.
  * Added unit test verifying label truncation for narrow layouts in `Code.test.ts`.

  Closes #2049

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code block border labels so language tags now truncate gracefully in narrow spaces instead of overflowing.
  * Prevented label rendering when the available width is too small, keeping the border layout clean.
* **Tests**
  * Added coverage for narrow-width rendering to verify the label and border corner display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->