### PR TITLE
fix(widgets): preserve styling when Checkbox is truncated

### DIFF
--- a/packages/widgets/src/input/Checkbox.test.ts
+++ b/packages/widgets/src/input/Checkbox.test.ts
@@ -289,4 +289,22 @@ describe('Checkbox', () => {
             expect(checkbox.isChecked()).toBe(false);
         });
     });
+
+    describe('10. Truncation rendering styling consistency', () => {
+        it('preserves focused colors and checkmark state when label is truncated', () => {
+            const checkbox = new Checkbox('Very long notification label description', {}, { checked: true });
+            checkbox.isFocused = true;
+            checkbox.updateRect({ x: 0, y: 0, width: 8, height: 1 });
+            const screen = new Screen(8, 1);
+            checkbox.render(screen);
+
+            // Left and right brackets of box should have focusColor (cyan)
+            expect(screen.back[0][0].fg).toEqual({ type: 'named', name: 'cyan' });
+            expect(screen.back[0][2].fg).toEqual({ type: 'named', name: 'cyan' });
+
+            // Checkmark should be colored green
+            expect(screen.back[0][1].char).toBe(caps.unicode ? '✓' : '+');
+            expect(screen.back[0][1].fg).toEqual({ type: 'named', name: 'green' });
+        });
+    });
 });

--- a/packages/widgets/src/input/Checkbox.ts
+++ b/packages/widgets/src/input/Checkbox.ts
@@ -203,37 +203,40 @@ export class Checkbox extends Widget {
 
         const focusColor: Color = { type: 'named', name: 'cyan' };
 
-        if (stringWidth(fullLine) > width) {
-            // Not enough room — render truncated
-            screen.writeString(x, y, truncate(fullLine, width), { fg: labelColor });
-            return;
+        // Write '['
+        if (width >= 1) {
+            screen.setCell(x, y, {
+                char: boxOpen,
+                fg: this.isFocused ? focusColor : labelColor,
+            });
         }
 
-        // Write '['
-        screen.setCell(x, y, {
-            char: boxOpen,
-            fg: this.isFocused ? focusColor : labelColor,
-        });
-
         // Write mark char
-        screen.setCell(x + 1, y, {
-            char: mark,
-            fg: markColor,
-            dim: showMark && progress < 0.5,
-            bold: showMark && progress >= 0.5,
-        });
+        if (width >= 2) {
+            screen.setCell(x + 1, y, {
+                char: mark,
+                fg: markColor,
+                dim: showMark && progress < 0.5,
+                bold: showMark && progress >= 0.5,
+            });
+        }
 
         // Write ']'
-        screen.setCell(x + 2, y, {
-            char: boxClose,
-            fg: this.isFocused ? focusColor : labelColor,
-        });
+        if (width >= 3) {
+            screen.setCell(x + 2, y, {
+                char: boxClose,
+                fg: this.isFocused ? focusColor : labelColor,
+            });
+        }
 
         // Write ' Label'
-        const labelX = x + boxWidth + stringWidth(gap);
-        screen.writeString(labelX, y, labelPart, {
-            fg: labelColor,
-            dim: this._disabled,
-        });
+        if (width > 4) {
+            const labelX = x + 4;
+            const remainingWidth = width - 4;
+            screen.writeString(labelX, y, truncate(labelPart, remainingWidth), {
+                fg: labelColor,
+                dim: this._disabled,
+            });
+        }
     }
 }


### PR DESCRIPTION
Closes Issue #2159 

> **Description**:
> Unifies the rendering paths of the Checkbox widget by writing individual components (`[`, mark, `]`, and label) with bounds checks instead of relying on a fallback unstyled string branch.
>
> **Changes**:
> - Removed the unstyled truncation branch in `Checkbox.ts`.
> - Applied visual width boundaries on the rendering of the brackets, checkmark, and truncated label text.
> - Added a unit test in `Checkbox.test.ts` to verify focused and checkmark colors are preserved under narrow widths.
>
> **Validation**:
> - Ran `bun vitest run packages/widgets/src/input/Checkbox.test.ts` (31/31 tests passed).


## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [ ] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [ ] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->
