### PR TITLE
[Fix] Export missing resetCell function from @termuijs/core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
 // ── Terminal ──────────────────────────────────────────
 export { Terminal } from './terminal/Terminal.js';
 export type { TerminalOptions } from './terminal/Terminal.js';
-export { Screen, emptyCell, cellsEqual } from './terminal/Screen.js';
+export { Screen, emptyCell, cellsEqual, resetCell } from './terminal/Screen.js';
 export type { Cell } from './terminal/Screen.js';
 export { Renderer } from './terminal/Renderer.js';
 export type { FrameStats } from './terminal/Renderer.js';


### PR DESCRIPTION
## Summary

Exported the missing `resetCell` function from `@termuijs/core`. This function resets a cell in-place to default attributes without allocation, and is the counterpart to `emptyCell()`. Both are needed for building custom widgets or doing manual screen manipulation.

## Changes

- Added `resetCell` to the export from `./terminal/Screen.js` in `packages/core/src/index.ts`

## How to Test

1. Run `bun vitest run packages/core` to verify no regressions
2. Run `bun run typecheck` to verify type safety
3. Verify that `import { resetCell } from '@termuijs/core'` resolves correctly

## Related Issues

Closes #2365

## GSSoC 2026

This contribution is part of GSSoC 2026.