### PR TITLE
[Fix] Export missing PanelOptions type from @termuijs/widgets

### DIFF
--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -217,6 +217,7 @@ export type { TooltipOptions } from './display/Tooltip.js';
 
 
 export { Panel } from './layout/Panel.js';
+export type { PanelOptions } from './layout/Panel.js';
 export { Clock } from './display/Clock.js';
 export type { ClockOptions } from './display/Clock.js';
 


### PR DESCRIPTION
## Summary

Added the missing `PanelOptions` type export from `@termuijs/widgets`. The `Panel` widget was exported but its options type was not, unlike every other layout widget in the package (Grid, ScrollView, Card, Center, Stack all export their options types).

## Changes

- Added `export type { PanelOptions } from './layout/Panel.js';` to `packages/widgets/src/index.ts`

## How to Test

1. Run `bun vitest run packages/widgets` to verify no regressions
2. Run `bun run typecheck` to verify type safety
3. Verify that `import { PanelOptions } from '@termuijs/widgets'` resolves correctly

## Related Issues

Closes #2361

## GSSoC 2026

This contribution is part of GSSoC 2026.