### PR TITLE
fix(widgets): implement getText getter on BigText

### DIFF
--- a/packages/widgets/src/display/BigText.test.ts
+++ b/packages/widgets/src/display/BigText.test.ts
@@ -187,4 +187,9 @@ describe('BigText – mutation regression tests', () => {
 
         expect(widget.isDirty).toBe(true);
     });
+
+    it('returns the uppercase text via getText()', () => {
+        const widget = new BigText('hello');
+        expect(widget.getText()).toBe('HELLO');
+    });
 });

--- a/packages/widgets/src/display/BigText.ts
+++ b/packages/widgets/src/display/BigText.ts
@@ -84,6 +84,10 @@ export class BigText extends Widget {
         this.markDirty();
     }
 
+    getText(): string {
+        return this._text;
+    }
+
     protected _renderSelf(screen: Screen): void {
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;


### PR DESCRIPTION
Closes Issue #2225 

> **Description**:
> Implements `getText()` on `BigText` to return the current uppercase string.
>
> **Changes**:
> - Added `getText(): string` to `BigText.ts`.
> - Added a unit test in `BigText.test.ts` verifying the getter.
>
> **Validation**:
> - Ran `bun vitest run packages/widgets/src/display/BigText.test.ts` (13/13 tests passed).


## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a way to retrieve the current text shown by the large text widget.
* **Tests**
  * Added coverage to confirm the widget returns text in uppercase as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->