### PR TITLE
Clear quiz feedback timeout

### DIFF
--- a/packages/ui/src/QuizPrompt.test.ts
+++ b/packages/ui/src/QuizPrompt.test.ts
@@ -100,4 +100,19 @@ describe('QuizPrompt', () => {
         expect(result.total).toBe(1);
         expect(result.answers).toEqual([0]);
     });
+
+    it('clears pending feedback timeout when destroyed', () => {
+        vi.useFakeTimers();
+        const onComplete = vi.fn();
+        const quiz = new QuizPrompt([SAMPLE_QUESTIONS[0]], undefined, { onComplete });
+
+        quiz.handleKey({ key: 'down' } as any);
+        quiz.handleKey({ key: 'enter' } as any);
+        quiz.destroy();
+        vi.advanceTimersByTime(800);
+
+        expect(quiz['_currentIndex']).toBe(0);
+        expect(onComplete).not.toHaveBeenCalled();
+        vi.useRealTimers();
+    });
 });

--- a/packages/ui/src/QuizPrompt.ts
+++ b/packages/ui/src/QuizPrompt.ts
@@ -104,6 +104,23 @@ export class QuizPrompt extends Widget {
         }, 800);
     }
 
+    override destroy(): void {
+        this.clearFeedbackTimeout();
+        super.destroy();
+    }
+
+    override unmount(): void {
+        this.clearFeedbackTimeout();
+        super.unmount();
+    }
+
+    private clearFeedbackTimeout(): void {
+        if (this._feedbackTimeout) {
+            clearTimeout(this._feedbackTimeout);
+            this._feedbackTimeout = null;
+        }
+    }
+
     protected _renderSelf(screen: Screen): void {
         const { x, y, width, height } = this._rect;
         if (width <= 0 || height <= 0) return;


### PR DESCRIPTION
## Summary
- clear pending QuizPrompt feedback timers on destroy and unmount
- add coverage to prevent delayed completion after teardown

Fixes #2449

## Validation
- not run; Bun is not installed on this machine
