### PR TITLE
fix(store): update commit/rollback closure when setState updates existing batch entry

### DIFF
--- a/packages/store/src/store.test.ts
+++ b/packages/store/src/store.test.ts
@@ -645,6 +645,54 @@ describe('middleware', () => {
             expect(useStore.getState().count).toBe(1)
         })
     })
+
+    it('setState after mutate inside batch does not lose intermediate state', async () => {
+        const useStore = createStore((set) => ({
+            count: 0,
+            name: '',
+        }))
+        const spy = vi.fn()
+        useStore.subscribe(spy)
+
+        batch(() => {
+            // mutate creates the batch entry (commit captures nextState const)
+            useStore.mutate((draft) => {
+                draft.count = 1
+            })
+            // setState updates the existing entry but must also update the commit closure
+            useStore.setState({ name: 'test' })
+        })
+
+        await new Promise(resolve => queueMicrotask(resolve))
+
+        expect(spy).toHaveBeenCalledOnce()
+        expect(useStore.getState()).toEqual({ count: 1, name: 'test' })
+    })
+
+    it('nested batch with mutate and setState does not lose state', async () => {
+        const useStore = createStore((set) => ({
+            count: 0,
+            name: '',
+            label: '',
+        }))
+        const spy = vi.fn()
+        useStore.subscribe(spy)
+
+        batch(() => {
+            useStore.setState({ count: 1 })
+            batch(() => {
+                useStore.mutate((draft) => {
+                    draft.name = 'inner'
+                })
+                useStore.setState({ label: 'nested' })
+            })
+        })
+
+        await new Promise(resolve => queueMicrotask(resolve))
+
+        expect(spy).toHaveBeenCalledOnce()
+        expect(useStore.getState()).toEqual({ count: 1, name: 'inner', label: 'nested' })
+    })
 })
 
 describe('persistence', () => {

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -421,6 +421,8 @@ export function createStore<T extends object>(
                     } else {
                         Object.assign(existing.changes, finalPartial);
                         existing.nextState = nextState;
+                        existing.commit = () => { state = { ...state, ...existing.changes } as T; persistState(); return state; };
+                        existing.rollback = () => { state = existing.prevState; };
                     }
                 } else {
                     state = nextState; 


### PR DESCRIPTION
## Description

When `setState` is called inside a batch after `mutate` created the batch entry, the `commit` closure was not updated. The `mutate` function's `commit` closure captures a local `nextState` const via `produce()`. Subsequent `setState` calls updated `existing.nextState` but left the stale `commit` closure in place, silently losing intermediate state mutations.

### Root Cause

In `setState`, when an existing batch entry is found (lines 421-423), only `existing.changes` and `existing.nextState` were updated via `Object.assign`. The `existing.commit` and `existing.rollback` closures were left unchanged — still pointing to the old values captured when `mutate` (or a prior `setState`) created the entry. This caused the `commit` to reference a stale `nextState`, losing the intermediate `setState` change.

### Fix

Updated the existing entry's `commit` and `rollback` closures whenever `setState` updates an existing batch entry, ensuring they reflect the latest accumulated state.

### Tests added

- `setState after mutate inside batch does not lose intermediate state` — reproduces the exact race condition
- `nested batch with mutate and setState does not lose state` — nested variant with mixed `setState`/`mutate`

Closes #1658

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved state updates during batched operations so multiple changes are merged correctly.
  * Fixed nested batch behavior to preserve all updates from outer and inner changes.
  * Ensured listeners fire only once after batched updates complete, with the final combined state applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->