### PR TITLE
Fix Autocomplete grapheme backspace

### DIFF
--- a/packages/ui/src/Autocomplete.test.ts
+++ b/packages/ui/src/Autocomplete.test.ts
@@ -70,6 +70,17 @@ describe('Autocomplete', () => {
         expect(onChange).toHaveBeenCalledWith('ap');
     });
 
+    it('backspace removes one grapheme from the query', () => {
+        const onChange = vi.fn();
+        const widget = new Autocomplete({}, { items: [], onChange });
+
+        widget.query = 'Cafe\u0301';
+        widget.handleKey(makeKey('backspace'));
+
+        expect(widget.query).toBe('Caf');
+        expect(onChange).toHaveBeenCalledWith('Caf');
+    });
+
     it('arrow keys and tab navigate suggestions list', () => {
         const widget = new Autocomplete({}, {
             items: ['apple', 'apricot', 'banana'],

--- a/packages/ui/src/Autocomplete.ts
+++ b/packages/ui/src/Autocomplete.ts
@@ -12,7 +12,8 @@ import {
     styleToCellAttrs,
     caps,
     truncate,
-    stringWidth
+    stringWidth,
+    splitGraphemes
 } from '@termuijs/core';
 import { Widget } from '@termuijs/widgets';
 
@@ -143,7 +144,7 @@ export class Autocomplete extends Widget {
 
         if (key === 'backspace') {
             if (this._query.length > 0) {
-                this._query = this._query.slice(0, -1);
+                this._query = splitGraphemes(this._query).slice(0, -1).join('');
                 this._isOpen = true;
                 this._selectedIndex = -1;
                 this._onChange?.(this._query);


### PR DESCRIPTION
﻿## Summary
- removes the last query grapheme instead of the last UTF-16 code unit
- adds a regression test for combining-mark input

## Validation
- npx --yes bun@1.3.14 vitest run packages/ui/src/Autocomplete.test.ts

Closes #2545


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Autocomplete backspace handling for accented characters and other complex Unicode characters.
  * Backspace now removes one complete visible character at a time without leaving partial character fragments.

* **Tests**
  * Added coverage to verify correct deletion of combining-character text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->