### PR TITLE
[Doc] Add README.md to examples/showcase

### DIFF
--- a/examples/showcase/README.md
+++ b/examples/showcase/README.md
@@ -64,4 +64,4 @@ bun run dev
 ## Learn More
 
 - [TermUI Documentation](https://termui.io)
-- [Other Examples](../README.md)
+- [Other Examples](../)

--- a/examples/showcase/README.md
+++ b/examples/showcase/README.md
@@ -1,0 +1,67 @@
+# Showcase Example
+
+A comprehensive demonstration of all TermUI packages in a single interactive app. Navigate through 5 tabs to explore dashboard widgets, UI components, theming, animations, and dev tools.
+
+## Features
+
+- **Dashboard Tab** - Real-time system metrics with gauges and sparklines
+- **Components Tab** - Interactive gallery of display and input widgets
+- **Theming Tab** - Live theme switching with 6 built-in themes
+- **Animations Tab** - Spring physics and easing animation demos
+- **DevTools Tab** - Performance metrics and hot-reload debugging
+
+## Project Structure
+
+```text
+showcase/
+├── package.json
+├── README.md
+├── themes/
+└── src/
+    ├── index.tsx
+    └── tabs/
+        ├── dashboard.tsx
+        ├── components.tsx
+        ├── theming.tsx
+        ├── animations.tsx
+        └── devtools.tsx
+```
+
+## Installation & Usage
+
+```bash
+cd examples/showcase
+bun install
+bun run dev
+```
+
+## Controls
+
+- **1-5** - Switch between tabs
+- **t** - Cycle through themes
+- **Space** - Retrigger animations (Animations tab)
+- **q / Ctrl+C** - Quit application
+
+## What's Demonstrated
+
+1. **@termuijs/core** - App lifecycle, Screen rendering, Input handling
+2. **@termuijs/widgets** - Box, Text, Table, Gauge, Sparkline, and more
+3. **@termuijs/ui** - Modal, Select, Tree, Divider, Toast notifications
+4. **@termuijs/tss** - Theme engine with 6 built-in themes
+5. **@termuijs/motion** - Spring physics and transition animations
+6. **@termuijs/dev-server** - DevTools panel and performance metrics
+
+## Dependencies
+
+- `@termuijs/core` - Core framework
+- `@termuijs/widgets` - Widget library
+- `@termuijs/ui` - High-level UI components
+- `@termuijs/jsx` - JSX runtime and hooks
+- `@termuijs/tss` - Theming system
+- `@termuijs/motion` - Animation engine
+- `@termuijs/dev-server` - Hot-reload dev server
+
+## Learn More
+
+- [TermUI Documentation](https://termui.io)
+- [Other Examples](../README.md)


### PR DESCRIPTION
## Summary

Added README.md to the `examples/showcase/` directory. This is one of 25 example directories missing a README, as noted in the ROADMAP (Wave 5: "expanded thin READMEs").

## Changes

Created `examples/showcase/README.md` following the pattern of `examples/ai-assistant/README.md`:

- Title and description of the showcase example
- Features list (5 tabs: Dashboard, Components, Theming, Animations, DevTools)
- Project structure overview
- Installation and usage instructions
- Keyboard controls
- What's demonstrated (6 packages)
- Dependencies list

## How to Test

1. Verify the README renders correctly on GitHub
2. Follow the instructions to run the example

## Related Issues

Closes #2378

## GSSoC 2026

This contribution is part of GSSoC 2026.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for the Showcase Example application.
  * Documented installation, startup instructions, navigation controls, themes, animations, demonstrated packages, project structure, and additional resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->