### PR TITLE
Return a defensive copy from TimePicker value

### DIFF
--- a/packages/ui/src/TimePicker.test.ts
+++ b/packages/ui/src/TimePicker.test.ts
@@ -35,6 +35,16 @@ describe("TimePicker", () => {
         expect(picker.value.getHours()).toBe(15);
     });
 
+    it("returns a defensive copy from value getter", () => {
+        const d = new Date(2020, 1, 1, 14, 30);
+        const picker = new TimePicker({ value: d });
+
+        const value = picker.value;
+        value.setHours(23);
+
+        expect(picker.value.getHours()).toBe(14);
+    });
+
     it("handles keyboard events to increment minutes", () => {
         const d = new Date(2020, 1, 1, 14, 30);
         const picker = new TimePicker({ value: d });

--- a/packages/ui/src/TimePicker.ts
+++ b/packages/ui/src/TimePicker.ts
@@ -22,7 +22,7 @@ export class TimePicker extends Widget {
     }
 
     get value(): Date {
-        return this._date;
+        return new Date(this._date);
     }
 
     set value(val: Date) {


### PR DESCRIPTION
## Summary

Fixes #2095.

Updates `TimePicker.value` so callers receive a defensive `Date` copy rather than the widget's internal mutable date object.

## Details

- Returns `new Date(this._date)` from the getter.
- Keeps the setter as the controlled mutation path.
- Adds regression coverage for mutating a returned value object.

## Validation

- Ran `git diff --check`.
- Could not run the Bun test script locally because Bun is not installed in this environment.