### PR TITLE
fix(core): pass gap parameter to resolveConstraints for constraint layout mode

### DIFF
--- a/packages/core/src/layout/LayoutEngine.ts
+++ b/packages/core/src/layout/LayoutEngine.ts
@@ -349,7 +349,7 @@ function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, p
         else if (style.justifyContent === 'center') flexJustify = Flex.Center;
         else if (style.justifyContent === 'flex-end') flexJustify = Flex.End;
         
-        const results = resolveConstraints(mainAvail, style.constraints, flexJustify);
+        const results = resolveConstraints(mainAvail, style.constraints, flexJustify, gap);
         
         let visibleIndex = 0;
         for (let i = 0; i < node.children.length; i++) {


### PR DESCRIPTION
## Summary
Fixes #2467 — The constraint layout path called `resolveConstraints()` without
passing the `gap` parameter, so gap-based spacing was silently ignored for
constraint-mode layouts.

## Changes
- `packages/core/src/layout/LayoutEngine.ts`: Passed the `gap` parameter to
  the `resolveConstraints()` call in the constraint layout mode.

## Testing
- Verified that constraint-mode layouts respect the gap setting.