### PR TITLE
fix(widgets): implement getSections getter on Accordion #2231

### DIFF
--- a/packages/widgets/src/display/Accordion.test.ts
+++ b/packages/widgets/src/display/Accordion.test.ts
@@ -389,4 +389,11 @@ describe('Accordion', () => {
             vi.restoreAllMocks();
         });
     });
+
+    describe('12. getSections getter API', () => {
+        it('returns correct sections', () => {
+            const accordion = makeAccordion(SECTIONS);
+            expect(accordion.getSections()).toBe(SECTIONS);
+        });
+    });
 });

--- a/packages/widgets/src/display/Accordion.ts
+++ b/packages/widgets/src/display/Accordion.ts
@@ -144,6 +144,11 @@ export class Accordion extends Widget {
         this.markDirty();
     }
 
+    /** Get the current list of sections. */
+    getSections(): AccordionSection[] {
+        return this._sections;
+    }
+
     // ── Keyboard ────────────────────────────────────────────────────────
 
     /**


### PR DESCRIPTION
Closes Issue #2231 
> **Description**:
> Adds the `getSections(): AccordionSection[]` method to `Accordion.ts` to return the current array of sections.
>
> **Changes**:
> - Added `getSections(): AccordionSection[]` to `Accordion.ts`.
> - Added a unit test in `Accordion.test.ts` to verify the new getter.
>
> **Validation**:
> - Ran `bun vitest run packages/widgets/src/display/Accordion.test.ts` (39/39 tests passed).

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [ ] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [ ] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->
