### PR TITLE
test(jsx): add unit tests for FocusContext

### DIFF
--- a/packages/jsx/src/focus-context.test.ts
+++ b/packages/jsx/src/focus-context.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { FocusContext, type FocusContextValue } from './focus-context.js';
+
+describe('FocusContext', () => {
+    it('exposes a Provider component', () => {
+        expect(typeof FocusContext.Provider).toBe('function');
+    });
+
+    it('has a unique internal id symbol', () => {
+        expect(typeof FocusContext._id).toBe('symbol');
+    });
+
+    it('defaults to no focused element', () => {
+        const value = FocusContext.defaultValue as FocusContextValue;
+        expect(value.focused).toBeNull();
+    });
+
+    it('default focus/blur handlers are safe no-ops', () => {
+        const value = FocusContext.defaultValue as FocusContextValue;
+        expect(typeof value.focus).toBe('function');
+        expect(typeof value.blur).toBe('function');
+        expect(() => value.focus('element-1')).not.toThrow();
+        expect(() => value.blur()).not.toThrow();
+    });
+});


### PR DESCRIPTION
Add unit tests for packages/jsx/src/focus-context.ts. The tests verify that FocusContext exposes a Provider component, carries a unique internal id symbol, defaults to a null focused element, and that its default focus/blur handlers are safe no-ops. Improves coverage of the jsx focus propagation API.

Closes the linked issue.

GSSoC26

Closes #2479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage validating the focus context’s provider, identifier, default state, and safe focus/blur handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->