### PR TITLE
[Doc] Add JSDoc documentation to A11yProps and emitA11y in a11y/index.ts

### DIFF
--- a/packages/core/src/a11y/index.ts
+++ b/packages/core/src/a11y/index.ts
@@ -1,8 +1,32 @@
+/**
+ * Accessibility properties for widgets that expose metadata to screen readers.
+ * Used with {@link emitA11y} to emit VTE-compatible OSC 133 sequences.
+ */
 export interface A11yProps {
+    /**
+     * ARIA-like role describing the element's purpose.
+     * Supported values: 'region', 'alert', 'status', 'log', 'navigation'.
+     * Defaults to 'region' if not specified.
+     */
     role?: 'region' | 'alert' | 'status' | 'log' | 'navigation';
+    /**
+     * Accessible name for the element, read aloud by screen readers.
+     * Should be a concise description of the region's content.
+     */
     label?: string;
 }
 
+/**
+ * Emit accessibility metadata via VTE-compatible OSC 133 sequences.
+ *
+ * Sends structured metadata that screen readers (e.g. Footnotes in VTE-based
+ * terminals) can use to announce widget roles and labels. This is a no-op on
+ * terminals that do not support VTE (checked via VTE_VERSION/TERM_PROGRAM).
+ *
+ * @param props - Accessibility properties (role, label). If undefined or empty, no metadata is emitted.
+ * @param write - Callback to write the escape sequence to the terminal.
+ * @param action - 'start' opens an accessible region, 'end' closes it.
+ */
 export function emitA11y(props: A11yProps | undefined, write: (data: string) => void, action: 'start' | 'end'): void {
     if (!props || (!props.role && !props.label)) return;
 


### PR DESCRIPTION
## Summary

Added JSDoc documentation to the `A11yProps` interface and `emitA11y` function in `packages/core/src/a11y/index.ts`. These are the accessibility primitives that allow widgets to communicate with screen readers via VTE-compatible OSC 133 sequences.

## Changes

- Added interface-level JSDoc to `A11yProps` explaining its role in screen reader communication
- Added property-level JSDoc for `role` (lists supported ARIA-like roles) and `label` (accessible name)
- Added function-level JSDoc to `emitA11y` documenting:
  - That it emits VTE-compatible OSC 133 sequences
  - That it checks for VTE/terminal support before emitting
  - The `action` parameter: 'start' opens an accessible region, 'end' closes it
  - The `write` callback pattern for terminal output
- Added @param tags for all function parameters

## How to Test

1. Run `bun vitest run packages/core` to verify no regressions
2. Run `bun run typecheck` to verify type safety
3. Review JSDoc in IDE tooltips for A11yProps and emitA11y

## Related Issues

Closes #2356

## GSSoC 2026

This contribution is part of GSSoC 2026.