### PR TITLE
Generate starter router screen

### DIFF
--- a/packages/create-termui-app/src/templates.test.ts
+++ b/packages/create-termui-app/src/templates.test.ts
@@ -202,4 +202,17 @@ it('cli-tool template generates a minimal entry under 15 source lines', () => {
         expect(starterTest?.content).toContain('@termuijs/testing')
         expect(starterTest?.content).toContain('describe(')
     })
+
+    it('generates a starter screen when router support is selected', () => {
+        const files = generateProject({
+            ...baseConfig,
+            features: { ...baseConfig.features, router: true },
+        })
+
+        const paths = files.map((f) => f.path)
+        expect(paths).toContain('screens/index.tsx')
+
+        const config = files.find((f) => f.path === 'termui.config.ts')!
+        expect(config.content).toContain("router: { dir: './screens' }")
+    })
 })

--- a/packages/create-termui-app/src/templates.ts
+++ b/packages/create-termui-app/src/templates.ts
@@ -109,6 +109,23 @@ export default defineConfig({
 `,
     });
 
+    if (config.features.router) {
+        files.push({
+            path: 'screens/index.tsx',
+            content: `/** @jsxImportSource @termuijs/jsx */
+
+export default function HomeScreen() {
+    return (
+        <box flexDirection="column" padding={1}>
+            <text bold>${config.name}</text>
+            <text>Edit screens/index.tsx to customize this route.</text>
+        </box>
+    );
+}
+`,
+        });
+    }
+
     // ── Theme file ──
     const themeSrc = getBuiltinTheme(config.theme);
     if (themeSrc) {


### PR DESCRIPTION
## Summary
- generate a starter `screens/index.tsx` when router support is selected
- add a generator test covering the router screen and config path

Fixes #2401

## Validation
- not run; the repository requires Bun and it is not installed on this machine


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Router-enabled projects now include a starter home screen at `screens/index.tsx`.
  * The generated home screen displays the project name and guidance for customization.

* **Tests**
  * Added coverage to verify router configuration and starter screen generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->