### PR TITLE
test(widgets): verify markDirty is called by Gauge.setLabel and setValue

### DIFF
--- a/packages/widgets/src/data/Gauge.test.ts
+++ b/packages/widgets/src/data/Gauge.test.ts
@@ -74,5 +74,35 @@ describe('Gauge', () => {
         expect(rendered).toMatch(/[█░]/);
         expect(rendered).not.toContain('#');
     });
+
+    it('setLabel marks the widget dirty', async () => {
+        const { Gauge } = await import('./Gauge.js');
+        const g = new Gauge('CPU');
+        g.clearDirty();
+        g.setLabel('Memory');
+        expect(g.isDirty).toBe(true);
+    });
+
+    it('setValue marks the widget dirty when called on a clean widget', async () => {
+        const { Gauge } = await import('./Gauge.js');
+        const g = new Gauge('CPU');
+        g.setValue(0.5);
+        g.clearDirty();
+        g.setValue(0.75);
+        expect(g.isDirty).toBe(true);
+    });
+
+    // Gauge.setValue always calls markDirty() regardless of whether the value
+    // changed. This differs from ProgressBar.setValue which guards with an
+    // early return when the value is unchanged. This test documents the current
+    // intentional behaviour so that a future refactor does not silently break it.
+    it('setValue marks the widget dirty even when the value is unchanged', async () => {
+        const { Gauge } = await import('./Gauge.js');
+        const g = new Gauge('CPU');
+        g.setValue(0.5);
+        g.clearDirty();
+        g.setValue(0.5);
+        expect(g.isDirty).toBe(true);
+    });
 });
 


### PR DESCRIPTION
## Description

Gauge.setLabel() and Gauge.setValue() both call 	his.markDirty() internally, but the existing test suite never tested the **already-clean → re-dirty** transition. This means a future refactor that accidentally removes the markDirty() call from either method would pass CI silently.

Three tests are added inside the existing \Gauge\ describe block:

1. **setLabel marks the widget dirty** — clears dirty state first, calls \setLabel\, asserts \isDirty\ is \	rue\.
2. **setValue marks the widget dirty when value changes** — sets a value, clears dirty, sets a different value, asserts \isDirty\ is \	rue\.
3. **setValue marks dirty even when value is unchanged** — documents that \Gauge.setValue\ always calls \markDirty()\ unconditionally (unlike \ProgressBar.setValue\ which guards with an early-return on equal values). Keeps the behaviour explicit so any future change is intentional.

No source files were modified. Only \Gauge.test.ts\ is touched.

## Related Issue

Closes #2178

## Which package(s)?

\@termuijs/widgets\

## Type of Change

- [x] 🐛 Bug fix (\	ype:bug\)

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: \un vitest run packages/widgets/src/data/Gauge.test.ts\ — 8/8 passed
- [x] Build passes: \un run build\
- [x] Typecheck passes: \un run typecheck\
- [x] You read [\CONTRIBUTING.md\](./CONTRIBUTING.md).
- [x] Your PR title follows \	ype: short description\.
- [x] Widget state mutators call \markDirty()\ (no source changes; only test file modified).
- [x] No new \ny\ types without an inline comment.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: https://gssoc.girlscript.org/profile/29a359a6-8a8f-4198-9486-d6cf94bcb95a

## Notes for the Reviewer

Only \packages/widgets/src/data/Gauge.test.ts\ is changed — 30 lines added, nothing removed. The third test includes an inline comment explaining why \Gauge.setValue\ behaves differently from \ProgressBar.setValue\, flagging it for a potential follow-up if the maintainer wants to add the idempotency guard.
