### PR TITLE
fix(widgets): buffer drawing commands on Canvas before initial layout

### DIFF
--- a/packages/widgets/src/display/Canvas.test.ts
+++ b/packages/widgets/src/display/Canvas.test.ts
@@ -109,4 +109,20 @@ describe('Canvas', () => {
         }
         expect(hasContent).toBe(true);
     });
+
+    it('buffers drawing commands before layout and replays them on initial render', () => {
+        const canvas = new Canvas({ width: 5, height: 3 });
+        const screen = new Screen(10, 5);
+
+        // Draw immediately before layout/render
+        canvas.setPixel(0, 0, true);
+        canvas.setPixel(1, 0, true);
+
+        // Layout and render
+        canvas.updateRect({ x: 0, y: 0, width: 5, height: 3 });
+        canvas.render(screen);
+
+        const expectedCharCode = BRAILLE_OFFSET | BRAILLE_DOTS[0][0] | BRAILLE_DOTS[0][1];
+        expect(screen.back[0][0].char).toBe(String.fromCharCode(expectedCharCode));
+    });
 });

--- a/packages/widgets/src/display/Canvas.ts
+++ b/packages/widgets/src/display/Canvas.ts
@@ -15,6 +15,7 @@ export class Canvas extends Widget {
     private _canvasWidth: number = 0;
     private _canvasHeight: number = 0;
     private _color: Color | undefined;
+    private _commands: Array<() => void> = [];
 
     constructor(style: Partial<Style> = {}) {
         super(style);
@@ -32,6 +33,10 @@ export class Canvas extends Widget {
      * Clears the entire canvas.
      */
     public clear(): void {
+        if (this._canvasWidth === 0) {
+            this._commands = [];
+            return;
+        }
         if (this._pixels.length > 0) {
             this._pixels.fill(0);
             this.markDirty();
@@ -42,6 +47,10 @@ export class Canvas extends Widget {
      * Sets a single sub-cell pixel.
      */
     public setPixel(x: number, y: number, value: boolean = true): void {
+        if (this._canvasWidth === 0) {
+            this._commands.push(() => this.setPixel(x, y, value));
+            return;
+        }
         x = Math.floor(x);
         y = Math.floor(y);
         if (x < 0 || x >= this._canvasWidth || y < 0 || y >= this._canvasHeight) return;
@@ -60,6 +69,10 @@ export class Canvas extends Widget {
      * Fills a rectangle with the current drawing state.
      */
     public fillRect(x: number, y: number, w: number, h: number): void {
+        if (this._canvasWidth === 0) {
+            this._commands.push(() => this.fillRect(x, y, w, h));
+            return;
+        }
         x = Math.floor(x);
         y = Math.floor(y);
         w = Math.floor(w);
@@ -84,6 +97,10 @@ export class Canvas extends Widget {
      * Draws an unfilled circle.
      */
     public drawCircle(cx: number, cy: number, r: number): void {
+        if (this._canvasWidth === 0) {
+            this._commands.push(() => this.drawCircle(cx, cy, r));
+            return;
+        }
         cx = Math.floor(cx);
         cy = Math.floor(cy);
         r = Math.floor(r);
@@ -121,6 +138,10 @@ export class Canvas extends Widget {
      * Draws a line from (x0, y0) to (x1, y1).
      */
     public lineTo(x0: number, y0: number, x1: number, y1: number): void {
+        if (this._canvasWidth === 0) {
+            this._commands.push(() => this.lineTo(x0, y0, x1, y1));
+            return;
+        }
         x0 = Math.floor(x0);
         y0 = Math.floor(y0);
         x1 = Math.floor(x1);
@@ -162,6 +183,7 @@ export class Canvas extends Widget {
         const pxHeight = innerHeight * 4;
 
         if (this._canvasWidth !== pxWidth || this._canvasHeight !== pxHeight) {
+            const isInitialAllocation = this._canvasWidth === 0;
             const newPixels = new Uint8Array(pxWidth * pxHeight);
             
             // Optionally preserve old pixels if resizing
@@ -174,6 +196,14 @@ export class Canvas extends Widget {
             this._pixels = newPixels;
             this._canvasWidth = pxWidth;
             this._canvasHeight = pxHeight;
+
+            if (isInitialAllocation) {
+                const commandsToReplay = this._commands;
+                this._commands = [];
+                for (const cmd of commandsToReplay) {
+                    cmd();
+                }
+            }
         }
 
         const { bg, fg } = styleToCellAttrs(this._style);


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

The Canvas widget does not accept dimensions in its constructor (it only takes a style object) and starts with a width and height of 0. The pixel buffer is only allocated during the first _renderSelf pass when the layout engine computes the rect. If a developer initializes a Canvas and immediately draws on it (e.g. canvas.lineTo(0,0, 10,10)) during setup or component initialization, all drawing operations are silently discarded because they fail the boundary checks (which check against 0).


## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #2058 

## Which package(s)?

Canvas.ts

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [ ] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [ ] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Drawing commands issued before the canvas is first rendered are now preserved and shown correctly on the initial output.
  * Clearing the canvas before it is fully initialized now correctly discards any pending drawing actions.
  * Added test coverage to verify early drawing appears in the expected position after the first render.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->