### PR TITLE
fix(adapters): load dotenv in CommonJS builds

### DIFF
--- a/packages/adapters/src/dotenv/index.ts
+++ b/packages/adapters/src/dotenv/index.ts
@@ -16,7 +16,9 @@ interface DotenvModule {
 
 let _dotenv: DotenvModule | undefined
 
-const _require = createRequire(import.meta.url)
+const _require = createRequire(
+  typeof __filename !== 'undefined' ? __filename : import.meta.url
+)
 
 // Lazily loads dotenv. Uses a cached reference after first load.
 function resolveDotenv(): DotenvModule {


### PR DESCRIPTION
## Summary

- make the dotenv adapter choose a CommonJS-safe filename when creating `require`
- preserve `import.meta.url` for ESM builds
- prevent the package entry point from throwing during `require('@termuijs/adapters')`

## Root cause

The CJS bundle replaced `import.meta` with an empty object, so `createRequire(import.meta.url)` received `undefined` during module initialization.

## Validation

- `bun run --filter @termuijs/adapters build`
- `bun run --filter @termuijs/adapters typecheck`
- `bun vitest run packages/adapters`
- `node -e "require('./packages/adapters/dist/index.cjs')"`

Closes #2605