### PR TITLE
[Fix] Add missing publishConfig, typecheck, and clean scripts to CLI package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,11 +7,26 @@
   "type": "module",
   "bin": { "termuijs": "./dist/index.js" },
   "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "files": ["dist"],
-  "scripts": { "build": "tsup", "dev": "tsup --watch", "test": "vitest run" },
+  "publishConfig": { "access": "public" },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist",
+    "dev": "tsup --watch",
+    "test": "vitest run --config ../../vitest.config.ts"
+  },
   "dependencies": { "@termuijs/widgets": "workspace:*", "@termuijs/core": "workspace:*" },
   "devDependencies": { "tsup": "^8.0.0", "typescript": "^5.3.0", "vitest": "^4.1.8" },
   "keywords": ["terminal", "tui", "cli", "components", "add"],
-  "engines": { "node": ">=18" },
+  "engines": { "bun": ">=1.3.0", "node": ">=18" },
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary

Fixed structural inconsistencies in `packages/cli/package.json`. The CLI package was missing fields that every other published package in the monorepo has, causing `bun run typecheck` and `bun run clean` to skip it, and affecting npm publishing and IDE support.

## Changes

Added the following missing fields to align with the other 14 packages:

- `publishConfig: { "access": "public" }` - required for npm publishing
- `module: "./dist/index.js"` - bundler resolution for ESM
- `types: "./dist/index.d.ts"` - TypeScript IDE support
- `exports` field - proper module resolution for modern tools
- `typecheck` script - `tsc --noEmit` for type checking
- `clean` script - `rm -rf dist` for build cleanup
- `engines.bun` - `>=1.3.0` to match other packages

## How to Test

1. Run `bun run typecheck` from root - CLI package should now be included
2. Run `bun run clean` from root - CLI dist should be cleaned
3. Verify `bun install` still works after package.json changes

## Related Issues

Closes #2359

## GSSoC 2026

This contribution is part of GSSoC 2026.