### PR TITLE
test(data): add unit tests for reactive data hooks

### DIFF
--- a/packages/data/src/hooks.test.ts
+++ b/packages/data/src/hooks.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render } from "@termuijs/testing";
+import { h } from "@termuijs/jsx";
+import {
+    useCpu,
+    useMemory,
+    useDisk,
+    useNetwork,
+    useSystemInfo,
+    useTopProcesses,
+    type CpuMetrics,
+    type MemoryMetrics,
+    type DiskMetrics,
+    type NetworkMetrics,
+    type SystemInfo,
+} from "./hooks.js";
+
+function renderHook<T>(factory: () => T) {
+    let value!: T;
+    function Probe() {
+        value = factory();
+        return h("text", null, "probe");
+    }
+    const screen = render(h(Probe, null));
+    return {
+        get current() {
+            return value;
+        },
+        unmount: () => screen.unmount(),
+    };
+}
+
+describe("data reactive hooks", () => {
+    const probes = [] as Array<{ unmount: () => void }>;
+
+    afterEach(() => {
+        while (probes.length) probes.pop()?.unmount();
+    });
+
+    it("useCpu exposes a numeric metrics snapshot", () => {
+        const { current, unmount } = renderHook(() => useCpu(100_000));
+        probes.push({ unmount });
+        const m = current as CpuMetrics;
+        expect(typeof m.percent).toBe("number");
+        expect(Array.isArray(m.perCore)).toBe(true);
+        expect(typeof m.model).toBe("string");
+    });
+
+    it("useMemory exposes used/free/total strings", () => {
+        const { current, unmount } = renderHook(() => useMemory(100_000));
+        probes.push({ unmount });
+        const m = current as MemoryMetrics;
+        expect(typeof m.used).toBe("string");
+        expect(typeof m.total).toBe("string");
+        expect(typeof m.percent).toBe("number");
+    });
+
+    it("useDisk exposes partitions and percent", () => {
+        const { current, unmount } = renderHook(() => useDisk(100_000));
+        probes.push({ unmount });
+        const m = current as DiskMetrics;
+        expect(Array.isArray(m.partitions)).toBe(true);
+        expect(typeof m.percent).toBe("number");
+    });
+
+    it("useNetwork exposes interface list and hostname", () => {
+        const { current, unmount } = renderHook(() => useNetwork(100_000));
+        probes.push({ unmount });
+        const m = current as NetworkMetrics;
+        expect(Array.isArray(m.interfaces)).toBe(true);
+        expect(typeof m.hostname).toBe("string");
+    });
+
+    it("useSystemInfo captures a static snapshot", () => {
+        const { current, unmount } = renderHook(() => useSystemInfo());
+        probes.push({ unmount });
+        const m = current as SystemInfo;
+        expect(typeof m.platform).toBe("string");
+        expect(typeof m.uptimeSeconds).toBe("number");
+        expect(typeof m.nodeVersion).toBe("string");
+    });
+
+    it("useTopProcesses returns an array", () => {
+        const { current, unmount } = renderHook(() => useTopProcesses(5, 100_000));
+        probes.push({ unmount });
+        expect(Array.isArray(current)).toBe(true);
+    });
+});


### PR DESCRIPTION
Add unit tests covering the synchronous reactive hooks in packages/data/src/hooks.ts (useCpu, useMemory, useDisk, useNetwork, useSystemInfo, useTopProcesses). These verify that each hook returns a correctly-shaped metrics snapshot without throwing. Increases coverage of the data package public hook API.

Closes the linked issue.

GSSoC26

Closes #2477

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for data monitoring hooks.
  * Verified CPU, memory, disk, network, system information, and top-process metrics return the expected data types and structures.
  * Added cleanup handling to ensure test components are properly unmounted after each test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->