### PR TITLE
fix(widgets): implement missing getters on Banner

### DIFF
--- a/packages/widgets/src/feedback/Banner.test.ts
+++ b/packages/widgets/src/feedback/Banner.test.ts
@@ -295,4 +295,13 @@ describe('Banner', () => {
         expect(cell(screen, 0, 3).char).not.toBe(' ');
         expect(cell(screen, 9, 3).char).not.toBe(' ');
     });
+
+    describe('Banner — getters', () => {
+        it('returns correct title, body, and variant via getters', () => {
+            const banner = new Banner({}, { title: 'T', body: 'B', variant: 'warning' });
+            expect(banner.getTitle()).toBe('T');
+            expect(banner.getBody()).toBe('B');
+            expect(banner.getVariant()).toBe('warning');
+        });
+    });
 });

--- a/packages/widgets/src/feedback/Banner.ts
+++ b/packages/widgets/src/feedback/Banner.ts
@@ -53,6 +53,10 @@ export class Banner extends Widget {
         this.markDirty();
     }
 
+    getTitle(): string {
+        return this._title;
+    }
+
     setBody(body: string): void {
         if (this._body === body) return;
 
@@ -60,11 +64,19 @@ export class Banner extends Widget {
         this.markDirty();
     }
 
+    getBody(): string {
+        return this._body;
+    }
+
     setVariant(variant: StatusVariant): void {
         if (this._variant === variant) return;
         
         this._variant = variant;
         this.markDirty();
+    }
+
+    getVariant(): StatusVariant {
+        return this._variant;
     }
 
     protected _renderSelf(screen: Screen): void {


### PR DESCRIPTION
Closes Issue #2240
> **Description**:
> Implements `getTitle()`, `getBody()`, and `getVariant()` on the `Banner` widget to ensure complete setter-getter API symmetry.
>
> **Changes**:
> - Added `getTitle(): string`, `getBody(): string`, and `getVariant(): StatusVariant` to `Banner.ts`.
> - Added a unit test in `Banner.test.ts` to verify the new getters.
>
> **Validation**:
> - Ran `bun vitest run packages/widgets/src/feedback/Banner.test.ts` (18/18 tests passed).

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->
