### PR TITLE
fix(widgets): improve horizontal scroll handling for wide characters (Closes #2073)

### DIFF
--- a/packages/widgets/src/display/Text.ts
+++ b/packages/widgets/src/display/Text.ts
@@ -109,10 +109,13 @@ export class Text extends Widget {
                     if (skipped + charWidth > this._scrollX) {
                         // scrollX lands in the middle of this character
                         // For wide characters, we need to handle the partial column
-                        if (charWidth === 2 && skipped < this._scrollX) {
-                            // We're at the second column of a wide character
-                            // Add a placeholder for the remaining column and skip the character
-                            line = ' ' + line.slice(charIndex + ch.length);
+                        if (charWidth > 1 && skipped < this._scrollX) {
+                            // We're in the middle of a wide character
+                            // Calculate how many columns of this character are visible
+                            const visibleColumns = this._scrollX - skipped;
+                            const remainingColumns = charWidth - visibleColumns;
+                            // Add placeholders for the visible columns that were skipped
+                            line = ' '.repeat(visibleColumns) + line.slice(charIndex + ch.length);
                             lineRebuilt = true;
                         }
                         break;


### PR DESCRIPTION
## Description

This PR fixes an edge case in the `Text` widget's horizontal scrolling logic when rendering wide Unicode characters.

Previously, the implementation only handled double-width characters and assumed the scroll position always landed on the second column of the character. The updated logic correctly handles scrolling into any position within a wide character by calculating the skipped columns and preserving text alignment.

## Related Issue

Closes #2073

## Which package(s)?

* @termuijs/widgets

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)

## Checklist

* [x] ⭐ You starred the repo.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read `CONTRIBUTING.md`.
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if applicable).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.

## Notes for the Reviewer

### Changes

* Generalized the horizontal scrolling logic to support characters with widths greater than one.
* Correctly calculates the number of skipped columns when the scroll position falls within a wide character.
* Preserves text alignment by inserting the appropriate number of placeholder spaces.
* Improves rendering for CJK characters, emojis, and other wide Unicode characters during horizontal scrolling.

This change is limited to the horizontal scrolling logic and maintains the existing behavior for single-width characters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved horizontal scrolling for wide characters so text now renders more consistently when the scroll position lands partway through a character.
  * Extended the handling from only double-width characters to any character wider than one column, reducing visual glitches in scrolling text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->