### PR TITLE
fix(widgets): support KeyEvent in KeyValue handleKey signature #2053

### DIFF
--- a/packages/widgets/src/data/KeyValue.test.ts
+++ b/packages/widgets/src/data/KeyValue.test.ts
@@ -187,6 +187,20 @@ describe('KeyValue', () => {
                 kv.handleKey('unknown');
             }).not.toThrow();
         });
+
+        it('handles KeyEvent objects correctly', () => {
+            const kv = new KeyValue({
+                name: 'Alice',
+                age: 30
+            });
+            kv.isFocused = true;
+            
+            kv.handleKey({ key: 'down' } as any);
+            expect((kv as any)._selectedIndex).toBe(1);
+
+            kv.handleKey({ key: 'up' } as any);
+            expect((kv as any)._selectedIndex).toBe(0);
+        });
     });
 
     // Edge cases

--- a/packages/widgets/src/data/KeyValue.ts
+++ b/packages/widgets/src/data/KeyValue.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets — KeyValue widget
 // ─────────────────────────────────────────────────────
 
-import { type Screen, type Style, styleToCellAttrs, stringWidth, caps } from '@termuijs/core';
+import { type Screen, type Style, styleToCellAttrs, stringWidth, caps, type KeyEvent } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
 export interface KeyValuePair {
@@ -126,13 +126,13 @@ export class KeyValue extends Widget {
         }
     }
 
-    handleKey(key: string): void {
-        const lowerKey = key.toLowerCase();
-        if (lowerKey === 'up' || lowerKey === 'k') {
+    handleKey(event: KeyEvent | string): void {
+        const keyName = typeof event === 'string' ? event.toLowerCase() : event.key.toLowerCase();
+        if (keyName === 'up' || keyName === 'k' || keyName === 'arrowup') {
             this.moveUp();
-        } else if (lowerKey === 'down' || lowerKey === 'j') {
+        } else if (keyName === 'down' || keyName === 'j' || keyName === 'arrowdown') {
             this.moveDown();
-        } else if (lowerKey === 'enter' || lowerKey === ' ' || lowerKey === 'space') {
+        } else if (keyName === 'enter' || keyName === ' ' || keyName === 'space') {
             this.toggleSelected();
         }
     }


### PR DESCRIPTION

  ### Description
  Changes the `handleKey` signature of the `KeyValue` widget to accept `KeyEvent | string` for backward compatibility. This aligns the widget with standard framework routing while preserving string-based invocations in existing tests.

  ### Changes
  * Imported `KeyEvent` type from `@termuijs/core` in `KeyValue.ts`.
  * Modified signature to `handleKey(event: KeyEvent | string)`.
  * Added unit tests verifying `KeyEvent` handling.

  Closes #2053