### PR TITLE
fix(widgets): respect custom padding styling in Alert

### DIFF
--- a/packages/widgets/src/feedback/Alert.test.ts
+++ b/packages/widgets/src/feedback/Alert.test.ts
@@ -169,4 +169,13 @@ describe('Alert — Setters and Getters', () => {
         expect(alert.isDirty).toBe(true);
     });
 
+    describe('Alert — Custom padding overrides', () => {
+        it('respects custom padding styling overrides', () => {
+            const { screen } = renderAlert({ variant: 'info', message: 'Hello' }, { padding: 0 }, 30, 3);
+            // With padding = 0, row 1 (inside 1 border height) is the content row.
+            // Check content is rendered on row 1 (x + border(1) + padding(0) = cx = 1)
+            const rowChars = screen.back[1].map(c => c.char).join('');
+            expect(rowChars).toContain('● Hello');
+        });
+    });
 });

--- a/packages/widgets/src/feedback/Alert.ts
+++ b/packages/widgets/src/feedback/Alert.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets — Alert widget
 // ─────────────────────────────────────────────────────
 
-import { type Screen, type Style, type Color, styleToCellAttrs, getBorderChars, caps, stringWidth, truncate } from '@termuijs/core';
+import { type Screen, type Style, type Color, styleToCellAttrs, getBorderChars, caps, stringWidth, truncate, normalizeEdges } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 import { type StatusVariant } from './StatusMessage.js';
 
@@ -128,11 +128,12 @@ export class Alert extends Widget {
             }
         }
 
-        // Content area (inside border + padding=1)
-        const cx = x + 2; // border(1) + padding(1)
-        const cy = y + 2;
-        const contentWidth = Math.max(0, width - 4);  // left/right border+padding
-        const contentHeight = Math.max(0, height - 4); // top/bottom border+padding
+        // Content area (inside border + padding)
+        const padding = normalizeEdges(this._style.padding);
+        const cx = x + 1 + padding.left; // border(1) + padding.left
+        const cy = y + 1 + padding.top;
+        const contentWidth = Math.max(0, width - 2 - padding.left - padding.right);
+        const contentHeight = Math.max(0, height - 2 - padding.top - padding.bottom);
 
         if (contentHeight <= 0 || contentWidth <= 0) return;
 


### PR DESCRIPTION
Closes Issue #2242 

> **Description**:
> Fixes the hardcoded padding calculations in the Alert widget to dynamically resolve and normalize padding edges from `this._style.padding`.
>
> **Changes**:
> - Imported `normalizeEdges` from `@termuijs/core`.
> - Replaced hardcoded padding constants in `Alert.ts` with dynamic lookups using `normalizeEdges(this._style.padding)`.
> - Added a unit test in `Alert.test.ts` to assert that custom padding options are respected.
>
> **Validation**:
> - Ran `bun vitest run packages/widgets/src/feedback/Alert.test.ts` (15/15 tests passed).

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->
