### PR TITLE
[Feat] Add optional onError callback to EventEmitter for debugging

### DIFF
--- a/packages/core/src/events/EventEmitter.ts
+++ b/packages/core/src/events/EventEmitter.ts
@@ -11,6 +11,9 @@ export class EventEmitter<TEventMap extends Record<string, any>> {
     private _onceHandlers: Map<keyof TEventMap, Set<(data: any) => void>> = new Map();
     private _emitting: Set<keyof TEventMap> = new Set();
 
+    /** Optional error handler for event handler errors. Called when a handler throws. */
+    onError?: (event: keyof TEventMap, error: unknown) => void;
+
     /**
      * Subscribe to an event.
      * @returns Unsubscribe function.
@@ -82,8 +85,8 @@ export class EventEmitter<TEventMap extends Record<string, any>> {
             const handlers = this._handlers.get(event);
             if (handlers) {
                 for (const handler of [...handlers]) {
-                    try { handler(data); } catch (_err) {
-                        // handler errors are silently ignored to prevent crash during rendering
+                    try { handler(data); } catch (err) {
+                        this.onError?.(event, err);
                     }
                 }
             }
@@ -92,8 +95,8 @@ export class EventEmitter<TEventMap extends Record<string, any>> {
 
         // Once handlers — fire removed handlers
         for (const handler of onceSnapshot) {
-            try { handler(data); } catch (_err) {
-                // handler errors are silently ignored to prevent crash during rendering
+            try { handler(data); } catch (err) {
+                this.onError?.(event, err);
             }
         }
     }


### PR DESCRIPTION
## Summary

Added an optional `onError` callback to the `EventEmitter` class. Previously, all handler errors were silently swallowed with no diagnostic path, making debugging extremely difficult.

## Changes

- Added `onError?: (event: keyof TEventMap, error: unknown) => void` property to `EventEmitter`
- Updated both regular and once handler error catches to call `this.onError?.(event, err)` instead of silently discarding

## How to Test

1. Run `bun vitest run packages/core` to verify no regressions
2. Run `bun run typecheck` to verify type safety
3. Usage example:

`	ypescript
const events = new EventEmitter<{ click: void }>();
events.onError = (event, err) => console.error(Error in :, err);
events.on('click', () => { throw new Error('boom'); });
events.emit('click', undefined); // logs: Error in click: Error: boom
`

## Related Issues

Closes #2373

## GSSoC 2026

This contribution is part of GSSoC 2026.