### PR TITLE
[Doc] Add JSDoc documentation to caps object properties in env-caps.ts

### DIFF
--- a/packages/core/src/terminal/env-caps.ts
+++ b/packages/core/src/terminal/env-caps.ts
@@ -1,17 +1,30 @@
 import { ColorDepth, detectColorDepth } from '../style/Color.js';
 
+/**
+ * Terminal capability detection hub.
+ *
+ * Used by every package to adapt rendering to the current terminal.
+ * Widget authors should check these properties before using
+ * non-ASCII characters, animations, or color sequences.
+ */
 export const caps = {
+  /** Detected color depth (None, ANSI16, ANSI256, TrueColor). */
   get colorDepth(): ColorDepth {
     return detectColorDepth();
   },
+  /** Whether color output is enabled. Returns false when NO_COLOR or TERM=dumb. */
   get color(): boolean {
     if (process.env.NO_COLOR !== undefined) return false;
     if (process.env.TERM === 'dumb') return false;
     return this.colorDepth !== ColorDepth.None;
   },
+  /** Whether Unicode characters are supported. Disabled by NO_UNICODE or TERM=dumb. */
   unicode: !process.env.NO_UNICODE && process.env.TERM !== 'dumb',
+  /** Whether animations are enabled. Disabled by NO_MOTION or CI environments. */
   motion:  !process.env.NO_MOTION && !process.env.CI,
+  /** Whether running inside a CI system (CI=1). */
   ci:      !!process.env.CI,
+  /** Terminal background color (light/dark). Checks TERM_BACKGROUND then COLORFGBG. */
   get background(): 'light' | 'dark' {
     // Explicit override takes priority over terminal heuristics.
     if (process.env.TERM_BACKGROUND === 'light') return 'light';
@@ -26,6 +39,7 @@ export const caps = {
 
     return 'dark';
   },
+  /** Keyboard navigation mode: 'default' (arrow keys), 'vim' (hjkl), or 'emacs' (C-n/p). */
   get keybindingMode(): 'vim' | 'emacs' | 'default' {
     const mode = process.env.TERMUI_KEYBINDINGS;
     if (mode === 'vim' || mode === 'emacs') return mode;


### PR DESCRIPTION
## Summary

Added JSDoc documentation to the `caps` object in `packages/core/src/terminal/env-caps.ts`. This object is the central capability detection hub used by every package to adapt rendering to the current terminal environment.

## Changes

- Added top-level JSDoc to the `caps` object describing its purpose
- Added JSDoc to each property documenting what environment variables it reads and its fallback behavior
- `colorDepth` - documents the ColorDepth enum values
- `color` - documents NO_COLOR and TERM=dumb handling
- `unicode` - documents NO_UNICODE support
- `motion` - documents NO_MOTION and CI suppression
- `ci` - documents CI environment detection
- `background` - documents TERM_BACKGROUND and COLORFGBG fallback chain
- `keybindingMode` - documents TERMUI_KEYBINDINGS and available modes

## How to Test

1. Run `bun vitest run packages/core` to verify no regressions
2. Run `bun run typecheck` to verify type safety
3. Review JSDoc in IDE tooltips for each caps property

## Related Issues

Closes #2350

## GSSoC 2026

This contribution is part of GSSoC 2026.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing terminal capability detection, including color support, background capabilities, and keyboard navigation settings.
  * Clarified how terminal color-enabling rules and detected color depth are reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->