### PR TITLE
fix(jsx): update render.test.ts to expect stderr write, not console.error

### DIFF
--- a/packages/jsx/src/render.test.ts
+++ b/packages/jsx/src/render.test.ts
@@ -14,9 +14,10 @@ describe('unmountApps', () => {
     });
 
     it('should catch errors thrown during unmount to prevent crashing', () => {
-        const errorConsoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const err = new Error('Failure during unmount');
+        const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
         const unmount1 = vi.fn().mockImplementation(() => {
-            throw new Error('Failure during unmount');
+            throw err;
         });
         const unmount2 = vi.fn();
         const apps = [{ unmount: unmount1 }, { unmount: unmount2 }];
@@ -24,11 +25,10 @@ describe('unmountApps', () => {
         expect(() => unmountApps(apps)).not.toThrow();
         expect(unmount1).toHaveBeenCalled();
         expect(unmount2).toHaveBeenCalled();
-        expect(errorConsoleSpy).toHaveBeenCalledWith(
-            '[jsx] Error during unmount():',
-            expect.any(Error)
+        expect(stderrSpy).toHaveBeenCalledWith(
+            '[jsx] Error during unmount(): ' + String(err) + '\n'
         );
-        errorConsoleSpy.mockRestore();
+        stderrSpy.mockRestore();
     });
 
     it('should safely ignore app instances without unmount method', () => {


### PR DESCRIPTION
## Summary

`render.ts`'s `unmountApps` error handler was switched from `console.error` to `process.stderr.write` in #2108. That PR updated `unmountHelpers.test.ts` (which tests the same function) but missed this duplicate/older test file, `render.test.ts` — so it kept asserting on `console.error`, and has been failing `build-and-test` on every commit to `main` since #2108 merged.

## Fix

Updates the one assertion in `render.test.ts` to spy on `process.stderr.write` instead, matching the pattern already used in `unmountHelpers.test.ts`.

## Test plan
- [x] `bunx turbo build` — full workspace build passes
- [x] `vitest run packages/jsx/src/render.test.ts packages/jsx/src/unmountHelpers.test.ts` — 4/4 pass
- [x] Full suite: 391/393 files pass (only remaining failure is a pre-existing local-machine symlink-path test unrelated to this change, reproduced identically on unmodified `main`)

Co-authored-by: Karanjot786 <karanjots801@gmail.com>