### PR TITLE
fix(widgets): truncate Progress rows to content width #2238

### DIFF
--- a/packages/widgets/src/feedback/Progress.test.ts
+++ b/packages/widgets/src/feedback/Progress.test.ts
@@ -81,4 +81,17 @@ describe("Progress", () => {
         expect(widget.isDirty).toBe(true);
     });
 
-})
+    it("truncates rendering output to fit available width", () => {
+        const widget = new Progress({
+            tasks: [{ label: 'VeryLongDownloadingLabelTaskTextDescription', value: 0.5 }],
+            columns: [TextColumn(), PercentageColumn()]
+        });
+        const screen = new Screen(12, 1);
+        widget.updateRect({ x: 0, y: 0, width: 12, height: 1 });
+        widget.render(screen);
+
+        const row = screen.back[0].map(c => c.char).join('');
+        expect(row.length).toBeLessThanOrEqual(12);
+        expect(row).toBe('VeryLongDown');
+    });
+});

--- a/packages/widgets/src/feedback/Progress.ts
+++ b/packages/widgets/src/feedback/Progress.ts
@@ -9,7 +9,7 @@ import {
     TextColumn,
     PercentageColumn,
 } from './ProgressColumn.js';
-import type { Screen, Style } from '@termuijs/core';
+import { type Screen, type Style, truncate } from '@termuijs/core';
 export interface ProgressTask {
     label?: string;
     value?: number;
@@ -169,7 +169,7 @@ this._columns =
         screen.writeString(
             x,
             y + index,
-            parts.join(' '),
+            truncate(parts.join(' '), width, ''),
             this.style,
         );
     });


### PR DESCRIPTION
Closes Issue #2238
> **Description**:
> Wraps the rendered row string in `truncate()` to ensure that progress indicators do not exceed the container width bounds.
>
> **Changes**:
> - Imported `truncate` from `@termuijs/core`.
> - Wrapped the `parts.join(' ')` string with `truncate(..., width, '')` before rendering.
> - Added a unit test in `Progress.test.ts` to verify that long rows are truncated to the layout width.
>
> **Validation**:
> - Ran `bun vitest run packages/widgets/src/feedback/Progress.test.ts` (5/5 tests passed).
## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->
