### PR TITLE
fix(widgets): implement getItems getter and setItems ref check on UnorderedList #2181

### DIFF
--- a/packages/widgets/src/display/UnorderedList.test.ts
+++ b/packages/widgets/src/display/UnorderedList.test.ts
@@ -107,4 +107,15 @@ describe('UnorderedList', () => {
         list.render(nextScreen);
         expect(rowText(nextScreen, 0)).toContain('New item');
     });
+
+    it('getItems returns the items and setItems does not dirty when unchanged', () => {
+        const items = [{ text: 'Item' }];
+        const { list } = renderList(items);
+
+        expect(list.getItems()).toBe(items);
+
+        list.clearDirty();
+        list.setItems(items);
+        expect(list.isDirty).toBe(false);
+    });
 });

--- a/packages/widgets/src/display/UnorderedList.ts
+++ b/packages/widgets/src/display/UnorderedList.ts
@@ -48,8 +48,15 @@ export class UnorderedList extends Widget {
     }
 
     setItems(items: ListItem[]): void {
+        if (items === this._items) {
+            return;
+        }
         this._items = items;
         this.markDirty();
+    }
+
+    getItems(): ListItem[] {
+        return this._items;
     }
 
     protected _renderSelf(screen: Screen): void {


### PR DESCRIPTION
closes #2181 
> **Description**:
> Adds `getItems()` getter to `UnorderedList` and updates `setItems` to return early if the array reference is unchanged.
>
> **Changes**:
> - Added `getItems(): ListItem[]` to `UnorderedList.ts`.
> - Updated `setItems()` in `UnorderedList.ts` to return early when `items === this._items`.
> - Added unit tests in `UnorderedList.test.ts` verifying `getItems` and same-reference early returns.
>
> **Validation**:
> - Ran `bun vitest run packages/widgets/src/display/UnorderedList.test.ts` (6/6 tests passed).

---

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [ ] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [ ] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->
