### PR TITLE
Use ASCII separators in registry READMEs

### DIFF
--- a/registry/components/alert/README.md
+++ b/registry/components/alert/README.md
@@ -33,10 +33,10 @@ constructor(opts?: NotificationBadgeOptions, style?: Partial<Style>)
 
 ### Methods
 
-- `setCount(count: number): void` — Update the notification count
-- `getCount(): number` — Get the current notification count
-- `setPosition(position: BadgePosition): void` — Change corner position
-- `getPosition(): BadgePosition` — Get the current position
+- `setCount(count: number): void` - Update the notification count
+- `getCount(): number` - Get the current notification count
+- `setPosition(position: BadgePosition): void` - Change corner position
+- `getPosition(): BadgePosition` - Get the current position
 
 ## Example
 

--- a/registry/components/badge/README.md
+++ b/registry/components/badge/README.md
@@ -34,10 +34,10 @@ constructor(text: string, style?: Partial<Style>, opts?: BadgeOptions)
 
 ### Methods
 
-- `setText(text: string): void` — Update the badge text
-- `getText(): string` — Get the current badge text
-- `setVariant(variant: BadgeVariant): void` — Update the badge variant
-- `getVariant(): BadgeVariant` — Get the current badge variant
+- `setText(text: string): void` - Update the badge text
+- `getText(): string` - Get the current badge text
+- `setVariant(variant: BadgeVariant): void` - Update the badge variant
+- `getVariant(): BadgeVariant` - Get the current badge variant
 
 ## Example
 

--- a/registry/components/chat-thread/README.md
+++ b/registry/components/chat-thread/README.md
@@ -23,10 +23,10 @@ const assistantMessage = new ChatThread({
 
 ## Message Roles
 
-- **user** — User message (cyan badge)
-- **assistant** — Assistant response (green badge)
-- **system** — System message (yellow badge)
-- **tool** — Tool output (magenta badge)
+- **user** - User message (cyan badge)
+- **assistant** - Assistant response (green badge)
+- **system** - System message (yellow badge)
+- **tool** - Tool output (magenta badge)
 
 ## Features
 
@@ -46,10 +46,10 @@ constructor(options: ChatMessageOptions, style?: Partial<Style>)
 
 ### Methods
 
-- `setContent(content: string): void` — Update the message content
-- `getContent(): string` — Get the current content
-- `getRole(): MessageRole` — Get the message role
-- `getTimestamp(): Date | undefined` — Get the timestamp
+- `setContent(content: string): void` - Update the message content
+- `getContent(): string` - Get the current content
+- `getRole(): MessageRole` - Get the message role
+- `getTimestamp(): Date | undefined` - Get the timestamp
 
 ## Example
 

--- a/registry/components/markdown/README.md
+++ b/registry/components/markdown/README.md
@@ -23,12 +23,12 @@ The current implementation supports:
 * Headings
 * Paragraph text
 * Line breaks
-* **Bold** — `**text**`
-* *Italic* — `_text_`
-* Inline code — `` `code` ``
-* Unordered lists — `- item`
-* Ordered lists — `1. item`
-* Code fences — fenced code blocks
+* **Bold** - `**text**`
+* *Italic* - `_text_`
+* Inline code - `` `code` ``
+* Unordered lists - `- item`
+* Ordered lists - `1. item`
+* Code fences - fenced code blocks
 
 ## Features
 
@@ -46,8 +46,8 @@ constructor(opts: MarkdownOptions, style?: Partial<Style>)
 
 ### Methods
 
-* `setContent(content: string): void` — Update the markdown content
-* `getContent(): string` — Get the current markdown content
+* `setContent(content: string): void` - Update the markdown content
+* `getContent(): string` - Get the current markdown content
 
 ## Example
 

--- a/registry/components/progress/README.md
+++ b/registry/components/progress/README.md
@@ -31,8 +31,8 @@ constructor(style?: Partial<Style>, options?: ProgressBarOptions)
 
 ### Methods
 
-* `setValue(value: number): void` — Update the current progress value
-* `getValue(): number` — Get the current progress value
+* `setValue(value: number): void` - Update the current progress value
+* `getValue(): number` - Get the current progress value
 
 ## Example
 


### PR DESCRIPTION
## Summary

- replace em dash separators in registry component READMEs with ASCII hyphens
- avoid terminal/codepage rendering issues when these docs are viewed or copied

## Validation

- Checked registry component README files for remaining em dash separators

Fixes #2306