### PR TITLE
fix: clean up resize subscription on unmount

### DIFF
--- a/packages/core/src/app/App.test.ts
+++ b/packages/core/src/app/App.test.ts
@@ -2,7 +2,6 @@
 // @termuijs/core — Tests for App lifecycle
 // ─────────────────────────────────────────────────────
 
-import { EventEmitter } from 'events';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { App, type AppOptions, type RootWidget } from './App.js';
 import type { Screen } from '../terminal/Screen.js';
@@ -191,37 +190,17 @@ describe('App', () => {
         });
 
         it('removes the resize subscription on unmount', async () => {
-            const fakeStdout = Object.assign(new EventEmitter(), {
-                columns: 80,
-                rows: 24,
-                isTTY: true,
-                write() { return true; },
-            });
-            const fakeStdin = {
-                isTTY: true,
-                isRaw: false,
-                setRawMode() {},
-                resume() {},
-                pause() {},
-                on() {},
-                off() {},
-            };
-
-            const app = new App(createMockRootWidget(), {
-                forceFallback: false,
-                skipFallback: true,
-                screenMode: 'main',
-                stdout: fakeStdout as unknown as NodeJS.WriteStream,
-                stdin: fakeStdin as unknown as NodeJS.ReadStream,
-            });
+            const cleanup = vi.fn();
+            const app = new App(createMockRootWidget(), createInteractiveTestOptions());
+            const onResizeSpy = vi.spyOn(app.terminal, 'onResize').mockImplementation(() => cleanup);
             const mountPromise = app.mount();
 
-            expect(fakeStdout.listenerCount('resize')).toBe(1);
+            expect(onResizeSpy).toHaveBeenCalledTimes(1);
 
             app.unmount();
             await mountPromise;
 
-            expect(fakeStdout.listenerCount('resize')).toBe(0);
+            expect(cleanup).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/packages/core/src/app/App.test.ts
+++ b/packages/core/src/app/App.test.ts
@@ -2,6 +2,7 @@
 // @termuijs/core — Tests for App lifecycle
 // ─────────────────────────────────────────────────────
 
+import { EventEmitter } from 'events';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { App, type AppOptions, type RootWidget } from './App.js';
 import type { Screen } from '../terminal/Screen.js';
@@ -187,6 +188,40 @@ describe('App', () => {
 
             const code = await mountPromise;
             expect(code).toBe(0);
+        });
+
+        it('removes the resize subscription on unmount', async () => {
+            const fakeStdout = Object.assign(new EventEmitter(), {
+                columns: 80,
+                rows: 24,
+                isTTY: true,
+                write() { return true; },
+            });
+            const fakeStdin = {
+                isTTY: true,
+                isRaw: false,
+                setRawMode() {},
+                resume() {},
+                pause() {},
+                on() {},
+                off() {},
+            };
+
+            const app = new App(createMockRootWidget(), {
+                forceFallback: false,
+                skipFallback: true,
+                screenMode: 'main',
+                stdout: fakeStdout as unknown as NodeJS.WriteStream,
+                stdin: fakeStdin as unknown as NodeJS.ReadStream,
+            });
+            const mountPromise = app.mount();
+
+            expect(fakeStdout.listenerCount('resize')).toBe(1);
+
+            app.unmount();
+            await mountPromise;
+
+            expect(fakeStdout.listenerCount('resize')).toBe(0);
         });
     });
 

--- a/packages/core/src/app/App.ts
+++ b/packages/core/src/app/App.ts
@@ -80,6 +80,7 @@ export class App {
     private _unsubKey: (() => void) | null = null;
     private _unsubMouse: (() => void) | null = null;
     private _unsubPaste: (() => void) | null = null;
+    private _unsubResize: (() => void) | null = null;
     private _unsubFocus: (() => void) | null = null;
     private _unsubBlur: (() => void) | null = null;
     private _unsubSigInt: (() => void) | null = null;
@@ -171,7 +172,7 @@ export class App {
         }
 
         // Handle resize
-        this.terminal.onResize((cols, rows) => {
+        this._unsubResize = this.terminal.onResize((cols, rows) => {
             this.screen.resize(cols, rows);
             this.screen.invalidate();
             this.layers.resize(cols, rows);
@@ -332,6 +333,8 @@ export class App {
         this._unsubBlur = null;
         this._unsubPaste?.();
         this._unsubPaste = null;
+        this._unsubResize?.();
+        this._unsubResize = null;
         this._unsubUncaughtException?.();
         this._unsubUncaughtException = null;
         this._unsubUnhandledRejection?.();


### PR DESCRIPTION
## Description

This PR fixes a lifecycle bug where the application continued to retain a terminal resize subscription after being unmounted. The resize listener is now properly cleaned up during teardown, and a regression test has been added to ensure the subscription is removed and cannot leak across application lifecycles.

## Related Issue

Closes #2071 

## Which package(s)?

* `@termuijs/core`

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)
* [x] 🧪 Tests (`type:testing`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.

Your GSSoC profile:
`https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

N/A – This is a backend lifecycle fix with no user-facing UI changes.

## Notes for the Reviewer

* The fix stores the unsubscribe callback returned by `terminal.onResize(...)` and invokes it during `App.unmount()`.
* The regression test verifies the observable lifecycle behavior by ensuring the resize listener is removed after unmount.
* The change is intentionally minimal and only affects resize subscription cleanup without altering rendering or terminal behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app shutdown/unmount behavior by ensuring the terminal resize listener is properly cleaned up.
  * Helps prevent lingering event subscriptions after closing the app.
* **Tests**
  * Added an unmount lifecycle test to confirm the resize listener cleanup occurs as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->