### PR TITLE
Add file watcher fallback

### DIFF
--- a/packages/dev-server/src/watcher.test.ts
+++ b/packages/dev-server/src/watcher.test.ts
@@ -1,17 +1,21 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { FileWatcher } from './watcher.js';
-import { watch, existsSync } from 'node:fs';
+import { watch, existsSync, readdirSync, statSync } from 'node:fs';
 import { EventEmitter } from 'node:events';
 
-const { watch: mockWatch, existsSync: mockExistsSync } = vi.hoisted(() => ({
+const { watch: mockWatch, existsSync: mockExistsSync, readdirSync: mockReaddirSync, statSync: mockStatSync } = vi.hoisted(() => ({
     watch: vi.fn(),
     existsSync: vi.fn(() => true),
+    readdirSync: vi.fn(() => []),
+    statSync: vi.fn(() => ({ isDirectory: () => false })),
 }));
 
 
 vi.mock('node:fs', () => ({
     watch: mockWatch,
     existsSync: mockExistsSync,
+    readdirSync: mockReaddirSync,
+    statSync: mockStatSync,
 }));
 
 describe('FileWatcher', () => {
@@ -22,6 +26,8 @@ describe('FileWatcher', () => {
         mockWatcherEmitter = new EventEmitter();
         vi.mocked(watch).mockReturnValue(mockWatcherEmitter as any);
         vi.mocked(existsSync).mockReturnValue(true);
+        vi.mocked(readdirSync).mockReturnValue([]);
+        vi.mocked(statSync).mockReturnValue({ isDirectory: () => false } as any);
     });
 
     afterEach(() => {
@@ -357,6 +363,34 @@ describe('FileWatcher', () => {
 
         // Only one call for the existing directory
         expect(vi.mocked(watch)).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to explicit directory watchers when recursive watch is unavailable', () => {
+        const rootEmitter = new EventEmitter();
+        const childEmitter = new EventEmitter();
+        vi.mocked(watch)
+            .mockImplementationOnce(() => {
+                throw new Error('recursive watch unavailable');
+            })
+            .mockImplementationOnce(() => rootEmitter as any)
+            .mockImplementationOnce(() => childEmitter as any);
+        vi.mocked(readdirSync).mockImplementation((dir) => {
+            if (String(dir).endsWith('src')) return ['components'] as any;
+            return [] as any;
+        });
+        vi.mocked(statSync).mockReturnValue({ isDirectory: () => true } as any);
+
+        const watcher = new FileWatcher(['./src']);
+        const changeSpy = vi.fn();
+
+        watcher.onChange(changeSpy);
+        watcher.start();
+
+        childEmitter.emit('change', 'change', 'Button.tsx');
+        vi.advanceTimersByTime(100);
+
+        expect(vi.mocked(watch)).toHaveBeenCalledTimes(3);
+        expect(changeSpy).toHaveBeenCalledTimes(1);
     });
 
     // ─── 13. Timestamp generation ─────────────────────────────────────────────

--- a/packages/dev-server/src/watcher.ts
+++ b/packages/dev-server/src/watcher.ts
@@ -2,8 +2,8 @@
 // File Watcher — watches .tsx and .tss files
 // ─────────────────────────────────────────────────────
 
-import { watch, existsSync } from 'node:fs';
-import { resolve, extname } from 'node:path';
+import { watch, existsSync, readdirSync, statSync } from 'node:fs';
+import { resolve, extname, join } from 'node:path';
 
 export interface FileChange {
     filename: string;
@@ -37,41 +37,59 @@ export class FileWatcher {
             this._abortControllers.push(ac);
 
             try {
-                const watcher = watch(dir, { recursive: true, signal: ac.signal });
-
-                watcher.on('change', (_event, filename) => {
-                    if (!filename || typeof filename !== 'string') return;
-                    const ext = extname(filename);
-                    let type: FileChange['type'] | null = null;
-                    if (filename.includes('termui.config')) type = 'config';
-                    else if (ext === '.tsx' || ext === '.ts' || ext === '.jsx' || ext === '.js') type = 'tsx';
-                    else if (ext === '.tss') type = 'tss';
-                    if (!type) return;
-
-                    // Use a per-directory resolved path as the debounce key so files with
-                    // the same basename in different watched directories don't collide.
-                    const resolved = resolve(dir, filename);
-
-                    // Debounce: coalesce rapid saves for the same resolved file path
-                    const existing = this._debounceTimers.get(resolved);
-                    if (existing) clearTimeout(existing);
-                    this._debounceTimers.set(resolved, setTimeout(() => {
-                        this._debounceTimers.delete(resolved);
-                        // Preserve the original filename in the emitted FileChange to
-                        // avoid changing the public API observed by callers/tests.
-                        const change: FileChange = { filename, type: type!, timestamp: Date.now() };
-                        for (const cb of this._onChangeCallbacks) cb(change);
-                    }, 100));
-                });
-
-                watcher.on('error', (err) => {
-                    if ((err as any).name === 'AbortError') return;
-                    for (const cb of this._onErrorCallbacks) cb(err);
-                });
+                this.watchDir(dir, dir, ac, true);
             } catch (err) {
-                for (const cb of this._onErrorCallbacks) cb(err as Error);
+                try {
+                    this.watchDirectoryTree(dir, ac);
+                } catch (fallbackErr) {
+                    for (const cb of this._onErrorCallbacks) cb(fallbackErr as Error);
+                }
             }
         }
+    }
+
+    private watchDirectoryTree(rootDir: string, ac: AbortController): void {
+        this.watchDir(rootDir, rootDir, ac, false);
+
+        for (const entry of readdirSync(rootDir)) {
+            const child = join(rootDir, entry);
+            if (statSync(child).isDirectory()) {
+                this.watchDirectoryTree(child, ac);
+            }
+        }
+    }
+
+    private watchDir(rootDir: string, dir: string, ac: AbortController, recursive: boolean): void {
+        const watcher = watch(dir, { recursive, signal: ac.signal });
+
+        watcher.on('change', (_event, filename) => {
+            this.emitChange(rootDir, dir, filename);
+        });
+
+        watcher.on('error', (err) => {
+            if ((err as any).name === 'AbortError') return;
+            for (const cb of this._onErrorCallbacks) cb(err);
+        });
+    }
+
+    private emitChange(rootDir: string, dir: string, filename: string | Buffer | null): void {
+        if (!filename || typeof filename !== 'string') return;
+        const ext = extname(filename);
+        let type: FileChange['type'] | null = null;
+        if (filename.includes('termui.config')) type = 'config';
+        else if (ext === '.tsx' || ext === '.ts' || ext === '.jsx' || ext === '.js') type = 'tsx';
+        else if (ext === '.tss') type = 'tss';
+        if (!type) return;
+
+        const resolved = resolve(dir, filename);
+        const existing = this._debounceTimers.get(resolved);
+        if (existing) clearTimeout(existing);
+        this._debounceTimers.set(resolved, setTimeout(() => {
+            this._debounceTimers.delete(resolved);
+            const emittedFilename = dir === rootDir ? filename : resolve(dir, filename).slice(rootDir.length + 1);
+            const change: FileChange = { filename: emittedFilename, type: type!, timestamp: Date.now() };
+            for (const cb of this._onChangeCallbacks) cb(change);
+        }, 100));
     }
 
     stop(): void {


### PR DESCRIPTION
## Summary
- fall back to explicit directory watchers when recursive `fs.watch` is unavailable
- keep the existing debounce and error forwarding behavior
- add coverage for the fallback path

Fixes #2407

## Validation
- not run; the repository requires Bun and it is not installed on this machine
