### PR TITLE
test(widgets): add public API smoke test for index

### DIFF
--- a/packages/widgets/src/index.test.ts
+++ b/packages/widgets/src/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as pkg from './index.js';
+
+describe('@termuijs/widgets public API', () => {
+    it('exposes the expected public surface', () => {
+        expect(pkg.Widget).toBeDefined();
+        expect(pkg.Box).toBeDefined();
+    });
+});


### PR DESCRIPTION
Add a smoke test that imports the package entry point (index) and asserts that the expected public symbols are exported. This guards against accidental breakage of the public API surface in widgets.

Closes the linked issue.

GSSoC26

Closes #2483