### PR TITLE
Preserve multi-value TSS spacing declarations

### DIFF
--- a/packages/tss/src/engine.test.ts
+++ b/packages/tss/src/engine.test.ts
@@ -63,6 +63,20 @@ describe('ThemeEngine', () => {
         expect(style.fg).toEqual({ type: 'named', name: 'cyan' });
     });
 
+    it('resolves multi-value padding and margin declarations', () => {
+        const engine = new ThemeEngine();
+        engine.load(`
+            Box {
+                padding: 1 2;
+                margin: 1 2 3 4;
+            }
+        `);
+
+        const style = engine.resolveStyle('Box');
+        expect(style.padding).toEqual({ top: 1, bottom: 1, left: 2, right: 2 });
+        expect(style.margin).toEqual({ top: 1, right: 2, bottom: 3, left: 4 });
+    });
+
     it('onChange notifies listeners on theme switch', () => {
         const engine = new ThemeEngine();
         engine.load(TSS_SOURCE);

--- a/packages/tss/src/parser.test.ts
+++ b/packages/tss/src/parser.test.ts
@@ -75,4 +75,22 @@ describe('TSS Parser', () => {
         expect(prop.value.kind).toBe('number');
         expect((prop.value as any).value).toBe(50);
     });
+
+    it('preserves multi-token spacing values', () => {
+        const ast = parseTSS(`
+            Box {
+                padding: 1 2;
+                margin: 1 2 3 4;
+            }
+        `);
+
+        expect(ast.rules[0].properties[0].value).toEqual({
+            kind: 'literal',
+            value: '1 2',
+        });
+        expect(ast.rules[0].properties[1].value).toEqual({
+            kind: 'literal',
+            value: '1 2 3 4',
+        });
+    });
 });

--- a/packages/tss/src/parser.ts
+++ b/packages/tss/src/parser.ts
@@ -215,29 +215,52 @@ export function parse(tokens: Token[]): TSSStylesheet {
     }
 
     function parseValue(): TSSValue {
-        const t = peek();
-        if (t.type === TokenType.Var) {
-            advance();
-            return { kind: 'var', name: t.value };
+        const valueTokens: Token[] = [];
+        while (peek().type !== TokenType.Semicolon && peek().type !== TokenType.RBrace && peek().type !== TokenType.EOF) {
+            valueTokens.push(advance());
         }
-        if (t.type === TokenType.Color) {
-            advance();
-            return { kind: 'color', value: t.value };
+
+        if (valueTokens.length === 1) {
+            const t = valueTokens[0];
+            if (t.type === TokenType.Var) {
+                return { kind: 'var', name: t.value };
+            }
+            if (t.type === TokenType.Color) {
+                return { kind: 'color', value: t.value };
+            }
+            if (t.type === TokenType.Number) {
+                return { kind: 'number', value: parseFloat(t.value) };
+            }
+            if (t.type === TokenType.String || t.type === TokenType.Ident) {
+                return { kind: 'literal', value: t.value };
+            }
         }
-        if (t.type === TokenType.Number) {
-            advance();
-            return { kind: 'number', value: parseFloat(t.value) };
+
+        return {
+            kind: 'literal',
+            value: valueTokens.map(tokenToRawValue).join(' ').trim(),
+        };
+    }
+
+    function tokenToRawValue(token: Token): string {
+        switch (token.type) {
+            case TokenType.Color:
+            case TokenType.Ident:
+            case TokenType.Number:
+            case TokenType.String:
+            case TokenType.Var:
+            case TokenType.Variable:
+            case TokenType.Percent:
+                return token.value;
+            case TokenType.Colon:
+                return ':';
+            case TokenType.Comma:
+                return ',';
+            case TokenType.Dot:
+                return '.';
+            default:
+                return token.value;
         }
-        if (t.type === TokenType.String) {
-            advance();
-            return { kind: 'literal', value: t.value };
-        }
-        if (t.type === TokenType.Ident) {
-            advance();
-            return { kind: 'literal', value: t.value };
-        }
-        advance();
-        return { kind: 'literal', value: t.value };
     }
 
     function parseRawValue(): string {


### PR DESCRIPTION
## Summary

Fixes #2089.

Updates the TSS parser so spacing declarations such as `padding: 1 2;` and `margin: 1 2 3 4;` are preserved as full values instead of being truncated to the first token.

## Details

- Collects declaration value tokens up to `;` or `}`.
- Keeps existing typed behavior for single-token `var`, color, number, string, and identifier values.
- Adds parser coverage for multi-token spacing values.
- Adds engine coverage for two-value padding and four-value margin resolution.

## Validation

- Ran `git diff --check`.
- Could not run the Bun test script locally because Bun is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multi-value spacing declarations so values like `padding: 1 2;` and `margin: 1 2 3 4;` are parsed and resolved correctly.
  * Expanded support for preserving exact value text in complex declarations, including punctuation and multi-token expressions.
* **Tests**
  * Added coverage for parsing and style resolution of multi-value spacing properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->