### PR TITLE
perf(core): reduce allocations in renderer hot path

### DIFF
--- a/packages/core/src/terminal/Renderer.test.ts
+++ b/packages/core/src/terminal/Renderer.test.ts
@@ -263,6 +263,19 @@ describe('Renderer profiling hooks', () => {
         expect(resetCount).toBeGreaterThanOrEqual(2);
     });
 
+    it('reuses the current style state for identical adjacent cells', () => {
+        const screen = new Screen(5, 1);
+        const renderer = new Renderer(terminal, screen);
+
+        screen.setCell(0, 0, { char: 'A', bold: true, fg: { type: 'named', name: 'red' } });
+        screen.setCell(1, 0, { char: 'B', bold: true, fg: { type: 'named', name: 'red' } });
+        renderer.renderNow();
+
+        const output = fakeStdout.writes;
+        const resetCount = (output.match(/\x1b\[0m/g) || []).length;
+        expect(resetCount).toBeGreaterThanOrEqual(1);
+    });
+
     it('correctly adjusts span start backwards and renders from adjustedStart', () => {
         const narrowScreen = new Screen(10, 2);
         const renderer = new Renderer(terminal, narrowScreen);

--- a/packages/core/src/terminal/Renderer.ts
+++ b/packages/core/src/terminal/Renderer.ts
@@ -4,7 +4,7 @@
 
 import type { Terminal } from './Terminal.js';
 import { type Cell, cellsEqual, type Screen } from './Screen.js';
-import { type ColorDepth, colorToAnsiFg, colorToAnsiBg } from '../style/Color.js';
+import { type Color, type ColorDepth, colorToAnsiFg, colorToAnsiBg } from '../style/Color.js';
 import { moveTo, beginSyncUpdate, endSyncUpdate, reset as ansiReset, stripAnsiControl } from '../utils/ansi.js';
 import { RenderHook } from '../renderer/render-hook.js';
 
@@ -138,7 +138,7 @@ export class Renderer {
 
             if (this._diffRenderer) {
                 for (let r = 0; r < rows; r++) {
-                    this._lastStyleFingerprint = null;
+                    this._lastStyleState = null;
                     output += this._renderDiffLine(r, front, back, cols);
                 }
 
@@ -187,37 +187,46 @@ export class Renderer {
         } catch (_err) {
             // Re-request render so the next frame tick retries.
             this._renderRequested = true;
-            // Reset style fingerprint to prevent color bleed on retry.
-            this._lastStyleFingerprint = null;
+            // Reset style state to prevent color bleed on retry.
+            this._lastStyleState = null;
         }
     }
 
-    /** Style fingerprint of the last rendered cell (to suppress redundant ANSI reset/apply). */
-    private _lastStyleFingerprint: string | null = null;
+    /** The last rendered style state for the current row (to suppress redundant ANSI reset/apply). */
+    private _lastStyleState: {
+        bold: boolean;
+        dim: boolean;
+        italic: boolean;
+        underline: boolean;
+        strikethrough: boolean;
+        inverse: boolean;
+        fg: Color;
+        bg: Color;
+    } | null = null;
 
-    /** Build a stable style fingerprint string for a cell (avoids allocation-heavy object comparison). */
-    private _styleFingerprint(cell: Cell): string {
-        const fg = cell.fg;
-        const bg = cell.bg;
-        let fgKey: string;
-        switch (fg.type) {
-            case 'none': fgKey = 'n'; break;
-            case 'named': fgKey = `N:${fg.name}`; break;
-            case 'ansi256': fgKey = `A:${fg.code}`; break;
-            case 'rgb': fgKey = `R:${fg.r},${fg.g},${fg.b}`; break;
-            case 'hex': fgKey = `H:${fg.hex.toLowerCase()}`; break;
-            default: fgKey = 'n';
-        }
-        let bgKey: string;
-        switch (bg.type) {
-            case 'none': bgKey = 'n'; break;
-            case 'named': bgKey = `N:${bg.name}`; break;
-            case 'ansi256': bgKey = `A:${bg.code}`; break;
-            case 'rgb': bgKey = `R:${bg.r},${bg.g},${bg.b}`; break;
-            case 'hex': bgKey = `H:${bg.hex.toLowerCase()}`; break;
-            default: bgKey = 'n';
-        }
-        return `${cell.bold ? 'B' : ''}${cell.dim ? 'D' : ''}${cell.italic ? 'I' : ''}${cell.underline ? 'U' : ''}${cell.strikethrough ? 'S' : ''}${cell.inverse ? 'V' : ''}|${fgKey}|${bgKey}`;
+    private _stylesEqual(cell: Cell): boolean {
+        const last = this._lastStyleState;
+        if (!last) return false;
+
+        return last.bold === cell.bold &&
+            last.dim === cell.dim &&
+            last.italic === cell.italic &&
+            last.underline === cell.underline &&
+            last.strikethrough === cell.strikethrough &&
+            last.inverse === cell.inverse &&
+            this._colorsEqual(last.fg, cell.fg) &&
+            this._colorsEqual(last.bg, cell.bg);
+    }
+
+    private _colorsEqual(a: Color, b: Color): boolean {
+        if (a.type !== b.type) return false;
+
+        if (a.type === 'none') return true;
+        if (a.type === 'named' && b.type === 'named') return a.name === b.name;
+        if (a.type === 'ansi256' && b.type === 'ansi256') return a.code === b.code;
+        if (a.type === 'rgb' && b.type === 'rgb') return a.r === b.r && a.g === b.g && a.b === b.b;
+        if (a.type === 'hex' && b.type === 'hex') return a.hex.toLowerCase() === b.hex.toLowerCase();
+        return false;
     }
 
     /**
@@ -226,9 +235,8 @@ export class Renderer {
      */
     private _renderCell(cell: Cell): string {
         let seq = '';
-        const fp = this._styleFingerprint(cell);
 
-        if (fp !== this._lastStyleFingerprint) {
+        if (!this._stylesEqual(cell)) {
             seq += ansiReset;
             if (cell.bold) seq += '\x1b[1m';
             if (cell.dim) seq += '\x1b[2m';
@@ -238,7 +246,16 @@ export class Renderer {
             if (cell.inverse) seq += '\x1b[7m';
             seq += colorToAnsiFg(cell.fg, this._colorDepth);
             seq += colorToAnsiBg(cell.bg, this._colorDepth);
-            this._lastStyleFingerprint = fp;
+            this._lastStyleState = {
+                bold: cell.bold,
+                dim: cell.dim,
+                italic: cell.italic,
+                underline: cell.underline,
+                strikethrough: cell.strikethrough,
+                inverse: cell.inverse,
+                fg: cell.fg,
+                bg: cell.bg,
+            };
         }
 
         // Write the character (sanitized to prevent escape injection)

--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -351,9 +351,15 @@ export class Screen {
 
         const existing = this.back[row][col];
         if (cell.char !== undefined) {
-            cell = { ...cell, char: stripAnsiControl(cell.char) };
+            const sanitizedChar = stripAnsiControl(cell.char);
+            if (sanitizedChar !== cell.char) {
+                Object.assign(existing, cell, { char: sanitizedChar });
+            } else {
+                Object.assign(existing, cell);
+            }
+        } else {
+            Object.assign(existing, cell);
         }
-        Object.assign(existing, cell);
     }
 
     /**


### PR DESCRIPTION
## Description

This PR optimizes the renderer's hot path by reducing unnecessary allocations and repeated style comparison work during frame rendering. The optimization is internal only and preserves the existing rendering behavior, output, and public API while improving efficiency in render-heavy workloads.

## Related Issue

Closes #2598

## Which package(s)?

`@termuijs/core`

## Type of Change

* [ ] 🐛 Bug fix (`type:bug`)
* [ ] ✨ Feature (`type:feature`)
* [ ] 📝 Docs (`type:docs`)
* [ ] 🧪 Tests (`type:testing`)
* [ ] ♻️ Refactor (`type:refactor`)
* [ ] 🎨 Design / UX (`type:design`)
* [ ] ♿ Accessibility (`type:accessibility`)
* [x] ⚡ Performance (`type:performance`)
* [ ] 🔧 DevOps / CI (`type:devops`)
* [ ] 🔒 Security (`type:security`)

## Checklist

* [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
* [x] Tests pass locally: `bun vitest run`
* [x] Build passes: `bun run build`
* [x] Typecheck passes: `bun run typecheck`
* [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
* [x] Your PR title follows `type: short description`.
* [x] Widget state mutators call `markDirty()` (Not applicable — this change does not modify widget state or rendering invalidation.)
* [x] No new `any` types without an inline comment explaining why.
* [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

* [x] You are a GSSoC 2026 contributor.
* Your GSSoC profile: `https://gssoc.girlscript.org/profile/3652c85d-e890-41f5-a48f-584ed0a7f209`

## Screenshots / Recordings (UI changes)

Not applicable. This PR contains internal performance optimizations only and introduces no user-facing UI changes.

## Notes for the Reviewer

### Summary

* Optimized the renderer's per-cell hot path by reducing repeated style comparison work.
* Reduced unnecessary allocations during screen buffer writes.
* Preserved rendering semantics, ANSI output, cursor behavior, and public APIs.
* Added a regression test to verify identical rendering behavior for repeated adjacent style states.

### Validation

* ✅ Full test suite passed (5649 tests passed, 1 skipped)
* ✅ TypeScript typecheck passed
* ✅ Build passed
* ✅ Lint passed
