### PR TITLE
Delete search input graphemes on backspace

### DIFF
--- a/packages/ui/src/SearchInput.test.ts
+++ b/packages/ui/src/SearchInput.test.ts
@@ -77,6 +77,27 @@ describe('SearchInput', () => {
         expect(onSearch).toHaveBeenCalledWith('');
     });
 
+    it('backspace removes one grapheme at a time', () => {
+        const input = new SearchInput();
+        input.setValue('e\u0301👍🏽');
+
+        input.handleKey(createKeyEvent({
+            key: 'backspace',
+            raw: Buffer.from('\b'),
+            ctrl: false, alt: false, shift: false,
+        }));
+
+        expect(input.value).toBe('e\u0301');
+
+        input.handleKey(createKeyEvent({
+            key: 'backspace',
+            raw: Buffer.from('\b'),
+            ctrl: false, alt: false, shift: false,
+        }));
+
+        expect(input.value).toBe('');
+    });
+
     it('uses ASCII icon when unicode is off and Unicode icon when on', () => {
         vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
         const asciiInput = new SearchInput({ placeholder: 'x' });

--- a/packages/ui/src/SearchInput.ts
+++ b/packages/ui/src/SearchInput.ts
@@ -16,6 +16,7 @@ import {
     truncate,
     caps,
     stringWidth,
+    splitGraphemes,
 } from '@termuijs/core';
 
 export interface SearchInputOptions {
@@ -65,7 +66,9 @@ export class SearchInput extends Widget {
                 break;
             case 'backspace':
                 if (this._value.length > 0) {
-                    this._value = this._value.slice(0, -1);
+                    const graphemes = splitGraphemes(this._value);
+                    graphemes.pop();
+                    this._value = graphemes.join('');
                     this.markDirty();
                     this._scheduleSearch();
                 }


### PR DESCRIPTION
## Summary
- delete the previous grapheme instead of a UTF-16 code unit on SearchInput backspace
- add coverage for combining marks and emoji skin-tone modifiers

Fixes #2452

## Validation
- not run; Bun is not installed on this machine
