### PR TITLE
[Feat] Export calculateSpringScroll and ScrollSpringState from @termuijs/widgets

### DIFF
--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -40,6 +40,10 @@ export { PerformanceOverlay } from './display/PerformanceOverlay.js';
 export { computeRange, computeVariableRange } from './input/virtual-scroll.js';
 export type { ScrollRange } from './input/virtual-scroll.js';
 
+// ── Spring Scroll Helper ─────────────────────────────
+export { calculateSpringScroll } from './scroll.js';
+export type { ScrollSpringState } from './scroll.js';
+
 // ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Exported the `calculateSpringScroll` utility function and `ScrollSpringState` type from `@termuijs/widgets`. This is a reusable spring physics helper for smooth scroll animations, and consumers building custom scroll interactions would benefit from having it available.

## Changes

- Added `export { calculateSpringScroll } from './scroll.js'` to `packages/widgets/src/index.ts`
- Added `export type { ScrollSpringState } from './scroll.js'` to `packages/widgets/src/index.ts`

## How to Test

1. Run `bun vitest run packages/widgets` to verify no regressions
2. Run `bun run typecheck` to verify type safety
3. Verify that `import { calculateSpringScroll } from '@termuijs/widgets'` resolves correctly

## Related Issues

Closes #2371

## GSSoC 2026

This contribution is part of GSSoC 2026.