### PR TITLE
fix(widgets): truncate double-width characters visually in Badge

### DIFF
--- a/packages/widgets/src/display/Badge.test.ts
+++ b/packages/widgets/src/display/Badge.test.ts
@@ -120,6 +120,12 @@ describe('Badge', () => {
         expect(() => renderBadge('test', {}, {}, 0, 0)).not.toThrow();
     });
 
+    it('truncates double-width characters correctly to fit within layout width', () => {
+        const { screen } = renderBadge('测试试', {}, {}, 6, 3);
+        const row = rowText(screen, 1);
+        expect(row.length).toBeLessThanOrEqual(6);
+    });
+
     // ── 6. Constructor signature ────────────────────────────────────────────
     it('canonical signature Badge(text, style, opts) works correctly', () => {
         const { badge } = renderBadge('test', {}, { variant: 'info' });

--- a/packages/widgets/src/display/Badge.ts
+++ b/packages/widgets/src/display/Badge.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets — Badge widget
 // ─────────────────────────────────────────────────────
 
-import { type Screen, type Style, type Color, stringWidth, caps } from '@termuijs/core';
+import { type Screen, type Style, type Color, stringWidth, caps, truncate } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
 export type BadgeVariant = 'info' | 'success' | 'warning' | 'error' | 'neutral';
@@ -108,7 +108,7 @@ export class Badge extends Widget {
             screen.setCell(x, y + 1, { char: vt, ...borderAttrs });
 
             // Write padded text with colored background
-            const visibleText = padded.slice(0, innerWidth);
+            const visibleText = truncate(padded, innerWidth, '');
             screen.writeString(x + 1, y + 1, visibleText, contentAttrs);
 
             // Fill remaining inner space with background


### PR DESCRIPTION
closes #2127
> **Description**:
> Employs `truncate()` to visually slice badge text to the internal container width.
>
> **Changes**:
> - Imported `truncate` from `@termuijs/core`.
> - Replaced `.slice(0, innerWidth)` with `truncate(padded, innerWidth, '')` in `Badge.ts`.
> - Added a unit test in `Badge.test.ts` verifying that double-width characters are truncated correctly.
>
> **Validation**:
> - Ran `bun vitest run packages/widgets/src/display/Badge.test.ts` (19/19 tests passed).


## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved badge text rendering so double-width characters are trimmed correctly and stay within the available space.
  * Fixed content row sizing for badges in narrow layouts, preventing overflow and layout issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->