### PR TITLE
Clipboard paste support added, and pr cleaned

### DIFF
--- a/packages/core/src/input/InputParser.ts
+++ b/packages/core/src/input/InputParser.ts
@@ -139,12 +139,13 @@ export class InputParser {
       const endIdx = this._pasteBuffer.indexOf(PASTE_END);
       if (endIdx !== -1) {
         const pastedText = this._pasteBuffer.substring(0, endIdx);
+        const remaining = this._pasteBuffer.substring(endIdx + PASTE_END.length); // ← Fix: capture before clearing
+
         this._isPasting = false;
         this._pasteBuffer = '';
         this._clearPasteTimeout();
         this._events.emit('paste', pastedText);
 
-        const remaining = this._pasteBuffer.substring(endIdx + PASTE_END.length);
         if (remaining.length > 0) {
           this._processInput(Buffer.from(remaining, 'utf8'));
         }

--- a/packages/core/src/input/InputParser.ts
+++ b/packages/core/src/input/InputParser.ts
@@ -14,15 +14,15 @@ import { splitGraphemes } from './grapheme.js';
 const ESCAPE_TIMEOUT_MS = 500;
 
 export interface CursorPosition {
-    row: number;
-    col: number;
+  row: number;
+  col: number;
 }
 
 interface InputEvents {
-    key: KeyEvent;
-    mouse: MouseEvent;
-    focuschange: boolean;
-    paste: string;
+  key: KeyEvent;
+  mouse: MouseEvent;
+  focuschange: boolean;
+  paste: string;
 }
 
 /**
@@ -30,445 +30,448 @@ interface InputEvents {
  * Handles escape sequences, multi-byte keys, ctrl+key, and SGR mouse events.
  */
 export class InputParser {
-    private _events = new EventEmitter<InputEvents>();
-    private _stdin: NodeJS.ReadStream;
-    private _decoder = new StringDecoder('utf8');
-    private _graphemeBuffer = '';
-    private _graphemeTimeout: ReturnType<typeof setTimeout> | null = null;
-    private _handler: ((data: Buffer) => void) | null = null;
-    private _escapeTimeout: ReturnType<typeof setTimeout> | null = null;
-    private _escapeBuffer: Buffer = Buffer.alloc(0);
-    private _isPasting = false;
-    private _pasteBuffer = '';
-    private _pasteTimeout: ReturnType<typeof setTimeout> | null = null;
-    private _cursorRequests: Array<{
-        resolve: (position: CursorPosition) => void;
-        reject: (error: Error) => void;
-        timeout: ReturnType<typeof setTimeout>;
-    }> = [];
+  private _events = new EventEmitter<InputEvents>();
+  private _stdin: NodeJS.ReadStream;
+  private _decoder = new StringDecoder('utf8');
+  private _graphemeBuffer = '';
+  private _graphemeTimeout: ReturnType<typeof setTimeout> | null = null;
+  private _handler: ((data: Buffer) => void) | null = null;
+  private _escapeTimeout: ReturnType<typeof setTimeout> | null = null;
+  private _escapeBuffer: Buffer = Buffer.alloc(0);
+  private _isPasting = false;
+  private _pasteBuffer = '';
+  private _pasteTimeout: ReturnType<typeof setTimeout> | null = null;
+  private _cursorRequests: Array<{
+    resolve: (position: CursorPosition) => void;
+    reject: (error: Error) => void;
+    timeout: ReturnType<typeof setTimeout>;
+  }> = [];
 
-    constructor(stdin: NodeJS.ReadStream) {
-        this._stdin = stdin;
-    }
+  constructor(stdin: NodeJS.ReadStream) {
+    this._stdin = stdin;
+  }
 
-    /** Subscribe to key events */
-    onKey(handler: (event: KeyEvent) => void): () => void {
-        return this._events.on('key', handler);
-    }
+  /** Subscribe to key events */
+  onKey(handler: (event: KeyEvent) => void): () => void {
+    return this._events.on('key', handler);
+  }
 
-    /** Subscribe to mouse events */
-    onMouse(handler: (event: MouseEvent) => void): () => void {
-        return this._events.on('mouse', handler);
-    }
+  /** Subscribe to mouse events */
+  onMouse(handler: (event: MouseEvent) => void): () => void {
+    return this._events.on('mouse', handler);
+  }
 
-    /** Subscribe to terminal focus-in (true) / focus-out (false) reports. */
-    onFocusChange(handler: (focused: boolean) => void): () => void {
-        return this._events.on('focuschange', handler);
-    }
+  /** Subscribe to terminal focus-in (true) / focus-out (false) reports. */
+  onFocusChange(handler: (focused: boolean) => void): () => void {
+    return this._events.on('focuschange', handler);
+  }
 
-    onPaste(handler: (text: string) => void): () => void {
-        return this._events.on('paste', handler);
-    }
+  onPaste(handler: (text: string) => void): () => void {
+    return this._events.on('paste', handler);
+  }
 
-    requestCursorPosition(timeoutMs = 200): Promise<CursorPosition> {
-        return new Promise<CursorPosition>((resolve, reject) => {
-            const timeout = setTimeout(() => {
-                const idx = this._cursorRequests.findIndex((item) => item.reject === reject);
-                if (idx !== -1) {
-                    this._cursorRequests.splice(idx, 1);
-                }
-                reject(new Error('Cursor position request timed out'));
-            }, timeoutMs);
-
-            this._cursorRequests.push({ resolve, reject, timeout });
-        });
-    }
-
-    /** Start listening for input */
-    start(): void {
-        if (this._handler) return;
-
-        this._handler = (data: Buffer) => {
-            this._processInput(data);
-        };
-
-        this._stdin.on('data', this._handler);
-    }
-
-    /** Stop listening for input */
-    stop(): void {
-        if (this._handler) {
-            this._stdin.off('data', this._handler);
-            this._handler = null;
+  requestCursorPosition(timeoutMs = 200): Promise<CursorPosition> {
+    return new Promise<CursorPosition>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const idx = this._cursorRequests.findIndex((item) => item.reject === reject);
+        if (idx !== -1) {
+          this._cursorRequests.splice(idx, 1);
         }
-        if (this._escapeTimeout) {
-            clearTimeout(this._escapeTimeout);
-            this._escapeTimeout = null;
-        }
-        if (this._graphemeTimeout) {
-            clearTimeout(this._graphemeTimeout);
-            this._graphemeTimeout = null;
-        }
-        if (this._pasteTimeout) {
-            clearTimeout(this._pasteTimeout);
-            this._pasteTimeout = null;
-        }
-        this._escapeBuffer = Buffer.alloc(0);
-        this._graphemeBuffer = '';
+        reject(new Error('Cursor position request timed out'));
+      }, timeoutMs);
+
+      this._cursorRequests.push({ resolve, reject, timeout });
+    });
+  }
+
+  /** Start listening for input */
+  start(): void {
+    if (this._handler) return;
+
+    this._handler = (data: Buffer) => {
+      this._processInput(data);
+    };
+
+    this._stdin.on('data', this._handler);
+  }
+
+  /** Stop listening for input */
+  stop(): void {
+    if (this._handler) {
+      this._stdin.off('data', this._handler);
+      this._handler = null;
+    }
+    if (this._escapeTimeout) {
+      clearTimeout(this._escapeTimeout);
+      this._escapeTimeout = null;
+    }
+    if (this._graphemeTimeout) {
+      clearTimeout(this._graphemeTimeout);
+      this._graphemeTimeout = null;
+    }
+    if (this._pasteTimeout) {
+      clearTimeout(this._pasteTimeout);
+      this._pasteTimeout = null;
+    }
+    this._escapeBuffer = Buffer.alloc(0);
+    this._graphemeBuffer = '';
+    this._isPasting = false;
+    this._pasteBuffer = '';
+    this._decoder.end();
+    for (const req of this._cursorRequests) {
+      clearTimeout(req.timeout);
+      req.reject(new Error('InputParser stopped'));
+    }
+    this._cursorRequests = [];
+  }
+
+  /**
+   * Process a chunk of raw input bytes.
+   */
+  private _processInput(data: Buffer): void {
+    const PASTE_START = '\x1b[200~';
+    const PASTE_END = '\x1b[201~';
+    const str = data.toString('utf8');
+
+    // If we are currently collecting a paste, append and look for the end marker.
+    if (this._isPasting) {
+      const endIdx = str.indexOf(PASTE_END);
+      if (endIdx !== -1) {
+        this._pasteBuffer += str.substring(0, endIdx);
+        const pastedText = this._pasteBuffer;
         this._isPasting = false;
         this._pasteBuffer = '';
-        this._decoder.end();
-        for (const req of this._cursorRequests) {
-            clearTimeout(req.timeout);
-            req.reject(new Error('InputParser stopped'));
-        }
-        this._cursorRequests = [];
-    }
-
-    /**
-     * Process a chunk of raw input bytes.
-     */
-    private _processInput(data: Buffer): void {
-        const PASTE_START = '\x1b[200~';
-        const PASTE_END = '\x1b[201~';
-
-        if (this._isPasting) {
-            const str = this._decoder.write(data);
-            const endIdx = str.indexOf(PASTE_END);
-            if (endIdx !== -1) {
-                this._pasteBuffer += str.substring(0, endIdx);
-                const pastedText = this._pasteBuffer;
-                this._isPasting = false;
-                this._pasteBuffer = '';
-                this._clearPasteTimeout();
-                this._events.emit('paste', pastedText);
-                
-                const remaining = str.substring(endIdx + PASTE_END.length);
-                if (remaining.length > 0) {
-                    this._processInput(Buffer.from(remaining, 'utf8'));
-                }
-            } else {
-                this._pasteBuffer += str;
-                this._startPasteTimeout();
-            }
-            return;
-        }
-
-        // If we are currently collecting an escape sequence, continue collecting it
-        if (this._escapeBuffer.length > 0) {
-            this._escapeBuffer = Buffer.concat([this._escapeBuffer, data]);
-            if (this._escapeTimeout) {
-                clearTimeout(this._escapeTimeout);
-                this._escapeTimeout = null;
-            }
-            this._tryParseEscape();
-            // If the sequence is still incomplete, restart the timeout
-            // so fragmented TCP chunks won't trigger a false standalone ESC.
-            if (this._escapeBuffer.length > 0) {
-                this._startEscapeTimeout();
-            }
-            return;
-        }
-
-        const str = data.toString('utf8');
-        
-        const startIdx = str.indexOf(PASTE_START);
-        if (startIdx !== -1) {
-            if (startIdx > 0) {
-                const before = str.substring(0, startIdx);
-                this._processInput(Buffer.from(before, 'utf8'));
-            }
-
-            const afterStart = str.substring(startIdx + PASTE_START.length);
-            const endIdx = afterStart.indexOf(PASTE_END);
-            
-            if (endIdx !== -1) {
-                this._events.emit('paste', afterStart.substring(0, endIdx));
-                const remaining = afterStart.substring(endIdx + PASTE_END.length);
-                if (remaining.length > 0) {
-                    this._processInput(Buffer.from(remaining, 'utf8'));
-                }
-            } else {
-                this._isPasting = true;
-                this._pasteBuffer = afterStart;
-                this._startPasteTimeout();
-            }
-            return;
-        }
-
-        // Check if this starts an escape sequence
-        if (str.startsWith('\x1b') && str.length === 1) {
-            // Lone ESC — wait for more bytes
-            this._escapeBuffer = data;
-            this._startEscapeTimeout();
-            return;
-        }
-
-        if (str.startsWith('\x1b')) {
-            this._escapeBuffer = data;
-            this._tryParseEscape();
-            if (this._escapeBuffer.length > 0) {
-                this._startEscapeTimeout();
-            }
-            return;
-        }
-
-        // Decode input and append to grapheme buffer
-        const decoded = this._decoder.write(data);
-        this._graphemeBuffer += decoded;
-
-        if (this._graphemeTimeout) {
-            clearTimeout(this._graphemeTimeout);
-            this._graphemeTimeout = null;
-        }
-
-        // Process after a short 10ms delay to merge split chunks (like modifiers or ZWJ sequences)
-        this._graphemeTimeout = setTimeout(() => {
-            this._processGraphemeBuffer();
-            this._graphemeTimeout = null;
-        }, 10);
-    }
-
-    private _processGraphemeBuffer(): void {
-        if (!this._graphemeBuffer) return;
-
-        const graphemes = splitGraphemes(this._graphemeBuffer);
-        if (graphemes.length === 0) return;
-
-        let processCount = graphemes.length;
-        // Check if the last grapheme is potentially incomplete
-        const lastGrapheme = graphemes[graphemes.length - 1];
-        if (this._isPossiblyIncompleteGrapheme(lastGrapheme)) {
-            processCount = graphemes.length - 1;
-        }
-
-        for (let i = 0; i < processCount; i++) {
-            const ch = graphemes[i];
-            const code = ch.codePointAt(0)!;
-            const raw = Buffer.from(ch, 'utf8');
-
-            // Ctrl+key (0x01-0x1A, excluding tab/enter/backspace)
-            if (code >= 0x01 && code <= 0x1A) {
-                const keyName = CTRL_KEYS[code];
-                const isCtrl = code !== 0x09 && code !== 0x0D && code !== 0x0A;
-                this._events.emit('key', createKeyEvent({
-                    key: keyName || String.fromCharCode(code + 96),
-                    raw,
-                    ctrl: isCtrl,
-                    alt: false,
-                    shift: false,
-                }));
-                continue;
-            }
-
-            // Special keys
-            if (code in SPECIAL_KEYS) {
-                this._events.emit('key', createKeyEvent({
-                    key: SPECIAL_KEYS[code],
-                    raw,
-                    ctrl: false,
-                    alt: false,
-                    shift: false,
-                }));
-                continue;
-            }
-
-            // Regular printable character
-            if (code >= 0x20) {
-                this._events.emit('key', createKeyEvent({
-                    key: ch,
-                    raw,
-                    ctrl: false,
-                    alt: false,
-                    shift: ch !== ch.toLowerCase() && ch === ch.toUpperCase(),
-                }));
-            }
-        }
-
-        // Update the remaining buffer
-        this._graphemeBuffer = graphemes.slice(processCount).join('');
-    }
-
-    private _isPossiblyIncompleteGrapheme(ch: string): boolean {
-        if (!ch) return false;
-        // ZWJ sequence continuation check
-        if (ch.endsWith('\u200D')) return true;
-        // Surrogate pair incomplete check (last char is high surrogate)
-        const lastCharCode = ch.charCodeAt(ch.length - 1);
-        if (lastCharCode >= 0xD800 && lastCharCode <= 0xDBFF) return true;
-        
-        // Regional Indicator Symbols (flags: U+1F1E6 to U+1F1FF)
-        // Check if there's an odd number of regional indicator symbols in this grapheme
-        const codePoints = Array.from(ch);
-        const lastCpVal = codePoints[codePoints.length - 1].codePointAt(0)!;
-        if (lastCpVal >= 0x1F1E6 && lastCpVal <= 0x1F1FF) {
-            let riCount = 0;
-            for (let i = codePoints.length - 1; i >= 0; i--) {
-                const cp = codePoints[i].codePointAt(0)!;
-                if (cp >= 0x1F1E6 && cp <= 0x1F1FF) {
-                    riCount++;
-                } else {
-                    break;
-                }
-            }
-            if (riCount % 2 !== 0) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Start or restart the escape sequence timeout.
-     * Fires when no additional bytes arrive within the window,
-     * treating the buffered bytes as a standalone Escape key.
-     */
-    private _startEscapeTimeout(): void {
-        if (this._escapeTimeout) {
-            clearTimeout(this._escapeTimeout);
-        }
-        this._escapeTimeout = setTimeout(() => {
-            const remained = this._escapeBuffer;
-            this._escapeBuffer = Buffer.alloc(0);
-            this._escapeTimeout = null;
-            this._events.emit('key', createKeyEvent({
-                key: 'escape',
-                raw: remained,
-                ctrl: false,
-                alt: false,
-                shift: false,
-            }));
-        }, ESCAPE_TIMEOUT_MS);
-    }
-
-    /**
-     * Start or restart the paste inactivity timeout.
-     * If no additional paste data arrives within the timeout,
-     * the paste state is aborted to prevent stale state.
-     */
-    private _startPasteTimeout(): void {
         this._clearPasteTimeout();
-        this._pasteTimeout = setTimeout(() => {
-            this._isPasting = false;
-            this._pasteBuffer = '';
-            this._pasteTimeout = null;
-        }, 500);
+        this._events.emit('paste', pastedText);
+
+        const remaining = str.substring(endIdx + PASTE_END.length);
+        if (remaining.length > 0) {
+          this._processInput(Buffer.from(remaining, 'utf8'));
+        }
+      } else {
+        this._pasteBuffer += str;
+        this._startPasteTimeout();
+      }
+      return;
     }
 
-    private _clearPasteTimeout(): void {
-        if (this._pasteTimeout) {
-            clearTimeout(this._pasteTimeout);
-            this._pasteTimeout = null;
-        }
+    // If we are currently collecting an escape sequence, continue collecting it.
+    if (this._escapeBuffer.length > 0) {
+      this._escapeBuffer = Buffer.concat([this._escapeBuffer, data]);
+      if (this._escapeTimeout) {
+        clearTimeout(this._escapeTimeout);
+        this._escapeTimeout = null;
+      }
+      this._tryParseEscape();
+      // If the sequence is still incomplete, restart the timeout so fragmented TCP chunks
+      // won't trigger a false standalone ESC.
+      if (this._escapeBuffer.length > 0) {
+        this._startEscapeTimeout();
+      }
+      return;
     }
 
-    /**
-     * Try to parse buffered escape sequence.
-     */
-    private _tryParseEscape(): void {
-        const seq = this._escapeBuffer.toString('utf8');
+    // Detect bracketed paste start/end in this chunk.
+    const startIdx = str.indexOf(PASTE_START);
+    if (startIdx !== -1) {
+      // Process any normal input before the paste start.
+      if (startIdx > 0) {
+        const before = str.substring(0, startIdx);
+        this._processInput(Buffer.from(before, 'utf8'));
+      }
 
-        const PASTE_START = '\x1b[200~';
-        const pasteStartIdx = seq.indexOf(PASTE_START);
-        if (pasteStartIdx !== -1) {
-            this._escapeBuffer = Buffer.alloc(0);
-            if (pasteStartIdx > 0) {
-                const before = seq.substring(0, pasteStartIdx);
-                this._processInput(Buffer.from(before, 'utf8'));
-            }
-            const after = seq.substring(pasteStartIdx);
-            this._processInput(Buffer.from(after, 'utf8'));
-            return;
+      const afterStart = str.substring(startIdx + PASTE_START.length);
+      const endIdx = afterStart.indexOf(PASTE_END);
+
+      if (endIdx !== -1) {
+        // Both markers in one chunk: emit paste and process trailing input.
+        this._events.emit('paste', afterStart.substring(0, endIdx));
+        const remaining = afterStart.substring(endIdx + PASTE_END.length);
+        if (remaining.length > 0) {
+          this._processInput(Buffer.from(remaining, 'utf8'));
         }
+      } else {
+        // Paste spans multiple chunks: start collecting.
+        this._isPasting = true;
+        this._pasteBuffer = afterStart;
+        this._startPasteTimeout();
+      }
+      return;
+    }
 
-        // Check for mouse event first
-        if (isMouseSequence(seq)) {
-            const mouseEvt = parseMouseEvent(seq);
-            if (mouseEvt) {
-                this._events.emit('mouse', mouseEvt);
-                this._escapeBuffer = Buffer.alloc(0);
-                return;
-            }
-            // Might be incomplete mouse sequence — wait for more data (no timeout, FSM handles via _escapeBuffer)
-            if (seq.length < 20) { // safety cap
-                return;
-            }
+    // Check if this starts an escape sequence.
+    if (str.startsWith('\x1b') && str.length === 1) {
+      // Lone ESC — wait for more bytes.
+      this._escapeBuffer = data;
+      this._startEscapeTimeout();
+      return;
+    }
+
+    if (str.startsWith('\x1b')) {
+      this._escapeBuffer = data;
+      this._tryParseEscape();
+      if (this._escapeBuffer.length > 0) {
+        this._startEscapeTimeout();
+      }
+      return;
+    }
+
+    // Decode input and append to grapheme buffer.
+    const decoded = this._decoder.write(data);
+    this._graphemeBuffer += decoded;
+
+    if (this._graphemeTimeout) {
+      clearTimeout(this._graphemeTimeout);
+      this._graphemeTimeout = null;
+    }
+
+    // Process after a short 10ms delay to merge split chunks (like modifiers or ZWJ sequences).
+    this._graphemeTimeout = setTimeout(() => {
+      this._processGraphemeBuffer();
+      this._graphemeTimeout = null;
+    }, 10);
+  }
+
+  private _processGraphemeBuffer(): void {
+    if (!this._graphemeBuffer) return;
+
+    const graphemes = splitGraphemes(this._graphemeBuffer);
+    if (graphemes.length === 0) return;
+
+    let processCount = graphemes.length;
+    // Check if the last grapheme is potentially incomplete.
+    const lastGrapheme = graphemes[graphemes.length - 1];
+    if (this._isPossiblyIncompleteGrapheme(lastGrapheme)) {
+      processCount = graphemes.length - 1;
+    }
+
+    for (let i = 0; i < processCount; i++) {
+      const ch = graphemes[i];
+      const code = ch.codePointAt(0)!;
+      const raw = Buffer.from(ch, 'utf8');
+
+      // Ctrl+key (0x01-0x1A, excluding tab/enter/backspace).
+      if (code >= 0x01 && code <= 0x1A) {
+        const keyName = CTRL_KEYS[code];
+        const isCtrl = code !== 0x09 && code !== 0x0D && code !== 0x0A;
+        this._events.emit('key', createKeyEvent({
+          key: keyName || String.fromCharCode(code + 96),
+          raw,
+          ctrl: isCtrl,
+          alt: false,
+          shift: false,
+        }));
+        continue;
+      }
+
+      // Special keys.
+      if (code in SPECIAL_KEYS) {
+        this._events.emit('key', createKeyEvent({
+          key: SPECIAL_KEYS[code],
+          raw,
+          ctrl: false,
+          alt: false,
+          shift: false,
+        }));
+        continue;
+      }
+
+      // Regular printable character.
+      if (code >= 0x20) {
+        this._events.emit('key', createKeyEvent({
+          key: ch,
+          raw,
+          ctrl: false,
+          alt: false,
+          shift: ch !== ch.toLowerCase() && ch === ch.toUpperCase(),
+        }));
+      }
+    }
+
+    // Update the remaining buffer.
+    this._graphemeBuffer = graphemes.slice(processCount).join('');
+  }
+
+  private _isPossiblyIncompleteGrapheme(ch: string): boolean {
+    if (!ch) return false;
+    // ZWJ sequence continuation check.
+    if (ch.endsWith('\u200D')) return true;
+    // Surrogate pair incomplete check (last char is high surrogate).
+    const lastCharCode = ch.charCodeAt(ch.length - 1);
+    if (lastCharCode >= 0xD800 && lastCharCode <= 0xDBFF) return true;
+
+    // Regional Indicator Symbols (flags: U+1F1E6 to U+1F1FF).
+    // Check if there's an odd number of regional indicator symbols in this grapheme.
+    const codePoints = Array.from(ch);
+    const lastCpVal = codePoints[codePoints.length - 1].codePointAt(0)!;
+    if (lastCpVal >= 0x1F1E6 && lastCpVal <= 0x1F1FF) {
+      let riCount = 0;
+      for (let i = codePoints.length - 1; i >= 0; i--) {
+        const cp = codePoints[i].codePointAt(0)!;
+        if (cp >= 0x1F1E6 && cp <= 0x1F1FF) {
+          riCount++;
+        } else {
+          break;
         }
+      }
+      if (riCount % 2 !== 0) {
+        return true;
+      }
+    }
+    return false;
+  }
 
-        // Cursor position report
-        const cursorMatch = seq.match(/^\x1b\[(\d+);(\d+)R$/);
-        if (cursorMatch) {
-            const row = parseInt(cursorMatch[1], 10);
-            const col = parseInt(cursorMatch[2], 10);
-            const position = { row, col };
+  /**
+   * Start or restart the escape sequence timeout.
+   * Fires when no additional bytes arrive within the window,
+   * treating the buffered bytes as a standalone Escape key.
+   */
+  private _startEscapeTimeout(): void {
+    if (this._escapeTimeout) {
+      clearTimeout(this._escapeTimeout);
+    }
+    this._escapeTimeout = setTimeout(() => {
+      const remained = this._escapeBuffer;
+      this._escapeBuffer = Buffer.alloc(0);
+      this._escapeTimeout = null;
+      this._events.emit('key', createKeyEvent({
+        key: 'escape',
+        raw: remained,
+        ctrl: false,
+        alt: false,
+        shift: false,
+      }));
+    }, ESCAPE_TIMEOUT_MS);
+  }
 
-            for (const request of this._cursorRequests) {
-                clearTimeout(request.timeout);
-                request.resolve(position);
-            }
-            this._cursorRequests = [];
-            this._escapeBuffer = Buffer.alloc(0);
-            return;
-        }
+  /**
+   * Start or restart the paste inactivity timeout.
+   * If no additional paste data arrives within the timeout,
+   * the paste state is aborted to prevent stale state.
+   */
+  private _startPasteTimeout(): void {
+    this._clearPasteTimeout();
+    this._pasteTimeout = setTimeout(() => {
+      this._isPasting = false;
+      this._pasteBuffer = '';
+      this._pasteTimeout = null;
+    }, 500);
+  }
 
-        // Focus tracking sequences
-        if (seq === '\x1b[I') {
-            this._events.emit('focuschange', true);
-            this._escapeBuffer = Buffer.alloc(0);
-            return;
-        }
+  private _clearPasteTimeout(): void {
+    if (this._pasteTimeout) {
+      clearTimeout(this._pasteTimeout);
+      this._pasteTimeout = null;
+    }
+  }
 
-        if (seq === '\x1b[O') {
-            this._events.emit('focuschange', false);
-            this._escapeBuffer = Buffer.alloc(0);
-            return;
-        }
+  /**
+   * Try to parse buffered escape sequence.
+   */
+  private _tryParseEscape(): void {
+    const seq = this._escapeBuffer.toString('utf8');
 
-        // Check known escape sequences
-        if (seq in ESCAPE_SEQUENCES) {
-            const keyName = ESCAPE_SEQUENCES[seq];
-            const isShift = keyName.startsWith('shift+');
-            const isCtrl = keyName.startsWith('ctrl+');
-            const isAlt = keyName.startsWith('alt+');
-            const cleanKey = keyName.replace(/^(shift|ctrl|alt)\+/, '');
+    const PASTE_START = '\x1b[200~';
+    const pasteStartIdx = seq.indexOf(PASTE_START);
+    if (pasteStartIdx !== -1) {
+      this._escapeBuffer = Buffer.alloc(0);
+      if (pasteStartIdx > 0) {
+        const before = seq.substring(0, pasteStartIdx);
+        this._processInput(Buffer.from(before, 'utf8'));
+      }
+      const after = seq.substring(pasteStartIdx);
+      this._processInput(Buffer.from(after, 'utf8'));
+      return;
+    }
 
-            this._events.emit('key', createKeyEvent({
-                key: cleanKey,
-                raw: this._escapeBuffer,
-                ctrl: isCtrl,
-                alt: isAlt,
-                shift: isShift,
-            }));
-            this._escapeBuffer = Buffer.alloc(0);
-            return;
-        }
-
-        // Alt+key: ESC followed by a regular character
-        if (
-            seq.length === 2 &&
-            seq[0] === '\x1b' &&
-            seq[1] !== '[' &&
-            seq[1] !== 'O'
-        ) {
-            const ch = seq[1];
-            this._events.emit('key', createKeyEvent({
-                key: ch,
-                raw: this._escapeBuffer,
-                ctrl: false,
-                alt: true,
-                shift: ch !== ch.toLowerCase() && ch === ch.toUpperCase(),
-            }));
-            this._escapeBuffer = Buffer.alloc(0);
-            return;
-        }
-
-        // If the sequence is getting too long, give up
-        if (seq.length > 20) {
-            this._escapeBuffer = Buffer.alloc(0);
-            return;
-        }
-
-        // Wait for more bytes (might be an incomplete sequence; FSM handles via _escapeBuffer)
+    // Check for mouse event first.
+    if (isMouseSequence(seq)) {
+      const mouseEvt = parseMouseEvent(seq);
+      if (mouseEvt) {
+        this._events.emit('mouse', mouseEvt);
+        this._escapeBuffer = Buffer.alloc(0);
         return;
+      }
+      // Might be incomplete mouse sequence — wait for more data (no timeout, FSM handles via _escapeBuffer).
+      if (seq.length < 20) { // safety cap
+        return;
+      }
     }
+
+    // Cursor position report.
+    const cursorMatch = seq.match(/^\x1b\[(\d+);(\d+)R$/);
+    if (cursorMatch) {
+      const row = parseInt(cursorMatch[1], 10);
+      const col = parseInt(cursorMatch[2], 10);
+      const position = { row, col };
+
+      for (const request of this._cursorRequests) {
+        clearTimeout(request.timeout);
+        request.resolve(position);
+      }
+      this._cursorRequests = [];
+      this._escapeBuffer = Buffer.alloc(0);
+      return;
+    }
+
+    // Focus tracking sequences.
+    if (seq === '\x1b[I') {
+      this._events.emit('focuschange', true);
+      this._escapeBuffer = Buffer.alloc(0);
+      return;
+    }
+
+    if (seq === '\x1b[O') {
+      this._events.emit('focuschange', false);
+      this._escapeBuffer = Buffer.alloc(0);
+      return;
+    }
+
+    // Check known escape sequences.
+    if (seq in ESCAPE_SEQUENCES) {
+      const keyName = ESCAPE_SEQUENCES[seq];
+      const isShift = keyName.startsWith('shift+');
+      const isCtrl = keyName.startsWith('ctrl+');
+      const isAlt = keyName.startsWith('alt+');
+      const cleanKey = keyName.replace(/^(shift|ctrl|alt)\+/, '');
+
+      this._events.emit('key', createKeyEvent({
+        key: cleanKey,
+        raw: this._escapeBuffer,
+        ctrl: isCtrl,
+        alt: isAlt,
+        shift: isShift,
+      }));
+      this._escapeBuffer = Buffer.alloc(0);
+      return;
+    }
+
+    // Alt+key: ESC followed by a regular character.
+    if (
+      seq.length === 2 &&
+      seq[0] === '\x1b' &&
+      seq[1] !== '[' &&
+      seq[1] !== 'O'
+    ) {
+      const ch = seq[1];
+      this._events.emit('key', createKeyEvent({
+        key: ch,
+        raw: this._escapeBuffer,
+        ctrl: false,
+        alt: true,
+        shift: ch !== ch.toLowerCase() && ch === ch.toUpperCase(),
+      }));
+      this._escapeBuffer = Buffer.alloc(0);
+      return;
+    }
+
+    // If the sequence is getting too long, give up.
+    if (seq.length > 20) {
+      this._escapeBuffer = Buffer.alloc(0);
+      return;
+    }
+
+    // Wait for more bytes (might be an incomplete sequence; FSM handles via _escapeBuffer).
+    return;
+  }
 }

--- a/packages/core/src/input/InputParser.ts
+++ b/packages/core/src/input/InputParser.ts
@@ -135,21 +135,20 @@ export class InputParser {
 
     // If we are currently collecting a paste, append and look for the end marker.
     if (this._isPasting) {
-      const endIdx = str.indexOf(PASTE_END);
+      this._pasteBuffer += str;
+      const endIdx = this._pasteBuffer.indexOf(PASTE_END);
       if (endIdx !== -1) {
-        this._pasteBuffer += str.substring(0, endIdx);
-        const pastedText = this._pasteBuffer;
+        const pastedText = this._pasteBuffer.substring(0, endIdx);
         this._isPasting = false;
         this._pasteBuffer = '';
         this._clearPasteTimeout();
         this._events.emit('paste', pastedText);
 
-        const remaining = str.substring(endIdx + PASTE_END.length);
+        const remaining = this._pasteBuffer.substring(endIdx + PASTE_END.length);
         if (remaining.length > 0) {
           this._processInput(Buffer.from(remaining, 'utf8'));
         }
       } else {
-        this._pasteBuffer += str;
         this._startPasteTimeout();
       }
       return;
@@ -163,8 +162,6 @@ export class InputParser {
         this._escapeTimeout = null;
       }
       this._tryParseEscape();
-      // If the sequence is still incomplete, restart the timeout so fragmented TCP chunks
-      // won't trigger a false standalone ESC.
       if (this._escapeBuffer.length > 0) {
         this._startEscapeTimeout();
       }
@@ -174,7 +171,6 @@ export class InputParser {
     // Detect bracketed paste start/end in this chunk.
     const startIdx = str.indexOf(PASTE_START);
     if (startIdx !== -1) {
-      // Process any normal input before the paste start.
       if (startIdx > 0) {
         const before = str.substring(0, startIdx);
         this._processInput(Buffer.from(before, 'utf8'));
@@ -184,14 +180,12 @@ export class InputParser {
       const endIdx = afterStart.indexOf(PASTE_END);
 
       if (endIdx !== -1) {
-        // Both markers in one chunk: emit paste and process trailing input.
         this._events.emit('paste', afterStart.substring(0, endIdx));
         const remaining = afterStart.substring(endIdx + PASTE_END.length);
         if (remaining.length > 0) {
           this._processInput(Buffer.from(remaining, 'utf8'));
         }
       } else {
-        // Paste spans multiple chunks: start collecting.
         this._isPasting = true;
         this._pasteBuffer = afterStart;
         this._startPasteTimeout();
@@ -201,7 +195,6 @@ export class InputParser {
 
     // Check if this starts an escape sequence.
     if (str.startsWith('\x1b') && str.length === 1) {
-      // Lone ESC — wait for more bytes.
       this._escapeBuffer = data;
       this._startEscapeTimeout();
       return;
@@ -225,7 +218,6 @@ export class InputParser {
       this._graphemeTimeout = null;
     }
 
-    // Process after a short 10ms delay to merge split chunks (like modifiers or ZWJ sequences).
     this._graphemeTimeout = setTimeout(() => {
       this._processGraphemeBuffer();
       this._graphemeTimeout = null;
@@ -239,7 +231,6 @@ export class InputParser {
     if (graphemes.length === 0) return;
 
     let processCount = graphemes.length;
-    // Check if the last grapheme is potentially incomplete.
     const lastGrapheme = graphemes[graphemes.length - 1];
     if (this._isPossiblyIncompleteGrapheme(lastGrapheme)) {
       processCount = graphemes.length - 1;
@@ -250,7 +241,6 @@ export class InputParser {
       const code = ch.codePointAt(0)!;
       const raw = Buffer.from(ch, 'utf8');
 
-      // Ctrl+key (0x01-0x1A, excluding tab/enter/backspace).
       if (code >= 0x01 && code <= 0x1A) {
         const keyName = CTRL_KEYS[code];
         const isCtrl = code !== 0x09 && code !== 0x0D && code !== 0x0A;
@@ -264,7 +254,6 @@ export class InputParser {
         continue;
       }
 
-      // Special keys.
       if (code in SPECIAL_KEYS) {
         this._events.emit('key', createKeyEvent({
           key: SPECIAL_KEYS[code],
@@ -276,7 +265,6 @@ export class InputParser {
         continue;
       }
 
-      // Regular printable character.
       if (code >= 0x20) {
         this._events.emit('key', createKeyEvent({
           key: ch,
@@ -288,20 +276,15 @@ export class InputParser {
       }
     }
 
-    // Update the remaining buffer.
     this._graphemeBuffer = graphemes.slice(processCount).join('');
   }
 
   private _isPossiblyIncompleteGrapheme(ch: string): boolean {
     if (!ch) return false;
-    // ZWJ sequence continuation check.
     if (ch.endsWith('\u200D')) return true;
-    // Surrogate pair incomplete check (last char is high surrogate).
     const lastCharCode = ch.charCodeAt(ch.length - 1);
     if (lastCharCode >= 0xD800 && lastCharCode <= 0xDBFF) return true;
-
-    // Regional Indicator Symbols (flags: U+1F1E6 to U+1F1FF).
-    // Check if there's an odd number of regional indicator symbols in this grapheme.
+    
     const codePoints = Array.from(ch);
     const lastCpVal = codePoints[codePoints.length - 1].codePointAt(0)!;
     if (lastCpVal >= 0x1F1E6 && lastCpVal <= 0x1F1FF) {
@@ -321,15 +304,8 @@ export class InputParser {
     return false;
   }
 
-  /**
-   * Start or restart the escape sequence timeout.
-   * Fires when no additional bytes arrive within the window,
-   * treating the buffered bytes as a standalone Escape key.
-   */
   private _startEscapeTimeout(): void {
-    if (this._escapeTimeout) {
-      clearTimeout(this._escapeTimeout);
-    }
+    if (this._escapeTimeout) clearTimeout(this._escapeTimeout);
     this._escapeTimeout = setTimeout(() => {
       const remained = this._escapeBuffer;
       this._escapeBuffer = Buffer.alloc(0);
@@ -344,11 +320,6 @@ export class InputParser {
     }, ESCAPE_TIMEOUT_MS);
   }
 
-  /**
-   * Start or restart the paste inactivity timeout.
-   * If no additional paste data arrives within the timeout,
-   * the paste state is aborted to prevent stale state.
-   */
   private _startPasteTimeout(): void {
     this._clearPasteTimeout();
     this._pasteTimeout = setTimeout(() => {
@@ -365,9 +336,6 @@ export class InputParser {
     }
   }
 
-  /**
-   * Try to parse buffered escape sequence.
-   */
   private _tryParseEscape(): void {
     const seq = this._escapeBuffer.toString('utf8');
 
@@ -384,7 +352,6 @@ export class InputParser {
       return;
     }
 
-    // Check for mouse event first.
     if (isMouseSequence(seq)) {
       const mouseEvt = parseMouseEvent(seq);
       if (mouseEvt) {
@@ -392,13 +359,9 @@ export class InputParser {
         this._escapeBuffer = Buffer.alloc(0);
         return;
       }
-      // Might be incomplete mouse sequence — wait for more data (no timeout, FSM handles via _escapeBuffer).
-      if (seq.length < 20) { // safety cap
-        return;
-      }
+      if (seq.length < 20) return;
     }
 
-    // Cursor position report.
     const cursorMatch = seq.match(/^\x1b\[(\d+);(\d+)R$/);
     if (cursorMatch) {
       const row = parseInt(cursorMatch[1], 10);
@@ -414,7 +377,6 @@ export class InputParser {
       return;
     }
 
-    // Focus tracking sequences.
     if (seq === '\x1b[I') {
       this._events.emit('focuschange', true);
       this._escapeBuffer = Buffer.alloc(0);
@@ -427,7 +389,6 @@ export class InputParser {
       return;
     }
 
-    // Check known escape sequences.
     if (seq in ESCAPE_SEQUENCES) {
       const keyName = ESCAPE_SEQUENCES[seq];
       const isShift = keyName.startsWith('shift+');
@@ -446,7 +407,6 @@ export class InputParser {
       return;
     }
 
-    // Alt+key: ESC followed by a regular character.
     if (
       seq.length === 2 &&
       seq[0] === '\x1b' &&
@@ -465,13 +425,9 @@ export class InputParser {
       return;
     }
 
-    // If the sequence is getting too long, give up.
     if (seq.length > 20) {
       this._escapeBuffer = Buffer.alloc(0);
       return;
     }
-
-    // Wait for more bytes (might be an incomplete sequence; FSM handles via _escapeBuffer).
-    return;
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

This PR updates `@termuijs/core` input parsing to reliably handle terminal bracketed paste mode, so pasted text is collected correctly even when the start/end markers arrive across multiple stdin chunks. It also ensures any non-paste input before and after a paste sequence is still processed through the existing key parsing path without being dropped.

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #1619 

## Which package(s)?

@termuijs/core

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run` 
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (not applicable for this core input change).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/a59d754a-8095-4997-91d8-2fb4c1577efa`

## Screenshots / Recordings (UI changes)

_Not applicable — this change is in the core input parser and does not alter UI rendering._

## Notes for the Reviewer
The changes in this PR are scoped to:

- `packages/core/src/input/InputParser.ts`:
  - Add and use paste collection state (`_isPasting`, `_pasteBuffer`, `_pasteTimeout`) to buffer text between `ESC[200~` and `ESC[201~`.
  - Move the `const str = data.toString('utf8')` declaration to the top of `_processInput` so it is in scope before first use.
  - Detect bracketed paste markers within a chunk, emit a single `paste` event for the buffered content, and recursively process any remaining non-paste input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved bracketed paste handling for pasted text containing UTF-8 characters, including when the paste data is received in multiple chunks.
  * Paste termination now more reliably captures the full pasted content and correctly handles any remaining input after the end marker, preventing unintended trailing processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->