### PR TITLE
Dynamic theme switching feature

### DIFF
--- a/packages/tss/src/index.ts
+++ b/packages/tss/src/index.ts
@@ -49,6 +49,8 @@ export type { AutoThemeProviderProps } from './AutoThemeProvider.js';
 // Imperative ThemeProvider singleton
 export { ThemeProvider } from './themeProvider.js';
 export type { ThemeChangeListener } from './themeProvider.js';
+export { themeStore } from './themeStore.js';
+export type { ThemeStoreState } from './themeStore.js';
 export * from './media.js';
 export * from './importer.js';
 export { lighten, darken, alpha, evalColorFunction } from './color-functions.js';

--- a/packages/tss/src/themeStore.ts
+++ b/packages/tss/src/themeStore.ts
@@ -1,0 +1,52 @@
+// ─────────────────────────────────────────────────────
+// ThemeStore — Reactive Zustand-style theme state
+// ─────────────────────────────────────────────────────
+
+import { createStore } from '@termuijs/store';
+import { ThemeProvider } from './themeProvider.js';
+import { getNamedTheme } from './named-themes.js';
+import type { ThemeTokens } from './tokens.js';
+
+export interface ThemeStoreState {
+    theme: ThemeTokens;
+    activeThemeName: string;
+    setActiveTheme: (theme: string | ThemeTokens) => void;
+}
+
+const baseStore = createStore<ThemeStoreState>((set) => {
+    // Sync with the underlying imperative ThemeProvider
+    ThemeProvider.subscribe((newTheme) => {
+        set({ theme: newTheme });
+    });
+
+    return {
+        theme: ThemeProvider.getTheme(),
+        activeThemeName: 'defaultDark',
+        setActiveTheme: (themeInput: string | ThemeTokens) => {
+            let nextTheme: ThemeTokens;
+            let name = 'custom';
+
+            if (typeof themeInput === 'string') {
+                nextTheme = getNamedTheme(themeInput);
+                name = themeInput;
+            } else {
+                nextTheme = themeInput;
+            }
+
+            set({ activeThemeName: name, theme: nextTheme });
+            // This triggers the global listeners bound in components
+            ThemeProvider.setTheme(nextTheme);
+        }
+    };
+});
+
+/**
+ * A reactive store for the currently active theme.
+ * Allows switching the theme at runtime, which automatically updates the underlying
+ * ThemeProvider, triggering global re-renders for styles using TSS variables.
+ */
+export const themeStore = Object.assign(baseStore, {
+    setActiveTheme: (themeInput: string | ThemeTokens) => {
+        baseStore.getState().setActiveTheme(themeInput);
+    }
+});


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

This PR introduces the `themeStore` in `@termuijs/tss`. Previously, changing the active TSS dictionary at runtime required cumbersome imperative calls that didn't automatically re-render declarative JSX trees smoothly. By wrapping `ThemeProvider` in a `@termuijs/store` reactive singleton, users can now swap themes using `themeStore.setActiveTheme('dracula')` natively!

The store transparently maps named strings to their corresponding `ThemeTokens` palettes (e.g. `catppuccin`, `tokyo-night`) while ensuring the underlying layout engine globally recalculates any component styles relying on CSS-like variables (e.g. `var(--bg)`).

## Related Issue

Closes #2262

## Which package(s)?

`@termuijs/tss`

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/YOUR_PROFILE_ID_HERE`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

The implementation uses `Object.assign()` directly on the `createStore` hook so the user doesn't have to `useStore()` just to swap the theme; they can do `themeStore.setActiveTheme(...)` purely procedurally from outside of the React-style render loops.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a centralized theme store for accessing current theme tokens and the active theme name.
  * Added support for switching themes by name or by providing custom theme tokens.
  * Theme changes now stay synchronized across the application and are available through the library’s public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->