### PR TITLE
docs(tss): add JSDoc to evalCalc

### DIFF
--- a/packages/tss/src/calc.ts
+++ b/packages/tss/src/calc.ts
@@ -1,3 +1,11 @@
+/**
+ * Evaluate a CSS-like `calc(...)` expression with optional `var(--name)` lookups.
+ *
+ * @param expression - The expression, e.g. `calc(10 + var(gap) * 2)`.
+ * @param variables - Map of variable names to their string values.
+ * @returns The computed numeric result.
+ * @throws Error if the expression is malformed or a variable is missing.
+ */
 export function evalCalc(
     expression: string,
     variables: Record<string, string>,


### PR DESCRIPTION
Add JSDoc documentation to packages/tss/src/calc.ts describing the public symbols and their behaviour. Improves API discoverability and matches the project's documentation standards.

Closes the linked issue.

GSSoC26

Closes #2524