### PR TITLE
Add core config helper

### DIFF
--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { defineConfig, type TermUIConfig } from './config.js';
+
+describe('defineConfig', () => {
+    it('returns the config object unchanged', () => {
+        const config = {
+            theme: 'default',
+            hotReload: true,
+            router: { dir: './screens' },
+        } satisfies TermUIConfig;
+
+        expect(defineConfig(config)).toBe(config);
+    });
+});

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,0 +1,11 @@
+export interface TermUIConfig {
+    theme?: string;
+    hotReload?: boolean;
+    router?: {
+        dir?: string;
+    };
+}
+
+export function defineConfig<T extends TermUIConfig>(config: T): T {
+    return config;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -91,6 +91,8 @@ export { shouldUseFallback, renderFallback } from './app/Fallback.js';
 export { renderInlineToTerminal, createInlineViewport } from './inline-viewport.js';
 
 // ── Utilities ─────────────────────────────────────────
+export { defineConfig } from './config.js';
+export type { TermUIConfig } from './config.js';
 export { stringWidth, truncate, stripAnsi, wordWrap } from './utils/unicode.js';
 export * as ansi from './utils/ansi.js';
 export { stripAnsiEscapes, hasAnsiEscapes, sanitizeForDisplay } from './terminal/sanitize.js';


### PR DESCRIPTION
## Summary
- add a typed config helper exported from `@termuijs/core`
- cover the helper with a focused unit test

Fixes #2399

## Validation
- `bun vitest run packages/core/src/config.test.ts` could not run because `bun` is not installed on this machine
- `npx vitest@4.1.8 run packages/core/src/config.test.ts` could not load the repo config without local dependencies installed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a type-safe configuration interface for theme, hot reload, and router settings.
  * Added a configuration helper available from the package’s main entry point.

* **Tests**
  * Added coverage confirming configuration objects are preserved unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->