### PR TITLE
fix(widgets): truncate label and dots in LoadingDots to prevent overflow #2131

### DIFF
--- a/packages/widgets/src/feedback/LoadingDots.test.ts
+++ b/packages/widgets/src/feedback/LoadingDots.test.ts
@@ -148,4 +148,13 @@ describe('LoadingDots', () => {
         expect(second).toBe(first);
     });
 
+    it('truncates the label and dots when they exceed the width', () => {
+        const screen = new Screen(6, 1);
+        const ld = new LoadingDots({}, { label: 'Thinking', maxDots: 3 });
+        ld.updateRect({ x: 0, y: 0, width: 6, height: 1 });
+        ld.render(screen);
+        const row = screen.back[0].map(c => c.char).join('');
+        expect(row).toBe('Thinki');
+    });
+
 });

--- a/packages/widgets/src/feedback/LoadingDots.ts
+++ b/packages/widgets/src/feedback/LoadingDots.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets — LoadingDots widget
 // ─────────────────────────────────────────────────────
 
-import { type Style, type Color, type Screen, caps, styleToCellAttrs, stringWidth, prefersReducedMotion } from '@termuijs/core';
+import { type Style, type Color, type Screen, caps, styleToCellAttrs, stringWidth, prefersReducedMotion, truncate } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
 export interface LoadingDotsOptions {
@@ -50,14 +50,18 @@ export class LoadingDots extends Widget {
         let currentX = x;
 
         if (this._label) {
-            screen.writeString(currentX, y, this._label, attrs);
-            currentX += stringWidth(this._label);
+            const truncatedLabel = truncate(this._label, width, '');
+            screen.writeString(currentX, y, truncatedLabel, attrs);
+            currentX += stringWidth(truncatedLabel);
         }
 
-        const dotChar = caps.unicode ? '·' : '.';
-        const dots = dotChar.repeat(this._dotCount);
-        const padding = ' '.repeat(this._maxDots - this._dotCount);
-
-        screen.writeString(currentX, y, dots + padding, { ...attrs, fg: this._color });
+        const remaining = width - (currentX - x);
+        if (remaining > 0) {
+            const dotChar = caps.unicode ? '·' : '.';
+            const dots = dotChar.repeat(this._dotCount);
+            const padding = ' '.repeat(this._maxDots - this._dotCount);
+            const dotsStr = truncate(dots + padding, remaining, '');
+            screen.writeString(currentX, y, dotsStr, { ...attrs, fg: this._color });
+        }
     }
 }


### PR DESCRIPTION
Closes Issue #2131
> **Description**:
> Integrates `truncate()` to ensure that the label and dots are constrained within the available widget columns.
>
> **Changes**:
> - Imported `truncate` from `@termuijs/core`.
> - Truncated `this._label` to fit in `width` columns.
> - Truncated the dot prefix and spaces padding to the remaining layout width.
> - Added a unit test in `LoadingDots.test.ts` checking that labels and dots are correctly truncated.
>
> **Validation**:
> - Ran `bun vitest run packages/widgets/src/feedback/LoadingDots.test.ts` (11/11 tests passed).


## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->
