### PR TITLE
fix(widgets): support value option in Digits constructor

### DIFF
--- a/packages/widgets/src/display/Digits.test.ts
+++ b/packages/widgets/src/display/Digits.test.ts
@@ -17,6 +17,11 @@ describe('Digits', () => {
         expect(rows.some(row => row.includes('|'))).toBe(true);
     });
 
+    it('constructs with custom value option inside opts', () => {
+        const widget = new Digits({}, { value: '45' });
+        expect(widget.getValue()).toBe('45');
+    });
+
     it('renders multiple digits', () => {
         const widget = new Digits({ value: '42', width: 20, height: 3 } as never);
         widget.updateRect({ x: 0, y: 0, width: 20, height: 3 });

--- a/packages/widgets/src/display/Digits.ts
+++ b/packages/widgets/src/display/Digits.ts
@@ -6,6 +6,7 @@ import { type Screen, type Style, type Color, styleToCellAttrs } from '@termuijs
 import { Widget } from '../base/Widget.js';
 
 export interface DigitsOptions {
+    value?: string | number;
     color?: Color;
 }
 
@@ -44,7 +45,8 @@ export class Digits extends Widget {
 
     constructor(style: Partial<Style> = {}, opts: DigitsOptions = {}) {
         super({ height: DIGIT_HEIGHT, ...style });
-        this._value = String((style as Record<string, unknown>).value ?? '0');
+        const initVal = opts.value ?? (style as Record<string, unknown>).value ?? '0';
+        this._value = String(initVal);
         this._color = opts.color ?? { type: 'named', name: 'white' };
     }
 


### PR DESCRIPTION
Closes Issue #2223 

> **Description**:
> Adds `value` to the `DigitsOptions` interface and updates the constructor to read the value in a type-safe manner, while maintaining fallback support for legacy codebases passing `value` inside the `style` block.
>
> **Changes**:
> - Added `value?: string | number` to the `DigitsOptions` interface.
> - Updated the `Digits` constructor to resolve `opts.value` first, before falling back to `style.value`.
> - Added a unit test in `Digits.test.ts` to verify the new option.
>
> **Validation**:
> - Ran `bun vitest run packages/widgets/src/display/Digits.test.ts` (10/10 tests passed).


## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Digits widgets can now be initialized with a custom starting value through configuration options, with support for both text and numeric values.
  * If no value is provided, the widget still falls back to the existing default.

* **Tests**
  * Added coverage to verify that a custom initial value is applied correctly when creating a Digits widget.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->