### PR TITLE
Fix create-termui-app add registry endpoint

### DIFF
--- a/packages/create-termui-app/src/commands/add.test.ts
+++ b/packages/create-termui-app/src/commands/add.test.ts
@@ -10,36 +10,32 @@ vi.mock("node:child_process", () => ({
 import * as childProcess from "node:child_process";
 import { runAddCommand } from "./add";
 
-const registrySchema = {
-    components: [
-        {
-            name: "badge",
-            category: "utility",
-            description:
-                "Short inline label with colored background for status indicators.",
-            files: ["registry/components/badge/index.ts"],
-            deps: ["@termuijs/core", "@termuijs/widgets"],
-            peerDeps: [],
-            version: "0.1.0",
-        },
-    ],
-};
+const registryIndex = [
+    {
+        name: "Badge",
+        slug: "badge",
+        category: "utility",
+        description:
+            "Short inline label with colored background for status indicators.",
+        files: [
+            {
+                path: "badge.ts",
+                content: 'export const Badge = () => "badge";',
+            },
+        ],
+        dependencies: ["@termuijs/core", "@termuijs/widgets"],
+        version: "0.1.0",
+    },
+];
 
 let originalFetch: typeof fetch;
 
 function setupFetchMock() {
     const mockFetch = vi.fn(async (url: string) => {
-        if (url.endsWith("/registry/schema.json")) {
+        if (url.endsWith("/r/registry.json")) {
             return {
                 ok: true,
-                json: async () => registrySchema,
-            } as any;
-        }
-
-        if (url.endsWith("/registry/components/badge/index.ts")) {
-            return {
-                ok: true,
-                text: async () => 'export const Badge = () => "badge";',
+                json: async () => registryIndex,
             } as any;
         }
 
@@ -194,20 +190,19 @@ describe("runAddCommand", () => {
     });
 
     it("rejects path traversal in registry file paths", async () => {
-        const traversalSchema = {
-            components: [
-                {
-                    name: "evil",
-                    files: ["registry/components/evil/../../../../../../etc/passwd"],
-                    deps: [],
-                    peerDeps: [],
-                },
-            ],
-        };
+        const traversalIndex = [
+            {
+                name: "evil",
+                slug: "evil",
+                files: ["registry/components/evil/../../../../../../etc/passwd"],
+                deps: [],
+                peerDeps: [],
+            },
+        ];
 
         globalThis.fetch = vi.fn(async (url: string) => {
-            if (url.endsWith("/registry/schema.json")) {
-                return { ok: true, json: async () => traversalSchema } as any;
+            if (url.endsWith("/r/registry.json")) {
+                return { ok: true, json: async () => traversalIndex } as any;
             }
             return { ok: true, text: async () => "malicious content" } as any;
         }) as any;
@@ -215,5 +210,44 @@ describe("runAddCommand", () => {
         await expect(
             runAddCommand({ component: "evil", yes: true }),
         ).rejects.toThrow("is outside project root");
+    });
+
+    it("supports legacy registry entries that list file URLs", async () => {
+        const legacyIndex = {
+            components: [
+                {
+                    name: "badge",
+                    files: ["registry/components/badge/index.ts"],
+                    deps: ["@termuijs/core"],
+                    peerDeps: [],
+                },
+            ],
+        };
+
+        globalThis.fetch = vi.fn(async (url: string) => {
+            if (url.endsWith("/r/registry.json")) {
+                return { ok: true, json: async () => legacyIndex } as any;
+            }
+            if (url.endsWith("/registry/components/badge/index.ts")) {
+                return {
+                    ok: true,
+                    text: async () => 'export const Badge = () => "legacy";',
+                } as any;
+            }
+            return { ok: false, status: 404, statusText: "Not Found" } as any;
+        }) as any;
+
+        vi.spyOn(childProcess, "execFileSync");
+
+        await runAddCommand({ component: "badge", yes: true });
+
+        const destination = join(
+            tempDir,
+            "src",
+            "components",
+            "badge",
+            "index.ts",
+        );
+        expect(readFileSync(destination, "utf-8")).toContain("legacy");
     });
 });

--- a/packages/create-termui-app/src/commands/add.ts
+++ b/packages/create-termui-app/src/commands/add.ts
@@ -15,17 +15,17 @@ export interface AddCommandOptions {
 
 interface RegistryComponent {
     name: string;
+    slug?: string;
     category?: string;
     description?: string;
-    files: string[];
+    files: Array<string | { path: string; content: string }>;
+    dependencies?: string[];
     deps?: string[];
     peerDeps?: string[];
     version?: string;
 }
 
-interface RegistrySchema {
-    components: RegistryComponent[];
-}
+type RegistryIndex = RegistryComponent[] | { components: RegistryComponent[] };
 
 type PackageManager = "npm" | "yarn" | "pnpm" | "bun";
 
@@ -35,17 +35,18 @@ export async function runAddCommand(options: AddCommandOptions): Promise<void> {
         throw new Error("Component name is required.");
     }
 
-    const schema = await fetchRegistrySchema();
-    const componentEntry = findComponentEntry(schema, componentName);
+    const registry = await fetchRegistryIndex();
+    const componentEntry = findComponentEntry(registry, componentName);
 
     if (!componentEntry) {
-        printAvailableComponents(schema);
+        printAvailableComponents(registry);
         throw new Error(`Component "${componentName}" not found in registry.`);
     }
 
     const outputRoot = resolve(process.cwd(), options.dir ?? "src/components");
-    const destinationRoot = join(outputRoot, componentEntry.name);
-    const fileEntries = await downloadComponentFiles(componentEntry);
+    const componentDirName = componentEntry.slug ?? componentEntry.name;
+    const destinationRoot = join(outputRoot, componentDirName);
+    const fileEntries = await resolveComponentFiles(componentEntry);
 
     if (options.dryRun) {
         printDryRunPreview(destinationRoot, fileEntries);
@@ -63,7 +64,7 @@ export async function runAddCommand(options: AddCommandOptions): Promise<void> {
         }
     }
 
-    writeComponentFiles(destinationRoot, fileEntries, componentEntry.name);
+    writeComponentFiles(destinationRoot, fileEntries, componentDirName);
     await installPackages(componentEntry);
 
     console.log();
@@ -77,13 +78,13 @@ export async function runAddCommand(options: AddCommandOptions): Promise<void> {
     );
 }
 
-async function fetchRegistrySchema(): Promise<RegistrySchema> {
-    const url = `${REGISTRY_BASE_URL}/registry/schema.json`;
+async function fetchRegistryIndex(): Promise<RegistryIndex> {
+    const url = `${REGISTRY_BASE_URL}/r/registry.json`;
     const response = await fetch(url);
 
     if (!response.ok) {
         throw new Error(
-            `Failed to fetch registry schema from ${url}: ${response.status} ${response.statusText}`,
+            `Failed to fetch registry index from ${url}: ${response.status} ${response.statusText}`,
         );
     }
 
@@ -91,18 +92,21 @@ async function fetchRegistrySchema(): Promise<RegistrySchema> {
 }
 
 function findComponentEntry(
-    schema: RegistrySchema,
+    registry: RegistryIndex,
     componentName: string,
 ): RegistryComponent | undefined {
     const normalized = componentName.toLowerCase();
-    return schema.components.find(
-        (entry) => entry.name.toLowerCase() === normalized,
+    const components = Array.isArray(registry) ? registry : registry.components;
+    return components.find(
+        (entry) => entry.name.toLowerCase() === normalized ||
+            entry.slug?.toLowerCase() === normalized,
     );
 }
 
-function printAvailableComponents(schema: RegistrySchema): void {
-    const names = schema.components
-        .map((entry) => entry.name)
+function printAvailableComponents(registry: RegistryIndex): void {
+    const components = Array.isArray(registry) ? registry : registry.components;
+    const names = components
+        .map((entry) => entry.slug ?? entry.name)
         .sort((a, b) => a.localeCompare(b));
 
     console.log("Available registry components:");
@@ -111,10 +115,20 @@ function printAvailableComponents(schema: RegistrySchema): void {
     }
 }
 
-async function downloadComponentFiles(
+async function resolveComponentFiles(
     entry: RegistryComponent,
 ): Promise<Array<{ path: string; content: string }>> {
+    if (entry.files.every((file): file is { path: string; content: string } => {
+        return typeof file !== "string";
+    })) {
+        return entry.files.map(file => ({ path: file.path, content: file.content }));
+    }
+
     const downloads = entry.files.map(async (filePath) => {
+        if (typeof filePath !== "string") {
+            return filePath;
+        }
+
         const rawUrl = `${REGISTRY_BASE_URL}/${filePath}`;
         const response = await fetch(rawUrl);
 
@@ -180,9 +194,12 @@ function resolveDestinationPath(
     componentName: string,
 ): string {
     const prefix = `registry/components/${componentName}/`;
-    const relativePath = registryFilePath.startsWith(prefix)
+    let relativePath = registryFilePath.startsWith(prefix)
         ? registryFilePath.slice(prefix.length)
         : registryFilePath;
+    if (!relativePath.includes("/") && relativePath === `${componentName}.ts`) {
+        relativePath = "index.ts";
+    }
     const destination = resolve(destinationRoot, relativePath);
 
     const rel = relative(resolve(destinationRoot), destination);
@@ -204,12 +221,20 @@ function getDestinationRelativePath(
         return join(destinationRoot, relativePath);
     }
 
+    if (pathSegments.length === 1 && registryFilePath.endsWith(".ts")) {
+        return join(destinationRoot, "index.ts");
+    }
+
     return join(destinationRoot, registryFilePath);
 }
 
 async function installPackages(entry: RegistryComponent): Promise<void> {
     const deps = [
-        ...new Set([...(entry.deps ?? []), ...(entry.peerDeps ?? [])]),
+        ...new Set([
+            ...(entry.dependencies ?? []),
+            ...(entry.deps ?? []),
+            ...(entry.peerDeps ?? []),
+        ]),
     ];
     if (deps.length === 0) {
         return;


### PR DESCRIPTION
## Summary

Fixes #2087.

Updates `create-termui-app add` to read the published `/r/registry.json` endpoint instead of the missing `/registry/schema.json` path. The add command now supports the registry shape used by the live site, including embedded component file contents and `dependencies`, while preserving compatibility for legacy entries that list file paths.

## Details

- Load the registry index from `/r/registry.json`.
- Match components by `slug` or `name`.
- Use embedded file contents when present.
- Keep a fallback for entries that still list downloadable file paths.
- Write compact registry file names such as `badge.ts` to `index.ts` inside the generated component folder.

## Validation

- Ran `git diff --check`.
- Could not run the Bun test script locally because Bun is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a broader component registry format, including legacy component file entries.
  * Component files are now placed more consistently, with single-file components saved as `index.ts`.

* **Bug Fixes**
  * Improved handling of component names and slugs when adding components.
  * Prevented file path traversal outside the project root.
  * Expanded dependency installation to include additional package types from the registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->