### PR TITLE
docs(cli): add JSDoc to parseArgs and CliArgs

### DIFF
--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -1,11 +1,25 @@
+/**
+ * Parsed command-line arguments for the `@termuijs/cli` binary.
+ */
 export interface CliArgs {
+    /** Subcommand to run. Unknown/empty values default to `help`. */
     command: 'add' | 'list' | 'help';
+    /** Component names passed as positional arguments. */
     components: string[];
+    /** Target directory for `--dir`. */
     dir?: string;
+    /** When true, perform a dry run without writing changes. */
     dryRun: boolean;
+    /** When true, skip interactive confirmation prompts. */
     yes: boolean;
 }
 
+/**
+ * Parse a `process.argv`-style array (excluding the node/script entries) into a
+ * {@link CliArgs} object. Supports `--dir <path>`, `--dry-run`, `--yes`/`-y`.
+ *
+ * @throws Error if `--dir` is not followed by a non-flag value.
+ */
 export function parseArgs(argv: string[]): CliArgs {
     const [cmd, ...rest] = argv;
     const command: CliArgs['command'] =


### PR DESCRIPTION
Add JSDoc documentation to packages/cli/src/args.ts describing the public symbols and their behaviour. Improves API discoverability and matches the project's documentation standards.

Closes the linked issue.

GSSoC26

Closes #2516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-line argument parsing for commands, component names, directory selection, dry-run mode, and automatic confirmation.
  * Unrecognized or missing commands now default to the help command.
  * Added validation for missing directory values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->