### PR TITLE
fix(widgets): clamp count and truncate label in NotificationBadge

### DIFF
--- a/packages/widgets/src/display/NotificationBadge.test.ts
+++ b/packages/widgets/src/display/NotificationBadge.test.ts
@@ -131,6 +131,22 @@ describe('NotificationBadge', () => {
         const badge = new NotificationBadge({ count: 3 });
         expect(badge.getPosition()).toBe('top-right');
     });
+
+    it('clamps negative count values to 0', () => {
+        const badge = new NotificationBadge({ count: -5 });
+        expect(badge.getCount()).toBe(0);
+
+        badge.setCount(-10);
+        expect(badge.getCount()).toBe(0);
+    });
+
+    it('truncates badge label to fit narrow layout widths', () => {
+        const { screen } = renderBadge({ count: 150, position: 'top-left' }, {}, 2, 5);
+        // label "99+" is length 3, rendered in width 2, so it should be truncated to "99"
+        const topRow = rowText(screen, 0);
+        expect(topRow.length).toBeLessThanOrEqual(2);
+        expect(topRow).toBe('99');
+    });
 });
 
 describe('NotificationBadge – mutation regression tests', () => {

--- a/packages/widgets/src/display/NotificationBadge.ts
+++ b/packages/widgets/src/display/NotificationBadge.ts
@@ -1,6 +1,6 @@
 // @termuijs/widgets - NotificationBadge widget
 
-import { type Screen, type Style, type Color, stringWidth } from '@termuijs/core';
+import { type Screen, type Style, type Color, stringWidth, truncate } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
 export type BadgePosition = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
@@ -31,14 +31,15 @@ export class NotificationBadge extends Widget {
 
     constructor(opts: NotificationBadgeOptions = {}, style: Partial<Style> = {}) {
         super(style);
-        this._count = opts.count ?? 0;
+        this._count = Math.max(0, opts.count ?? 0);
         this._position = opts.position ?? 'top-right';
     }
 
     /** Update the notification count. */
     setCount(count: number): void {
-        if (count === this._count) return;
-        this._count = count;
+        const clamped = Math.max(0, count);
+        if (clamped === this._count) return;
+        this._count = clamped;
         this.markDirty();
     }
 
@@ -96,8 +97,9 @@ export class NotificationBadge extends Widget {
         // Clamp to widget bounds
         bx = Math.max(x, bx);
 
+        const visibleLabel = truncate(label, width, '');
         // Render the label with notification colors
         const attrs = { fg: BADGE_FG, bg: BADGE_BG, bold: true };
-        screen.writeString(bx, by, label, attrs);
+        screen.writeString(bx, by, visibleLabel, attrs);
     }
 }


### PR DESCRIPTION
Closes Issue #2227  

> **Description**:
> Adds bounds safety to `NotificationBadge` count updates and layout rendering.
>
> **Changes**:
> - Clamped count to `>= 0` in constructor and `setCount()` setter.
> - Applied `truncate()` to the visible label in `_renderSelf()` to ensure rendering respects the widget's allocated width.
> - Added unit tests in `NotificationBadge.test.ts` verifying count clamping and layout truncation.
>
> **Validation**:
> - Ran `bun vitest run packages/widgets/src/display/NotificationBadge.test.ts` (24/24 tests passed).


## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->
