### PR TITLE
Constrain ColorPicker hex row

### DIFF
--- a/packages/ui/src/ColorPicker.test.ts
+++ b/packages/ui/src/ColorPicker.test.ts
@@ -659,6 +659,22 @@ describe('ColorPicker', () => {
             // Should not throw (screen internally guards bounds)
             expect(() => picker.render(screen)).not.toThrow();
         });
+
+        it('truncates the hex input row to the content width', () => {
+            const width = 10;
+            const height = 7;
+            const screen = new Screen(width, height);
+            const picker = new ColorPicker({ value: '#123456' });
+            const writeSpy = vi.spyOn(screen, 'writeString');
+            picker.mount();
+            picker.updateRect({ x: 0, y: 0, width, height });
+
+            picker.render(screen);
+
+            const hexCall = writeSpy.mock.calls.find((call) => String(call[2]).startsWith('Hex'));
+            expect(hexCall).toBeDefined();
+            expect(String(hexCall![2]).length).toBeLessThanOrEqual(width - 2);
+        });
     });
 
     // ── 19. Rendering with small height (< 4) ───────────────────────────────

--- a/packages/ui/src/ColorPicker.ts
+++ b/packages/ui/src/ColorPicker.ts
@@ -20,7 +20,8 @@ import {
     parseColor,
     colorToRgb,
     Color,
-    NamedColor
+    NamedColor,
+    truncate
 } from '@termuijs/core';
 
 export interface ColorPickerOptions {
@@ -216,7 +217,7 @@ export class ColorPicker extends Widget {
         // 2. Render Hex Input & Live Swatch Line (Row 3)
         const hexPrefix = 'Hex: #';
         const hexFull = hexPrefix + this._hexValue;
-        screen.writeString(x, y + 3, hexFull, attrs);
+        screen.writeString(x, y + 3, truncate(hexFull, width), attrs);
 
         // Render input cursor if focused
         if (this.isFocused) {


### PR DESCRIPTION
﻿## Summary
- truncates the ColorPicker hex input row to the content width
- adds a narrow-width regression test for the hex row

## Validation
- npx --yes bun@1.3.14 vitest run packages/ui/src/ColorPicker.test.ts

Closes #2552
