### PR TITLE
fix(widgets): implement getItems getter on OrderedList #2183

### DIFF
--- a/packages/widgets/src/display/OrderedList.test.ts
+++ b/packages/widgets/src/display/OrderedList.test.ts
@@ -152,4 +152,11 @@ describe('OrderedList', () => {
         });
     });
 
+    describe('getItems getter API', () => {
+        it('returns correct items', () => {
+            const items = [{ text: 'Item 1' }];
+            const list = makeList(items);
+            expect(list.getItems()).toBe(items);
+        });
+    });
 });

--- a/packages/widgets/src/display/OrderedList.ts
+++ b/packages/widgets/src/display/OrderedList.ts
@@ -106,6 +106,10 @@ export class OrderedList extends Widget {
         this.markDirty();
     }
 
+    getItems(): OrderedListItem[] {
+        return this._items;
+    }
+
     protected _renderSelf(screen: Screen): void {
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;


### PR DESCRIPTION
closes issue #2183 

> **Description**:
> Implements a `getItems()` method on the `OrderedList` widget to retrieve the current array of list items.
>
> **Changes**:
> - Added `getItems(): OrderedListItem[]` to `OrderedList.ts`.
> - Added a unit test in `OrderedList.test.ts` to assert correct items are returned.
>
> **Validation**:
> - Ran `bun vitest run packages/widgets/src/display/OrderedList.test.ts` (8/8 tests passed).


## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->
