### PR TITLE
feat(widgets): implement z-index and Painter's Algorithm rendering for overlapping components #2430

### DIFF
--- a/packages/ui/src/Modal.test.ts
+++ b/packages/ui/src/Modal.test.ts
@@ -1414,5 +1414,13 @@ describe('Modal', () => {
             expect(t1).toBe(t2);
         });
     });
+
+    describe('zIndex stacking defaults', () => {
+        it('assigns a default zIndex of 1000', () => {
+            const modal = new Modal();
+            expect(modal.zIndex).toBe(1000);
+        });
+    });
 });
+
 

--- a/packages/ui/src/Modal.ts
+++ b/packages/ui/src/Modal.ts
@@ -20,7 +20,7 @@ export class Modal extends Widget {
     private _content: Widget | null = null;
 
     constructor(options: ModalOptions = {}, style?: Partial<Style>) {
-        super(mergeStyles(defaultStyle(), style ?? {}));
+        super(mergeStyles(defaultStyle(), { zIndex: 1000, ...style }));
         this._title = options.title ?? '';
         this._modalWidth = options.width ?? 50;
         this._modalHeight = options.height ?? 15;

--- a/packages/widgets/src/base/Widget.test.ts
+++ b/packages/widgets/src/base/Widget.test.ts
@@ -427,5 +427,48 @@ describe('Widget.layoutTransition', () => {
         await advanceSpring(5000);
         expect(widget.rect).toEqual({ x: 100, y: 100, width: 100, height: 100 });
     });
+
+    describe('z-index styling and rendering order', () => {
+        it('supports zIndex getter and setter', () => {
+            const w = new TestWidget();
+            expect(w.zIndex).toBe(0);
+            w.zIndex = 5;
+            expect(w.zIndex).toBe(5);
+            expect(w.style.zIndex).toBe(5);
+        });
+
+        it('renders children sorted by zIndex (Painter\'s Algorithm)', () => {
+            const parent = new TestWidget();
+            const order: string[] = [];
+
+            class OrderedWidget extends Widget {
+                private _name: string;
+                constructor(name: string, z: number) {
+                    super({ zIndex: z });
+                    this._name = name;
+                }
+                protected _renderSelf(): void {
+                    order.push(this._name);
+                }
+            }
+
+            const w1 = new OrderedWidget('first', 10);
+            const w2 = new OrderedWidget('second', 5);
+            const w3 = new OrderedWidget('third', 20);
+            const w4 = new OrderedWidget('fourth', 5); // same zIndex as w2, should preserve insertion order
+
+            parent.addChild(w1);
+            parent.addChild(w2);
+            parent.addChild(w3);
+            parent.addChild(w4);
+
+            const screen = new Screen(10, 5);
+            parent.render(screen);
+
+            // Sorted order by zIndex: w2 (5), w4 (5), w1 (10), w3 (20)
+            expect(order).toEqual(['second', 'fourth', 'first', 'third']);
+        });
+    });
 });
+
 

--- a/packages/widgets/src/base/Widget.ts
+++ b/packages/widgets/src/base/Widget.ts
@@ -163,6 +163,16 @@ export abstract class Widget {
     /** Get the current style */
     get style(): Style { return this._style; }
 
+    /** Get the z-index stacking order */
+    get zIndex(): number {
+        return this._style.zIndex ?? 0;
+    }
+
+    /** Set the z-index stacking order */
+    set zIndex(value: number) {
+        this.setStyle({ zIndex: value });
+    }
+
     get a11y(): A11yProps | undefined { return this._a11y; }
 
     public setA11y(props: A11yProps): this {
@@ -311,7 +321,12 @@ export abstract class Widget {
         this._renderBorder(screen);
 
         // Render children
-        for (const child of this._children) {
+        const sortedChildren = [...this._children].sort((a, b) => {
+            const az = a.style.zIndex ?? 0;
+            const bz = b.style.zIndex ?? 0;
+            return az - bz;
+        });
+        for (const child of sortedChildren) {
             child.render(screen);
         }
 


### PR DESCRIPTION
## Description

This PR implements `zIndex` styling properties on `Widget` base component, implements depth-sorted (Painter's Algorithm) rendering for overlapping child components, and sets a default `zIndex` of `1000` on the `Modal` overlay component.

## Related Issue

Closes #2430

## Which package(s)?

@termuijs/widgets, @termuijs/ui

## Type of Change

- [x] ✨ Feature (`type:feature`)
- [x] 🧪 Tests (`type:testing`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.

## Screenshots / Recordings (UI changes)

N/A (Depth order layout changes; validated with unit tests)

## Notes for the Reviewer

Added robust test coverage under `packages/widgets/src/base/Widget.test.ts` and `packages/ui/src/Modal.test.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added z-index controls for widgets, allowing their stacking order to be read and updated.
  * Widgets now render visible children in ascending z-index order, preserving insertion order for matching values.
  * Modals now default to a z-index of 1000.

* **Tests**
  * Added coverage for modal defaults, widget z-index styling, and rendering order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->