### PR TITLE
Fix SearchableSelect grapheme backspace

### DIFF
--- a/packages/ui/src/SearchableSelect.test.ts
+++ b/packages/ui/src/SearchableSelect.test.ts
@@ -88,6 +88,17 @@ describe('SearchableSelect', () => {
         expect(widget.filteredOptions[1].label).toBe('Alpine');
     });
 
+    it('backspace removes one grapheme from searchQuery', () => {
+        const widget = new SearchableSelect([
+            { label: 'Cafe', value: 'cafe' },
+        ]);
+
+        typeQuery(widget, 'Cafe\u0301');
+        widget.handleKey(makeKey('backspace'));
+
+        expect(widget.searchQuery).toBe('Caf');
+    });
+
     it('typing characters appends to searchQuery', () => {
         const widget = new SearchableSelect(sampleOptions);
         widget.handleKey(makeKey('h'));

--- a/packages/ui/src/SearchableSelect.ts
+++ b/packages/ui/src/SearchableSelect.ts
@@ -1,6 +1,6 @@
 // SearchableSelect — searchable dropdown selector with filtering
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, caps, truncate } from '@termuijs/core';
+import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, caps, truncate, splitGraphemes } from '@termuijs/core';
 
 export interface SearchableSelectOption {
     label: string;
@@ -61,7 +61,7 @@ export class SearchableSelect extends Widget {
         }
 
         if (event.key === 'backspace') {
-            this._searchQuery = this._searchQuery.slice(0, -1);
+            this._searchQuery = splitGraphemes(this._searchQuery).slice(0, -1).join('');
             this._filterOptions();
             this._selectedIndex = 0;
             this.markDirty();


### PR DESCRIPTION
﻿## Summary
- deletes the last search grapheme instead of the last UTF-16 code unit
- adds regression coverage for combining-mark input

## Validation
- npx --yes bun@1.3.14 vitest run packages/ui/src/SearchableSelect.test.ts

Closes #2546


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Backspace behavior in searchable selections to remove one complete character, including accented and combined characters.
  * Preserved filtering and selection updates after deleting text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->