### PR TITLE
fix(widgets): implement getTasks getter on TaskList #2236

### DIFF
--- a/packages/widgets/src/feedback/TaskList.test.ts
+++ b/packages/widgets/src/feedback/TaskList.test.ts
@@ -161,4 +161,9 @@ describe('TaskList', () => {
         expect(rows[2]).toContain('...');  // done
         expect(rows[3]).toContain('...');  // error
     });
+
+    it('returns task list via getTasks getter', () => {
+        const tl = new TaskList({}, {}, TASKS);
+        expect(tl.getTasks()).toBe(TASKS);
+    });
 });

--- a/packages/widgets/src/feedback/TaskList.ts
+++ b/packages/widgets/src/feedback/TaskList.ts
@@ -80,6 +80,11 @@ export class TaskList extends Widget {
         this.markDirty();
     }
 
+    /** Retrieve the current task list. */
+    getTasks(): TaskItem[] {
+        return this._tasks;
+    }
+
     /**
      * Advance the spinner animation by `dt` milliseconds.
      * Only has an effect when `wheelspin` is enabled and there is at least


### PR DESCRIPTION
Closes Issue #2236 

> **Description**:
> Implements `getTasks(): TaskItem[]` on the `TaskList` widget to allow reading the current task array.
>
> **Changes**:
> - Added `getTasks(): TaskItem[]` to `TaskList.ts`.
> - Added a unit test in `TaskList.test.ts` to verify the getter.
>
> **Validation**:
> - Ran `bun vitest run packages/widgets/src/feedback/TaskList.test.ts` (13/13 tests passed).


## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to ensure task lists retain the same items passed in during creation.
* **Refactor**
  * Exposed a new way to inspect the current task list state without changing existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->