### PR TITLE
Make root clean script portable

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "typecheck": "turbo run typecheck",
     "lint": "turbo run lint",
     "bench": "bun packages/core/src/benchmark/run-all.ts",
-    "clean": "turbo run clean && rm -rf node_modules",
+    "clean": "turbo run clean && node scripts/clean-root.mjs",
     "format": "prettier --write \".\"",
     "registry:build": "bun scripts/build-registry.ts"
   },

--- a/scripts/clean-root.mjs
+++ b/scripts/clean-root.mjs
@@ -1,0 +1,7 @@
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+rmSync(join(process.cwd(), 'node_modules'), {
+  recursive: true,
+  force: true,
+});


### PR DESCRIPTION
## Summary

- replace the root `rm -rf node_modules` command with a Node cleanup script
- keep the existing package clean step before removing root dependencies

## Validation

- Ran `node -c scripts/clean-root.mjs`
- Parsed the root `package.json` with Node

Fixes #2309