### PR TITLE
test(widgets): add spring scroll helper unit tests

### DIFF
--- a/packages/widgets/src/scroll.test.ts
+++ b/packages/widgets/src/scroll.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { calculateSpringScroll, type ScrollSpringState } from './scroll.js';
+
+describe('calculateSpringScroll', () => {
+    it('should return unchanged state when position is already at target and velocity is zero', () => {
+        const state: ScrollSpringState = { position: 10, velocity: 0 };
+        const result = calculateSpringScroll(state, 10, 1 / 60);
+        expect(result.position).toBeCloseTo(10, 4);
+        expect(result.velocity).toBeCloseTo(0, 4);
+    });
+
+    it('should move position closer to target over time when there is a displacement', () => {
+        let state: ScrollSpringState = { position: 100, velocity: 0 };
+        const target = 0;
+        const dt = 1 / 60;
+
+        // Step 1
+        state = calculateSpringScroll(state, target, dt);
+        expect(state.position).toBeLessThan(100);
+        expect(state.velocity).toBeLessThan(0); // moving left/downwards towards 0
+
+        // Simulate multiple steps to confirm convergence towards target
+        for (let i = 0; i < 2000; i++) {
+            state = calculateSpringScroll(state, target, dt);
+        }
+
+        expect(state.position).toBeCloseTo(0, 1);
+        expect(state.velocity).toBeCloseTo(0, 1);
+    });
+
+    it('should use default dt of 1/60 when dt is not provided', () => {
+        const state: ScrollSpringState = { position: 10, velocity: 5 };
+        const resultWithDefault = calculateSpringScroll(state, 0);
+        const resultWithExplicit = calculateSpringScroll(state, 0, 1 / 60);
+        expect(resultWithDefault).toEqual(resultWithExplicit);
+    });
+});


### PR DESCRIPTION
## Description

This PR adds comprehensive unit tests for the spring scroll helper function `calculateSpringScroll` inside `packages/widgets/src/scroll.ts`.

## Related Issue

Closes #2197

## Which package(s)?

@termuijs/widgets

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read `CONTRIBUTING.md`.
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/Harshithk951`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for spring-based scrolling behavior.
  * Verified stable results when already at the target with no movement.
  * Confirmed repeated updates move position toward the target while damping velocity.
  * Checked that the default time step matches an explicit 1/60-second update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->