### PR TITLE
Use installed component path in add hint

### DIFF
--- a/packages/create-termui-app/src/commands/add.test.ts
+++ b/packages/create-termui-app/src/commands/add.test.ts
@@ -138,6 +138,9 @@ describe("runAddCommand", () => {
         expect(logSpy).toHaveBeenCalledWith(
             expect.stringContaining("added successfully"),
         );
+        expect(logSpy).toHaveBeenCalledWith(
+            "    import { Badge } from './components/badge';",
+        );
     });
 
     it("uses bun when bun.lock is present", async () => {

--- a/packages/create-termui-app/src/commands/add.ts
+++ b/packages/create-termui-app/src/commands/add.ts
@@ -77,7 +77,7 @@ export async function runAddCommand(options: AddCommandOptions): Promise<void> {
     console.log();
     console.log("  Import it with:");
     console.log(
-        `    import { ${pascalCase(componentEntry.name)} } from './components/${componentEntry.name}';`,
+        `    import { ${pascalCase(componentEntry.name)} } from './components/${componentDirName}';`,
     );
 }
 


### PR DESCRIPTION
## Summary
- print the import hint with the installed component directory name
- add coverage for slug-based import output

Fixes #2403

## Validation
- not run; the repository requires Bun and it is not installed on this machine
