### PR TITLE
Normalize registry dependency fields

### DIFF
--- a/packages/cli/src/registry.test.ts
+++ b/packages/cli/src/registry.test.ts
@@ -20,6 +20,19 @@ describe('resolveComponent', () => {
         expect(c.dependencies).toEqual(['@termuijs/core']);
     });
 
+    it('normalizes deps and peerDeps from registry metadata', async () => {
+        globalThis.fetch = (async () => new Response(JSON.stringify({
+            name: 'Spinner',
+            files: [{ path: 'spinner.ts', content: 'x' }],
+            dependencies: ['@termuijs/core'],
+            deps: ['@termuijs/widgets'],
+            peerDeps: ['@termuijs/core'],
+        }), { status: 200 })) as typeof fetch;
+
+        const c = await resolveComponent('spinner');
+        expect(c.dependencies).toEqual(['@termuijs/core', '@termuijs/widgets']);
+    });
+
     it('throws a helpful error on 404', async () => {
         globalThis.fetch = (async () => new Response('not found', { status: 404 })) as typeof fetch;
         await expect(resolveComponent('nope')).rejects.toThrow(/not found in registry/);

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -5,6 +5,11 @@ export interface ResolvedComponent {
     dependencies: string[];
 }
 
+interface RegistryComponentJson extends Partial<ResolvedComponent> {
+    deps?: string[];
+    peerDeps?: string[];
+}
+
 const BASE_URL = process.env.TERMUI_REGISTRY_URL ?? 'https://termui.io';
 
 export async function fetchWithTimeout(url: string, init?: RequestInit, timeoutMs = 8000): Promise<Response> {
@@ -52,15 +57,22 @@ export async function resolveComponent(slug: string): Promise<ResolvedComponent>
     if (!res.ok) {
         throw new Error(`Component "${slug}" not found in registry (${res.status} ${url}).`);
     }
-    const json = await res.json() as Partial<ResolvedComponent>;
+    const json = await res.json() as RegistryComponentJson;
     if (!json.files || json.files.length === 0) {
         throw new Error(`Component "${slug}" has no source files in the registry.`);
     }
+    const dependencies = [
+        ...new Set([
+            ...(json.dependencies ?? []),
+            ...(json.deps ?? []),
+            ...(json.peerDeps ?? []),
+        ]),
+    ].sort();
     return {
         name: json.name ?? slug,
         slug,
         files: json.files,
-        dependencies: json.dependencies ?? [],
+        dependencies,
     };
 }
 


### PR DESCRIPTION
## Summary
- merge `dependencies`, `deps`, and `peerDeps` when resolving registry components
- dedupe and sort dependency names before installation
- add coverage for legacy registry metadata fields

Fixes #2406

## Validation
- not run; the repository requires Bun and it is not installed on this machine
