### PR TITLE
Validate histogram bins

### DIFF
--- a/packages/widgets/src/data/Histogram.test.ts
+++ b/packages/widgets/src/data/Histogram.test.ts
@@ -44,6 +44,13 @@ describe("Histogram", () => {
         expect(nonSpaceCells(renderHistogram(histogram))).toBe(0);
     });
 
+    it("rejects invalid bin counts", () => {
+        expect(() => new Histogram({}, { bins: 0 })).toThrow(/bins/);
+        expect(() => new Histogram({}, { bins: -1 })).toThrow(/bins/);
+        expect(() => new Histogram({}, { bins: 1.5 })).toThrow(/bins/);
+        expect(() => new Histogram({}, { bins: Number.NaN })).toThrow(/bins/);
+    });
+
     it("setData triggers markDirty", () => {
         const histogram = new Histogram();
         const markDirtySpy = vi.spyOn(histogram, "markDirty");

--- a/packages/widgets/src/data/Histogram.ts
+++ b/packages/widgets/src/data/Histogram.ts
@@ -16,7 +16,11 @@ export class Histogram extends Widget {
     constructor(style: Partial<Style> = {}, opts: HistogramOptions = {}) {
         super(style);
 
-        this._bins = opts.bins ?? 10;
+        const bins = opts.bins ?? 10;
+        if (!Number.isInteger(bins) || bins <= 0) {
+            throw new Error("Histogram bins must be a positive integer");
+        }
+        this._bins = bins;
         this._barColor = opts.barColor ?? { type: "named", name: "cyan" };
         this._xLabel = opts.xLabel;
     }


### PR DESCRIPTION
## Summary
- validate histogram bin count during construction
- add coverage for zero, negative, fractional, and non-finite bin values

Fixes #2445

## Validation
- not run; Bun is not installed on this machine
