### PR TITLE
Keep Rating state finite

### DIFF
--- a/packages/ui/src/Rating.test.ts
+++ b/packages/ui/src/Rating.test.ts
@@ -146,6 +146,27 @@ describe('Rating', () => {
         expect(rating.max).toBe(10);
     });
 
+    it('defaults to a finite max when max is NaN', () => {
+        const { rating } = renderRating({ max: NaN });
+        expect(rating.max).toBe(5);
+        expect(Number.isNaN(rating.max)).toBe(false);
+    });
+
+    it('defaults to zero when initial value is NaN', () => {
+        const { rating } = renderRating({ value: NaN });
+        expect(rating.getValue()).toBe(0);
+        expect(Number.isNaN(rating.getValue())).toBe(false);
+    });
+
+    it('does not store NaN from setValue', () => {
+        const { rating } = renderRating({ value: 3 });
+
+        rating.setValue(NaN);
+
+        expect(rating.getValue()).toBe(0);
+        expect(Number.isNaN(rating.getValue())).toBe(false);
+    });
+
     it('defaults to max 5 and value 0', () => {
         const { rating } = renderRating();
         expect(rating.max).toBe(5);

--- a/packages/ui/src/Rating.ts
+++ b/packages/ui/src/Rating.ts
@@ -55,12 +55,15 @@ export class Rating extends Widget {
     focusable = true;
 
     constructor(style: Partial<Style> = {}, opts: RatingOptions = {}) {
-        const max = Math.max(opts.max ?? 5, 1);
+        const rawMax = opts.max ?? 5;
+        const max = Number.isFinite(rawMax) ? Math.max(Math.floor(rawMax), 1) : 5;
+        const rawValue = opts.value ?? 0;
+        const value = Number.isFinite(rawValue) ? rawValue : 0;
 
         super(mergeStyles(defaultStyle(), { ...style, height: 1 }));
 
         this._max = max;
-        this._value = Math.max(0, Math.min(opts.value ?? 0, max));
+        this._value = Math.max(0, Math.min(value, max));
         this._filledChar = opts.filledChar;
         this._emptyChar = opts.emptyChar;
         this._filledColor = opts.filledColor;
@@ -83,7 +86,8 @@ export class Rating extends Widget {
 
     /** Set the rating value (clamped to 0..max). Calls markDirty(). */
     setValue(value: number): void {
-        const clamped = Math.max(0, Math.min(value, this._max));
+        const finiteValue = Number.isFinite(value) ? value : 0;
+        const clamped = Math.max(0, Math.min(finiteValue, this._max));
         if (clamped === this._value) return;
         this._value = clamped;
         this.markDirty();


### PR DESCRIPTION
﻿## Summary
- normalizes non-finite max and value inputs during construction
- prevents setValue(NaN) from storing NaN state
- adds regression coverage for NaN inputs

## Validation
- npx --yes bun@1.3.14 vitest run packages/ui/src/Rating.test.ts

Closes #2551
