### PR TITLE
test(store): add missing middleware pipeline tests

### DIFF
--- a/packages/store/src/store.test.ts
+++ b/packages/store/src/store.test.ts
@@ -574,6 +574,41 @@ describe('middleware', () => {
     })
 
 
+    it('middleware that does not call next() suppresses the update', () => {
+        const blockAll = (_prev: any, _update: any, _next: any) => { // any: middleware receives heterogeneous state; no shared interface at this level
+            // deliberately never calls next() — the update is swallowed
+        }
+
+        const useStore = createStore(() => ({ count: 0 }), { middleware: [blockAll] })
+        const spy = vi.fn()
+        useStore.subscribe(spy)
+
+        useStore.setState({ count: 99 })
+
+        expect(useStore.getState().count).toBe(0)
+        expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('middleware receives the correct prevState and update arguments', () => {
+        const calls: Array<{ prev: Record<string, unknown>; update: Record<string, unknown> }> = []
+
+        const recorder = (prev: any, update: any, next: any) => { // any: middleware receives heterogeneous state; no shared interface at this level
+            calls.push({ prev: { ...prev }, update: { ...update } })
+            next(update)
+        }
+
+        const useStore = createStore(() => ({ count: 0, label: 'initial' }), { middleware: [recorder] })
+
+        useStore.setState({ count: 7 })
+        useStore.setState({ label: 'updated' })
+
+        expect(calls[0]?.prev).toEqual({ count: 0, label: 'initial' })
+        expect(calls[0]?.update).toEqual({ count: 7 })
+
+        expect(calls[1]?.prev).toEqual({ count: 7, label: 'initial' })
+        expect(calls[1]?.update).toEqual({ label: 'updated' })
+    })
+
     it('functional updaters chain correctly inside a batch', async () => {
         const useStore = createStore((set) => ({
             a: 0,


### PR DESCRIPTION
## Description

The \middleware\ describe block in \packages/store/src/store.test.ts\ had three tests but was missing two cases explicitly required by the issue:

**Suppress** — a middleware that never calls \
ext()\ should block the state update entirely. Neither the state value nor any subscriber should change.

**Arguments** — middleware should receive the exact \prevState\ snapshot at the time of the call and the exact \update\ object passed to \setState\. Verified across two sequential \setState\ calls to confirm \prevState\ updates correctly between calls.

Both tests are added directly inside the existing \middleware\ describe block. No source files were touched. Only \store.test.ts\ changed.

## Related Issue

Closes #2174

## Which package(s)?

\@termuijs/store\

## Type of Change

- [x] 🧪 Tests (\	ype:testing\)

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: \un vitest run packages/store\ — 77/77 passed
- [x] Build passes: \un run build\
- [x] Typecheck passes: \un run typecheck\
- [x] You read [\CONTRIBUTING.md\](./CONTRIBUTING.md).
- [x] Your PR title follows \	ype: short description\.
- [x] No new \ny\ types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile:  https://gssoc.girlscript.org/profile/29a359a6-8a8f-4198-9486-d6cf94bcb95a

## Notes for the Reviewer

Only \packages/store/src/store.test.ts\ changed — 35 lines added, nothing removed or modified. The two new \ny\ usages in the middleware callback signatures each carry an inline comment per the project style guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for middleware behavior when an update is blocked before reaching subscribers.
  * Added checks confirming middleware receives the expected previous state and update details across successive state updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->