### PR TITLE
fix(widgets): allow custom clamped initial value in TextInput options 

### DIFF
--- a/packages/widgets/src/input/TextInput.test.ts
+++ b/packages/widgets/src/input/TextInput.test.ts
@@ -35,6 +35,11 @@ describe('TextInput', () => {
         expect(input.style.height).toBe(3);
     });
 
+    it('initializes with custom initial value option and clamps it to maxLength', () => {
+        const input = new TextInput({}, { value: 'initial content', maxLength: 10 });
+        expect(input.value).toBe('initial co'); // truncated to maxLength 10
+    });
+
     it('sets and gets value correctly', () => {
         const input = new TextInput({}, { maxLength: 5 });
         input.value = 'hello world';

--- a/packages/widgets/src/input/TextInput.ts
+++ b/packages/widgets/src/input/TextInput.ts
@@ -35,6 +35,7 @@ export class TextInput extends Widget {
     constructor(
         style: Partial<Style> = {},
         options: {
+            value?: string;
             placeholder?: string;
             mask?: string;
             maxLength?: number;
@@ -51,6 +52,15 @@ export class TextInput extends Widget {
         this._onChange = options.onChange;
         this._onSubmit = options.onSubmit;
         this._suggestions = options.suggestions ?? [];
+
+        const initialVal = options.value ?? '';
+        const graphemes = splitGraphemes(initialVal);
+        if (graphemes.length > this._maxLength) {
+            this._value = graphemes.slice(0, this._maxLength).join('');
+        } else {
+            this._value = initialVal;
+        }
+        this._cursorPos = splitGraphemes(this._value).length;
 
         this.focusable = true;
 


### PR DESCRIPTION
closes Issue #2155 

> **Description**:
> Adds `value` to the options structure of `TextInput` and pre-populates the input buffer and cursor position at construction.
>
> **Changes**:
> - Updated `TextInput` options type to support `value?: string`.
> - Populated `_value` and adjusted `_cursorPos` to the end of the initial text, respecting `maxLength` constraints.
> - Added a unit test in `TextInput.test.ts` verifying correct initialization and length clipping.
>
> **Validation**:
> - Ran `bun vitest run packages/widgets/src/input/TextInput.test.ts` (32/32 tests passed).


## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Text inputs can now be created with an initial value.
  * Initial text is automatically trimmed to the maximum allowed length.

* **Bug Fixes**
  * Cursor placement now starts at the end of the provided initial text, so newly created fields behave more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->