### PR TITLE
Create registry website data directory

### DIFF
--- a/scripts/build-registry.ts
+++ b/scripts/build-registry.ts
@@ -450,6 +450,7 @@ async function main(): Promise<void> {
   // plus api, without the heavy files/dependencies (those live in public/r).
   const slim = entries.map(({ files: _files, dependencies: _deps, ...rest }) => rest);
   const srcData = join(ROOT, 'website', 'src', 'data', 'registry.json');
+  mkdirSync(dirname(srcData), { recursive: true });
   writeFileSync(srcData, JSON.stringify(slim, null, 2));
   console.log(`✓ website/src/data/registry.json — ${slim.length} entries (slim + api)`);
 }


### PR DESCRIPTION
## Summary

- create the parent directory for `website/src/data/registry.json` before writing it
- keep the existing registry output locations unchanged

## Validation

- Reviewed the generated path flow in `scripts/build-registry.ts`
- TypeScript/Bun checks were not run because dependencies and Bun are not installed in this environment

Fixes #2303