### PR TITLE
Virtual list feature

### DIFF
--- a/packages/widgets/src/input/VirtualList.ts
+++ b/packages/widgets/src/input/VirtualList.ts
@@ -229,6 +229,16 @@ export class VirtualList extends Widget {
         });
     }
 
+    /** Scroll to the very top */
+    scrollToTop(): void {
+        this.scrollToIndex(0, 'start');
+    }
+
+    /** Scroll to the very bottom */
+    scrollToBottom(): void {
+        this.scrollToIndex(this._totalItems - 1, 'end');
+    }
+
     /** Confirm the current selection */
     confirm(): void {
         if (this._totalItems > 0) {


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

This PR improves navigation for the `VirtualList` widget by introducing `scrollToTop()` and `scrollToBottom()` helper methods. When dealing with massive virtualized datasets (e.g. 100,000+ items), these methods allow developers to programmatically jump the viewport to the list bounds without having to manually calculate the offset math.

## Related Issue

Closes #2252

## Which package(s)?

`@termuijs/widgets`

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/YOUR_PROFILE_ID_HERE`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

These methods wrap the existing `scrollToIndex` engine but use the correct `alignment` arguments (`start` and `end`) to guarantee that the first/last items snap correctly to the edges of the visible viewport, preventing overscan bleed.
