### PR TITLE
Validate NumberInput options

### DIFF
--- a/packages/ui/src/NumberInput.test.ts
+++ b/packages/ui/src/NumberInput.test.ts
@@ -94,4 +94,16 @@ describe('NumberInput', () => {
         expect(onChange).toHaveBeenLastCalledWith(10);
         expect(onSubmit).toHaveBeenCalledWith(10);
     });
+
+    it('rejects invalid step options', () => {
+        expect(() => new NumberInput({}, { step: 0 })).toThrow(RangeError);
+        expect(() => new NumberInput({}, { step: -1 })).toThrow(RangeError);
+        expect(() => new NumberInput({}, { step: NaN })).toThrow(RangeError);
+    });
+
+    it('rejects invalid range options', () => {
+        expect(() => new NumberInput({}, { min: NaN })).toThrow(RangeError);
+        expect(() => new NumberInput({}, { max: NaN })).toThrow(RangeError);
+        expect(() => new NumberInput({}, { min: 10, max: 0 })).toThrow(RangeError);
+    });
 });

--- a/packages/ui/src/NumberInput.ts
+++ b/packages/ui/src/NumberInput.ts
@@ -41,8 +41,21 @@ export class NumberInput extends Widget {
         options: NumberInputOptions = {},
     ) {
         super({ border: 'single', height: 3, ...style });
+        const step = options.step ?? 1;
+        if (!Number.isFinite(step) || step <= 0) {
+            throw new RangeError('NumberInput step must be a finite positive number');
+        }
+        if (options.min !== undefined && !Number.isFinite(options.min)) {
+            throw new RangeError('NumberInput min must be a finite number');
+        }
+        if (options.max !== undefined && !Number.isFinite(options.max)) {
+            throw new RangeError('NumberInput max must be a finite number');
+        }
+        if (options.min !== undefined && options.max !== undefined && options.min > options.max) {
+            throw new RangeError('NumberInput min must be less than or equal to max');
+        }
         this._placeholder = options.placeholder ?? '';
-        this._step = options.step ?? 1;
+        this._step = step;
         this._min = options.min ?? -Infinity;
         this._max = options.max ?? Infinity;
         this._allowDecimal = options.allowDecimal ?? true;


### PR DESCRIPTION
﻿## Summary
- validates step, min, and max options during construction
- rejects non-finite steps, non-positive steps, non-finite explicit bounds, and inverted ranges
- adds regression coverage for invalid option combinations

## Validation
- npx --yes bun@1.3.14 vitest run packages/ui/src/NumberInput.test.ts

Closes #2550
