### PR TITLE
Clip narrow Button labels

### DIFF
--- a/packages/widgets/src/input/Button.test.ts
+++ b/packages/widgets/src/input/Button.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { Button } from './Button.js';
-import { Screen, caps } from '@termuijs/core';
+import { Screen, caps, stringWidth } from '@termuijs/core';
 
 afterEach(() => {
     vi.restoreAllMocks();
@@ -36,6 +36,19 @@ describe('Button', () => {
         const { screen } = renderButton('Click');
         const contentRow = rowText(screen, 1);
         expect(contentRow).toContain('Click');
+    });
+
+    it('clips long labels inside narrow button bounds', () => {
+        const button = new Button('Very long label');
+        const screen = new Screen(6, 3);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+        button.updateRect({ x: 0, y: 0, width: 6, height: 3 });
+
+        button.render(screen);
+
+        const labelCall = writeSpy.mock.calls[0];
+        expect(labelCall[0]).toBeGreaterThanOrEqual(1);
+        expect(stringWidth(String(labelCall[2]))).toBeLessThanOrEqual(4);
     });
 
     // ── 2. Variant rendering ─────────────────────────────────────────────

--- a/packages/widgets/src/input/Button.ts
+++ b/packages/widgets/src/input/Button.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets — Button widget
 // ─────────────────────────────────────────────────────
 
-import { type Screen, type Style, type Color, type KeyEvent, stringWidth, caps, prefersReducedMotion } from '@termuijs/core';
+import { type Screen, type Style, type Color, type KeyEvent, stringWidth, caps, prefersReducedMotion, truncate } from '@termuijs/core';
 import { timerPoolSubscribe } from '@termuijs/motion';
 import { Widget } from '../base/Widget.js';
 import { SPINNER_FRAMES } from '../feedback/Spinner.js';
@@ -180,9 +180,11 @@ export class Button extends Widget {
         if (height >= 2) {
             screen.setCell(x, y + 1, { char: vt, fg: borderFg, bg });
             const startX = x + 1;
-            const textStartX = startX + Math.floor((innerWidth - textWidth) / 2);
-            screen.writeString(textStartX, y + 1, padded, { fg: borderFg, bg });
-            for (let c = textStartX + textWidth; c < startX + innerWidth; c++) {
+            const visibleText = truncate(padded, innerWidth, '');
+            const visibleWidth = stringWidth(visibleText);
+            const textStartX = startX + Math.max(0, Math.floor((innerWidth - visibleWidth) / 2));
+            screen.writeString(textStartX, y + 1, visibleText, { fg: borderFg, bg });
+            for (let c = textStartX + visibleWidth; c < startX + innerWidth; c++) {
                 screen.setCell(c, y + 1, { char: ' ', fg: borderFg, bg });
             }
             if (innerWidth + 1 < width) {


### PR DESCRIPTION
﻿## Summary
- clips button label text to the available inner width before centering
- prevents long labels from being written before the button left edge
- adds a narrow-button regression test

## Validation
- npx --yes bun@1.3.14 vitest run packages/widgets/src/input/Button.test.ts

Closes #2553
