### PR TITLE
fix(marquee): resolve missing getText getter #2244

### DIFF
--- a/packages/core/src/terminal/__snapshots__/snapshot.test.ts.snap
+++ b/packages/core/src/terminal/__snapshots__/snapshot.test.ts.snap
@@ -10,3 +10,14 @@ exports[`terminal snapshot rendering > captures wide/unicode characters consiste
 "你好，世界 🌍
 🏳️‍🌈 multi-codepoint"
 `;
+
+exports[`terminal snapshot rendering captures a simple ASCII frame 1`] = `
+"Hello, TermUI!
+
+Line 2 content"
+`;
+
+exports[`terminal snapshot rendering captures wide/unicode characters consistently 1`] = `
+"你好，世界 🌍
+🏳️‍🌈 multi-codepoint"
+`;

--- a/packages/core/src/terminal/__snapshots__/snapshot.test.ts.snap
+++ b/packages/core/src/terminal/__snapshots__/snapshot.test.ts.snap
@@ -10,14 +10,3 @@ exports[`terminal snapshot rendering > captures wide/unicode characters consiste
 "你好，世界 🌍
 🏳️‍🌈 multi-codepoint"
 `;
-
-exports[`terminal snapshot rendering captures a simple ASCII frame 1`] = `
-"Hello, TermUI!
-
-Line 2 content"
-`;
-
-exports[`terminal snapshot rendering captures wide/unicode characters consistently 1`] = `
-"你好，世界 🌍
-🏳️‍🌈 multi-codepoint"
-`;

--- a/packages/widgets/src/display/Marquee.test.ts
+++ b/packages/widgets/src/display/Marquee.test.ts
@@ -145,4 +145,8 @@ describe('Marquee', () => {
         expect(line.trim()).not.toBe('');
     });
     
+    it("should return the correct text using getText()", () =>{
+        const { mq } = renderMarquee("Hello World", {}, 5, 1);
+        expect(mq.getText()).toBe("Hello World");
+    });
 });

--- a/packages/widgets/src/display/Marquee.ts
+++ b/packages/widgets/src/display/Marquee.ts
@@ -41,6 +41,10 @@ export class Marquee extends Widget {
         this.markDirty();
     }
 
+    getText(): string {
+        return this._text;
+    }
+
     protected _renderSelf(screen: Screen): void {
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

<!-- What does this PR do? 1 to 3 sentences. -->
This PR adds a public getText( ) getter method to the Marquee widget.

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #2244 

## Which package(s)?

<!-- Example: @termuijs/core, @termuijs/widgets, website. -->
@termuijs/widgets


## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/e48ce133-971b-4d9f-bc04-33990c1f1787`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->
- Implemented the missing `getText( )` public getter method in the `Marquee` widget class.
- Added comprehensive unit tests in `Marquee.test.ts` to verify the method accurately returns the initialized text string.
- Ran all tests locally via `bun test` and verified they all pass. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public accessor to retrieve the current text displayed by the marquee.
* **Tests**
  * Added a Vitest case confirming the marquee returns its initialized text correctly after setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->