### PR TITLE
Fix/multiple modals zindex

### DIFF
--- a/packages/core/src/app/App.ts
+++ b/packages/core/src/app/App.ts
@@ -627,12 +627,16 @@ export class App {
         }
         if (matches.length === 0) return null;
 
-        // 3. Sort by z-index descending (topmost wins)
+        // 3. Reverse the array so that later siblings (which are rendered on top) 
+        // win ties when stable-sorted by z-index.
+        matches.reverse();
+        
+        // 4. Sort by z-index descending (topmost wins)
         matches.sort((a, b) => b.zIndex - a.zIndex);
         const topZ = matches[0].zIndex;
         const topMatches = matches.filter(m => m.zIndex === topZ);
 
-        // 4. Among same z-index, prefer deepest child widget (most specific)
+        // 5. Among same z-index, prefer deepest child widget (most specific)
         if (topMatches.length > 1) {
             for (const m of topMatches) {
                 let p = m.widget.parent;


### PR DESCRIPTION
## Description

This PR fixes a bug where multiple Modals or full-screen overlays with the same Z-Index would route mouse events to the background Modal rather than the uppermost active Modal. It resolves an issue in `App.ts` where stable sorting during hit-testing preserved insertion order, causing earlier siblings (e.g., Modal A) to incorrectly win ties against later siblings (e.g., Modal B). 

By reversing the matches array before sorting, the engine correctly prioritizes later siblings which visually render on top.

## Related Issue

Closes #1954

## Which package(s)?

@termuijs/core

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/f49aa65e-aab2-4e9f-99d6-2174f339ecfe`

## Screenshots / Recordings (UI changes)

*(No visual changes, internal event routing fix)*

## Notes for the Reviewer

The issue suggested editing `InputParser.ts` and `MouseParser.ts` to hook into the `LayerManager`. However, since those components are low-level decoders, injecting a dependency on the app/layer structure there would violate the architecture. Instead, the bug was isolated to the hit-testing logic directly in `App.ts`, and fixing the Z-Index tie-breaker there completely resolves the event trapping issue without breaking separation of concerns.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved widget selection when multiple widgets overlap, making topmost items more reliably clickable/interactive.
  * Refined how ties are handled between widgets with the same stacking order, leading to more consistent selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->