### PR TITLE
fix(widgets): prevent overflow in StatusIndicator by truncating labels to content width

### DIFF
--- a/packages/widgets/src/data/StatusIndicator.test.ts
+++ b/packages/widgets/src/data/StatusIndicator.test.ts
@@ -75,4 +75,14 @@ describe('StatusIndicator', () => {
     si.setLabel('Database Server');
     expect(markDirtySpy).toHaveBeenCalled();
   });
+
+  it('truncates the label when it exceeds width bounds', () => {
+    const screen = new Screen(15, 1);
+    const si = new StatusIndicator('Very Long API Server Name', true);
+    si.updateRect({ x: 0, y: 0, width: 15, height: 1 });
+    si.render(screen);
+    const row = screen.back[0].map(c => c.char).join('');
+    // The screen has width 15. The rendered string should be truncated to fit within 15 columns.
+    expect(row.length).toBe(15);
+  });
 });

--- a/packages/widgets/src/data/StatusIndicator.ts
+++ b/packages/widgets/src/data/StatusIndicator.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets — StatusIndicator widget
 // ─────────────────────────────────────────────────────
 
-import { type Screen, type Style, type Color, styleToCellAttrs } from '@termuijs/core';
+import { type Screen, type Style, type Color, styleToCellAttrs, truncate } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
 export interface StatusIndicatorOptions {
@@ -58,9 +58,14 @@ export class StatusIndicator extends Widget {
         const color = this._isUp ? this._upColor : this._downColor;
 
         screen.setCell(x, y, { char: dot, fg: color });
-        screen.writeString(x + 2, y, `${this._label} — ${statusText}`, {
-            ...attrs,
-            fg: color,
-        });
+        
+        const labelText = `${this._label} — ${statusText}`;
+        const avail = width - 2;
+        if (avail > 0) {
+            screen.writeString(x + 2, y, truncate(labelText, avail), {
+                ...attrs,
+                fg: color,
+            });
+        }
     }
 }


### PR DESCRIPTION
Closes Issue #2109

> **Description**:
> Integrates `truncate()` to ensure that the combined label and status string is safely clamped within the available widget columns.

> **Changes**:
> - Imports `truncate` from `@termuijs/core`.
> - Clamps `labelText` to `width - 2` columns in `StatusIndicator.ts`.
> - Adds a unit test in `StatusIndicator.test.ts` confirming that long labels are truncated to the content bounds.

> **Validation**:
> - Added test and ran `bun vitest run packages/widgets/src/data/StatusIndicator.test.ts` (all passed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Status indicators now truncate long labels to fit within the available width, preventing text from overflowing the screen.
  * Rendering now avoids drawing label content when there isn’t enough horizontal space.

* **Tests**
  * Added coverage to verify that long status labels are correctly truncated in narrow layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->