### PR TITLE
test(widgets): add tests for DraggableWidget and DroppableWidget

### DIFF
--- a/packages/widgets/src/layout/DragAndDrop.test.ts
+++ b/packages/widgets/src/layout/DragAndDrop.test.ts
@@ -1,0 +1,194 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/widgets — Tests for DraggableWidget and DroppableWidget
+// ─────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { KeyEvent, MouseEvent as TermMouseEvent } from '@termuijs/core';
+import { DragState, DraggableWidget, DroppableWidget } from './DragAndDrop.js';
+
+function keyEvent(key: string): KeyEvent {
+    return {
+        key,
+        raw: Buffer.alloc(0),
+        ctrl: false,
+        alt: false,
+        shift: false,
+        stopPropagation: () => {},
+        preventDefault: () => {},
+    };
+}
+
+function mouseEvent(type: TermMouseEvent['type']): TermMouseEvent {
+    return { x: 0, y: 0, button: 'left', type };
+}
+
+beforeEach(() => {
+    DragState.activeDragId = null;
+    DragState.isDragging = false;
+});
+
+describe('DraggableWidget', () => {
+    it('space key starts dragging and sets DragState', () => {
+        const widget = new DraggableWidget({ id: 'a' });
+        widget.handleKey(keyEvent('space'));
+
+        expect(DragState.isDragging).toBe(true);
+        expect(DragState.activeDragId).toBe('a');
+    });
+
+    it('mousedown starts a drag', () => {
+        const widget = new DraggableWidget({ id: 'a' });
+        widget.handleMouse(mouseEvent('mousedown'));
+
+        expect(DragState.isDragging).toBe(true);
+        expect(DragState.activeDragId).toBe('a');
+    });
+
+    it('escape key cancels dragging and resets DragState', () => {
+        const widget = new DraggableWidget({ id: 'a' });
+        widget.handleKey(keyEvent('space'));
+        widget.handleKey(keyEvent('escape'));
+
+        expect(DragState.isDragging).toBe(false);
+        expect(DragState.activeDragId).toBeNull();
+    });
+
+    it('space key while already dragging cancels the drag', () => {
+        const widget = new DraggableWidget({ id: 'a' });
+        widget.handleKey(keyEvent('space'));
+        widget.handleKey(keyEvent('space'));
+
+        expect(DragState.isDragging).toBe(false);
+        expect(DragState.activeDragId).toBeNull();
+    });
+
+    it('onDragStart callback is called when drag starts', () => {
+        const onDragStart = vi.fn();
+        const widget = new DraggableWidget({ id: 'a', onDragStart });
+        widget.handleKey(keyEvent('space'));
+
+        expect(onDragStart).toHaveBeenCalledOnce();
+    });
+
+    it('onDragStart is not called again when drag is already active for this widget', () => {
+        const onDragStart = vi.fn();
+        const widget = new DraggableWidget({ id: 'a', onDragStart });
+        widget.handleKey(keyEvent('space'));
+        widget.handleKey(keyEvent('space')); // second press cancels, not restarts
+
+        expect(onDragStart).toHaveBeenCalledTimes(1);
+    });
+
+    it('markDirty is called when drag starts', () => {
+        const widget = new DraggableWidget({ id: 'a' });
+        const spy = vi.spyOn(widget, 'markDirty');
+        widget.handleKey(keyEvent('space'));
+
+        expect(spy).toHaveBeenCalled();
+    });
+
+    it('markDirty is called when drag cancels via escape', () => {
+        const widget = new DraggableWidget({ id: 'a' });
+        widget.handleKey(keyEvent('space'));
+        widget.clearDirty();
+
+        const spy = vi.spyOn(widget, 'markDirty');
+        widget.handleKey(keyEvent('escape'));
+
+        expect(spy).toHaveBeenCalled();
+    });
+
+    it('escape on a non-dragging widget is a no-op', () => {
+        const widget = new DraggableWidget({ id: 'a' });
+        widget.handleKey(keyEvent('escape'));
+
+        expect(DragState.isDragging).toBe(false);
+        expect(DragState.activeDragId).toBeNull();
+    });
+});
+
+describe('DroppableWidget', () => {
+    it('enter key triggers drop when a drag is active', () => {
+        const onDrop = vi.fn();
+        DragState.isDragging = true;
+        DragState.activeDragId = 'dragged';
+
+        const widget = new DroppableWidget({ id: 'target', onDrop });
+        widget.handleKey(keyEvent('enter'));
+
+        expect(onDrop).toHaveBeenCalledWith('dragged');
+    });
+
+    it('space key triggers drop when a drag is active', () => {
+        const onDrop = vi.fn();
+        DragState.isDragging = true;
+        DragState.activeDragId = 'dragged';
+
+        const widget = new DroppableWidget({ id: 'target', onDrop });
+        widget.handleKey(keyEvent('space'));
+
+        expect(onDrop).toHaveBeenCalledWith('dragged');
+    });
+
+    it('mouseup triggers drop when a drag is active', () => {
+        const onDrop = vi.fn();
+        DragState.isDragging = true;
+        DragState.activeDragId = 'dragged';
+
+        const widget = new DroppableWidget({ id: 'target', onDrop });
+        widget.handleMouse(mouseEvent('mouseup'));
+
+        expect(onDrop).toHaveBeenCalledWith('dragged');
+    });
+
+    it('onDrop receives the correct dragged widget id', () => {
+        const onDrop = vi.fn();
+        DragState.isDragging = true;
+        DragState.activeDragId = 'widget-42';
+
+        const widget = new DroppableWidget({ id: 'target', onDrop });
+        widget.handleKey(keyEvent('enter'));
+
+        expect(onDrop).toHaveBeenCalledWith('widget-42');
+    });
+
+    it('drop clears DragState', () => {
+        DragState.isDragging = true;
+        DragState.activeDragId = 'dragged';
+
+        const widget = new DroppableWidget({ id: 'target' });
+        widget.handleKey(keyEvent('enter'));
+
+        expect(DragState.isDragging).toBe(false);
+        expect(DragState.activeDragId).toBeNull();
+    });
+
+    it('drop is a no-op when no drag is active', () => {
+        const onDrop = vi.fn();
+        const widget = new DroppableWidget({ id: 'target', onDrop });
+        widget.handleKey(keyEvent('enter'));
+
+        expect(onDrop).not.toHaveBeenCalled();
+        expect(DragState.isDragging).toBe(false);
+    });
+
+    it('markDirty is called after a successful drop', () => {
+        DragState.isDragging = true;
+        DragState.activeDragId = 'dragged';
+
+        const widget = new DroppableWidget({ id: 'target' });
+        const spy = vi.spyOn(widget, 'markDirty');
+        widget.handleKey(keyEvent('enter'));
+
+        expect(spy).toHaveBeenCalled();
+    });
+
+    it('markDirty is not called when drop is a no-op', () => {
+        const widget = new DroppableWidget({ id: 'target' });
+        widget.clearDirty();
+        const spy = vi.spyOn(widget, 'markDirty');
+        widget.handleKey(keyEvent('enter'));
+
+        expect(spy).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Description

\DragAndDrop.ts\ had no test file. The drag/drop system uses a shared mutable singleton (\DragState\) which makes test isolation critical. \eforeEach\ resets \DragState\ before every test to prevent leaks.

**DraggableWidget** — 9 tests:
- \space\ key starts a drag and sets \DragState\
- \mousedown\ starts a drag
- \escape\ cancels drag and resets \DragState\
- second \space\ press cancels an active drag
- \onDragStart\ callback fires on drag start
- \onDragStart\ not called again when drag already active for this widget
- \markDirty\ called on drag start
- \markDirty\ called on drag cancel via \escape\
- \escape\ is a no-op when no drag is active

**DroppableWidget** — 8 tests:
- \enter\ key triggers drop when drag is active
- \space\ key triggers drop when drag is active
- \mouseup\ triggers drop when drag is active
- \onDrop\ receives the correct dragged widget id
- drop clears \DragState\
- drop is a no-op when no drag is active
- \markDirty\ called after successful drop
- \markDirty\ not called when drop is a no-op

## Related Issue

Closes #2166

## Which package(s)?

\@termuijs/widgets\

## Type of Change

- [x] 🐛 Bug fix (\	ype:bug\)

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: \un vitest run packages/widgets/src/layout/DragAndDrop.test.ts\ — 17/17 passed
- [x] Build passes: \un run build\
- [x] Typecheck passes: \un run typecheck\
- [x] You read [\CONTRIBUTING.md\](./CONTRIBUTING.md).
- [x] Your PR title follows \	ype: short description\.
- [x] No new \ny\ types without an inline comment.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: \https://gssoc.girlscript.org/profile/Tomeshwari-02\

## Notes for the Reviewer

Only \packages/widgets/src/layout/DragAndDrop.test.ts\ was created — 194 lines, new file. No source files modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for drag-and-drop interactions, including keyboard and mouse drag start, cancel, and drop behavior.
  * Verified successful drops trigger the expected action, clear active drag state, and update the UI when needed.
  * Confirmed no-op drop cases do not cause unintended changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->