### PR TITLE
Combobox feature

### DIFF
--- a/packages/ui/src/Combobox.ts
+++ b/packages/ui/src/Combobox.ts
@@ -54,6 +54,30 @@ export class Combobox extends Widget {
         );
     }
 
+    /**
+     * Programmatically clear the combobox input and selection.
+     */
+    public clear(): void {
+        this._inputValue = '';
+        this._committedValue = '';
+        this._selectedIndex = -1;
+        this._isOpen = false;
+        this.markDirty();
+    }
+
+    /**
+     * Programmatically set the selected value.
+     */
+    public setValue(value: string): void {
+        const option = this._options.find(o => o.value === value);
+        if (option) {
+            this._inputValue = option.label;
+            this._committedValue = option.value;
+            this._selectedIndex = -1;
+            this.markDirty();
+        }
+    }
+
     handleKey(event: KeyEvent): void {
         const key = event.key;
         const filtered = this.filtered;


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

This PR improves the usability of the `Combobox` widget in `@termuijs/ui` by exposing `clear()` and `setValue(value: string)` utility methods. These allow developers to easily reset or override the combobox state programmatically (e.g., when a form is cleared or a default value is loaded asynchronously).

## Related Issue

Closes #2254

## Which package(s)?

`@termuijs/ui`

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/YOUR_PROFILE_ID_HERE`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

Both methods correctly trigger `this.markDirty()` so the component will re-render automatically on the next engine tick when the state changes.
