### PR TITLE
Align alert registry export

### DIFF
--- a/registry/components/alert/README.md
+++ b/registry/components/alert/README.md
@@ -1,50 +1,46 @@
 # Alert Component
 
-A notification badge that displays a count at a corner position. Useful for showing unread counts, alert indicators, and notification overlays.
+An inline alert message for status, warning, error, and success feedback.
 
 ## Usage
 
 ```typescript
 import { Alert } from './components/alert';
 
-// Create a notification badge with count
-const alert = new Alert({ count: 5 });
+const alert = new Alert({
+  type: 'warning',
+  message: 'Check your configuration before continuing.',
+});
 
-// Create a badge at a specific corner
-const topLeftAlert = new Alert({ count: 3, position: 'top-left' });
-
-// Available positions: 'top-right', 'top-left', 'bottom-right', 'bottom-left'
+const success = new Alert({
+  type: 'success',
+  title: 'Saved',
+  message: 'Changes were written successfully.',
+});
 ```
 
 ## Features
 
-- Count display with "99+" overflow indicator
-- Four corner position options
-- Hides automatically when count is 0
-- Updateable count without recreating component
+- Status-focused alert variants
+- Optional title and message content
+- Suitable for warnings, errors, success notices, and informational feedback
 
 ## API
 
 ### Constructor
 
 ```typescript
-constructor(opts?: NotificationBadgeOptions, style?: Partial<Style>)
+constructor(opts: AlertOptions, style?: Partial<Style>)
 ```
-
-### Methods
-
-- `setCount(count: number): void` - Update the notification count
-- `getCount(): number` - Get the current notification count
-- `setPosition(position: BadgePosition): void` - Change corner position
-- `getPosition(): BadgePosition` - Get the current position
 
 ## Example
 
 ```typescript
-const container = new Box({ height: 10, width: 30 });
-const alert = new Alert({ count: 5, position: 'top-right' });
+const container = new Box({ flexDirection: 'column' });
+const alert = new Alert({
+  type: 'error',
+  title: 'Connection failed',
+  message: 'Retry after checking the service URL.',
+});
 container.addChild(alert);
-
-// Update count when notification arrives
-alert.setCount(6);
 ```

--- a/registry/components/alert/alert.test.ts
+++ b/registry/components/alert/alert.test.ts
@@ -1,8 +1,18 @@
 import { describe, it, expect } from 'vitest';
 import { Alert } from './index';
+import type { AlertOptions } from './index';
 
 describe('registry alert', () => {
   it('exports Alert component', () => {
     expect(typeof Alert).toBe('function');
+  });
+
+  it('exports AlertOptions type', () => {
+    const options: AlertOptions = {
+      type: 'info',
+      message: 'Ready',
+    };
+
+    expect(options.message).toBe('Ready');
   });
 });

--- a/registry/components/alert/index.ts
+++ b/registry/components/alert/index.ts
@@ -1,2 +1,2 @@
-export { NotificationBadge as Alert } from '@termuijs/widgets';
-export type { NotificationBadgeOptions, BadgePosition } from '@termuijs/widgets';
+export { Alert } from '@termuijs/widgets';
+export type { AlertOptions } from '@termuijs/widgets';

--- a/registry/components/alert/meta.json
+++ b/registry/components/alert/meta.json
@@ -1,7 +1,7 @@
 {
   "name": "alert",
   "category": "feedback",
-  "description": "Notification badge with count display positioned at corner locations.",
+  "description": "Inline alert message for status, warning, error, and success feedback.",
   "files": [
     "registry/components/alert/index.ts"
   ],


### PR DESCRIPTION
## Summary
- export the real widget `Alert` from the alert registry component
- update the alert README and metadata to describe alert behavior
- add type coverage for the registry export

Fixes #2408

## Validation
- not run; the repository requires Bun and it is not installed on this machine
