### PR TITLE
Add package test scripts

### DIFF
--- a/packages/create-termui-app/package.json
+++ b/packages/create-termui-app/package.json
@@ -18,7 +18,8 @@
   ],
   "scripts": {
     "build": "tsup",
-    "dev": "tsup --watch"
+    "dev": "tsup --watch",
+    "test": "vitest run --config ../../vitest.config.ts"
   },
   "dependencies": {
     "@termuijs/tss": "workspace:*"

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -27,7 +27,8 @@
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "test": "vitest run --config ../../vitest.config.ts"
   },
   "dependencies": {
     "@termuijs/jsx": "workspace:*"

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -29,7 +29,8 @@
   },
   "scripts": {
     "build": "tsup",
-    "dev": "tsup --watch"
+    "dev": "tsup --watch",
+    "test": "vitest run --config ../../vitest.config.ts"
   },
   "dependencies": {
     "@termuijs/core": "workspace:*",

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -36,7 +36,8 @@
   },
   "scripts": {
     "build": "tsup",
-    "dev": "tsup --watch"
+    "dev": "tsup --watch",
+    "test": "vitest run --config ../../vitest.config.ts"
   },
   "dependencies": {
     "@termuijs/core": "workspace:*",

--- a/packages/motion/package.json
+++ b/packages/motion/package.json
@@ -26,7 +26,8 @@
   },
   "scripts": {
     "build": "tsup",
-    "dev": "tsup --watch"
+    "dev": "tsup --watch",
+    "test": "vitest run --config ../../vitest.config.ts"
   },
   "dependencies": {
     "@termuijs/core": "workspace:*"

--- a/packages/quick/package.json
+++ b/packages/quick/package.json
@@ -27,7 +27,8 @@
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "test": "vitest run --config ../../vitest.config.ts"
   },
   "dependencies": {
     "@termuijs/core": "workspace:*",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,55 +1,56 @@
 {
-    "name": "@termuijs/router",
-    "homepage": "https://www.termui.io/docs/router/overview",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Karanjot786/TermUI"
-    },
-    "version": "0.1.7",
-    "description": "File-based screen routing for TermUI with typed params and navigation guards",
-    "type": "module",
-    "main": "./dist/index.cjs",
-    "module": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js",
-            "require": "./dist/index.cjs"
-        }
-    },
-    "files": [
-        "dist"
-    ],
-    "publishConfig": {
-        "access": "public"
-    },
-    "scripts": {
-        "build": "tsup",
-        "dev": "tsup --watch"
-    },
-    "dependencies": {
-        "@termuijs/core": "workspace:*",
-        "@termuijs/jsx": "workspace:*",
-        "@termuijs/motion": "workspace:*",
-        "@termuijs/widgets": "workspace:*"
-    },
-    "devDependencies": {
-        "@termuijs/testing": "workspace:*",
-        "tsup": "^8.0.0",
-        "typescript": "^5.3.0"
-    },
-    "keywords": [
-        "terminal",
-        "tui",
-        "cli",
-        "router",
-        "navigation",
-        "screens"
-    ],
-    "license": "MIT",
-    "engines": {
-        "bun": ">=1.3.0",
-        "node": ">=18.0.0"
+  "name": "@termuijs/router",
+  "homepage": "https://www.termui.io/docs/router/overview",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Karanjot786/TermUI"
+  },
+  "version": "0.1.7",
+  "description": "File-based screen routing for TermUI with typed params and navigation guards",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run --config ../../vitest.config.ts"
+  },
+  "dependencies": {
+    "@termuijs/core": "workspace:*",
+    "@termuijs/jsx": "workspace:*",
+    "@termuijs/motion": "workspace:*",
+    "@termuijs/widgets": "workspace:*"
+  },
+  "devDependencies": {
+    "@termuijs/testing": "workspace:*",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.0"
+  },
+  "keywords": [
+    "terminal",
+    "tui",
+    "cli",
+    "router",
+    "navigation",
+    "screens"
+  ],
+  "license": "MIT",
+  "engines": {
+    "bun": ">=1.3.0",
+    "node": ">=18.0.0"
+  }
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -26,7 +26,8 @@
   },
   "scripts": {
     "build": "tsup",
-    "dev": "tsup --watch"
+    "dev": "tsup --watch",
+    "test": "vitest run --config ../../vitest.config.ts"
   },
   "dependencies": {
     "@termuijs/jsx": "workspace:*",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -26,7 +26,8 @@
   },
   "scripts": {
     "build": "tsup",
-    "dev": "tsup --watch"
+    "dev": "tsup --watch",
+    "test": "vitest run --config ../../vitest.config.ts"
   },
   "dependencies": {
     "@termuijs/core": "workspace:*",

--- a/packages/tss/package.json
+++ b/packages/tss/package.json
@@ -26,7 +26,8 @@
   },
   "scripts": {
     "build": "tsup",
-    "dev": "tsup --watch"
+    "dev": "tsup --watch",
+    "test": "vitest run --config ../../vitest.config.ts"
   },
   "dependencies": {
     "@termuijs/core": "workspace:*",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -26,7 +26,8 @@
   },
   "scripts": {
     "build": "tsup",
-    "dev": "tsup --watch"
+    "dev": "tsup --watch",
+    "test": "vitest run --config ../../vitest.config.ts"
   },
   "dependencies": {
     "@standard-schema/spec": "^1.1.0",
@@ -40,7 +41,7 @@
     "@termuijs/testing": "workspace:*",
     "tsup": "^8.0.0",
     "typescript": "^5.4.0",
-     "zod": "^4.4.3"
+    "zod": "^4.4.3"
   },
   "keywords": [
     "terminal",


### PR DESCRIPTION
## Summary

- add package-level test scripts for packages that already contain test files
- align the commands with packages that already run Vitest through the root config

## Validation

- Parsed all edited package.json files with Node
- Bun is not installed in this environment, so the Vitest commands were not run

Fixes #2301

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Testing**
  * Added standardized test commands across the project’s packages.
  * Tests can now be run consistently using the shared test configuration.
  * Improved package-level validation for more reliable development and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->