### PR TITLE
fix(widgets): align horizontal BarChart labels by visual column width #2111

### DIFF
--- a/packages/widgets/src/data/BarChart.test.ts
+++ b/packages/widgets/src/data/BarChart.test.ts
@@ -91,6 +91,27 @@ describe('BarChart', () => {
             // Wider canvas → more bar cells
             expect(wideFilled).toBeGreaterThan(narrowFilled);
         });
+
+        it('correctly aligns mixed single-byte and multi-byte labels', () => {
+            const chart = new BarChart(
+                [
+                    {
+                        bars: [
+                            { value: 50, label: 'a' },
+                            { value: 50, label: '测试' },
+                        ],
+                    },
+                ],
+                {},
+                { direction: 'horizontal', max: 100, barWidth: 1, barGap: 0 },
+            );
+            const rows = renderChart(chart, 30, 4);
+            // maxLabelWidth is 4.
+            // Row 0 label for 'a': padded to 4 cols -> "   a"
+            // Row 1 label for '测试': padded to 4 cols -> "测试"
+            expect(rows[0]!.startsWith('   a')).toBe(true);
+            expect(rows[1]!.startsWith('测试')).toBe(true);
+        });
     });
 
     // ── Vertical ─────────────────────────────────────

--- a/packages/widgets/src/data/BarChart.ts
+++ b/packages/widgets/src/data/BarChart.ts
@@ -240,7 +240,8 @@ export class BarChart extends Widget {
                     // Label on first row
                     if (row === 0 && bar.label) {
                         const label = bar.label.slice(0, maxLabelWidth);
-                        const padded = label.padStart(maxLabelWidth);
+                        const padCount = Math.max(0, maxLabelWidth - stringWidth(label));
+                        const padded = ' '.repeat(padCount) + label;
                         screen.writeString(ox, cellY, padded, { fg: this._labelColor });
                     }
 


### PR DESCRIPTION
closes Issue #2111
> **Description**:
> Replaces `padStart` in horizontal BarChart label rendering with a custom padding helper that calculates visual width using `stringWidth`.
>
> **Changes**:
> - Replaces `label.padStart(maxLabelWidth)` with custom padding using `stringWidth` in `BarChart.ts`.
> - Adds a unit test in `BarChart.test.ts` validating perfect right-alignment of mixed single-byte and CJK labels.
>
> **Validation**:
> - Added regression test and ran `bun vitest run packages/widgets/src/data/BarChart.test.ts` (all passed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved horizontal bar chart label alignment so labels with mixed character widths display correctly.
  * Fixed padding for the first rendered row, making spacing consistent for single-byte and multi-byte text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->