### PR TITLE
fix: call clearFocus before unmountAll in router back() and forward()

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -396,6 +396,8 @@ export class Router {
         }
 
         this._currentMatch = match;
+        const app = getCurrentApp();
+        if (app) app.focus.clearFocus();
         if (this.autoUnmount) unmountAll();
         const screen = this.wrapScreen(match);
 
@@ -445,6 +447,8 @@ export class Router {
         this._forwardStack.pop();
         this._history.push(nextPath);
         this._currentMatch = match;
+        const fwdApp = getCurrentApp();
+        if (fwdApp) fwdApp.focus.clearFocus();
         if (this.autoUnmount) unmountAll();
         const screen = this.wrapScreen(match);
         this.events.emit('navigate', { match, screen, direction: 'forward' });


### PR DESCRIPTION
## Summary
Clear focus state before unmounting components in `back()` and `forward()` router methods.

## Problem
When navigating via `back()` or `forward()`, the previous app's focus state wasn't cleared before unmounting, causing stale focus pointers that led to `Cannot read properties of undefined (reading 'off')` errors and visual glitches on the next navigation.

## Changes
- `router.ts:126`: Added `getCurrentApp()?.focus.clearFocus()` before `unmountAll()` in the `back()` success path
- `router.ts:148`: Added `getCurrentApp()?.focus.clearFocus()` before `unmountAll()` in the `forward()` success path

## Testing
- Focus is properly cleared when navigating back/forward
- No more "Cannot read properties of undefined" errors after multi-app navigation

Fixes #2536
