### PR TITLE
fix: clean up Pty process listeners on destroy

### DIFF
--- a/packages/widgets/src/display/Pty.test.ts
+++ b/packages/widgets/src/display/Pty.test.ts
@@ -6,6 +6,35 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { Pty } from './Pty.js';
 import { Screen } from '@termuijs/core';
 
+type MockPtyProcess = {
+    _emitStdout: (data: string) => void;
+    _emitStderr: (data: string) => void;
+    _emitClose: () => void;
+    stdin: { writable: boolean; write: ReturnType<typeof vi.fn> };
+    stdout: {
+        on: (event: string, cb: (...args: unknown[]) => void) => void;
+        removeListener: (event: string, cb: (...args: unknown[]) => void) => void;
+        listenerCount: (event: string) => number;
+    };
+    stderr: {
+        on: (event: string, cb: (...args: unknown[]) => void) => void;
+        removeListener: (event: string, cb: (...args: unknown[]) => void) => void;
+        listenerCount: (event: string) => number;
+    };
+    on: (event: string, cb: (...args: unknown[]) => void) => void;
+    removeListener: (event: string, cb: (...args: unknown[]) => void) => void;
+    listenerCount: (event: string) => number;
+    kill: ReturnType<typeof vi.fn>;
+};
+
+function getMockProcess(pty: Pty): MockPtyProcess {
+    const process = (pty as unknown as { _process: MockPtyProcess | null })._process;
+    if (!process) {
+        throw new Error('Expected Pty to have a spawned process');
+    }
+    return process;
+}
+
 // Mock child_process to avoid actually spawning shells during tests
 vi.mock('node:child_process', () => {
     return {
@@ -88,7 +117,7 @@ describe('Pty', () => {
         pty.updateRect({ x: 0, y: 0, width: 20, height: 5 });
         
         // Grab the mocked process to simulate output
-        const mockProcess = (pty as any)._process;
+        const mockProcess = getMockProcess(pty);
         mockProcess._emitStdout('Hello terminal\nSecond line');
         
         pty.render(screen);
@@ -108,7 +137,7 @@ describe('Pty', () => {
     
         pty.updateRect({ x: 0, y: 0, width: 20, height: 5 });
     
-        const mockProcess = (pty as any)._process;
+        const mockProcess = getMockProcess(pty);
     
         mockProcess._emitStderr('Error occurred');
     
@@ -125,7 +154,7 @@ describe('Pty', () => {
     
         pty.updateRect({ x: 0, y: 0, width: 30, height: 5 });
     
-        const mockProcess = (pty as any)._process;
+        const mockProcess = getMockProcess(pty);
     
         mockProcess._emitClose();
     
@@ -143,7 +172,7 @@ describe('Pty', () => {
         const screen = new Screen(20, 5);
         pty.updateRect({ x: 0, y: 0, width: 20, height: 5 });
         
-        const mockProcess = (pty as any)._process;
+        const mockProcess = getMockProcess(pty);
         // Output with red text ANSI
         mockProcess._emitStdout('\x1b[31mColored text\x1b[0m');
         
@@ -155,7 +184,7 @@ describe('Pty', () => {
 
     it('pipes keys to stdin', () => {
         const pty = new Pty();
-        const mockProcess = (pty as any)._process;
+        const mockProcess = getMockProcess(pty);
         
         pty.handleKey({ key: 'a', raw: Buffer.from('a'), ctrl: false, alt: false, shift: false } as any);
         expect(mockProcess.stdin.write).toHaveBeenCalledWith(Buffer.from('a'));
@@ -167,7 +196,7 @@ describe('Pty', () => {
     it('returns false when stdin is not writable', () => {
         const pty = new Pty();
     
-        const mockProcess = (pty as any)._process;
+        const mockProcess = getMockProcess(pty);
     
         mockProcess.stdin.writable = false;
     
@@ -185,11 +214,11 @@ describe('Pty', () => {
 
     it('cleans up process on destroy', () => {
         const pty = new Pty();
-        const mockProcess = (pty as any)._process;
+        const mockProcess = getMockProcess(pty);
         
         pty.destroy();
         expect(mockProcess.kill).toHaveBeenCalled();
-        expect((pty as any)._process).toBeNull();
+        expect((pty as unknown as { _process: MockPtyProcess | null })._process).toBeNull();
     });
 
     it('ignores late process output after destroy', () => {
@@ -198,7 +227,7 @@ describe('Pty', () => {
         pty.updateRect({ x: 0, y: 0, width: 20, height: 5 });
         pty.render(screen);
 
-        const mockProcess = (pty as any)._process;
+        const mockProcess = getMockProcess(pty);
         pty.destroy();
 
         mockProcess._emitStdout('late output');
@@ -219,7 +248,7 @@ describe('Pty', () => {
     it('trims buffer to the last 1000 lines', () => {
         const pty = new Pty();
     
-        const mockProcess = (pty as any)._process;
+        const mockProcess = getMockProcess(pty);
     
         const output =
             Array.from({ length: 1100 }, (_, i) => `line-${i}`).join('\n');

--- a/packages/widgets/src/display/Pty.test.ts
+++ b/packages/widgets/src/display/Pty.test.ts
@@ -10,33 +10,53 @@ import { Screen } from '@termuijs/core';
 vi.mock('node:child_process', () => {
     return {
         spawn: vi.fn().mockImplementation(() => {
-            let stdoutCb: any;
-            let stderrCb: any;
-            let closeCb: any;
-            
+            const listeners = {
+                stdoutData: new Set<(...args: unknown[]) => void>(),
+                stderrData: new Set<(...args: unknown[]) => void>(),
+                close: new Set<(...args: unknown[]) => void>(),
+            };
+
             return {
                 stdout: {
-                    on: (event: string, cb: any) => { if (event === 'data') stdoutCb = cb; }
+                    on: (event: string, cb: (...args: unknown[]) => void) => {
+                        if (event === 'data') listeners.stdoutData.add(cb);
+                    },
+                    removeListener: (event: string, cb: (...args: unknown[]) => void) => {
+                        if (event === 'data') listeners.stdoutData.delete(cb);
+                    },
+                    listenerCount: (event: string) => event === 'data' ? listeners.stdoutData.size : 0,
                 },
                 stderr: {
-                    on: (event: string, cb: any) => { if (event === 'data') stderrCb = cb; }
+                    on: (event: string, cb: (...args: unknown[]) => void) => {
+                        if (event === 'data') listeners.stderrData.add(cb);
+                    },
+                    removeListener: (event: string, cb: (...args: unknown[]) => void) => {
+                        if (event === 'data') listeners.stderrData.delete(cb);
+                    },
+                    listenerCount: (event: string) => event === 'data' ? listeners.stderrData.size : 0,
                 },
                 stdin: {
                     writable: true,
                     write: vi.fn()
                 },
-                on: (event: string, cb: any) => { if (event === 'close') closeCb = cb; },
+                on: (event: string, cb: (...args: unknown[]) => void) => {
+                    if (event === 'close') listeners.close.add(cb);
+                },
+                removeListener: (event: string, cb: (...args: unknown[]) => void) => {
+                    if (event === 'close') listeners.close.delete(cb);
+                },
+                listenerCount: (event: string) => event === 'close' ? listeners.close.size : 0,
                 kill: vi.fn(),
                 
                 // Helper to simulate output in tests
                 _emitStdout: (data: string) => {
-                    if (stdoutCb) stdoutCb(Buffer.from(data));
+                    for (const cb of listeners.stdoutData) cb(Buffer.from(data));
                 },
                 _emitStderr: (data: string) => {
-                    if (stderrCb) stderrCb(Buffer.from(data));
+                    for (const cb of listeners.stderrData) cb(Buffer.from(data));
                 },
                 _emitClose: () => {
-                    if (closeCb) closeCb();
+                    for (const cb of listeners.close) cb();
                 }
             };
         })
@@ -170,6 +190,30 @@ describe('Pty', () => {
         pty.destroy();
         expect(mockProcess.kill).toHaveBeenCalled();
         expect((pty as any)._process).toBeNull();
+    });
+
+    it('ignores late process output after destroy', () => {
+        const pty = new Pty();
+        const screen = new Screen(20, 5);
+        pty.updateRect({ x: 0, y: 0, width: 20, height: 5 });
+        pty.render(screen);
+
+        const mockProcess = (pty as any)._process;
+        pty.destroy();
+
+        mockProcess._emitStdout('late output');
+        mockProcess._emitStderr('late stderr');
+        mockProcess._emitClose();
+
+        pty.render(screen);
+
+        const output = screen.back
+            .map(row => row.map(c => c.char).join(''))
+            .join('\n');
+
+        expect(output).not.toContain('late output');
+        expect(output).not.toContain('late stderr');
+        expect(output).not.toContain('[Process Exited]');
     });
 
     it('trims buffer to the last 1000 lines', () => {

--- a/packages/widgets/src/display/Pty.ts
+++ b/packages/widgets/src/display/Pty.ts
@@ -22,6 +22,15 @@ export class Pty extends Widget {
     private _process: ChildProcessWithoutNullStreams | null = null;
     private _lines: string[] = [];
     private _autoScroll = true;
+    private readonly _onStdoutData = (data: Buffer): void => {
+        this._handleOutput(data.toString());
+    };
+    private readonly _onStderrData = (data: Buffer): void => {
+        this._handleOutput(data.toString());
+    };
+    private readonly _onClose = (): void => {
+        this._handleOutput('\n[Process Exited]');
+    };
 
     constructor(style: Partial<Style> = {}, opts: PtyOptions = {}) {
         super(style);
@@ -33,17 +42,11 @@ export class Pty extends Widget {
         try {
             this._process = spawn(cmd, args);
             
-            this._process.stdout.on('data', (data) => {
-                this._handleOutput(data.toString());
-            });
+            this._process.stdout.on('data', this._onStdoutData);
             
-            this._process.stderr.on('data', (data) => {
-                this._handleOutput(data.toString());
-            });
+            this._process.stderr.on('data', this._onStderrData);
             
-            this._process.on('close', () => {
-                this._handleOutput('\n[Process Exited]');
-            });
+            this._process.on('close', this._onClose);
         } catch (err) {
             this._lines.push(`Failed to spawn ${cmd}`);
         }
@@ -104,6 +107,9 @@ export class Pty extends Widget {
      */
     override destroy(): void {
         if (this._process) {
+            this._process.stdout.removeListener('data', this._onStdoutData);
+            this._process.stderr.removeListener('data', this._onStderrData);
+            this._process.removeListener('close', this._onClose);
             this._process.kill();
             this._process = null;
         }


### PR DESCRIPTION
## Description

This PR fixes a lifecycle issue in the `Pty` widget where child process events could still be processed after the widget was destroyed. It ensures all process listeners registered by the widget are cleaned up during teardown and adds a regression test verifying that late stdout, stderr, and close events are ignored after `destroy()`.

## Related Issue

Closes #2062 

## Which package(s)?

@termuijs/widgets

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [x] 🧪 Tests (`type:testing`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209

## Screenshots / Recordings (UI changes)

N/A – This change affects the widget lifecycle and process cleanup only. A regression test has been added to verify the behavior.

## Notes for the Reviewer

- The fix is intentionally minimal and only removes the process listeners registered by `Pty`.
- Existing runtime behavior while the widget is active is unchanged.
- The regression test verifies observable behavior by ensuring late child process events do not affect the widget after `destroy()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal/process output so messages arriving after the widget/session is closed no longer appear in the display.
  * Suppressed process-exit notices after destruction to prevent stale “[Process Exited]” output.
  * Improved cleanup so stdout/stderr/exit updates don’t continue after shutdown.
* **Tests**
  * Enhanced the mocked process behavior and added coverage to ensure late output is ignored after destroy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->