### PR TITLE
docs(ui): add JSDoc to validateInput and InputValidator

### DIFF
--- a/packages/ui/src/validation.ts
+++ b/packages/ui/src/validation.ts
@@ -1,9 +1,21 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 
+/**
+ * A validator for interactive inputs. Either a Standard Schema (v1) or a
+ * function returning an error message (or `undefined`/`null` when valid).
+ * May be synchronous or asynchronous.
+ */
 export type InputValidator =
     | StandardSchemaV1
     | ((v: unknown) => string | undefined | null | Promise<string | undefined | null>);
 
+/**
+ * Run `validator` against `value` and return the first error message, or
+ * `undefined` when the value is valid.
+ *
+ * Supports both function validators and Standard Schema validators, including
+ * the async (`Promise`) variants of either.
+ */
 export async function validateInput(
     validator: InputValidator | undefined,
     value: unknown,


### PR DESCRIPTION
Add JSDoc documentation to packages/ui/src/validation.ts describing the public symbols and their behaviour. Improves API discoverability and matches the project's documentation standards.

Closes the linked issue.

GSSoC26

Closes #2520