### PR TITLE
fix(widgets): truncate double-width characters visually in Tag #2229

### DIFF
--- a/packages/widgets/src/display/Tag.test.ts
+++ b/packages/widgets/src/display/Tag.test.ts
@@ -147,6 +147,12 @@ describe('Tag', () => {
         expect(() => renderTag('test', {}, {}, 0, 0)).not.toThrow();
     });
 
+    it('truncates double-width characters correctly without overflow', () => {
+        const { screen } = renderTag('测试试', {}, {}, 6, 3);
+        const row = rowText(screen, 1);
+        expect(row.length).toBeLessThanOrEqual(6);
+    });
+
     // ── 6. Constructor signature ────────────────────────────────────────────
     it('canonical signature Tag(text, style, opts) works correctly', () => {
         const { tag } = renderTag('test', {}, { variant: 'info' });

--- a/packages/widgets/src/display/Tag.ts
+++ b/packages/widgets/src/display/Tag.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets — Tag widget
 // ─────────────────────────────────────────────────────
 
-import { type Screen, type Style, type Color, stringWidth, caps } from '@termuijs/core';
+import { type Screen, type Style, type Color, stringWidth, caps, truncate } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
 export type TagVariant = 'info' | 'success' | 'warning' | 'error' | 'neutral';
@@ -106,7 +106,7 @@ export class Tag extends Widget {
             screen.setCell(x, y + 1, { char: vt, ...borderAttrs });
 
             // Write padded text with variant foreground, no background
-            const visibleText = padded.slice(0, innerWidth);
+            const visibleText = truncate(padded, innerWidth, '');
             screen.writeString(x + 1, y + 1, visibleText, textAttrs);
 
             if (innerWidth + 1 < width) {


### PR DESCRIPTION
Closes Issue #2229
> **Description**:
> Employs `truncate()` to visually slice tag text to the internal container width.
>
> **Changes**:
> - Imported `truncate` from `@termuijs/core`.
> - Replaced `.slice(0, innerWidth)` with `truncate(padded, innerWidth, '')` in `Tag.ts`.
> - Added a unit test in `Tag.test.ts` verifying that double-width characters are truncated correctly.
>
> **Validation**:
> - Ran `bun vitest run packages/widgets/src/display/Tag.test.ts` (18/18 tests passed).

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [ ] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [ ] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->
