### PR TITLE
Add Bun shebang to dev server CLI build

### DIFF
--- a/packages/dev-server/tsup.config.ts
+++ b/packages/dev-server/tsup.config.ts
@@ -1,9 +1,21 @@
 import { defineConfig } from 'tsup';
-export default defineConfig({
-    entry: ['src/index.ts', 'src/cli.ts'],
-    format: ['esm', 'cjs'],
-    dts: true,
-    clean: true,
-    target: 'es2022',
-    sourcemap: true,
-});
+
+export default defineConfig([
+    {
+        entry: ['src/index.ts'],
+        format: ['esm', 'cjs'],
+        dts: true,
+        clean: true,
+        target: 'es2022',
+        sourcemap: true,
+    },
+    {
+        entry: ['src/cli.ts'],
+        format: ['esm'],
+        dts: false,
+        clean: false,
+        target: 'es2022',
+        sourcemap: true,
+        banner: { js: '#!/usr/bin/env bun' },
+    },
+]);


### PR DESCRIPTION
## Summary

- split the dev-server tsup config into library and CLI builds
- keep `src/index.ts` as the library entry with ESM/CJS output and declarations
- build `src/cli.ts` as an executable ESM entry with a Bun shebang

## Validation

- Reviewed the tsup config diff
- Node cannot import the TypeScript config directly in this checkout, and Bun/dependencies are not installed, so a build was not run

Fixes #2304