### PR TITLE
ci: cache Bun dependencies in benchmark workflow

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -23,10 +23,20 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
-
+      
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            **/node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+      
       - name: Install dependencies
         run: bun install --frozen-lockfile
-
+      
       - name: Bench HEAD
         run: |
           bun run bench | tee bench-head.txt


### PR DESCRIPTION
## Description

This PR adds dependency caching to the benchmark GitHub Actions workflow using `actions/cache`. By caching Bun's package cache and workspace `node_modules` directories, repeated workflow runs can restore dependencies instead of reinstalling them from scratch, improving CI performance.

## Related Issue

Closes #2219

## Which package(s)?

GitHub Actions / CI

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♻️ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [x] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/a80c7e63-fb5a-4d58-aec9-115f9a2798b7`

## Screenshots / Recordings (UI changes)

N/A (CI workflow change)

## Notes for the Reviewer

- Added GitHub Actions dependency caching using `actions/cache@v4`.
- Cached Bun package cache (`~/.bun/install/cache`) and workspace `node_modules` directories.
- Cache keys are based on the `bun.lock` lockfile to ensure cache invalidation when dependencies change.
- No benchmark logic or workflow behaviour was modified apart from dependency caching.