### PR TITLE
fix(widgets): cancel layout transition animations on destroy/unmount

### DIFF
--- a/packages/widgets/src/base/Widget.ts
+++ b/packages/widgets/src/base/Widget.ts
@@ -234,10 +234,12 @@ export abstract class Widget {
 
     /**
      * Destroy this widget and all its descendants.
-     * Cleans up event handlers, removes parent references, and clears children.
-     * Fiber-level cleanup is handled by the reconciler's _pruneInstancesForWidget.
+     * Cleans up event handlers, cancels active animations, removes parent references, and clears children.
      */
     destroy(): void {
+        this._layoutCancel?.();
+        this._layoutCancel = null;
+        this._targetRect = null;
         this.unmount();
         const children = [...this._children];
         this._children = [];
@@ -626,6 +628,9 @@ export abstract class Widget {
     unmount(): void {
         if (this._unmounted) return;
         this._unmounted = true;
+        this._layoutCancel?.();
+        this._layoutCancel = null;
+        this._targetRect = null;
         for (const child of this._children) {
             child.unmount();
         }


### PR DESCRIPTION
## fix(widgets): cancel layout transition animations on destroy/unmount

Closes #2584

### Problem
When a widget with `layoutTransition` is destroyed, neither `destroy()` nor `unmount()` calls `this._layoutCancel?.()`. The spring animation continues running on the destroyed widget, causing memory leaks, CPU waste, and ghost rendering via `markDirty()` calls.

### Changes
- **`Widget.ts` `destroy()`**: Added `this._layoutCancel?.()` call before setting to null, plus cleanup of `_targetRect`
- **`Widget.ts` `unmount()`**: Added `this._layoutCancel?.()` call with idempotency guard
- **`Widget.ts`**: Updated doc comment to reflect animation cancellation

### Impact
- Prevents memory leaks from destroyed widgets retained by spring callback closures
- Stops CPU waste from spring physics simulations running on destroyed widgets
- Eliminates ghost rendering from `markDirty()` calls on destroyed layout nodes