### PR TITLE
test(ui): add public API smoke test for index

### DIFF
--- a/packages/ui/src/index.test.ts
+++ b/packages/ui/src/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as pkg from './index.js';
+
+describe('@termuijs/ui public API', () => {
+    it('exposes the expected public surface', () => {
+        expect(pkg.Slider).toBeDefined();
+        expect(pkg.RangeInput).toBeDefined();
+    });
+});


### PR DESCRIPTION
Add a smoke test that imports the package entry point (index) and asserts that the expected public symbols are exported. This guards against accidental breakage of the public API surface in ui.

Closes the linked issue.

GSSoC26

Closes #2485