### PR TITLE
Ignore parallel completions after cancel

### DIFF
--- a/packages/motion/src/sequence.test.ts
+++ b/packages/motion/src/sequence.test.ts
@@ -160,4 +160,27 @@ describe('parallel()', () => {
         expect(cancelSpy1).toHaveBeenCalledTimes(1);
         expect(cancelSpy2).toHaveBeenCalledTimes(1);
     });
+
+    it('ignores late completion callbacks after cancellation', () => {
+        const onComplete = vi.fn();
+        let finish1: () => void = () => {};
+        let finish2: () => void = () => {};
+
+        const anim1: AnimationRunner = (done) => {
+            finish1 = done;
+            return () => {};
+        };
+        const anim2: AnimationRunner = (done) => {
+            finish2 = done;
+            return () => {};
+        };
+
+        const cancelMaster = parallel([anim1, anim2], onComplete);
+        cancelMaster();
+
+        finish1();
+        finish2();
+
+        expect(onComplete).not.toHaveBeenCalled();
+    });
 });

--- a/packages/motion/src/sequence.ts
+++ b/packages/motion/src/sequence.ts
@@ -59,10 +59,12 @@ export function parallel(
   }
 
   let remaining = runners.length
+  let cancelled = false
   const cancellers: Array<() => void> = []
 
   for (const runner of runners) {
     const cancel = runner(() => {
+      if (cancelled) return
       remaining--
       if (remaining === 0) onComplete?.()
     })
@@ -70,6 +72,7 @@ export function parallel(
   }
 
   return () => {
+    cancelled = true
     cancellers.forEach(c => c())
   }
 }


### PR DESCRIPTION
## Summary
- track cancellation in `parallel()`
- ignore late animation completion callbacks after a group is cancelled
- add regression coverage for cancelled parallel animations

Fixes #2450

## Validation
- not run; Bun is not installed on this machine
