### PR TITLE
Strip registry prefixes in cli add

### DIFF
--- a/packages/cli/src/commands/add.test.ts
+++ b/packages/cli/src/commands/add.test.ts
@@ -22,6 +22,16 @@ describe('writeComponentFiles', () => {
         expect(existsSync(join(root, 'spinner', 'spinner.ts'))).toBe(false);
     });
 
+    it('strips registry component prefixes before writing files', () => {
+        const root = mkdtempSync(join(tmpdir(), 'tcli-'));
+        const written = writeComponentFiles(root, 'spinner',
+            [{ path: 'registry/components/spinner/index.ts', content: 'x' }], { dryRun: false });
+
+        const target = join(root, 'spinner', 'index.ts');
+        expect(existsSync(target)).toBe(true);
+        expect(written).toEqual([target]);
+    });
+
     it('rejects a file path that escapes the destination root', () => {
         const root = mkdtempSync(join(tmpdir(), 'tcli-'));
         expect(() => writeComponentFiles(root, 'spinner',

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -15,7 +15,7 @@ export function writeComponentFiles(
     const componentRoot = resolve(destRoot, slug);
     const written: string[] = [];
     for (const file of files) {
-        const dest = resolve(componentRoot, file.path);
+        const dest = resolve(componentRoot, normalizeComponentPath(slug, file.path));
         const rel = relative(componentRoot, dest);
         if (rel.startsWith('..') || isAbsolute(rel)) {
             throw new Error(`Refusing to write ${dest}: path is outside ${componentRoot}`);
@@ -26,6 +26,14 @@ export function writeComponentFiles(
         writeFileSync(dest, file.content, 'utf-8');
     }
     return written;
+}
+
+function normalizeComponentPath(slug: string, filePath: string): string {
+    const prefix = `registry/components/${slug}/`;
+    if (filePath.startsWith(prefix)) {
+        return filePath.slice(prefix.length);
+    }
+    return filePath;
 }
 
 export async function runAdd(args: CliArgs): Promise<void> {


### PR DESCRIPTION
## Summary
- strip `registry/components/<slug>/` from package CLI add file paths
- add coverage for registry-prefixed component files

Fixes #2405

## Validation
- not run; the repository requires Bun and it is not installed on this machine
