### PR TITLE
docs(core): add JSDoc to CommandHistory

### DIFF
--- a/packages/core/src/history/CommandHistory.ts
+++ b/packages/core/src/history/CommandHistory.ts
@@ -1,7 +1,18 @@
+/**
+ * Options for configuring a {@link CommandHistory} instance.
+ */
 export interface CommandHistoryOptions {
+    /** Maximum number of commands retained. Defaults to 100. */
     maxSize?: number;
 }
 
+/**
+ * A simple in-memory command history with shell-style navigation.
+ *
+ * Tracks entered commands and supports walking backwards/forwards with
+ * `previous()`/`next()`, fuzzy `search()`, and serialisation via
+ * `export()`/`import()`.
+ */
 export class CommandHistory {
     private commands: string[] = [];
     private index = -1;
@@ -11,6 +22,10 @@ export class CommandHistory {
         this.maxSize = options.maxSize ?? 100;
     }
 
+    /**
+     * Append a command to the history.
+     * Blank/whitespace-only commands are ignored. Trims to `maxSize`.
+     */
     add(command: string): void {
         if (!command.trim()) return;
 
@@ -23,6 +38,9 @@ export class CommandHistory {
         this.index = this.commands.length;
     }
 
+    /**
+     * Move the cursor back one entry and return it, or `null` at the start.
+     */
     previous(): string | null {
         if (this.commands.length === 0) {
             return null;
@@ -32,6 +50,9 @@ export class CommandHistory {
         return this.commands[this.index];
     }
 
+    /**
+     * Move the cursor forward one entry and return it, or `null` past the end.
+     */
     next(): string | null {
         if (this.commands.length === 0) {
             return null;
@@ -49,6 +70,9 @@ export class CommandHistory {
         return this.commands[this.index];
     }
 
+    /**
+     * Return every command containing `query` (case-insensitive substring match).
+     */
     search(query: string): string[] {
         const value = query.toLowerCase();
 
@@ -57,19 +81,23 @@ export class CommandHistory {
         );
     }
 
+    /** Return a shallow copy of all stored commands. */
     getAll(): string[] {
         return [...this.commands];
     }
 
+    /** Remove all commands and reset the navigation cursor. */
     clear(): void {
         this.commands = [];
         this.index = -1;
     }
 
+    /** Serialise the history to a JSON string for persistence. */
     export(): string {
         return JSON.stringify(this.commands);
     }
 
+    /** Restore history from a JSON string produced by {@link export}. */
     import(data: string): void {
         const parsed: string[] = JSON.parse(data);
         this.commands = parsed.slice(-this.maxSize);


### PR DESCRIPTION
Add JSDoc documentation to packages/core/src/history/CommandHistory.ts describing the public symbols and their behaviour. Improves API discoverability and matches the project's documentation standards.

Closes the linked issue.

GSSoC26

Closes #2506