### PR TITLE
fix(core): add ASCII fallback for focus ring rendering (Closes #2075)

### DIFF
--- a/packages/widgets/src/base/Widget.ts
+++ b/packages/widgets/src/base/Widget.ts
@@ -505,28 +505,33 @@ export abstract class Widget {
             const fg = this._style.focusRingColor ?? { type: 'named' as const, name: 'cyan' as const };
             const cellStyle = { fg, bold: true };
 
+            const useAscii = (this._style.asciiOnly ?? false) || !caps.unicode;
+            const corner = useAscii ? '+' : '┌';
+            const horizontal = useAscii ? '-' : '─';
+            const vertical = useAscii ? '|' : '│';
+
             // Top-left corner
-            screen.setCell(x, y, { char: '┌', ...cellStyle });
-            if (width > 2) screen.setCell(x + 1, y, { char: '─', ...cellStyle });
+            screen.setCell(x, y, { char: corner, ...cellStyle });
+            if (width > 2) screen.setCell(x + 1, y, { char: horizontal, ...cellStyle });
 
             // Top-right corner
-            screen.setCell(x + width - 1, y, { char: '┐', ...cellStyle });
-            if (width > 2) screen.setCell(x + width - 2, y, { char: '─', ...cellStyle });
+            screen.setCell(x + width - 1, y, { char: corner, ...cellStyle });
+            if (width > 2) screen.setCell(x + width - 2, y, { char: horizontal, ...cellStyle });
 
             // Bottom-left corner
-            screen.setCell(x, y + height - 1, { char: '└', ...cellStyle });
-            if (width > 2) screen.setCell(x + 1, y + height - 1, { char: '─', ...cellStyle });
+            screen.setCell(x, y + height - 1, { char: corner, ...cellStyle });
+            if (width > 2) screen.setCell(x + 1, y + height - 1, { char: horizontal, ...cellStyle });
 
             // Bottom-right corner
-            screen.setCell(x + width - 1, y + height - 1, { char: '┘', ...cellStyle });
-            if (width > 2) screen.setCell(x + width - 2, y + height - 1, { char: '─', ...cellStyle });
+            screen.setCell(x + width - 1, y + height - 1, { char: corner, ...cellStyle });
+            if (width > 2) screen.setCell(x + width - 2, y + height - 1, { char: horizontal, ...cellStyle });
 
             // Short vertical marks if tall enough
             if (height > 2) {
-                screen.setCell(x, y + 1, { char: '│', ...cellStyle });
-                screen.setCell(x + width - 1, y + 1, { char: '│', ...cellStyle });
-                screen.setCell(x, y + height - 2, { char: '│', ...cellStyle });
-                screen.setCell(x + width - 1, y + height - 2, { char: '│', ...cellStyle });
+                screen.setCell(x, y + 1, { char: vertical, ...cellStyle });
+                screen.setCell(x + width - 1, y + 1, { char: vertical, ...cellStyle });
+                screen.setCell(x, y + height - 2, { char: vertical, ...cellStyle });
+                screen.setCell(x + width - 1, y + height - 2, { char: vertical, ...cellStyle });
             }
         }
     }


### PR DESCRIPTION
## Description

This PR fixes the focus ring rendering in `Widget.ts` by respecting terminal Unicode capabilities.

Previously, the focus ring always used Unicode box-drawing characters, which rendered incorrectly on ASCII-only terminals. The implementation now checks `caps.unicode` and `asciiOnly` to render appropriate ASCII fallbacks when Unicode is unavailable.

## Related Issue

Closes #2075

## Which package(s)?

* @termuijs/core

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)

## Checklist

* [x] ⭐ You starred the repo.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read `CONTRIBUTING.md`.
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if applicable).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.

## Notes for the Reviewer

### Changes

* Added a `caps.unicode` check before rendering Unicode box-drawing characters.
* Added ASCII fallbacks (`+`, `-`, `|`) for terminals without Unicode support.
* Respected the `asciiOnly` style option.
* Kept the behavior consistent with the existing border rendering implementation.
