### PR TITLE
Parse TSS calc expressions as complete values

### DIFF
--- a/packages/tss/src/engine.test.ts
+++ b/packages/tss/src/engine.test.ts
@@ -63,6 +63,18 @@ describe('ThemeEngine', () => {
         expect(style.fg).toEqual({ type: 'named', name: 'cyan' });
     });
 
+    it('resolves calc expressions in numeric style properties', () => {
+        const engine = new ThemeEngine();
+        engine.load(`
+            Box {
+                width: calc(10 - 2);
+            }
+        `);
+
+        const style = engine.resolveStyle('Box');
+        expect(style.width).toBe(8);
+    });
+
     it('onChange notifies listeners on theme switch', () => {
         const engine = new ThemeEngine();
         engine.load(TSS_SOURCE);

--- a/packages/tss/src/parser.test.ts
+++ b/packages/tss/src/parser.test.ts
@@ -75,4 +75,14 @@ describe('TSS Parser', () => {
         expect(prop.value.kind).toBe('number');
         expect((prop.value as any).value).toBe(50);
     });
+
+    it('parses calc expressions as literal values', () => {
+        const ast = parseTSS(`
+            Box {
+                width: calc(10 - 2);
+            }
+        `);
+        const prop = ast.rules[0].properties[0];
+        expect(prop.value).toEqual({ kind: 'literal', value: 'calc(10 - 2)' });
+    });
 });

--- a/packages/tss/src/parser.ts
+++ b/packages/tss/src/parser.ts
@@ -232,6 +232,10 @@ export function parse(tokens: Token[]): TSSStylesheet {
             advance();
             return { kind: 'literal', value: t.value };
         }
+        if (t.type === TokenType.Calc) {
+            advance();
+            return { kind: 'literal', value: t.value };
+        }
         if (t.type === TokenType.Ident) {
             advance();
             return { kind: 'literal', value: t.value };

--- a/packages/tss/src/tokenizer.test.ts
+++ b/packages/tss/src/tokenizer.test.ts
@@ -53,6 +53,13 @@ describe('TSS Tokenizer', () => {
         expect(v!.value).toBe('--primary');
     });
 
+    it('tokenizes calc() expressions as a single value', () => {
+        const tokens = tokenize('width: calc(10 - 2);');
+        const calc = tokens.find(t => t.type === TokenType.Calc);
+        expect(calc).toBeDefined();
+        expect(calc!.value).toBe('calc(10 - 2)');
+    });
+
     it('tokenizes pseudo-classes', () => {
         const tokens = tokenize('Box:focused { }');
         const pseudo = tokens.find(t => t.type === TokenType.PseudoClass);

--- a/packages/tss/src/tokenizer.ts
+++ b/packages/tss/src/tokenizer.ts
@@ -22,6 +22,7 @@ export enum TokenType {
     Number = 'NUMBER',
     Color = 'COLOR',           // #rrggbb or #rgb
     Var = 'VAR',               // var(--name)
+    Calc = 'CALC',             // calc(...)
     Variable = 'VARIABLE',     // --name
 
     // Pseudo-selectors
@@ -165,13 +166,23 @@ export function tokenize(source: string): Token[] {
             let ident = '';
             while (pos < source.length && /[a-zA-Z0-9_-]/.test(peek())) ident += advance();
 
-            if (ident === 'var' && peek() === '(') {
+            if ((ident === 'var' || ident === 'calc') && peek() === '(') {
                 advance();
                 while (pos < source.length && /\s/.test(peek())) advance();
-                let varName = '';
-                while (pos < source.length && peek() !== ')') varName += advance();
-                if (pos < source.length) advance();
-                tokens.push({ type: TokenType.Var, value: varName.trim(), line, col: startCol });
+                let value = '';
+                let depth = 1;
+                while (pos < source.length && depth > 0) {
+                    const next = advance();
+                    if (next === '(') depth++;
+                    if (next === ')') depth--;
+                    if (depth > 0) value += next;
+                }
+                tokens.push({
+                    type: ident === 'var' ? TokenType.Var : TokenType.Calc,
+                    value: ident === 'var' ? value.trim() : `calc(${value.trim()})`,
+                    line,
+                    col: startCol,
+                });
             } else {
                 tokens.push({ type: TokenType.Ident, value: ident, line, col: startCol });
             }


### PR DESCRIPTION
## Summary

Fixes #2090.

Adds tokenizer and parser support for preserving `calc(...)` declarations as complete literal values so the existing `evalCalc` path in the theme engine can resolve them.

## Details

- Adds a `Calc` token type for `calc(...)` expressions.
- Preserves the full expression text during tokenization.
- Parses calc values as literals for `_resolveValue()`.
- Adds tokenizer, parser, and engine coverage for `width: calc(10 - 2);`.

## Validation

- Ran `git diff --check`.
- Could not run the Bun test script locally because Bun is not installed in this environment.