### PR TITLE
fix(store): prevent state corruption when batch() listener throws during notification (#2060)

### DIFF
--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -117,10 +117,21 @@ function flushBatch(threw: boolean, immediate = false) {
             if (_batchEpoch !== epochAtFlush) return;
             const stores = Array.from(_batchStores.entries());
             _batchStores.clear();
-            for (const [listeners, { prevState, commit }] of stores) {
-                const newState = commit();
-                for (const listener of listeners) {
-                    listener(newState, prevState);
+            const newStates = new Map<Set<any>, any>();
+            for (const [listeners, { commit }] of stores) {
+                newStates.set(listeners, commit());
+            }
+            for (const [listeners, { prevState }] of stores) {
+                const newState = newStates.get(listeners);
+                try {
+                    for (const listener of listeners) {
+                        listener(newState, prevState);
+                    }
+                } catch (e) {
+                    for (const [, entry] of stores) {
+                        entry.rollback();
+                    }
+                    throw e;
                 }
             }
         };


### PR DESCRIPTION
## Description

Fixes #2060

`flushBatch()` committed all store states before notifying listeners. If a listener threw
during notification, the committed state was irrecoverable — permanent data corruption.

### Changes (`packages/store/src/store.ts`)
1. Split commit and notify phases: all commits run first, then all notifications
2. Wrapped listener notification in try-catch
3. On notification failure, all committed stores are rolled back via their `rollback()` function

### Impact
- Listener exceptions during batch notification trigger a full rollback
- Consistent state across all subscribers — no partial application

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch update behavior so store listeners are notified from a consistent snapshot of state.
  * If a listener errors during notification, all batched store updates are now rolled back before the error is rethrown, helping prevent partial updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->