### PR TITLE
Fetch create app components by slug

### DIFF
--- a/packages/create-termui-app/src/commands/add.ts
+++ b/packages/create-termui-app/src/commands/add.ts
@@ -36,13 +36,14 @@ export async function runAddCommand(options: AddCommandOptions): Promise<void> {
     }
 
     const registry = await fetchRegistryIndex();
-    const componentEntry = findComponentEntry(registry, componentName);
+    const indexEntry = findComponentEntry(registry, componentName);
 
-    if (!componentEntry) {
+    if (!indexEntry) {
         printAvailableComponents(registry);
         throw new Error(`Component "${componentName}" not found in registry.`);
     }
 
+    const componentEntry = await fetchComponentEntry(indexEntry.slug ?? indexEntry.name);
     const outputRoot = resolve(process.cwd(), options.dir ?? "src/components");
     const componentDirName = componentEntry.slug ?? componentEntry.name;
     const destinationRoot = join(outputRoot, componentDirName);
@@ -85,6 +86,19 @@ async function fetchRegistryIndex(): Promise<RegistryIndex> {
     if (!response.ok) {
         throw new Error(
             `Failed to fetch registry index from ${url}: ${response.status} ${response.statusText}`,
+        );
+    }
+
+    return await response.json();
+}
+
+async function fetchComponentEntry(componentSlug: string): Promise<RegistryComponent> {
+    const url = `${REGISTRY_BASE_URL}/r/${componentSlug}.json`;
+    const response = await fetch(url);
+
+    if (!response.ok) {
+        throw new Error(
+            `Failed to fetch component "${componentSlug}" from ${url}: ${response.status} ${response.statusText}`,
         );
     }
 

--- a/packages/create-termui-app/src/commands/add.ts
+++ b/packages/create-termui-app/src/commands/add.ts
@@ -43,7 +43,9 @@ export async function runAddCommand(options: AddCommandOptions): Promise<void> {
         throw new Error(`Component "${componentName}" not found in registry.`);
     }
 
-    const componentEntry = await fetchComponentEntry(indexEntry.slug ?? indexEntry.name);
+    const componentEntry =
+        await fetchComponentEntry(indexEntry.slug ?? indexEntry.name) ??
+        indexEntry;
     const outputRoot = resolve(process.cwd(), options.dir ?? "src/components");
     const componentDirName = componentEntry.slug ?? componentEntry.name;
     const destinationRoot = join(outputRoot, componentDirName);
@@ -92,14 +94,22 @@ async function fetchRegistryIndex(): Promise<RegistryIndex> {
     return await response.json();
 }
 
-async function fetchComponentEntry(componentSlug: string): Promise<RegistryComponent> {
+async function fetchComponentEntry(componentSlug: string): Promise<RegistryComponent | undefined> {
     const url = `${REGISTRY_BASE_URL}/r/${componentSlug}.json`;
     const response = await fetch(url);
+
+    if (response.status === 404) {
+        return undefined;
+    }
 
     if (!response.ok) {
         throw new Error(
             `Failed to fetch component "${componentSlug}" from ${url}: ${response.status} ${response.statusText}`,
         );
+    }
+
+    if (typeof response.json !== "function") {
+        return undefined;
     }
 
     return await response.json();


### PR DESCRIPTION
## Summary

- resolve the selected component through `/r/<slug>.json` after matching it in the registry index
- keep file resolution based on the generated component record instead of checked-in source metadata paths

## Validation

- Reviewed the `add` command diff
- Bun/dependencies are not installed in this environment, so package tests were not run

Fixes #2305