### PR TITLE
fix(core): include full color value in getStyleLine hash to avoid collision

### DIFF
--- a/packages/core/src/terminal/Screen.test.ts
+++ b/packages/core/src/terminal/Screen.test.ts
@@ -201,6 +201,42 @@ describe('Screen', () => {
         screen.popTranslateY();
     });
 
+    it('getStyleLine produces different hashes for different color codes within same type', () => {
+        const screen = new Screen(40, 5);
+        screen.setCell(0, 0, { fg: { type: 'ansi256', code: 1 } });
+        const hash1 = screen.getStyleLine(0);
+        screen.setCell(0, 0, { fg: { type: 'ansi256', code: 9 } });
+        const hash2 = screen.getStyleLine(0);
+        expect(hash1).not.toBe(hash2);
+    });
+
+    it('getStyleLine distinguishes different named colors', () => {
+        const screen = new Screen(40, 5);
+        screen.setCell(0, 0, { fg: { type: 'named', name: 'red' } });
+        const hash1 = screen.getStyleLine(0);
+        screen.setCell(0, 0, { fg: { type: 'named', name: 'blue' } });
+        const hash2 = screen.getStyleLine(0);
+        expect(hash1).not.toBe(hash2);
+    });
+
+    it('getStyleLine distinguishes different RGB colors', () => {
+        const screen = new Screen(40, 5);
+        screen.setCell(0, 0, { fg: { type: 'rgb', r: 255, g: 0, b: 0 } });
+        const hash1 = screen.getStyleLine(0);
+        screen.setCell(0, 0, { fg: { type: 'rgb', r: 0, g: 0, b: 255 } });
+        const hash2 = screen.getStyleLine(0);
+        expect(hash1).not.toBe(hash2);
+    });
+
+    it('saveLines and getStyleLine detect style-only updates', () => {
+        const screen = new Screen(40, 5);
+        screen.writeString(0, 0, 'Hello', { fg: { type: 'ansi256', code: 1 } });
+        screen.saveLines();
+        // Same chars, different color code
+        screen.writeString(0, 0, 'Hello', { fg: { type: 'ansi256', code: 9 } });
+        expect(screen.getStyleLine(0)).not.toBe(screen.getPreviousStyleLine(0));
+    });
+
     it('setCell is clipped by translate-adjusted region when parents have translate', () => {
         const screen = new Screen(30, 20);
         // Simulate: outer container at absolute y=10 with scrollOffset=5

--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -106,6 +106,24 @@ function colorsEqual(a: Color, b: Color): boolean {
     }
 }
 
+function colorSeed(c: Color): number {
+    switch (c.type) {
+        case 'none': return 0;
+        case 'named': {
+            let h = 0;
+            for (let i = 0; i < c.name.length; i++)
+                h = ((h << 5) - h + c.name.charCodeAt(i)) | 0;
+            return h;
+        }
+        case 'ansi256': return c.code;
+        case 'rgb': return (c.r << 16) | (c.g << 8) | c.b;
+        case 'hex': {
+            const n = parseInt(c.hex.slice(1), 16);
+            return isNaN(n) ? 0 : n;
+        }
+    }
+}
+
 /**
  * Double-buffered 2D cell grid for the terminal.
  *
@@ -198,8 +216,6 @@ export class Screen {
         let hash = 0;
         for (const cell of this.back[row]) {
             if (cell.width === 0) continue;
-            const fg = cell.fg.type;
-            const bg = cell.bg.type;
             const bits =
                 (cell.bold ? 1 : 0) |
                 (cell.italic ? 2 : 0) |
@@ -207,7 +223,7 @@ export class Screen {
                 (cell.dim ? 8 : 0) |
                 (cell.strikethrough ? 16 : 0) |
                 (cell.inverse ? 32 : 0);
-            const seed = fg.charCodeAt(0) * 65536 + bg.charCodeAt(0) * 4096 + bits;
+            const seed = colorSeed(cell.fg) * 65536 + colorSeed(cell.bg) * 4096 + bits;
             hash = ((hash << 7) - hash + seed) | 0;
             if (cell.link) {
                 for (let i = 0; i < cell.link.length; i++)


### PR DESCRIPTION
## Description

The `Screen.getStyleLine` method computed a hash using only the first character of the color type string (`fg.charCodeAt(0)`), causing hash collisions when colors changed within the same type (e.g., ANSI256 code 1 → code 9).

## Fix

Added a `colorSeed` function that computes a unique numeric value for each `Color` variant, including the actual distinguishing properties:

- **named**: hashes the full name string
- **ansi256**: uses the numeric code
- **rgb**: encodes r/g/b values
- **hex**: parses the hex string to a number
- **none**: returns 0

## Tests added

- `getStyleLine produces different hashes for different color codes within same type`
- `getStyleLine distinguishes different named colors`
- `getStyleLine distinguishes different RGB colors`
- `saveLines and getStyleLine detect style-only updates`

Closes #1659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved style change detection so text updates are recognized even when only the color changes.
  * Fixed style matching to better distinguish colors of the same type, including named colors, 256-color values, and RGB values.

* **Tests**
  * Added coverage for style hash behavior and previous-line tracking to verify color-only changes are detected correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->