### PR TITLE
Resolve chained TSS variable aliases

### DIFF
--- a/packages/tss/src/engine.test.ts
+++ b/packages/tss/src/engine.test.ts
@@ -63,6 +63,41 @@ describe('ThemeEngine', () => {
         expect(style.fg).toEqual({ type: 'named', name: 'cyan' });
     });
 
+    it('resolves variable aliases that reference another variable', () => {
+        const engine = new ThemeEngine();
+        engine.load(`
+            @theme default {
+                --primary: cyan;
+                --accent: var(--primary);
+            }
+
+            Box {
+                color: var(--accent);
+            }
+        `);
+
+        const style = engine.resolveStyle('Box');
+        expect(style.fg).toEqual({ type: 'named', name: 'cyan' });
+    });
+
+    it('resolves chained variable aliases', () => {
+        const engine = new ThemeEngine();
+        engine.load(`
+            @theme default {
+                --primary: cyan;
+                --accent: var(--primary);
+                --focus: var(--accent);
+            }
+
+            Box {
+                border-color: var(--focus);
+            }
+        `);
+
+        const style = engine.resolveStyle('Box');
+        expect(style.borderColor).toEqual({ type: 'named', name: 'cyan' });
+    });
+
     it('resolves negative numeric style values', () => {
         const engine = new ThemeEngine();
         engine.load(`

--- a/packages/tss/src/engine.ts
+++ b/packages/tss/src/engine.ts
@@ -165,10 +165,13 @@ export class ThemeEngine {
                 const rawValue = this._variables[value.name];
                 if (!rawValue) return '';
                 _visited.add(value.name);
-                // If stored value is itself a var() reference, resolve recursively
+                // Theme variable aliases are stored either as "--name" or "var(--name)".
+                if (rawValue.startsWith('--')) {
+                    return this._resolveValue({ kind: 'var', name: rawValue }, _visited);
+                }
                 const varMatch = rawValue.match(/^var\(--([^)]+)\)$/);
                 if (varMatch) {
-                    return this._resolveValue({ kind: 'var', name: varMatch[1] }, _visited);
+                    return this._resolveValue({ kind: 'var', name: `--${varMatch[1]}` }, _visited);
                 }
                 return rawValue;
             }


### PR DESCRIPTION
## Summary

Fixes #2092.

Preserves the leading `--` when recursively resolving theme variable aliases such as `--accent: var(--primary)`.

## Details

- Re-adds the CSS variable prefix before recursive lookups.
- Adds coverage for one-level aliases.
- Adds coverage for chained aliases resolving into `border-color`.

## Validation

- Ran `git diff --check`.
- Could not run the Bun test script locally because Bun is not installed in this environment.