### PR TITLE
Validate timer options

### DIFF
--- a/packages/widgets/src/display/Timer.test.ts
+++ b/packages/widgets/src/display/Timer.test.ts
@@ -59,6 +59,21 @@ describe('Timer – rendering', () => {
     });
 });
 
+describe('Timer validation', () => {
+    it('rejects invalid durations', () => {
+        expect(() => new Timer({ duration: -1 })).toThrow(/duration/);
+        expect(() => new Timer({ duration: Number.NaN })).toThrow(/duration/);
+        expect(() => new Timer({ duration: Infinity })).toThrow(/duration/);
+    });
+
+    it('rejects invalid intervals', () => {
+        expect(() => new Timer({ duration: 1_000, interval: 0 })).toThrow(/interval/);
+        expect(() => new Timer({ duration: 1_000, interval: -1 })).toThrow(/interval/);
+        expect(() => new Timer({ duration: 1_000, interval: Number.NaN })).toThrow(/interval/);
+        expect(() => new Timer({ duration: 1_000, interval: Infinity })).toThrow(/interval/);
+    });
+});
+
 // ── 2. Timer fires onComplete ─────────────────────────────────────────────────
 describe('Timer – onComplete callback', () => {
     beforeEach(() => {

--- a/packages/widgets/src/display/Timer.ts
+++ b/packages/widgets/src/display/Timer.ts
@@ -49,6 +49,12 @@ export class Timer extends Widget {
 
     constructor(options: TimerOptions, style: Partial<Style> = {}) {
         super({ height: 1, ...style });
+        if (!Number.isFinite(options.duration) || options.duration < 0) {
+            throw new Error('Timer duration must be a finite non-negative number');
+        }
+        if (options.interval !== undefined && (!Number.isFinite(options.interval) || options.interval <= 0)) {
+            throw new Error('Timer interval must be a finite positive number');
+        }
         this._duration = options.duration;
         this._interval = options.interval ?? 1000;
         this._remaining = options.duration;


### PR DESCRIPTION
## Summary
- reject non-finite or negative timer durations
- reject non-finite or non-positive timer intervals
- add validation coverage for invalid timer options

Fixes #2444

## Validation
- not run; Bun is not installed on this machine


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for timer duration and interval values.
  * Invalid, negative, zero, or non-finite values now produce clear errors instead of being accepted.

* **Tests**
  * Added coverage for invalid duration and interval inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->