### PR TITLE
Render SurveyPrompt inside content rect

### DIFF
--- a/packages/ui/src/SurveyPrompt.test.ts
+++ b/packages/ui/src/SurveyPrompt.test.ts
@@ -34,6 +34,17 @@ describe("SurveyPrompt", () => {
         expect(text).toContain("1 / 2");
     });
 
+    it("renders content inside the content rect", () => {
+        const prompt = new SurveyPrompt(QUESTIONS, { border: "single" });
+        const screen = new Screen(40, 10);
+
+        prompt.updateRect({ x: 0, y: 0, width: 40, height: 10 });
+        prompt.render(screen);
+
+        expect(screen.back[1][0].char).not.toBe("1");
+        expect(screen.back[1][1].char).toBe("1");
+    });
+
     it("enter on a text question advances to question 2", () => {
         const prompt = new SurveyPrompt(QUESTIONS);
 

--- a/packages/ui/src/SurveyPrompt.ts
+++ b/packages/ui/src/SurveyPrompt.ts
@@ -124,7 +124,7 @@ export class SurveyPrompt extends Widget {
     }
 
     protected _renderSelf(screen: Screen): void {
-        const { x, y, width, height } = this._rect;
+        const { x, y, width, height } = this._getContentRect();
 
         if (width <= 0 || height <= 0) return;
 


### PR DESCRIPTION
﻿## Summary
- renders SurveyPrompt content from the content rect instead of the outer widget rect
- adds regression coverage for bordered prompts

## Validation
- npx --yes bun@1.3.14 vitest run packages/ui/src/SurveyPrompt.test.ts

Closes #2549
