### PR TITLE
fix(widgets): implement getSegments getter on Breadcrumbs

### DIFF
--- a/packages/widgets/src/display/Breadcrumbs.test.ts
+++ b/packages/widgets/src/display/Breadcrumbs.test.ts
@@ -142,4 +142,10 @@ describe('Breadcrumbs', () => {
 
         expect(row.length).toBeLessThanOrEqual(3);
     });
+
+    it('returns the segments via getSegments API', () => {
+        const segments = ['Home', 'Docs'];
+        const bc = new Breadcrumbs(segments);
+        expect(bc.getSegments()).toBe(segments);
+    });
 });

--- a/packages/widgets/src/display/Breadcrumbs.ts
+++ b/packages/widgets/src/display/Breadcrumbs.ts
@@ -42,6 +42,10 @@ export class Breadcrumbs extends Widget {
         this.markDirty();
     }
 
+    getSegments(): string[] {
+        return this._segments;
+    }
+
     protected _renderSelf(screen: Screen): void {
         const { x, y, width, height } = this._getContentRect();
         if (width <= 0 || height <= 0 || this._segments.length === 0) return;


### PR DESCRIPTION
 closes #2179 

> **Description**:
> Implements the `getSegments()` getter on the `Breadcrumbs` widget to match the `setSegments()` setter API.
>
> **Changes**:
> - Added `getSegments(): string[]` to `Breadcrumbs.ts`.
> - Added a unit test in `Breadcrumbs.test.ts` to verify the getter.
>
> **Validation**:
> - Ran `bun vitest run packages/widgets/src/display/Breadcrumbs.test.ts` (12/12 tests passed).

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

