### PR TITLE
[Doc] Add JSDoc documentation to error classes in packages/core/src/errors.ts

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,3 +1,7 @@
+/**
+ * Base error class for all TermUI-specific errors.
+ * Extend this class when creating new error types for the framework.
+ */
 export class TermUIError extends Error {
     constructor(message: string) {
         super(message);
@@ -5,6 +9,10 @@ export class TermUIError extends Error {
     }
 }
 
+/**
+ * Thrown when the user aborts an interactive prompt by pressing Escape.
+ * Catch this to implement graceful cancellation in prompt-based workflows.
+ */
 export class TermUIAbortError extends TermUIError {
     constructor(message = 'Prompt aborted') {
         super(message);
@@ -12,6 +20,10 @@ export class TermUIAbortError extends TermUIError {
     }
 }
 
+/**
+ * Thrown when an operation is cancelled programmatically (e.g. via a guard or timeout).
+ * Distinguishable from TermUIAbortError which is user-initiated.
+ */
 export class TermUICancelError extends TermUIError {
     constructor(message = 'Prompt cancelled') {
         super(message);
@@ -19,7 +31,12 @@ export class TermUICancelError extends TermUIError {
     }
 }
 
+/**
+ * Thrown when a form field fails validation.
+ * Contains the name of the invalid field to help consumers display targeted error messages.
+ */
 export class TermUIValidationError extends TermUIError {
+    /** The name of the form field that failed validation. */
     field: string;
 
     constructor(field: string, message: string) {


### PR DESCRIPTION
## Summary

Added JSDoc documentation to the four error classes in `packages/core/src/errors.ts`. These are the foundational error types used across the entire framework, and new contributors need to understand when each error is thrown and how to handle it.

## Changes

- `TermUIError` - Base class documentation explaining its role as the framework's root error type
- `TermUIAbortError` - Documents that it is thrown when the user presses Escape during prompts
- `TermUICancelError` - Documents that it is thrown on programmatic cancellation (distinct from user abort)
- `TermUIValidationError` - Documents the `field` property indicating which form field failed validation

## How to Test

1. Run `bun vitest run packages/core` to verify no regressions
2. Run `bun run typecheck` to verify type safety
3. Review that JSDoc appears correctly in IDE tooltips for each error class

## Related Issues

Closes #2348

## GSSoC 2026

This contribution is part of GSSoC 2026.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error details by identifying the specific field associated with invalid input.
  * Standardized validation error naming for clearer error handling.

* **Documentation**
  * Added documentation for application error types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->