### PR TITLE
perf(widgets): cache grapheme segmentation in StreamingText

### DIFF
--- a/packages/widgets/src/display/StreamingText.ts
+++ b/packages/widgets/src/display/StreamingText.ts
@@ -30,6 +30,7 @@ const segmenter = new Intl.Segmenter();
  */
 export class StreamingText extends Widget {
     private _text: string;
+    private _segments: Intl.SegmentData[];
     private _cursor: string;
     private _speed: number;
     private _blinkInterval: number;
@@ -41,6 +42,7 @@ export class StreamingText extends Widget {
     constructor(options: StreamingTextOptions, style: Partial<Style> = {}) {
         super(style);
         this._text = options.text;
+        this._segments = Array.from(segmenter.segment(this._text));
         this._cursor = options.cursor ?? (caps.unicode ? '▋' : '_');
         this._speed = options.speed ?? 0;
         this._blinkInterval = options.blinkInterval ?? 530;
@@ -52,6 +54,7 @@ export class StreamingText extends Widget {
     setText(text: string): void {
         if (text === this._text) return;
         this._text = text;
+        this._segments = Array.from(segmenter.segment(text));
         this._revealed = 0;
         this.markDirty();
     }
@@ -62,7 +65,7 @@ export class StreamingText extends Widget {
      */
     tick(): void {
         if (this._speed <= 0 || this.isComplete()) return;
-        const len = Array.from(segmenter.segment(this._text)).length;
+        const len = this._segments.length;
         this._revealed = Math.min(this._revealed + this._speed, len);
         this.markDirty();
     }
@@ -70,7 +73,7 @@ export class StreamingText extends Widget {
     /** Returns true when all text has been revealed. */
     isComplete(): boolean {
         if (this._speed === 0) return true;
-        const len = Array.from(segmenter.segment(this._text)).length;
+        const len = this._segments.length;
         return this._revealed >= len;
     }
 
@@ -102,7 +105,7 @@ export class StreamingText extends Widget {
         const attrs = styleToCellAttrs(this._style);
 
         // Determine how much text to display
-        const segments = Array.from(segmenter.segment(this._text));
+        const segments = this._segments;
         const displayText = this._speed > 0
             ? segments.slice(0, this._revealed).map(s => s.segment).join('')
             : this._text;


### PR DESCRIPTION
## Description

This PR improves the performance of the `StreamingText` widget by caching the grapheme segmentation of the input text instead of recomputing it during every render, `tick()`, and `isComplete()` call.

The cached segments are initialized in the constructor and refreshed whenever the text changes via `setText()`. This reduces unnecessary allocations while preserving the existing widget behavior.

## Related Issue

Closes #2195 

## Which package(s)?

- `@termuijs/widgets`

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [x] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A (Performance improvement only)

## Notes for the Reviewer

- Cached grapheme segments are stored in a private `_segments` field.
- The cache is initialized in the constructor and refreshed in `setText()`.
- `tick()`, `isComplete()`, and `_renderSelf()` now reuse the cached segmentation instead of repeatedly calling `Intl.Segmenter`.
- No behavioural changes are intended; this PR only reduces repeated segmentation work for unchanged text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Streaming text now uses cached text segments, reducing repeated re-processing during updates and rendering.
  * This should make animated text display smoother and more responsive, especially for longer content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->