### PR TITLE
Normalize add paths with registry slug

### DIFF
--- a/packages/create-termui-app/src/commands/add.test.ts
+++ b/packages/create-termui-app/src/commands/add.test.ts
@@ -250,4 +250,50 @@ describe("runAddCommand", () => {
         );
         expect(readFileSync(destination, "utf-8")).toContain("legacy");
     });
+
+    it("uses the registry slug to normalize fetched component file paths", async () => {
+        const index = [
+            {
+                name: "Chat Thread",
+                slug: "chat-thread",
+                files: [],
+            },
+        ];
+
+        globalThis.fetch = vi.fn(async (url: string) => {
+            if (url.endsWith("/r/registry.json")) {
+                return { ok: true, json: async () => index } as any;
+            }
+            if (url.endsWith("/r/chat-thread.json")) {
+                return {
+                    ok: true,
+                    json: async () => ({
+                        name: "Chat Thread",
+                        files: [
+                            {
+                                path: "registry/components/chat-thread/index.ts",
+                                content: "export const ChatThread = true;",
+                            },
+                        ],
+                        deps: [],
+                        peerDeps: [],
+                    }),
+                } as any;
+            }
+            return { ok: false, status: 404, statusText: "Not Found" } as any;
+        }) as any;
+
+        vi.spyOn(childProcess, "execFileSync");
+
+        await runAddCommand({ component: "chat-thread", yes: true });
+
+        const destination = join(
+            tempDir,
+            "src",
+            "components",
+            "chat-thread",
+            "index.ts",
+        );
+        expect(readFileSync(destination, "utf-8")).toContain("ChatThread");
+    });
 });

--- a/packages/create-termui-app/src/commands/add.ts
+++ b/packages/create-termui-app/src/commands/add.ts
@@ -47,7 +47,7 @@ export async function runAddCommand(options: AddCommandOptions): Promise<void> {
         await fetchComponentEntry(indexEntry.slug ?? indexEntry.name) ??
         indexEntry;
     const outputRoot = resolve(process.cwd(), options.dir ?? "src/components");
-    const componentDirName = componentEntry.slug ?? componentEntry.name;
+    const componentDirName = indexEntry.slug ?? componentEntry.slug ?? indexEntry.name;
     const destinationRoot = join(outputRoot, componentDirName);
     const fileEntries = await resolveComponentFiles(componentEntry);
 


### PR DESCRIPTION
## Summary
- use the registry index slug as the installed component directory
- add coverage for fetched component metadata whose display name differs from the slug

Fixes #2404

## Validation
- not run; the repository requires Bun and it is not installed on this machine
