### PR TITLE
fix(widgets): extract Avatar initials using Unicode code points #2051

### DIFF
--- a/packages/widgets/src/display/Avatar.test.ts
+++ b/packages/widgets/src/display/Avatar.test.ts
@@ -112,4 +112,19 @@ describe('Avatar', () => {
         const rendered = screen.back[0].map(c => c.char).join('').trim();
         expect(rendered).toBe('[]');
     });
+
+    it('handles unicode multi-byte characters (emojis) correctly', async () => {
+        const { Avatar } = await import('./Avatar.js');
+        const { Screen, caps } = await import('@termuijs/core');
+        
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+        
+        const a = new Avatar('🌟 Star');
+        a.updateRect({ x: 0, y: 0, width: 10, height: 1 });
+        const screen = new Screen(10, 1);
+        a.render(screen);
+        
+        const rendered = screen.back[0].map(c => c.char).join('').trim();
+        expect(rendered).toContain('[🌟S]');
+    });
 });

--- a/packages/widgets/src/display/Avatar.ts
+++ b/packages/widgets/src/display/Avatar.ts
@@ -66,9 +66,11 @@ export class Avatar extends Widget {
         if (parts.length === 0 || parts[0] === '') return '';
         let init = '';
         if (parts.length === 1) {
-            init = parts[0].substring(0, 2).toUpperCase();
+            init = Array.from(parts[0]).slice(0, 2).join('').toUpperCase();
         } else {
-            init = (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+            const firstChar = Array.from(parts[0])[0] || '';
+            const lastChar = Array.from(parts[parts.length - 1])[0] || '';
+            init = (firstChar + lastChar).toUpperCase();
         }
         if (!caps.unicode) {
             init = init.replace(/[^\x00-\x7F]/g, '?');


### PR DESCRIPTION


  ### Description
  Replaces direct index/substring lookup on name strings in `_extractInitials()` with `Array.from()` conversions. This guarantees that multi-byte code points (like emoji symbols) are treated as single characters, preventing surrogate pair splitting.

  ### Changes
  * Used `Array.from()` to extract code points in `Avatar.ts`'s `_extractInitials()`.
  * Added unit test checking emoji-name initials rendering in `Avatar.test.ts`.

  Closes #2051