### PR TITLE
test(widgets): expand Sparkline test coverage

### DIFF
--- a/packages/widgets/src/data/Sparkline.test.ts
+++ b/packages/widgets/src/data/Sparkline.test.ts
@@ -27,4 +27,129 @@ describe('Sparkline', () => {
         expect(rendered).toContain('Load 12345678');
         expect(rendered).not.toMatch(/[▁▂▃▄▅▆▇█]/);
     });
+
+    it('renders unicode spark chars when unicode is enabled', async () => {
+        vi.stubEnv('NO_UNICODE', '');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { Sparkline } = await import('./Sparkline.js');
+
+        const sparkline = new Sparkline('Net');
+        sparkline.setData([0, 4, 7]);
+        sparkline.updateRect({ x: 0, y: 0, width: 20, height: 1 });
+        const screen = new Screen(20, 1);
+        sparkline.render(screen);
+
+        const rendered = screen.back[0].map(c => c.char).join('');
+        expect(rendered).toMatch(/[▁▂▃▄▅▆▇█]/);
+        expect(rendered).not.toMatch(/[12345678]/);
+    });
+
+    it('label renders at the start of the row', async () => {
+        vi.stubEnv('NO_UNICODE', '1');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { Sparkline } = await import('./Sparkline.js');
+
+        const sparkline = new Sparkline('CPU');
+        sparkline.setData([1, 2, 3]);
+        sparkline.updateRect({ x: 0, y: 0, width: 20, height: 1 });
+        const screen = new Screen(20, 1);
+        sparkline.render(screen);
+
+        const rendered = screen.back[0].map(c => c.char).join('');
+        expect(rendered.startsWith('CPU ')).toBe(true);
+    });
+
+    it('setData replaces data and marks the widget dirty', async () => {
+        vi.stubEnv('NO_UNICODE', '');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Sparkline } = await import('./Sparkline.js');
+
+        const sparkline = new Sparkline('IO');
+        sparkline.setData([1, 2, 3]);
+        sparkline.clearDirty();
+
+        sparkline.setData([4, 5, 6]);
+
+        expect(sparkline.isDirty).toBe(true);
+    });
+
+    it('pushValue appends a value and marks the widget dirty', async () => {
+        vi.stubEnv('NO_UNICODE', '');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Sparkline } = await import('./Sparkline.js');
+
+        const sparkline = new Sparkline('IO');
+        sparkline.setData([1, 2, 3]);
+        sparkline.clearDirty();
+
+        sparkline.pushValue(9);
+
+        expect(sparkline.isDirty).toBe(true);
+    });
+
+    it('showRange renders min-max label on row 1', async () => {
+        vi.stubEnv('NO_UNICODE', '');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { Sparkline } = await import('./Sparkline.js');
+
+        const sparkline = new Sparkline('Mem', {}, { showRange: true });
+        sparkline.setData([10, 50, 90]);
+        sparkline.updateRect({ x: 0, y: 0, width: 20, height: 2 });
+        const screen = new Screen(20, 2);
+        sparkline.render(screen);
+
+        const row1 = screen.back[1].map(c => c.char).join('');
+        // min=10, max=90 — the range string "10–90" must appear on row 1
+        expect(row1).toContain('10');
+        expect(row1).toContain('90');
+    });
+
+    it('renders without error and blank row on empty data', async () => {
+        vi.stubEnv('NO_UNICODE', '');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { Sparkline } = await import('./Sparkline.js');
+
+        const sparkline = new Sparkline('X');
+        sparkline.setData([]);
+        sparkline.updateRect({ x: 0, y: 0, width: 20, height: 1 });
+        const screen = new Screen(20, 1);
+
+        expect(() => sparkline.render(screen)).not.toThrow();
+
+        const rendered = screen.back[0].map(c => c.char).join('');
+        expect(rendered).not.toMatch(/[▁▂▃▄▅▆▇█12345678]/);
+    });
+
+    it('marker braille renders braille characters instead of block chars', async () => {
+        vi.stubEnv('NO_UNICODE', '');
+        vi.stubEnv('TERM', '');
+        vi.resetModules();
+        const { Screen } = await import('@termuijs/core');
+        const { Sparkline } = await import('./Sparkline.js');
+
+        const sparkline = new Sparkline('Lat', {}, { marker: 'braille' });
+        sparkline.setData([0, 2, 4, 6, 8, 10]);
+        sparkline.updateRect({ x: 0, y: 0, width: 20, height: 1 });
+        const screen = new Screen(20, 1);
+        sparkline.render(screen);
+
+        const rendered = screen.back[0].map(c => c.char).join('');
+        // Braille mode uses BrailleCanvas which produces chars in U+2800–U+28FF
+        const hasBraille = [...rendered].some(
+            ch => ch.codePointAt(0)! >= 0x2800 && ch.codePointAt(0)! <= 0x28ff,
+        );
+        expect(hasBraille).toBe(true);
+        // Block spark chars must not appear
+        expect(rendered).not.toMatch(/[▁▂▃▄▅▆▇█]/);
+    });
 });


### PR DESCRIPTION
## Description

\Sparkline.test.ts\ had a single test — ASCII fallback characters when \NO_UNICODE=1\. Seven behaviors had zero coverage:

- Unicode spark chars (\▁▂▃▄▅▆▇█\) rendered when unicode is enabled
- Label text rendered at the start of the row
- \setData()\ marks the widget dirty (tested with \clearDirty()\ first)
- \pushValue()\ marks the widget dirty
- \showRange: true\ writes the min–max label on row 1 of the screen
- Empty data array renders without throwing and leaves row blank
- \marker: 'braille'\ produces braille-range characters (U+2800–U+28FF) instead of block chars

Seven new tests added alongside the original. All use a real \Screen\ and \updateRect\. Env-dependent tests use \i.stubEnv\ + \i.resetModules\.

## Related Issue

Closes #2168

## Which package(s)?

\@termuijs/widgets\

## Type of Change

- [x] 🐛 Bug fix (\	ype:bug\)

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: \un vitest run packages/widgets/src/data/Sparkline.test.ts\ — 8/8 passed
- [x] Build passes: \un run build\
- [x] Typecheck passes: \un run typecheck\
- [x] You read [\CONTRIBUTING.md\](./CONTRIBUTING.md).
- [x] Your PR title follows \	ype: short description\.
- [x] No new \ny\ types without an inline comment.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: \https://gssoc.girlscript.org/profile/Tomeshwari-02\

## Notes for the Reviewer

Only \packages/widgets/src/data/Sparkline.test.ts\ changed — 125 lines added (the original 1-test file grew to 8 tests). No source files modified.