### PR TITLE
Use public exports in registry components

### DIFF
--- a/registry/components/alert/index.ts
+++ b/registry/components/alert/index.ts
@@ -1,2 +1,2 @@
-export { NotificationBadge as Alert } from '../../../packages/widgets/src/display/NotificationBadge';
-export type { NotificationBadgeOptions, BadgePosition } from '../../../packages/widgets/src/display/NotificationBadge';
+export { NotificationBadge as Alert } from '@termuijs/widgets';
+export type { NotificationBadgeOptions, BadgePosition } from '@termuijs/widgets';

--- a/registry/components/badge/index.ts
+++ b/registry/components/badge/index.ts
@@ -1,2 +1,2 @@
-export { Badge } from '../../../packages/widgets/src/display/Badge';
-export type { BadgeOptions, BadgeVariant } from '../../../packages/widgets/src/display/Badge';
+export { Badge } from '@termuijs/widgets';
+export type { BadgeOptions, BadgeVariant } from '@termuijs/widgets';

--- a/registry/components/chat-thread/index.ts
+++ b/registry/components/chat-thread/index.ts
@@ -1,2 +1,2 @@
-export { ChatMessage as ChatThread } from '../../../packages/widgets/src/display/ChatMessage';
-export type { ChatMessageOptions, MessageRole } from '../../../packages/widgets/src/display/ChatMessage';
+export { ChatMessage as ChatThread } from '@termuijs/widgets';
+export type { ChatMessageOptions, MessageRole } from '@termuijs/widgets';

--- a/registry/components/markdown/index.ts
+++ b/registry/components/markdown/index.ts
@@ -1,2 +1,2 @@
-export { Markdown } from '../../../packages/widgets/src/display/Markdown';
-export type { MarkdownOptions } from '../../../packages/widgets/src/display/Markdown';
+export { Markdown } from '@termuijs/widgets';
+export type { MarkdownOptions } from '@termuijs/widgets';

--- a/registry/components/progress/index.ts
+++ b/registry/components/progress/index.ts
@@ -1,2 +1,2 @@
-export { ProgressBar as Progress } from '../../../packages/widgets/src/feedback/ProgressBar';
-export type { ProgressBarOptions } from '../../../packages/widgets/src/feedback/ProgressBar';
+export { ProgressBar as Progress } from '@termuijs/widgets';
+export type { ProgressBarOptions } from '@termuijs/widgets';


### PR DESCRIPTION
## Summary

- update checked-in registry component entry files to import from `@termuijs/widgets`
- remove monorepo-internal relative source paths from copied component entries
- preserve the existing exported names and aliases

## Validation

- Checked registry component index files for remaining internal `packages/` paths

Fixes #2310