### PR TITLE
fix(jsx): replace console.error in render error handler (Closes #2107)

### DIFF
--- a/packages/jsx/src/render.ts
+++ b/packages/jsx/src/render.ts
@@ -25,7 +25,7 @@ export function unmountApps(apps: Array<{ unmount?: () => void }>): void {
             try {
                 app.unmount();
             } catch (err) {
-                console.error('[jsx] Error during unmount():', err);
+                process.stderr.write('[jsx] Error during unmount(): ' + String(err) + '\n');
             }
         }
     });

--- a/packages/jsx/src/unmountHelpers.test.ts
+++ b/packages/jsx/src/unmountHelpers.test.ts
@@ -7,7 +7,7 @@ describe('unmountApps', () => {
         const throwing = { unmount: vi.fn(() => { throw err; }) };
         const called = { unmount: vi.fn(() => { /* ok */ }) };
 
-        const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 
         try {
             // Should not throw
@@ -18,7 +18,7 @@ describe('unmountApps', () => {
 
             // Ensure we logged the error exactly once with the expected message
             expect(spy).toHaveBeenCalledTimes(1);
-            expect(spy).toHaveBeenCalledWith('[jsx] Error during unmount():', err);
+            expect(spy).toHaveBeenCalledWith('[jsx] Error during unmount(): ' + String(err) + '\n');
         } finally {
             spy.mockRestore();
         }


### PR DESCRIPTION
## Description

This PR replaces `console.error` in `render.ts` with `process.stderr.write` to comply with the project's no-console policy while preserving error reporting during application unmount.

## Related Issue

Closes #2107

## Which package(s)?

* @termuijs/jsx

## Type of Change

* [x] 🐛 Bug fix (`type:bug`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [CONTRIBUTING.md](https://github.com/Karanjot786/TermUI/blob/main/CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (if your change affects rendering).
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] Yes, I am a GSSoC 2026 contributor.


## Notes for the Reviewer

* Replaced `console.error` with `process.stderr.write` in the unmount error handler.
* Preserves error reporting while complying with the project's no-console rule.
* No functional changes beyond the error output mechanism.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when an app fails to unmount, sending the message directly to standard error with a clearer, consistent format.
* **Tests**
  * Updated coverage to verify the new error output behavior and exact message format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->