### PR TITLE
Validate create-termui-app add --dir values

### DIFF
--- a/packages/create-termui-app/src/args.test.ts
+++ b/packages/create-termui-app/src/args.test.ts
@@ -104,6 +104,24 @@ describe("CLI args", () => {
         expect(res.yes).toBe(true);
     });
 
+    it("rejects add command --dir without a path value", () => {
+        expect(() => parseArgs(["add", "Badge", "--dir"])).toThrow(
+            "--dir requires a value"
+        );
+    });
+
+    it("rejects add command --dir followed by another flag", () => {
+        expect(() => parseArgs(["add", "Badge", "--dir", "--dry-run"])).toThrow(
+            "--dir requires a value"
+        );
+    });
+
+    it("rejects add command --dir= without an inline path value", () => {
+        expect(() => parseArgs(["add", "Badge", "--dir="])).toThrow(
+            "--dir requires a value"
+        );
+    });
+
     it("isNonInteractive works", () => {
         expect(isNonInteractive(parseArgs(["app", "--yes"]))).toBe(true);
         expect(isNonInteractive(parseArgs(["app"]))).toBe(false);

--- a/packages/create-termui-app/src/args.ts
+++ b/packages/create-termui-app/src/args.ts
@@ -33,10 +33,18 @@ function getValue(
     const value = argv[index];
 
     if (value.includes("=")) {
-        return value.split("=")[1];
+        const inlineValue = value.split("=")[1];
+        if (!inlineValue || inlineValue.startsWith("-")) {
+            throw new Error(`${key} requires a value`);
+        }
+        return inlineValue;
     }
 
-    return argv[index + 1];
+    const next = argv[index + 1];
+    if (!next || next.startsWith("-")) {
+        throw new Error(`${key} requires a value`);
+    }
+    return next;
 }
 
 export function parseArgs(argv: string[]): CliArgs {


### PR DESCRIPTION
## Summary

Fixes #2088.

Adds validation for `create-termui-app add --dir` so the option cannot consume another flag or an empty inline assignment as its directory value.

## Details

- Rejects `--dir` when no path follows.
- Rejects `--dir --dry-run` instead of treating `--dry-run` as a directory.
- Rejects `--dir=` when no inline value is provided.
- Adds regression coverage for the invalid forms.

## Validation

- Ran `git diff --check`.
- Could not run the Bun test script locally because Bun is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line argument handling so `--dir` now requires a valid path value in all cases, including when it appears at the end of input, before another flag, or as `--dir=`.

* **Tests**
  * Added coverage for invalid `--dir` usage to confirm the correct error message is shown when no value is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->