### PR TITLE
Skip scaffold flag values for project name

### DIFF
--- a/packages/create-termui-app/src/args.test.ts
+++ b/packages/create-termui-app/src/args.test.ts
@@ -37,6 +37,32 @@ describe("CLI args", () => {
         expect(res.name).toBe("my-app");
     });
 
+    it("skips scaffold flag values when finding the project name", () => {
+        const res = parseArgs([
+            "--template",
+            "dashboard",
+            "my-app",
+            "--theme",
+            "default",
+        ]);
+
+        expect(res.name).toBe("my-app");
+        expect(res.template).toBe("dashboard");
+        expect(res.theme).toBe("default");
+    });
+
+    it("skips inline scaffold flags when finding the project name", () => {
+        const res = parseArgs([
+            "--template=dashboard",
+            "--theme=default",
+            "my-app",
+        ]);
+
+        expect(res.name).toBe("my-app");
+        expect(res.template).toBe("dashboard");
+        expect(res.theme).toBe("default");
+    });
+
     it("parses add command with component only", () => {
         const res = parseArgs(["add", "Badge"]);
 

--- a/packages/create-termui-app/src/args.ts
+++ b/packages/create-termui-app/src/args.ts
@@ -47,6 +47,27 @@ function getValue(
     return next;
 }
 
+function getFirstPositional(argv: string[]): string | undefined {
+    for (let index = 0; index < argv.length; index++) {
+        const value = argv[index];
+
+        if (value === "--template" || value === "--theme") {
+            index++;
+            continue;
+        }
+
+        if (value.startsWith("--template=") || value.startsWith("--theme=")) {
+            continue;
+        }
+
+        if (!value.startsWith("-")) {
+            return value;
+        }
+    }
+
+    return undefined;
+}
+
 export function parseArgs(argv: string[]): CliArgs {
     const args: CliArgs = {
         yes: false,
@@ -88,7 +109,7 @@ export function parseArgs(argv: string[]): CliArgs {
     }
 
     // positional (first non-flag)
-    const positional = argv.find(a => !a.startsWith("-"));
+    const positional = getFirstPositional(argv);
     if (positional) {
         args.name = positional;
     }


### PR DESCRIPTION
## Summary
- skip `--template` and `--theme` values when detecting the project name
- add coverage for flags before the scaffold positional argument

Fixes #2451

## Validation
- not run; Bun is not installed on this machine
