### PR TITLE
Fix TagInput grapheme backspace

### DIFF
--- a/packages/ui/src/TagInput.test.ts
+++ b/packages/ui/src/TagInput.test.ts
@@ -72,6 +72,18 @@ describe('TagInput', () => {
         expect(ti.tags).toEqual(['keep', 'a']);
     });
 
+    it('backspace on draft removes one grapheme', () => {
+        const ti = new TagInput();
+
+        for (const ch of 'Cafe\u0301') {
+            ti.handleKey(key(ch));
+        }
+        ti.handleKey(key('backspace'));
+        ti.handleKey(key('enter'));
+
+        expect(ti.tags).toEqual(['Caf']);
+    });
+
     it('placeholder renders when empty', () => {
         const ti = new TagInput({}, { placeholder: 'Add tags...' });
         const output = renderToString(ti);

--- a/packages/ui/src/TagInput.ts
+++ b/packages/ui/src/TagInput.ts
@@ -11,7 +11,7 @@
 // ─────────────────────────────────────────────────────
 
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, stringWidth, truncate, caps } from '@termuijs/core';
+import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, stringWidth, truncate, caps, splitGraphemes } from '@termuijs/core';
 
 export interface TagInputOptions {
     placeholder?: string;
@@ -77,7 +77,7 @@ export class TagInput extends Widget {
 
             case 'backspace':
                 if (this._draft.length > 0) {
-                    this._draft = this._draft.slice(0, -1);
+                    this._draft = splitGraphemes(this._draft).slice(0, -1).join('');
                     this.markDirty();
                 } else {
                     this.removeLast();


### PR DESCRIPTION
﻿## Summary
- removes the last draft grapheme when backspace is pressed
- adds regression coverage for combining-mark draft text

## Validation
- npx --yes bun@1.3.14 vitest run packages/ui/src/TagInput.test.ts

Closes #2547
