### PR TITLE
Bound pie chart legend rows

### DIFF
--- a/packages/widgets/src/data/PieChart.test.ts
+++ b/packages/widgets/src/data/PieChart.test.ts
@@ -87,4 +87,22 @@ describe('PieChart', () => {
         // The pie portion should be filled with the block char
         expect(allText).toContain('\u2588');
     });
+
+    it('does not render legend rows beyond the widget height', () => {
+        const pie = new PieChart({
+            slices: [
+                { label: 'One', value: 1, color: 'red' },
+                { label: 'Two', value: 1, color: 'blue' },
+                { label: 'Three', value: 1, color: 'green' },
+            ],
+        });
+        pie.updateRect({ x: 0, y: 0, width: 20, height: 2 });
+        const screen = new Screen(20, 4);
+        pie.render(screen);
+
+        const rows = screen.back.map(row => row.map(c => c.char).join(''));
+        expect(rows[0]).toContain('One');
+        expect(rows[1]).toContain('Two');
+        expect(rows[2].trim()).toBe('');
+    });
 });

--- a/packages/widgets/src/data/PieChart.ts
+++ b/packages/widgets/src/data/PieChart.ts
@@ -58,7 +58,7 @@ export class PieChart extends Widget {
 
         const totalHeight = this._showLegend ? Math.max(0, height - this._slices.length) : height;
         if (totalHeight <= 0) {
-            this._renderLegend(screen, x, y, width);
+            this._renderLegend(screen, x, y, width, height);
             return;
         }
 
@@ -69,7 +69,7 @@ export class PieChart extends Widget {
         }
 
         if (this._showLegend) {
-            this._renderLegend(screen, x, y + totalHeight, width);
+            this._renderLegend(screen, x, y + totalHeight, width, height - totalHeight);
         }
     }
 
@@ -133,11 +133,11 @@ export class PieChart extends Widget {
 
     // ── Legend ───────────────────────────────────────
 
-    private _renderLegend(screen: Screen, ox: number, oy: number, width: number): void {
+    private _renderLegend(screen: Screen, ox: number, oy: number, width: number, maxRows: number): void {
         const total = this._total();
         const bullet = caps.unicode ? LEGEND_BULLET_UNICODE : LEGEND_BULLET_ASCII;
         const attrs = styleToCellAttrs(this._style);
-        for (let i = 0; i < this._slices.length; i++) {
+        for (let i = 0; i < this._slices.length && i < maxRows; i++) {
             const slice = this._slices[i];
             if (!slice) continue;
             const pct = total > 0 ? Math.round((slice.value / total) * 100) : 0;


### PR DESCRIPTION
## Summary
- cap PieChart legend rendering to the available widget height
- add coverage for a short widget with more slices than visible rows

Fixes #2446

## Validation
- not run; Bun is not installed on this machine
