### PR TITLE
Preserve negative numbers in TSS values

### DIFF
--- a/packages/tss/src/engine.test.ts
+++ b/packages/tss/src/engine.test.ts
@@ -63,6 +63,18 @@ describe('ThemeEngine', () => {
         expect(style.fg).toEqual({ type: 'named', name: 'cyan' });
     });
 
+    it('resolves negative numeric style values', () => {
+        const engine = new ThemeEngine();
+        engine.load(`
+            Box {
+                margin: -2;
+            }
+        `);
+
+        const style = engine.resolveStyle('Box');
+        expect(style.margin).toBe(-2);
+    });
+
     it('onChange notifies listeners on theme switch', () => {
         const engine = new ThemeEngine();
         engine.load(TSS_SOURCE);

--- a/packages/tss/src/parser.test.ts
+++ b/packages/tss/src/parser.test.ts
@@ -75,4 +75,15 @@ describe('TSS Parser', () => {
         expect(prop.value.kind).toBe('number');
         expect((prop.value as any).value).toBe(50);
     });
+
+    it('parses negative numeric values', () => {
+        const ast = parseTSS(`
+            Box {
+                margin: -2;
+            }
+        `);
+        const prop = ast.rules[0].properties[0];
+        expect(prop.value.kind).toBe('number');
+        expect((prop.value as any).value).toBe(-2);
+    });
 });

--- a/packages/tss/src/tokenizer.test.ts
+++ b/packages/tss/src/tokenizer.test.ts
@@ -39,6 +39,13 @@ describe('TSS Tokenizer', () => {
         expect(num!.value).toBe('42');
     });
 
+    it('tokenizes negative numbers', () => {
+        const tokens = tokenize('margin: -2;');
+        const num = tokens.find(t => t.type === TokenType.Number);
+        expect(num).toBeDefined();
+        expect(num!.value).toBe('-2');
+    });
+
     it('tokenizes CSS variables --name', () => {
         const tokens = tokenize('--primary: cyan;');
         const variable = tokens.find(t => t.type === TokenType.Variable);

--- a/packages/tss/src/tokenizer.ts
+++ b/packages/tss/src/tokenizer.ts
@@ -141,9 +141,10 @@ export function tokenize(source: string): Token[] {
         }
 
         // Numbers
-        if (/[0-9]/.test(ch)) {
+        if (/[0-9]/.test(ch) || (ch === '-' && /[0-9.]/.test(at(pos + 1)))) {
             const startCol = col;
             let num = '';
+            if (ch === '-') num += advance();
             while (pos < source.length && /[0-9.]/.test(peek())) num += advance();
             tokens.push({ type: TokenType.Number, value: num, line, col: startCol });
             continue;


### PR DESCRIPTION
## Summary

Fixes #2091.

Updates the TSS tokenizer so negative numeric values keep their leading minus sign instead of being parsed as positive numbers.

## Details

- Accepts a leading `-` when followed by a numeric character.
- Leaves CSS variable tokenization for `--name` intact.
- Adds tokenizer, parser, and engine coverage for negative numeric values.

## Validation

- Ran `git diff --check`.
- Could not run the Bun test script locally because Bun is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for negative numeric values across parsing and style resolution.
  * Values like `-2` are now recognized and preserved correctly in input processing, so styles using negative numbers behave as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->