### PR TITLE
fix(widgets): prevent rendering overflow on double-width messages in Callout #2113

### DIFF
--- a/packages/widgets/src/feedback/Callout.test.ts
+++ b/packages/widgets/src/feedback/Callout.test.ts
@@ -72,4 +72,10 @@ describe('Callout', () => {
         expect(callout.isDirty).toBe(false);
     });
 
+    it('truncates double-width characters properly without overflowing available width', () => {
+        const callout = new Callout('🌟🌟🌟🌟🌟');
+        const output = render(callout, 6);
+        expect(output.length).toBeLessThanOrEqual(6);
+    });
+
 });

--- a/packages/widgets/src/feedback/Callout.ts
+++ b/packages/widgets/src/feedback/Callout.ts
@@ -84,7 +84,7 @@ export class Callout extends Widget {
         const msgStr = msgPrefix + this._message;
         const avail = width - cursor;
         if (avail > 0) {
-            screen.writeString(cursor, y, msgStr.slice(0, avail), { ...attrs, fg: color });
+            screen.writeString(cursor, y, truncate(msgStr, avail), { ...attrs, fg: color });
         }
     }
 }


### PR DESCRIPTION
closes #2113
> **Description**:
> Replaces character-based `slice()` with column-based `truncate()` when rendering the message body in Callout.
>
> **Changes**:
> - Replaces `msgStr.slice(0, avail)` with `truncate(msgStr, avail)` in `Callout.ts`.
> - Adds a unit test in `Callout.test.ts` verifying that double-width characters are truncated without exceeding layout boundaries.
>
> **Validation**:
> - Added regression test and ran `bun vitest run packages/widgets/src/feedback/Callout.test.ts` (all passed).