### PR TITLE
fix(widgets): implement getText getter and setText equality check on Typewriter #2173

### DIFF
--- a/packages/widgets/src/display/Typewriter.test.ts
+++ b/packages/widgets/src/display/Typewriter.test.ts
@@ -182,4 +182,21 @@ describe('Typewriter', () => {
     expect(row).not.toContain('▋');
     expect(row).not.toContain('_');
   });
+
+  it('returns correct text via getText and does not reset reveal count when same text is set', () => {
+    vi.spyOn(caps, 'motion', 'get').mockReturnValue(true);
+    const tw = new Typewriter('hello');
+    expect(tw.getText()).toBe('hello');
+
+    tw.tick();
+    expect(renderRow(tw)).toContain('h');
+
+    // Setting same text should not reset progress
+    tw.setText('hello');
+    expect(renderRow(tw)).toContain('h');
+
+    // Setting different text resets progress
+    tw.setText('world');
+    expect(renderRow(tw)).not.toContain('w');
+  });
 });

--- a/packages/widgets/src/display/Typewriter.ts
+++ b/packages/widgets/src/display/Typewriter.ts
@@ -83,9 +83,15 @@ export class Typewriter extends Widget {
 
   /** Replace the text and reset the reveal counter. */
   setText(text: string): void {
+    if (text === this._text) return;
     this._text = text;
     this._revealed = 0;
     this.markDirty();
+  }
+
+  /** Get the current text. */
+  getText(): string {
+    return this._text;
   }
 
   // ── Rendering ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
closes #2173 

> **Description**:
> Implements `getText()` getter on `Typewriter`, and optimizes `setText()` to return early without resetting progress if the text matches the current value.
>
> **Changes**:
> - Added `getText(): string` to `Typewriter.ts`.
> - Added a `text === this._text` check in `setText()` in `Typewriter.ts`.
> - Added unit tests in `Typewriter.test.ts` to verify correct text retrieval and progress preservation on identical text.
>
> **Validation**:
> - Ran `bun vitest run packages/widgets/src/display/Typewriter.test.ts` (16/16 tests passed).


<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [ ] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [ ] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a way to retrieve the current text from the typewriter display.
* **Bug Fixes**
  * Preserved reveal progress when updating the display with the same text.
  * Reset the reveal state correctly when the text changes.
* **Tests**
  * Added coverage for current-text retrieval and text update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->