### PR TITLE
Clamp scatter plot axis labels

### DIFF
--- a/packages/widgets/src/data/ScatterPlot.test.ts
+++ b/packages/widgets/src/data/ScatterPlot.test.ts
@@ -38,6 +38,21 @@ describe('ScatterPlot Widget', () => {
         expect(spy).toHaveBeenCalled();
     });
 
+    it('clamps long axis labels to the widget width', () => {
+        const screen = new Screen(8, 4);
+        const plot = new ScatterPlot({}, {
+            xLabel: 'Very long x axis label',
+            yLabel: 'Very long y axis label',
+        });
+        plot.updateRect({ x: 0, y: 0, width: 8, height: 4 });
+        plot.render(screen);
+
+        const rows = screen.back.map(row => row.map(c => c.char).join(''));
+        expect(rows.join('\n')).not.toContain('axis label');
+        expect(rows[0].trimEnd().length).toBeLessThanOrEqual(8);
+        expect(rows[3].trimEnd().length).toBeLessThanOrEqual(8);
+    });
+
     it('ASCII fallback renders "." when caps.unicode is false', () => {
         vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
         

--- a/packages/widgets/src/data/ScatterPlot.ts
+++ b/packages/widgets/src/data/ScatterPlot.ts
@@ -1,5 +1,5 @@
 import { Widget } from '../base/Widget.js';
-import { type Style, type Color, Screen, caps } from '@termuijs/core';
+import { type Style, type Color, Screen, caps, truncate } from '@termuijs/core';
 
 export interface ScatterPoint {
     x: number;
@@ -63,10 +63,10 @@ export class ScatterPlot extends Widget {
 
         // Render Labels
         if (this.options.yLabel) {
-            screen.writeString(x + 1, y, this.options.yLabel);
+            screen.writeString(x + 1, y, truncate(this.options.yLabel, Math.max(0, width - 1)));
         }
         if (this.options.xLabel) {
-            const xL = this.options.xLabel;
+            const xL = truncate(this.options.xLabel, Math.max(0, width - 1));
             const startX = Math.max(plotX, x + width - xL.length);
             screen.writeString(startX, originY, xL);
         }


### PR DESCRIPTION
## Summary
- truncate ScatterPlot axis labels to the available widget width
- add coverage for labels longer than the rendered plot area

Fixes #2448

## Validation
- not run; Bun is not installed on this machine
