### PR TITLE
fix(widgets): allow custom clamped initial value in Slider options

### DIFF
--- a/packages/widgets/src/input/Slider.test.ts
+++ b/packages/widgets/src/input/Slider.test.ts
@@ -13,6 +13,16 @@ describe("Slider", () => {
     expect(slider.getValue()).toBe(0);
   });
 
+  it("constructs with custom initial value and clamps it", async () => {
+    const { Slider } = await import("./Slider.js");
+
+    const slider = new Slider("Volume", {}, { min: 10, max: 90, value: 50 });
+    expect(slider.getValue()).toBe(50);
+
+    const clampedSlider = new Slider("Volume", {}, { min: 10, max: 90, value: 5 });
+    expect(clampedSlider.getValue()).toBe(10);
+  });
+
   it("setValue updates value", async () => {
     const { Slider } = await import("./Slider.js");
 

--- a/packages/widgets/src/input/Slider.ts
+++ b/packages/widgets/src/input/Slider.ts
@@ -13,6 +13,7 @@ export interface SliderOptions {
   min?: number;
   max?: number;
   step?: number;
+  value?: number;
   color?: Color;
   showValue?: boolean;
 }
@@ -40,6 +41,7 @@ export class Slider extends Widget {
     this._step = opts.step ?? 1;
     this._color = opts.color ?? { type: "named", name: "cyan" };
     this._showValue = opts.showValue ?? true;
+    this._value = Math.max(this._min, Math.min(this._max, opts.value ?? this._min));
   }
 
   getValue(): number {


### PR DESCRIPTION
Closes Issue #2163 

> **Description**:
> Adds `value` to `SliderOptions` and clamps the initial slider value inside the constructor between the configured `min` and `max`.
>
> **Changes**:
> - Updated `SliderOptions` to accept `value?: number`.
> - Clamped `this._value` to the range `[min, max]` using `Math.max(this._min, Math.min(this._max, opts.value ?? this._min))` in the constructor.
> - Added unit tests in `Slider.test.ts` to verify default construction, custom initial value option, and out-of-bounds clamping.
>
> **Validation**:
> - Ran `bun vitest run packages/widgets/src/input/Slider.test.ts` (8/8 tests passed).

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->
