### PR TITLE
fix(router): preserve forward stack on guard redirect during forward()

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -434,7 +434,11 @@ export class Router {
 
         if (typeof guardResult === 'string') {
             this._forwardStack.pop();
-            this.push(guardResult);
+            this._executeNavigation(guardResult, {
+                modifyHistory: 'push',
+                clearForwardStack: false,
+                direction: 'forward',
+            });
             return;
         }
 


### PR DESCRIPTION
## Summary
Fixes #2465 — When `router.forward()` hit a navigation guard that redirected,
it called `this.push()` which only pushes onto the **backward** stack, not the
forward stack. This meant the forward history was permanently lost.

## Changes
- `packages/router/src/router.ts`: Changed the guard redirect path inside
  `forward()` to use `_executeNavigation()` instead of `this.push()`, which
  correctly pushes onto the backward stack and clears the forward stack.

## Testing
- Verified that `forward()` with a guard redirect preserves the forward stack
  correctly.