### PR TITLE
feat(core): implement Screen.exportSVG rendering

### DIFF
--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -2,7 +2,7 @@
 // @termuijs/core — Screen buffer (double-buffered cell grid)
 // ─────────────────────────────────────────────────────
 
-import type { Color } from '../style/Color.js';
+import { type Color, colorToRgb } from '../style/Color.js';
 import { stringWidth, segmenter } from '../utils/unicode.js';
 import { stripAnsiControl } from '../utils/ansi.js';
 import { caps } from './env-caps.js';
@@ -480,14 +480,83 @@ export class Screen {
      * Export current screen as SVG.
      */
     exportSVG(): string {
-        return `
-<svg xmlns="http://www.w3.org/2000/svg"
-     width="${this._cols * 8}"
-     height="${this._rows * 16}">
-    <text x="10" y="20">
-        Terminal Export
-    </text>
-</svg>`;
+        const bgElements: string[] = [];
+        const textElements: string[] = [];
+
+        for (let r = 0; r < this._rows; r++) {
+            for (let c = 0; c < this._cols; c++) {
+                const cell = this.back[r][c];
+                if (cell.width === 0) {
+                    continue;
+                }
+
+                // Resolve colors (considering inverse)
+                let fg = cell.fg;
+                let bg = cell.bg;
+                if (cell.inverse) {
+                    fg = cell.bg;
+                    bg = cell.fg;
+                }
+
+                let fgHex = '#ffffff';
+                if (fg.type !== 'none') {
+                    fgHex = rgbToHex(colorToRgb(fg));
+                } else if (cell.inverse) {
+                    fgHex = '#000000';
+                }
+
+                let bgHex: string | null = null;
+                if (bg.type !== 'none') {
+                    bgHex = rgbToHex(colorToRgb(bg));
+                } else if (cell.inverse) {
+                    bgHex = '#ffffff';
+                }
+
+                // Draw background
+                if (bgHex) {
+                    const rectWidth = cell.width * 8;
+                    bgElements.push(
+                        `    <rect x="${c * 8}" y="${r * 16}" width="${rectWidth}" height="16" fill="${bgHex}" />`
+                    );
+                }
+
+                // Draw text
+                const char = cell.char;
+                if (char && char !== ' ' && char !== '\0') {
+                    const escaped = escapeXml(char);
+                    const attrs: string[] = [];
+                    
+                    if (cell.bold) attrs.push('font-weight="bold"');
+                    if (cell.italic) attrs.push('font-style="italic"');
+                    
+                    const decors: string[] = [];
+                    if (cell.underline) decors.push('underline');
+                    if (cell.strikethrough) decors.push('line-through');
+                    if (decors.length > 0) {
+                        attrs.push(`text-decoration="${decors.join(' ')}"`);
+                    }
+                    
+                    if (cell.dim) {
+                        attrs.push('opacity="0.6"');
+                    }
+
+                    const attrStr = attrs.length > 0 ? ' ' + attrs.join(' ') : '';
+                    textElements.push(
+                        `    <text x="${c * 8}" y="${r * 16 + 12}" fill="${fgHex}" font-family="monospace" font-size="14"${attrStr}>${escaped}</text>`
+                    );
+                }
+            }
+        }
+
+        const lines = [
+            `<svg xmlns="http://www.w3.org/2000/svg" width="${this._cols * 8}" height="${this._rows * 16}" xml:space="preserve">`,
+            `    <rect width="${this._cols * 8}" height="${this._rows * 16}" fill="#121212" />`,
+            ...bgElements,
+            ...textElements,
+            `</svg>`
+        ];
+
+        return lines.join('\n');
     }
 
     /**
@@ -560,4 +629,22 @@ export class Screen {
         this._backdropFilters = [];
     }
 
+}
+
+function escapeXml(str: string): string {
+    return str.replace(/[&<>"']/g, (m) => {
+        switch (m) {
+            case '&': return '&amp;';
+            case '<': return '&lt;';
+            case '>': return '&gt;';
+            case '"': return '&quot;';
+            case "'": return '&apos;';
+            default: return m;
+        }
+    });
+}
+
+function rgbToHex(rgb: [number, number, number]): string {
+    const [r, g, b] = rgb;
+    return '#' + [r, g, b].map(x => x.toString(16).padStart(2, '0')).join('');
 }

--- a/packages/core/src/terminal/exportSVG.test.ts
+++ b/packages/core/src/terminal/exportSVG.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { Screen } from './Screen.js';
+
+describe('Screen.exportSVG()', () => {
+    it('should export the correct dimensions and structure', () => {
+        const screen = new Screen(10, 5);
+        const svg = screen.exportSVG();
+        expect(svg).toContain('<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" xml:space="preserve">');
+        expect(svg).toContain('<rect width="80" height="80" fill="#121212" />');
+        expect(svg).toContain('</svg>');
+    });
+
+    it('should render simple characters and preserve positions', () => {
+        const screen = new Screen(10, 5);
+        screen.writeString(1, 1, 'Hi');
+        const svg = screen.exportSVG();
+        expect(svg).toContain('x="8" y="28"');
+        expect(svg).toContain('>H</text>');
+        expect(svg).toContain('x="16" y="28"');
+        expect(svg).toContain('>i</text>');
+    });
+
+    it('should escape XML special characters correctly', () => {
+        const screen = new Screen(10, 5);
+        screen.writeString(0, 0, '<&>');
+        const svg = screen.exportSVG();
+        expect(svg).toContain('&lt;');
+        expect(svg).toContain('&amp;');
+        expect(svg).toContain('&gt;');
+    });
+
+    it('should support colors and inverse styles', () => {
+        const screen = new Screen(10, 5);
+        screen.writeString(0, 0, 'A', {
+            fg: { type: 'rgb', r: 255, g: 0, b: 0 },
+            bg: { type: 'hex', hex: '#00ff00' }
+        });
+        const svg = screen.exportSVG();
+        expect(svg).toContain('fill="#00ff00"'); // rect
+        expect(svg).toContain('fill="#ff0000"'); // text
+
+        // Test inverse style
+        const screen2 = new Screen(10, 5);
+        screen2.writeString(0, 0, 'A', {
+            fg: { type: 'rgb', r: 255, g: 0, b: 0 },
+            bg: { type: 'hex', hex: '#00ff00' },
+            inverse: true
+        });
+        const svg2 = screen2.exportSVG();
+        expect(svg2).toContain('fill="#ff0000"'); // rect (since colors are inverted, bg gets fg color)
+        expect(svg2).toContain('fill="#00ff00"'); // text (since colors are inverted, fg gets bg color)
+    });
+
+    it('should support bold, italic, underline, strikethrough, and dim text', () => {
+        const screen = new Screen(10, 5);
+        screen.writeString(0, 0, 'A', {
+            bold: true,
+            italic: true,
+            underline: true,
+            strikethrough: true,
+            dim: true
+        });
+        const svg = screen.exportSVG();
+        expect(svg).toContain('font-weight="bold"');
+        expect(svg).toContain('font-style="italic"');
+        expect(svg).toContain('text-decoration="underline line-through"');
+        expect(svg).toContain('opacity="0.6"');
+    });
+
+    it('should correctly handle wide Unicode characters and skip continuation cells', () => {
+        const screen = new Screen(10, 5);
+        screen.writeString(0, 0, '🌍', { bg: { type: 'hex', hex: '#00ff00' } }); // width = 2
+        const svg = screen.exportSVG();
+        // Since width = 2, rect width should be 16
+        expect(svg).toContain('width="16"');
+        // It shouldn't render any text/rect for col 1 because it's a continuation cell (width = 0)
+        expect(svg).not.toContain('x="8" y="12"');
+        expect(svg).not.toContain('x="8" y="0"');
+    });
+});


### PR DESCRIPTION
***

## Description

Implements a complete and robust `Screen.exportSVG()` function that reads from the active screen cell buffer, translating character values, XML escaping, wide characters, styling (bold, italic, underline, strikethrough, dim), and background/foreground colors (including inverse translations) into formatted SVG elements.

## Related Issue

Closes #2340

## Which package(s)?

- `@termuijs/core`

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- https://gssoc.girlscript.org/profile/8b40127a-23e4-47b5-81e5-28b1c53e8819
## Screenshots / Recordings (UI changes)

*None (backend logic change for cell exports)*

## Notes for the Reviewer

- Reuses existing `colorToRgb` from `packages/core/src/style/Color.ts` to cleanly parse named, ANSI-256, hex, and truecolor formats.
- Follows standard monospace pixel dimensions of `8px` width and `16px` height to align perfectly with traditional terminal font proportions.
- Includes `xml:space="preserve"` to ensure browser renderers do not collapse consecutive blank spaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved terminal SVG export to accurately render the full back-buffer, including per-cell backgrounds, foreground/background colors, inverse rendering, and text styles (bold/italic/underline/strikethrough) with dim support.
  * Properly escapes XML special characters in exported SVG text.
* **Bug Fixes**
  * Fixed SVG layout to correctly position and size rendered characters, including correct handling for wide Unicode characters.
* **Tests**
  * Added a test suite covering SVG structure, coordinates, escaping, inverse color rendering, text attributes, dim opacity, and wide-character behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->