### PR TITLE
perf(core): reuse LayerManager hit grid for runtime widget hit-testing

### DIFF
--- a/packages/core/src/app/App.test.ts
+++ b/packages/core/src/app/App.test.ts
@@ -545,6 +545,73 @@ describe('App', () => {
         });
     });
 
+    describe('runtime hit-grid population', () => {
+        it('populates the layer hit-grid from the mounted widget tree', async () => {
+            const { root, first } = createFocusTestRoot();
+            const app = new App(root, createInteractiveTestOptions());
+
+            const mountPromise = app.mount();
+            await new Promise(r => setImmediate(r));
+
+            expect(app.layers.hitTest(0, 0)).toBe(first.id);
+
+            app.unmount();
+            await mountPromise.catch(() => {});
+        });
+
+        it('rebuilds the hit-grid when geometry changes without a full widget render pass', async () => {
+            const widget = {
+                id: 'moved',
+                rect: { x: 0, y: 0, width: 4, height: 4 },
+                style: { visible: true, zIndex: 0 },
+                parent: null,
+                events: { emit() {} },
+            };
+            const root = {
+                id: 'root',
+                rect: { x: 0, y: 0, width: 0, height: 0 },
+                style: { visible: true, zIndex: 0 },
+                children: [widget],
+                _children: [widget],
+                isDirty: false,
+                getLayoutNode() {
+                    return {
+                        id: 'root',
+                        style: {},
+                        children: [],
+                        computed: { x: 0, y: 0, width: 20, height: 20 },
+                    };
+                },
+                syncLayout() {},
+                render() {},
+                mount() {},
+                unmount() {},
+                clearDirty() { this.isDirty = false; },
+                markDirty() { this.isDirty = true; },
+            };
+            const app = new App(root as any, createInteractiveTestOptions());
+
+            const mountPromise = app.mount();
+            await new Promise(r => setImmediate(r));
+
+            (app as any)._hitGridDirty = true;
+            (app as any).requestRender();
+            await new Promise(r => setImmediate(r));
+
+            expect(app.layers.hitTest(1, 1)).toBe(widget.id);
+
+            widget.rect = { x: 10, y: 10, width: 4, height: 4 };
+            (app as any)._hitGridDirty = true;
+            (app as any).requestRender();
+            await new Promise(r => setImmediate(r));
+
+            expect(app.layers.hitTest(1, 1)).toBeNull();
+
+            app.unmount();
+            await mountPromise.catch(() => {});
+        });
+    });
+
     describe('_findWidgetAt z-order hit-testing', () => {
         function createHitWidget(id: string, rect: { x: number; y: number; width: number; height: number }, style?: { zIndex?: number; visible?: boolean }, parent?: any): any {
             return { id, rect, style, parent, events: { emit() {} } };

--- a/packages/core/src/app/App.ts
+++ b/packages/core/src/app/App.ts
@@ -90,6 +90,8 @@ export class App {
     private _widgetById = new Map<string, any>(); // any: Widget shape varies; narrowed at retrieval
     private _hoveredWidgetId: string | null = null;
     private _pendingFocusState = new Map<string, boolean>();
+    private _hitGridState = new Map<string, { x: number; y: number; width: number; height: number; visible: boolean; zIndex: number }>();
+    private _hitGridDirty = true;
     private _pendingFocusRetries = new Map<string, number>();
     private static readonly PENDING_FOCUS_MAX_RETRIES = 5;
 
@@ -178,6 +180,7 @@ export class App {
             this.screen.resize(cols, rows);
             this.screen.invalidate();
             this.layers.resize(cols, rows);
+            this._hitGridDirty = true;
             this.events.emit('resize', { cols, rows });
             (this._rootWidget as any).markDirty?.(); // as any: RootWidget.markDirty may be absent in some configs
             this.requestRender();
@@ -397,16 +400,19 @@ export class App {
             }
 
             try {
-                // Skip full render pass if neither the widget tree nor overlay
-                // layers have reported any changes. Done inside the deferred
-                // callback so the dirty check and the _isRenderPending guard
-                // are never racy with concurrent requestRender() calls.
-                if (this._rootWidget.isDirty === false && !this.layers.hasDirtyLayers()) {
+                const hitGridNeedsRebuild = this._hitGridDirty || this._hasHitGridStateChanged(this._rootWidget);
+                const shouldRender = this._rootWidget.isDirty !== false;
+
+                // Skip the full render pass if neither the widget tree, overlay
+                // layers, nor the runtime hit-grid need work. Done inside the
+                // deferred callback so the dirty check and the _isRenderPending
+                // guard are never racy with concurrent requestRender() calls.
+                if (!shouldRender && !this.layers.hasDirtyLayers() && !hitGridNeedsRebuild) {
                     this._isRenderPending = false;
                     return;
                 }
 
-                if (this._rootWidget.isDirty !== false) {
+                if (shouldRender) {
                     // Compute layout
                     const layoutRoot = this._rootWidget.getLayoutNode();
                     computeLayout(layoutRoot, this.terminal.cols, this.terminal.rows);
@@ -416,7 +422,16 @@ export class App {
 
                     // Rebuild the widget ID cache so _buildBubbleChain can do O(1) lookups
                     this._buildWidgetMap(this._rootWidget);
+                }
 
+                // Populate the existing spatial hit-grid from the runtime widget tree.
+                // Rebuild only when the widget geometry or visibility state changed.
+                if (hitGridNeedsRebuild) {
+                    this._populateHitGrid(this._rootWidget);
+                    this._hitGridDirty = false;
+                }
+
+                if (shouldRender) {
                     // Clear the back buffer and render widgets into it
                     this.screen.clear();
                     this._rootWidget.render(this.screen);
@@ -559,6 +574,87 @@ export class App {
         }
     }
 
+    private _populateHitGrid(root: any): void { // any: Widget tree shape not statically known at traversal
+        this.layers.clearHitGrid();
+        this._hitGridState.clear();
+
+        const stack = [root];
+        while (stack.length > 0) {
+            const widget = stack.pop();
+            if (!widget) continue;
+
+            const rect = widget.rect ?? widget._rect;
+            const style = widget.style ?? widget._style;
+            if (widget.id && rect && style?.visible !== false) {
+                const width = rect.width ?? 0;
+                const height = rect.height ?? 0;
+                if (width > 0 && height > 0) {
+                    this.layers.setHitRegion(widget.id, rect.x, rect.y, width, height, style?.zIndex ?? 0);
+                }
+
+                this._hitGridState.set(widget.id, {
+                    x: rect.x,
+                    y: rect.y,
+                    width,
+                    height,
+                    visible: style?.visible !== false,
+                    zIndex: style?.zIndex ?? 0,
+                });
+            }
+
+            const children = widget._children ?? widget.children ?? [];
+            if (Array.isArray(children)) {
+                for (let i = children.length - 1; i >= 0; i--) {
+                    stack.push(children[i]);
+                }
+            }
+        }
+    }
+
+    private _hasHitGridStateChanged(root: any): boolean { // any: Widget tree shape not statically known at traversal
+        const current = new Map<string, { x: number; y: number; width: number; height: number; visible: boolean; zIndex: number }>();
+        const stack = [root];
+
+        while (stack.length > 0) {
+            const widget = stack.pop();
+            if (!widget) continue;
+
+            const rect = widget.rect ?? widget._rect;
+            const style = widget.style ?? widget._style;
+            if (widget.id && rect && style?.visible !== false) {
+                const width = rect.width ?? 0;
+                const height = rect.height ?? 0;
+                current.set(widget.id, {
+                    x: rect.x,
+                    y: rect.y,
+                    width,
+                    height,
+                    visible: style?.visible !== false,
+                    zIndex: style?.zIndex ?? 0,
+                });
+            }
+
+            const children = widget._children ?? widget.children ?? [];
+            if (Array.isArray(children)) {
+                for (let i = children.length - 1; i >= 0; i--) {
+                    stack.push(children[i]);
+                }
+            }
+        }
+
+        if (this._hitGridState.size !== current.size) return true;
+
+        for (const [id, state] of current) {
+            const prev = this._hitGridState.get(id);
+            if (!prev) return true;
+            if (prev.x !== state.x || prev.y !== state.y || prev.width !== state.width || prev.height !== state.height || prev.visible !== state.visible || prev.zIndex !== state.zIndex) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private _handleFocusEvent(event: FocusEvent): void {
         const focused = event.type === 'focus';
         const changed = this._setWidgetFocused(event.targetId, focused);
@@ -617,7 +713,9 @@ export class App {
     }
 
     private _findWidgetAt(x: number, y: number): any { // any: widget shape varies; narrowed at retrieval
-        // 1. Use LayerManager hitTest for overlay layers (respects z-order)
+        // 1. Use the existing LayerManager hit-grid as the primary lookup path.
+        //    This covers both overlays and normal widgets once the runtime tree
+        //    has populated the grid during layout/render.
         const layerHitId = this.layers.hitTest(x, y);
         if (layerHitId) {
             const layerWidget = this._widgetById.get(layerHitId);
@@ -629,7 +727,8 @@ export class App {
             }
         }
 
-        // 2. Collect all matching widgets, filtering out hidden ones
+        // 2. Fallback scan for safety during the migration window.
+        //    This preserves behavior if the hit-grid has not been populated yet.
         const matches: Array<{ widget: any; zIndex: number }> = [];
         for (const widget of this._widgetById.values()) {
             const r = widget.rect;

--- a/packages/core/src/app/App.ts
+++ b/packages/core/src/app/App.ts
@@ -16,6 +16,15 @@ import { renderFallback, shouldUseFallback } from './Fallback.js';
 import { mergeBorders } from '../renderer/border-merge.js';
 import { renderInlineToTerminal } from '../inline-viewport.js';
 
+type HitGridEntry = {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    visible: boolean;
+    zIndex: number;
+};
+
 export interface AppOptions extends TerminalOptions {
     /** Frames per second for the render loop */
     fps?: number;
@@ -90,7 +99,7 @@ export class App {
     private _widgetById = new Map<string, any>(); // any: Widget shape varies; narrowed at retrieval
     private _hoveredWidgetId: string | null = null;
     private _pendingFocusState = new Map<string, boolean>();
-    private _hitGridState = new Map<string, { x: number; y: number; width: number; height: number; visible: boolean; zIndex: number }>();
+    private _hitGridState = new Map<string, HitGridEntry>();
     private _hitGridDirty = true;
     private _pendingFocusRetries = new Map<string, number>();
     private static readonly PENDING_FOCUS_MAX_RETRIES = 5;
@@ -400,14 +409,13 @@ export class App {
             }
 
             try {
-                const hitGridNeedsRebuild = this._hitGridDirty || this._hasHitGridStateChanged(this._rootWidget);
                 const shouldRender = this._rootWidget.isDirty !== false;
 
                 // Skip the full render pass if neither the widget tree, overlay
                 // layers, nor the runtime hit-grid need work. Done inside the
                 // deferred callback so the dirty check and the _isRenderPending
                 // guard are never racy with concurrent requestRender() calls.
-                if (!shouldRender && !this.layers.hasDirtyLayers() && !hitGridNeedsRebuild) {
+                if (!shouldRender && !this.layers.hasDirtyLayers() && !this._hitGridDirty) {
                     this._isRenderPending = false;
                     return;
                 }
@@ -424,10 +432,13 @@ export class App {
                     this._buildWidgetMap(this._rootWidget);
                 }
 
+                const hitGridSnapshot = this._createHitGridSnapshot(this._rootWidget);
+                const hitGridNeedsRebuild = this._hitGridDirty || this._hasHitGridStateChanged(hitGridSnapshot);
+
                 // Populate the existing spatial hit-grid from the runtime widget tree.
                 // Rebuild only when the widget geometry or visibility state changed.
                 if (hitGridNeedsRebuild) {
-                    this._populateHitGrid(this._rootWidget);
+                    this._populateHitGrid(hitGridSnapshot);
                     this._hitGridDirty = false;
                 }
 
@@ -574,77 +585,56 @@ export class App {
         }
     }
 
-    private _populateHitGrid(root: any): void { // any: Widget tree shape not statically known at traversal
+    private _createHitGridSnapshot(root: any): Map<string, HitGridEntry> { // any: Widget tree shape not statically known at traversal
+        const snapshot = new Map<string, HitGridEntry>();
+        const stack = [root];
+
+        while (stack.length > 0) {
+            const widget = stack.pop();
+            if (!widget) continue;
+
+            const rect = widget.rect ?? widget._rect;
+            const style = widget.style ?? widget._style;
+            if (widget.id && rect && style?.visible !== false) {
+                const width = rect.width ?? 0;
+                const height = rect.height ?? 0;
+                snapshot.set(widget.id, {
+                    x: rect.x,
+                    y: rect.y,
+                    width,
+                    height,
+                    visible: style?.visible !== false,
+                    zIndex: style?.zIndex ?? 0,
+                });
+            }
+
+            const children = widget._children ?? widget.children ?? [];
+            if (Array.isArray(children)) {
+                for (let i = children.length - 1; i >= 0; i--) {
+                    stack.push(children[i]);
+                }
+            }
+        }
+
+        return snapshot;
+    }
+
+    private _populateHitGrid(snapshot: Map<string, HitGridEntry>): void {
         this.layers.clearHitGrid();
         this._hitGridState.clear();
 
-        const stack = [root];
-        while (stack.length > 0) {
-            const widget = stack.pop();
-            if (!widget) continue;
-
-            const rect = widget.rect ?? widget._rect;
-            const style = widget.style ?? widget._style;
-            if (widget.id && rect && style?.visible !== false) {
-                const width = rect.width ?? 0;
-                const height = rect.height ?? 0;
-                if (width > 0 && height > 0) {
-                    this.layers.setHitRegion(widget.id, rect.x, rect.y, width, height, style?.zIndex ?? 0);
-                }
-
-                this._hitGridState.set(widget.id, {
-                    x: rect.x,
-                    y: rect.y,
-                    width,
-                    height,
-                    visible: style?.visible !== false,
-                    zIndex: style?.zIndex ?? 0,
-                });
+        for (const [id, state] of snapshot) {
+            if (state.width > 0 && state.height > 0) {
+                this.layers.setHitRegion(id, state.x, state.y, state.width, state.height, state.zIndex);
             }
-
-            const children = widget._children ?? widget.children ?? [];
-            if (Array.isArray(children)) {
-                for (let i = children.length - 1; i >= 0; i--) {
-                    stack.push(children[i]);
-                }
-            }
+            this._hitGridState.set(id, state);
         }
     }
 
-    private _hasHitGridStateChanged(root: any): boolean { // any: Widget tree shape not statically known at traversal
-        const current = new Map<string, { x: number; y: number; width: number; height: number; visible: boolean; zIndex: number }>();
-        const stack = [root];
+    private _hasHitGridStateChanged(snapshot: Map<string, HitGridEntry>): boolean {
+        if (this._hitGridState.size !== snapshot.size) return true;
 
-        while (stack.length > 0) {
-            const widget = stack.pop();
-            if (!widget) continue;
-
-            const rect = widget.rect ?? widget._rect;
-            const style = widget.style ?? widget._style;
-            if (widget.id && rect && style?.visible !== false) {
-                const width = rect.width ?? 0;
-                const height = rect.height ?? 0;
-                current.set(widget.id, {
-                    x: rect.x,
-                    y: rect.y,
-                    width,
-                    height,
-                    visible: style?.visible !== false,
-                    zIndex: style?.zIndex ?? 0,
-                });
-            }
-
-            const children = widget._children ?? widget.children ?? [];
-            if (Array.isArray(children)) {
-                for (let i = children.length - 1; i >= 0; i--) {
-                    stack.push(children[i]);
-                }
-            }
-        }
-
-        if (this._hitGridState.size !== current.size) return true;
-
-        for (const [id, state] of current) {
+        for (const [id, state] of snapshot) {
             const prev = this._hitGridState.get(id);
             if (!prev) return true;
             if (prev.x !== state.x || prev.y !== state.y || prev.width !== state.width || prev.height !== state.height || prev.visible !== state.visible || prev.zIndex !== state.zIndex) {


### PR DESCRIPTION
## Description

This PR improves runtime mouse hit-testing by reusing the existing `LayerManager` hit grid for normal widget lookups. Instead of relying on repeated widget-tree scans in `App._findWidgetAt()`, the runtime now populates the existing spatial hit grid during the layout/render lifecycle and uses it as the primary hit-testing mechanism, while preserving the previous widget scan as a safe fallback.

## Related Issue

Closes #2395

## Which package(s)?

@termuijs/core

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [x] ⚡ Performance (`type:performance`)
- [x] ♻️ Refactor (`type:refactor`)
- [x] 🧪 Tests (`type:testing`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/YOUR_USERNAME`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

### Summary
- Reused the existing `LayerManager` hit-grid instead of introducing a new cache.
- Populated the hit grid from the runtime widget tree during the layout/render lifecycle.
- Added hit-grid invalidation for geometry and visibility changes.
- Updated `App._findWidgetAt()` to use `LayerManager.hitTest()` as the primary lookup while retaining the previous widget scan as a fallback for migration safety.
- Added regression tests covering runtime hit-grid population and geometry-driven rebuilds.

### Verification

- ✅ `bun vitest run packages/core/src/app/App.test.ts`
- ✅ `bun vitest run packages/core`
- ✅ `bun run typecheck`

The fallback scan has intentionally been retained to preserve existing behavior during the migration and to reduce regression risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mouse hit detection so interactions consistently target the correct widget.
  * Hit-testing regions now update reliably when widgets move, resize, change visibility, or change layer order.
  * Improved hit detection after window resizing and during deferred rendering, with smooth behavior during initialization.
* **Tests**
  * Added runtime hit-testing coverage to verify the hit-testing grid is populated from the widget tree and rebuilt when widget geometry changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->