### PR TITLE
fix: preserve queued terminal output during restore

### DIFF
--- a/packages/core/src/terminal/Terminal.test.ts
+++ b/packages/core/src/terminal/Terminal.test.ts
@@ -13,7 +13,8 @@ function createFakeStdout() {
         columns: 80,
         rows: 24,
         on: vi.fn(),
-        off: vi.fn()
+        off: vi.fn(),
+        once: vi.fn()
     } as unknown as NodeJS.WriteStream;
 }
 
@@ -331,6 +332,32 @@ describe('Terminal', () => {
             // All writes should have been processed
             expect((terminal as any)._writeQueue.length).toBe(0);
             expect((terminal as any)._isWriting).toBe(false);
+        });
+
+        it('flushes pending queued writes before restore completes', () => {
+            const stdout = createFakeStdout();
+            const writes: string[] = [];
+            stdout.write.mockImplementation((data: string) => {
+                writes.push(data);
+                return true;
+            });
+            const terminal = new Terminal({ stdout });
+
+            terminal.write('first');
+            terminal.write('second');
+
+            const originalDisableMouse = terminal.disableMouse;
+            terminal.disableMouse = () => {
+                terminal.write('during-restore');
+                originalDisableMouse.call(terminal);
+            };
+
+            terminal.restore();
+
+            expect(writes).toContain('first');
+            expect(writes).toContain('second');
+            expect(writes).toContain('during-restore');
+            expect(writes.indexOf('first')).toBeLessThan(writes.indexOf('during-restore'));
         });
     });
 });

--- a/packages/core/src/terminal/Terminal.ts
+++ b/packages/core/src/terminal/Terminal.ts
@@ -206,11 +206,30 @@ export class Terminal {
      */
     write(data: string): void {
         if (!data) return;
-        
+
+        if (this._restoring) {
+            this.stdout.write(data);
+            return;
+        }
+
         this._writeQueue.push(data);
         if (this._isWriting) return;
 
         this._processWriteQueue();
+    }
+
+    private _flushWriteQueue(): void {
+        if (this._isWriting) return;
+
+        this._isWriting = true;
+        try {
+            while (this._writeQueue.length > 0) {
+                const chunk = this._writeQueue.shift()!;
+                this.stdout.write(chunk);
+            }
+        } finally {
+            this._isWriting = false;
+        }
     }
 
     /**
@@ -223,11 +242,7 @@ export class Terminal {
      */
     writeSync(data: string): void {
         if (!data) return;
-        while (this._writeQueue.length > 0) {
-            const chunk = this._writeQueue.shift()!;
-            this.stdout.write(chunk);
-        }
-        this._isWriting = false;
+        this._flushWriteQueue();
         this.stdout.write(data);
     }
 
@@ -304,9 +319,8 @@ export class Terminal {
             this._resizeTimer = null;
         }
 
-        // Clear hanging buffer data states
-        this._writeQueue = [];
-        this._isWriting = false;
+        // Flush any queued writes so shutdown does not drop buffered output.
+        this._flushWriteQueue();
 
         // Remove process-level handlers to prevent leaks
         if (this._exitHandler) process.off('exit', this._exitHandler);


### PR DESCRIPTION
## Description

This PR fixes a shutdown lifecycle issue where buffered terminal writes could be lost if `restore()` was called while writes were still queued. It preserves pending output during teardown and adds a regression test covering the shutdown sequence to prevent future regressions.

## Related Issue

Closes #2068 

## Which package(s)?

@termuijs/core

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [x] 🧪 Tests (`type:testing`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209

## Screenshots / Recordings (UI changes)

N/A – This change affects the terminal shutdown lifecycle and buffered write handling. A regression test has been added to verify the behavior.

## Notes for the Reviewer

- The fix is intentionally minimal and only changes the shutdown path in `Terminal`.
- Pending buffered writes are flushed before terminal restoration completes, preventing output from being lost during teardown.
- A regression test reproduces the shutdown scenario and verifies the observable behavior without relying on internal implementation details.
