### PR TITLE
Declare dashboard data dependency

### DIFF
--- a/packages/create-termui-app/src/templates.test.ts
+++ b/packages/create-termui-app/src/templates.test.ts
@@ -41,7 +41,7 @@ describe('generateProject', () => {
         const files = generateProject({
             ...baseConfig,
             template: 'dashboard',
-            features: { ...baseConfig.features, dataProviders: true },
+            features: { ...baseConfig.features, dataProviders: false },
         })
         const pkg = files.find((f) => f.path === 'package.json')!
         const parsed = JSON.parse(pkg.content)
@@ -50,6 +50,7 @@ describe('generateProject', () => {
             ...parsed.devDependencies,
         }
         expect('@termuijs/core' in deps).toBe(true)
+        expect(parsed.dependencies['@termuijs/data']).toBe('latest')
     })
 
     it('dashboard template copies static template files', () => {

--- a/packages/create-termui-app/src/templates.ts
+++ b/packages/create-termui-app/src/templates.ts
@@ -151,6 +151,7 @@ export default defineConfig({
 function createPackageJson(config: ProjectConfig): string {
     const isFileManager = config.template === 'file-manager';
     const isAiAssistant = config.template === 'ai-assistant';
+    const needsDataPackage = config.features.dataProviders || config.template === 'dashboard';
     return JSON.stringify({
         name: config.name,
         version: '0.1.0',
@@ -187,7 +188,7 @@ function createPackageJson(config: ProjectConfig): string {
                 '@termuijs/tss': 'latest',
                 '@termuijs/quick': 'latest',
                 '@termuijs/motion': 'latest',
-                ...(config.features.dataProviders ? { '@termuijs/data': 'latest' } : {}),
+                ...(needsDataPackage ? { '@termuijs/data': 'latest' } : {}),
                 ...(config.features.router ? { '@termuijs/router': 'latest' } : {}),
             },
         devDependencies: {


### PR DESCRIPTION
## Summary
- include `@termuijs/data` whenever the dashboard template is generated
- update the generator test to cover the dashboard dependency even when the feature toggle is off

Fixes #2402

## Validation
- not run; the repository requires Bun and it is not installed on this machine
