### PR TITLE
fix(widgets): implement setValue setter method on PinInput

### DIFF
--- a/packages/widgets/src/input/PinInput.test.ts
+++ b/packages/widgets/src/input/PinInput.test.ts
@@ -113,4 +113,14 @@ describe("PinInput", () => {
     expect(rendered).toContain("[ • ]");
     expect(rendered).not.toContain("[ 1 ]");
   });
+
+  it("programmatically sets the value using setValue", async () => {
+    const { PinInput } = await import("./PinInput.js");
+    const pin = new PinInput({}, { length: 4 });
+    pin.setValue("12");
+    expect(pin.value).toBe("12");
+
+    pin.setValue("12345");
+    expect(pin.value).toBe("1234");
+  });
 });

--- a/packages/widgets/src/input/PinInput.ts
+++ b/packages/widgets/src/input/PinInput.ts
@@ -48,6 +48,19 @@ export class PinInput extends Widget {
     return this._value.join("");
   }
 
+  /**
+   * Programmatically sets the pin input value.
+   * Clamps the value to the configured pin length and places the cursor at the end.
+   */
+  setValue(value: string): void {
+    const chars = value.split("").slice(0, this._length);
+    for (let i = 0; i < this._length; i++) {
+      this._value[i] = chars[i] ?? "";
+    }
+    this._cursorPos = Math.min(this._length - 1, chars.length);
+    this.markDirty();
+  }
+
   private get _isFull(): boolean {
     return this._value.every((v) => v !== "");
   }


### PR DESCRIPTION
Closes Issue #2161 

> **Description**:
> Implements `setValue(value: string)` to allow programmatic value updates. It splits the input string, slices it up to the configured pin length, updates the character cells, and places the cursor at the end.
>
> **Changes**:
> - Added `setValue(value: string)` to `PinInput.ts`.
> - Added a unit test in `PinInput.test.ts` to verify programmatic value changes and length clamping.
>
> **Validation**:
> - Ran `bun vitest run packages/widgets/src/input/PinInput.test.ts` (8/8 tests passed).


## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [ ] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [ ] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->
