### PR TITLE
fix(ui): schedule toast expiration

### DIFF
--- a/packages/ui/src/Toast.test.ts
+++ b/packages/ui/src/Toast.test.ts
@@ -2,8 +2,14 @@
 // @termuijs/ui — Tests for Toast component
 // ─────────────────────────────────────────────────────
 
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { Toast } from './Toast.js';
+import { Screen } from '@termuijs/core';
+
+afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+});
 
 describe('Toast', () => {
     it('starts with no messages', () => {
@@ -24,5 +30,24 @@ describe('Toast', () => {
         toast.warning('Warning message');
         toast.error('Error message');
         expect(toast).toBeDefined();
+    });
+
+    it('marks itself dirty when the exit animation is due', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+        const toast = new Toast({ durationMs: 1000, animationMs: 100 });
+        const screen = new Screen(40, 5);
+        const markDirty = vi.spyOn(toast, 'markDirty');
+
+        toast.updateRect({ x: 0, y: 0, width: 40, height: 5 });
+        toast.info('Saved');
+        vi.setSystemTime(100);
+        toast.render(screen);
+        markDirty.mockClear();
+
+        vi.advanceTimersByTime(799);
+        expect(markDirty).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(1);
+        expect(markDirty).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/ui/src/Toast.ts
+++ b/packages/ui/src/Toast.ts
@@ -70,6 +70,10 @@ export class Toast extends Widget {
   }
 
   protected _renderSelf(screen: Screen): void {
+    if (this._animationTimer !== undefined) {
+      clearTimeout(this._animationTimer);
+      this._animationTimer = undefined;
+    }
     const now = Date.now();
     this._messages = this._messages.filter(m => m.expireAt > now);
     if (this._messages.length === 0) return;
@@ -95,7 +99,12 @@ export class Toast extends Widget {
       const remaining = m.expireAt - now;
       return elapsed < this._animationMs || remaining < this._animationMs;
     });
-    if (anyAnimating) this._animationTimer = setTimeout(() => this.markDirty(), 16);
+    const nextExitStart = Math.min(...visible.map(m => m.expireAt - this._animationMs));
+    const delay = anyAnimating ? 16 : Math.max(0, nextExitStart - now);
+    this._animationTimer = setTimeout(() => {
+      this._animationTimer = undefined;
+      this.markDirty();
+    }, delay);
   }
 
   /** Lifecycle: stop the pending animation re-render timer. */


### PR DESCRIPTION
## Summary

- schedule the next Toast render at the start of its exit window
- continue using frame timers while a toast is actively animating
- clear and replace pending timers when rendering
- add a fake-timer regression test for idle expiration

## Root cause

Toast only requested frames during active animation. Once the entrance animation ended, no timer woke the widget for its exit animation or expiration.

## Validation

- `bun run build`
- `bun run typecheck`
- `bun vitest run packages/ui/src/Toast.test.ts`

Closes #2607