### PR TITLE
Render scatter plot inside content rect

### DIFF
--- a/packages/widgets/src/data/ScatterPlot.test.ts
+++ b/packages/widgets/src/data/ScatterPlot.test.ts
@@ -38,6 +38,20 @@ describe('ScatterPlot Widget', () => {
         expect(spy).toHaveBeenCalled();
     });
 
+    it('renders inside the content rect when padding is set', () => {
+        const screen = new Screen(12, 6);
+        const plot = new ScatterPlot({ padding: { left: 2, top: 1, right: 0, bottom: 0 } });
+        plot.updateRect({ x: 0, y: 0, width: 12, height: 6 });
+        plot.setData([{ x: 1, y: 1 }]);
+
+        plot.render(screen);
+
+        expect(screen.back[0].map(c => c.char).join('').trim()).toBe('');
+        expect(screen.back[1][0].char).toBe(' ');
+        expect(screen.back[1][1].char).toBe(' ');
+        expect(screen.back[1][2].char).not.toBe(' ');
+    });
+
     it('ASCII fallback renders "." when caps.unicode is false', () => {
         vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
         

--- a/packages/widgets/src/data/ScatterPlot.ts
+++ b/packages/widgets/src/data/ScatterPlot.ts
@@ -32,9 +32,7 @@ export class ScatterPlot extends Widget {
     }
 
     protected override _renderSelf(screen: Screen): void {
-        if (!this.rect) return;
-
-        const { x, y, width, height } = this.rect;
+        const { x, y, width, height } = this._getContentRect();
         if (width < 2 || height < 2) return;
 
         const isUnicode = caps.unicode;


### PR DESCRIPTION
## Summary
- render ScatterPlot using the widget content rect
- add coverage for padded plots so axes do not start in padding cells

Fixes #2447

## Validation
- not run; Bun is not installed on this machine
