### PR TITLE
perf: cache ThinkingBlock border strings

### DIFF
--- a/packages/widgets/src/display/ThinkingBlock.ts
+++ b/packages/widgets/src/display/ThinkingBlock.ts
@@ -28,6 +28,11 @@ export class ThinkingBlock extends Widget {
     private _dots = '';
     private _timerUnsub?: () => void;
 
+    private _topBorder = '';
+    private _bottomBorder = '';
+    private _cachedBorderWidth = -1;
+    private _cachedUnicode = caps.unicode;
+
     constructor(
         options: ThinkingBlockOptions = {},
         style: Partial<Style> = {},
@@ -99,10 +104,24 @@ export class ThinkingBlock extends Widget {
         const h = caps.unicode ? '─' : '-';
         const v = caps.unicode ? '│' : '|';
 
+        if (
+            this._cachedBorderWidth !== boxWidth ||
+            this._cachedUnicode !== caps.unicode
+        ) {
+            this._topBorder =
+                tl + h.repeat(Math.max(0, boxWidth - 2)) + tr;
+        
+            this._bottomBorder =
+                bl + h.repeat(Math.max(0, boxWidth - 2)) + br;
+        
+            this._cachedBorderWidth = boxWidth;
+            this._cachedUnicode = caps.unicode;
+        }
+        
         screen.writeString(
             rect.x,
             rect.y,
-            tl + h.repeat(Math.max(0, boxWidth - 2)) + tr,
+            this._topBorder,
             attrs,
         );
 
@@ -145,7 +164,7 @@ export class ThinkingBlock extends Widget {
         screen.writeString(
             rect.x,
             rect.y + limit + 1,
-            bl + h.repeat(Math.max(0, boxWidth - 2)) + br,
+            this._bottomBorder,
             attrs,
         );
     }


### PR DESCRIPTION
## Description

This PR caches the generated top and bottom border strings in `ThinkingBlock` and rebuilds them only when the widget width or Unicode capability changes.

This preserves the existing rendering behavior while reducing repeated string allocations and `repeat()` calls during rendering.

## Related Issue

Closes #2215 

## Which package(s)?

- @termuijs/widgets

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [x] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read `CONTRIBUTING.md`.
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.

Your GSSoC profile:`https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A (performance-only change)

## Notes for the Reviewer

This optimization caches the generated border strings and regenerates them only when the widget width or Unicode capability changes. The rendering output remains unchanged while avoiding repeated string construction during every render.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved rendering efficiency for expanded thinking blocks by reusing border strings when the size and character set haven’t changed.
  * This can make repeated redraws smoother, especially in views that update frequently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->