### PR TITLE
fix(core): prevent _pendingFocusState memory leak by removing stale entries after max retries (#2059)

### DIFF
--- a/packages/core/src/app/App.ts
+++ b/packages/core/src/app/App.ts
@@ -89,6 +89,8 @@ export class App {
     private _widgetById = new Map<string, any>(); // any: Widget shape varies; narrowed at retrieval
     private _hoveredWidgetId: string | null = null;
     private _pendingFocusState = new Map<string, boolean>();
+    private _pendingFocusRetries = new Map<string, number>();
+    private static readonly PENDING_FOCUS_MAX_RETRIES = 5;
 
     private _consecutiveRenderFailures = 0;
     private static readonly MAX_RENDER_FAILURES = 5;
@@ -598,6 +600,15 @@ export class App {
             const stateChanged = this._setWidgetFocused(id, focused);
             if (stateChanged !== null) {
                 this._pendingFocusState.delete(id);
+                this._pendingFocusRetries.delete(id);
+            } else {
+                const retries = this._pendingFocusRetries.get(id) ?? 0;
+                if (retries >= App.PENDING_FOCUS_MAX_RETRIES) {
+                    this._pendingFocusState.delete(id);
+                    this._pendingFocusRetries.delete(id);
+                } else {
+                    this._pendingFocusRetries.set(id, retries + 1);
+                }
             }
         }
     }


### PR DESCRIPTION
## Description

Fixes #2059

`_pendingFocusState` entries were never removed if the widget was destroyed or never
registered, causing unbounded memory growth in long-running applications.

### Changes (`packages/core/src/app/App.ts`)
1. Added `_pendingFocusRetries` Map to track retry count per pending entry
2. Added `PENDING_FOCUS_MAX_RETRIES = 5` static constant
3. In `_applyPendingFocusState()`: entries that return `null` (widget not found) are
   deleted after exceeding max retries, preventing stale entries from accumulating

### Impact
- Prevents unbounded `_pendingFocusState` Map growth in dynamic UIs
- Eliminates stale focus state drift when widgets are destroyed and their IDs reused

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus handling so pending focus changes are retried a limited number of times instead of being retried indefinitely.
  * Focus state is now cleared more reliably once a widget is found or when retries are exhausted, helping prevent stale focus behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->