### PR TITLE
fix(ui): add ConfirmDialog keyboard controls

### DIFF
--- a/packages/ui/src/ConfirmDialog.test.ts
+++ b/packages/ui/src/ConfirmDialog.test.ts
@@ -607,4 +607,46 @@ describe('ConfirmDialog', () => {
         expect(onCancel).not.toHaveBeenCalled();
         expect(dialog.visible).toBe(false);
     });
+
+    it('uses left and right to select an action', () => {
+        const dialog = new ConfirmDialog({ message: 'Continue?' });
+        dialog.show();
+
+        dialog.events.emit('key', makeKey('right'));
+        expect(allRows(renderDialog(dialog)).join('')).toContain('[No]');
+
+        dialog.events.emit('key', makeKey('left'));
+        expect(allRows(renderDialog(dialog)).join('')).toContain('[Yes]');
+    });
+
+    it('uses tab to toggle the selected action', () => {
+        const dialog = new ConfirmDialog({ message: 'Continue?' });
+        dialog.show();
+
+        dialog.events.emit('key', makeKey('tab'));
+        expect(allRows(renderDialog(dialog)).join('')).toContain('[No]');
+    });
+
+    it.each(['enter', 'return'])('%s invokes the selected action', (key) => {
+        const onCancel = vi.fn();
+        const dialog = new ConfirmDialog({ message: 'Continue?', onCancel });
+        dialog.show();
+        dialog.selectCancel();
+
+        dialog.events.emit('key', makeKey(key));
+
+        expect(onCancel).toHaveBeenCalledTimes(1);
+        expect(dialog.visible).toBe(false);
+    });
+
+    it.each(['left', 'right', 'tab', 'enter', 'return', 'escape'])('%s consumes the event while visible', (key) => {
+        const dialog = new ConfirmDialog({ message: 'Continue?' });
+        const event = makeKey(key);
+        dialog.show();
+
+        dialog.events.emit('key', event);
+
+        expect(event._defaultPrevented).toBe(true);
+        expect(event._propagationStopped).toBe(true);
+    });
 });

--- a/packages/ui/src/ConfirmDialog.ts
+++ b/packages/ui/src/ConfirmDialog.ts
@@ -47,12 +47,29 @@ export class ConfirmDialog extends Widget {
 
     private handleKey(event: KeyEvent): void {
         if (!this._visible) return;
-        if (event.key === 'escape') {
-            this.selectCancel();
-            this.confirm();
-            event.preventDefault();
-            event.stopPropagation();
+        switch (event.key) {
+            case 'escape':
+                this.selectCancel();
+                this.confirm();
+                break;
+            case 'left':
+                this.selectConfirm();
+                break;
+            case 'right':
+                this.selectCancel();
+                break;
+            case 'tab':
+                this.toggleSelection();
+                break;
+            case 'enter':
+            case 'return':
+                this.confirm();
+                break;
+            default:
+                return;
         }
+        event.preventDefault();
+        event.stopPropagation();
     }
 
     protected _renderSelf(screen: Screen): void {


### PR DESCRIPTION
## Summary

- support left, right, and tab selection in ConfirmDialog
- support enter and return activation
- consume handled dialog key events consistently
- add coverage for selection, activation, and propagation

## Impact

Focused confirmation dialogs are now fully operable from the keyboard instead of requiring imperative method calls.

## Validation

- `bun run build`
- `bun run typecheck`
- `bun vitest run packages/ui/src/ConfirmDialog.test.ts`

Closes #2608