### PR TITLE
Use ASCII markers in CLI output

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -44,7 +44,7 @@ export async function runAdd(args: CliArgs): Promise<void> {
         for (const dep of comp.dependencies) allDeps.add(dep);
 
         console.log(`\n  ${args.dryRun ? 'would add' : 'added'} ${comp.name}:`);
-        for (const w of written) console.log(`    ${args.dryRun ? '·' : '✓'} ${relative(process.cwd(), w)}`);
+        for (const w of written) console.log(`    ${args.dryRun ? '-' : '+'} ${relative(process.cwd(), w)}`);
     }
 
     const deps = [...allDeps].sort();


### PR DESCRIPTION
## Summary

- replace Unicode status markers in `termuijs add` output with ASCII markers
- avoid garbled output in terminals or shells with limited Unicode/codepage support

## Validation

- Checked `packages/cli/src/commands/add.ts` for the replaced markers
- Bun/dependencies are not installed in this environment, so package tests were not run

Fixes #2308