### PR TITLE
Markdown feature

### DIFF
--- a/packages/widgets/src/display/Markdown.ts
+++ b/packages/widgets/src/display/Markdown.ts
@@ -196,7 +196,16 @@ export class Markdown extends Widget {
     );
 
     screenRow++;
-}
+            else if (line.startsWith('---') || line.startsWith('***')) {
+                const hl = caps.unicode ? '─' : '-';
+                screen.writeString(
+                    rect.x,
+                    rect.y + screenRow,
+                    hl.repeat(rect.width),
+                    { dim: true }
+                );
+                screenRow++;
+            }
             else if (line.startsWith('- ')) {
                 const bullet = caps.unicode ? '•' : '*';
 


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

This PR expands the syntax support of the `Markdown` widget in `@termuijs/widgets` by introducing rendering logic for **Horizontal Rules**. It now successfully intercepts `---` and `***` lines in the AST and paints a full-width terminal divider utilizing Unicode block-drawing graphics.

## Related Issue

Closes #2255

## Which package(s)?

`@termuijs/widgets`

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/YOUR_PROFILE_ID_HERE`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

The implementation elegantly respects the `caps.unicode` boolean flag from the core library, automatically falling back to an ASCII hyphen (`-`) if the user's terminal environment does not support extended Unicode.
