### PR TITLE
Reset TypingIndicator on unmount

### DIFF
--- a/packages/widgets/src/display/TypingIndicator.test.ts
+++ b/packages/widgets/src/display/TypingIndicator.test.ts
@@ -92,4 +92,15 @@ describe('TypingIndicator', () => {
         
         expect(clearIntervalSpy).toHaveBeenCalled();
     });
+
+    it('resets running state on unmount so it can restart', () => {
+        const indicator = new TypingIndicator();
+        indicator.start();
+
+        indicator.unmount();
+        expect(indicator.isRunning()).toBe(false);
+
+        indicator.start();
+        expect(indicator.isRunning()).toBe(true);
+    });
 });

--- a/packages/widgets/src/display/TypingIndicator.ts
+++ b/packages/widgets/src/display/TypingIndicator.ts
@@ -71,7 +71,7 @@ export class TypingIndicator extends Widget {
     }
 
     unmount(): void {
-        this._clearInterval();
+        this.stop();
         super.unmount();
     }
 


### PR DESCRIPTION
﻿## Summary
- routes unmount through the existing stop path
- resets running state when a running indicator is unmounted
- adds regression coverage for unmounting and restarting

## Validation
- npx --yes bun@1.3.14 vitest run packages/widgets/src/display/TypingIndicator.test.ts

Closes #2554
