### PR TITLE
Constrain BasicAuthPrompt render width

### DIFF
--- a/packages/ui/src/BasicAuthPrompt.test.ts
+++ b/packages/ui/src/BasicAuthPrompt.test.ts
@@ -458,6 +458,23 @@ describe("BasicAuthPrompt – long input strings", () => {
         widget.updateRect({ x: 0, y: 0, width: 80, height: 10 });
         expect(() => widget.render(screen)).not.toThrow();
     });
+
+    it("truncates rendered credential rows to the widget width", () => {
+        const widget = new BasicAuthPrompt();
+        typeInto(widget, "a".repeat(50));
+        pressEnter(widget);
+        typeInto(widget, "b".repeat(50));
+
+        const screen = new Screen(12, 2);
+        const writeSpy = vi.spyOn(screen, "writeString");
+        widget.updateRect({ x: 0, y: 0, width: 12, height: 2 });
+        widget.render(screen);
+
+        expect(writeSpy).toHaveBeenCalledTimes(2);
+        for (const call of writeSpy.mock.calls) {
+            expect(call[2].length).toBeLessThanOrEqual(12);
+        }
+    });
 });
 
 // ─── 9. Password mask length matches password length ─────────────────────────

--- a/packages/ui/src/BasicAuthPrompt.ts
+++ b/packages/ui/src/BasicAuthPrompt.ts
@@ -1,5 +1,5 @@
 import { Widget } from "@termuijs/widgets";
-import { type Style, type KeyEvent, Screen, caps } from "@termuijs/core";
+import { type Style, type KeyEvent, Screen, caps, truncate } from "@termuijs/core";
 
 export interface BasicAuthCredentials {
     username: string;
@@ -81,9 +81,9 @@ export class BasicAuthPrompt extends Widget {
         const username = `${this._opts.usernameLabel} ${this._username}`;
         const masked = this._maskChar.repeat(this._password.length);
         const password = `${this._opts.passwordLabel} ${masked}`;
-        screen.writeString(x, y, username);
+        screen.writeString(x, y, truncate(username, width));
         if (height > 1) {
-            screen.writeString(x, y + 1, password);
+            screen.writeString(x, y + 1, truncate(password, width));
         }
     }
 }


### PR DESCRIPTION
﻿## Summary
- truncates username and password rows to the content width before rendering
- adds a narrow-width regression test for long credential input

## Validation
- npx --yes bun@1.3.14 vitest run packages/ui/src/BasicAuthPrompt.test.ts

Closes #2548
