### PR TITLE
fix(widgets): implement destroy in Clock widget to clean up Digits #2055

### DIFF
--- a/packages/widgets/src/display/Clock.test.ts
+++ b/packages/widgets/src/display/Clock.test.ts
@@ -115,4 +115,11 @@ describe('Clock', () => {
         clock.setTime(new Date());
         expect(spy).toHaveBeenCalled();
     });
+
+    it('destroy() destroys the internal Digits widget', () => {
+        const clock = new Clock({ width: 50, height: 3 });
+        const spy = vi.spyOn((clock as any)._digits, 'destroy');
+        clock.destroy();
+        expect(spy).toHaveBeenCalled();
+    });
 });

--- a/packages/widgets/src/display/Clock.ts
+++ b/packages/widgets/src/display/Clock.ts
@@ -84,4 +84,9 @@ export class Clock extends Widget {
             }
         }
     }
+
+    override destroy(): void {
+        this._digits.destroy();
+        super.destroy();
+    }
 }


### PR DESCRIPTION

  ### Description
  Implements the `destroy()` method in `Clock.ts` to forward the destruction signal to the internal `Digits` widget and then delegates to the base `super.destroy()`.

  ### Changes
  * Added `override destroy()` method in `Clock.ts` that invokes `this._digits.destroy()` and `super.destroy()`.
  * Added unit test in `Clock.test.ts` to verify the internal widget's destruction.

  Closes #2055