### PR TITLE
[Doc] Add JSDoc documentation to LayoutContext interface

### DIFF
--- a/packages/core/src/layout/LayoutContext.ts
+++ b/packages/core/src/layout/LayoutContext.ts
@@ -1,17 +1,36 @@
+/**
+ * Evaluation context for the position and dimension algebra system.
+ *
+ * Passed to every `Pos` and `Dim` evaluator during layout resolution.
+ * Properties are read lazily to enforce topological evaluation order.
+ */
 export interface LayoutContext {
+    /** Width of the parent container in cells. */
     parentWidth: number;
+    /** Height of the parent container in cells. */
     parentHeight: number;
+    /** Width available for content after padding/borders in cells. */
     contentWidth: number;
+    /** Height available for content after padding/borders in cells. */
     contentHeight: number;
     
     // Node properties (will be evaluated lazily to enforce topological sort)
+    /** Computed width of the current element in cells (lazily evaluated). */
     readonly elementWidth: number;
+    /** Computed height of the current element in cells (lazily evaluated). */
     readonly elementHeight: number;
+    /** Computed X position of the current element in cells (lazily evaluated). */
     readonly elementX: number;
+    /** Computed Y position of the current element in cells (lazily evaluated). */
     readonly elementY: number;
     
+    /** Layout direction: 'horizontal' for rows, 'vertical' for columns. */
     axis: 'horizontal' | 'vertical';
     
-    // Method to query group info
+    /**
+     * Query the computed size of a named group container.
+     * @param groupId - The group identifier to look up.
+     * @returns The group's computed size in cells along the current axis.
+     */
     getGroupSize(groupId: string): number;
 }


### PR DESCRIPTION
## Summary

Added JSDoc documentation to the `LayoutContext` interface in `packages/core/src/layout/LayoutContext.ts`. This interface is the evaluation context for the position and dimension algebra system, imported by the entire layout subsystem.

## Changes

- Added interface-level JSDoc describing its role in layout evaluation
- Added property-level JSDoc for all 10 properties:
  - `parentWidth` / `parentHeight` - parent container dimensions
  - `contentWidth` / `contentHeight` - available content area dimensions
  - `elementWidth` / `elementHeight` - computed element dimensions (lazily evaluated)
  - `elementX` / `elementY` - computed element positions (lazily evaluated)
  - `axis` - layout direction for flex containers
  - `getGroupSize` - method documentation with @param and @returns tags

## How to Test

1. Run `bun vitest run packages/core` to verify no regressions
2. Run `bun run typecheck` to verify type safety
3. Review JSDoc in IDE tooltips for each LayoutContext property

## Related Issues

Closes #2352

## GSSoC 2026

This contribution is part of GSSoC 2026.