### PR TITLE
docs(widgets): add JSDoc to calculateSpringScroll

### DIFF
--- a/packages/widgets/src/scroll.ts
+++ b/packages/widgets/src/scroll.ts
@@ -1,9 +1,19 @@
-// Spring scroll helper
+/**
+ * State of a spring-driven scroll animation.
+ */
 export interface ScrollSpringState {
+    /** Current scroll offset. */
     position: number;
+    /** Current scroll velocity. */
     velocity: number;
 }
 
+/**
+ * Advance a scroll spring by `dt` seconds toward `target`.
+ *
+ * Uses a damped-spring model (stiffness 0.15, damping 0.8) so scrolling eases
+ * into place instead of snapping. Pure and allocation-light.
+ */
 export const calculateSpringScroll = (
     current: ScrollSpringState,
     target: number,


### PR DESCRIPTION
Add JSDoc documentation to packages/widgets/src/scroll.ts describing the public symbols and their behaviour. Improves API discoverability and matches the project's documentation standards.

Closes the linked issue.

GSSoC26

Closes #2518