### PR TITLE
docs(core): add JSDoc to ChordMatcher

### DIFF
--- a/packages/core/src/input/ChordMatcher.ts
+++ b/packages/core/src/input/ChordMatcher.ts
@@ -4,13 +4,21 @@
 
 import type { KeyEvent } from '../events/types.js';
 
+/**
+ * A single key sequence binding: an ordered list of key tokens and its handler.
+ */
 export interface Chord {
   keys: string[];
   handler: () => void;
 }
 
+/**
+ * Configuration for a {@link ChordMatcher}.
+ */
 export interface ChordMatcherOptions {
+  /** Idle time before an in-progress sequence is discarded. Defaults to 800ms. */
   timeoutMs?: number;
+  /** Maximum number of buffered tokens before the buffer is reset. Defaults to 10. */
   maxBufferSize?: number;
 }
 
@@ -23,6 +31,13 @@ function getKeyEventToken(event: KeyEvent): string {
   return token;
 }
 
+/**
+ * Matches multi-key "chords" (e.g. `ctrl+k ctrl+s`) from a stream of key events.
+ *
+ * Each call to {@link feed} advances an internal buffer and fires the handler
+ * of any binding whose full sequence matches. A timeout resets the buffer if
+ * the sequence is not completed in time.
+ */
 export class ChordMatcher {
   private _bindings: { keys: string[]; handler: () => void; id: number }[] = [];
   private _nextId = 0;
@@ -36,6 +51,9 @@ export class ChordMatcher {
     this._maxBufferSize = opts?.maxBufferSize ?? 10;
   }
 
+  /**
+   * Register a chord. Returns an unbind function that removes the binding.
+   */
   bind(keys: string[], handler: () => void): () => void {
     const id = this._nextId++;
     this._bindings.push({ keys, handler, id });
@@ -44,6 +62,10 @@ export class ChordMatcher {
     };
   }
 
+  /**
+   * Feed a key event into the matcher.
+   * @returns `true` if the token advanced or completed a binding, `false` if it matched nothing.
+   */
   feed(event: KeyEvent): boolean {
     if (this._timer) {
       clearTimeout(this._timer);


### PR DESCRIPTION
Add JSDoc documentation to packages/core/src/input/ChordMatcher.ts describing the public symbols and their behaviour. Improves API discoverability and matches the project's documentation standards.

Closes the linked issue.

GSSoC26

Closes #2508