### PR TITLE
fix(core): export stripAnsiControl as a named export

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -99,7 +99,7 @@ export { stripAnsiEscapes, hasAnsiEscapes, sanitizeForDisplay } from './terminal
 export { debounce } from './utils/debounce.js';
 export type { DebounceOptions } from './utils/debounce.js';
 export * from './session/Session.js';
-export { writeClipboard, readClipboard } from './utils/ansi.js';
+export { writeClipboard, readClipboard, stripAnsiControl } from './utils/ansi.js';
 export { throttle } from './utils/throttle.js';
 export type { ThrottleOptions } from './utils/throttle.js';
 export { CommandHistory } from "./history/CommandHistory.js";


### PR DESCRIPTION
`main` is red. #1844 (Toast escape-injection fix) imports `stripAnsiControl` from `@termuijs/core`, but `packages/core/src/index.ts` only re-exported it inside the `ansi` namespace, never as a named export.

Result: `@termuijs/ui` fails its dts build.

```
src/Toast.ts(3,23): error TS2459: Module '"@termuijs/core"' declares 'stripAnsiControl' locally, but it is not exported.
```

Fix is one line: add `stripAnsiControl` to the named re-export already present on that line.

Verified locally: `bunx turbo build` -> 45/45 tasks successful.

Co-authored-by: Karanjot786 <karanjots801@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `stripAnsiControl` utility to the public API for removing ANSI control sequences from text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->