### PR TITLE
fix(ui): manage tab content lifecycle

### DIFF
--- a/packages/ui/src/Tabs.test.ts
+++ b/packages/ui/src/Tabs.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { Tabs } from './Tabs.js';
-import { Box, Text } from '@termuijs/widgets';
+import { Box, Text, Widget } from '@termuijs/widgets';
 import { Screen } from '@termuijs/core';
 
 const makeTabs = () => new Tabs([
@@ -12,6 +12,29 @@ const makeTabs = () => new Tabs([
     { label: 'Settings', content: new Box() },
     { label: 'About', content: new Box() },
 ]);
+
+class TrackedContent extends Widget {
+    mounts = 0;
+    unmounts = 0;
+    destroys = 0;
+
+    override mount(): void {
+        this.mounts++;
+        super.mount();
+    }
+
+    override unmount(): void {
+        this.unmounts++;
+        super.unmount();
+    }
+
+    override destroy(): void {
+        this.destroys++;
+        super.destroy();
+    }
+
+    protected override _renderSelf(): void {}
+}
 
 describe('Tabs', () => {
     it('starts at tab 0', () => {
@@ -104,5 +127,44 @@ describe('Tabs', () => {
         tabs.render(screen);
         const all = screen.back.map(r => r.map(c => c.char).join('')).join('');
         expect(all).not.toContain('Should Not Appear');
+    });
+
+    it('mounts and unmounts the active content with the container', () => {
+        const content = new TrackedContent();
+        const tabs = new Tabs([{ label: 'One', content }]);
+
+        tabs.mount();
+        expect(content.mounts).toBe(1);
+        tabs.unmount();
+        expect(content.unmounts).toBe(1);
+    });
+
+    it('transfers lifecycle ownership when selecting another tab', () => {
+        const first = new TrackedContent();
+        const second = new TrackedContent();
+        const tabs = new Tabs([
+            { label: 'One', content: first },
+            { label: 'Two', content: second },
+        ]);
+
+        tabs.mount();
+        tabs.selectTab(1);
+
+        expect(first.unmounts).toBe(1);
+        expect(second.mounts).toBe(1);
+    });
+
+    it('destroys every tab content widget', () => {
+        const first = new TrackedContent();
+        const second = new TrackedContent();
+        const tabs = new Tabs([
+            { label: 'One', content: first },
+            { label: 'Two', content: second },
+        ]);
+
+        tabs.destroy();
+
+        expect(first.destroys).toBe(1);
+        expect(second.destroys).toBe(1);
     });
 });

--- a/packages/ui/src/Tabs.ts
+++ b/packages/ui/src/Tabs.ts
@@ -14,6 +14,7 @@ export class Tabs extends Widget {
     private _activeIndex = 0;
     private _activeColor: Style['fg'];
     private _inactiveColor: Style['fg'];
+    private _contentMounted = false;
     focusable = true;
 
     constructor(tabs: Tab[], options: TabsOptions = {}) {
@@ -25,19 +26,44 @@ export class Tabs extends Widget {
 
     get activeIndex(): number { return this._activeIndex; }
     selectTab(i: number): void {
-        if (i >= 0 && i < this._tabs.length) { this._activeIndex = i; this.markDirty(); }
+        if (i < 0 || i >= this._tabs.length || i === this._activeIndex) return;
+        const previous = this.activeContent;
+        if (this._contentMounted) previous?.unmount();
+        this._activeIndex = i;
+        if (this._contentMounted) this.activeContent?.mount();
+        this.markDirty();
     }
     nextTab(): void {
         if (this._tabs.length === 0) return;
-        this._activeIndex = (this._activeIndex + 1) % this._tabs.length;
-        this.markDirty();
+        this.selectTab((this._activeIndex + 1) % this._tabs.length);
     }
     prevTab(): void {
         if (this._tabs.length === 0) return;
-        this._activeIndex = (this._activeIndex - 1 + this._tabs.length) % this._tabs.length;
-        this.markDirty();
+        this.selectTab((this._activeIndex - 1 + this._tabs.length) % this._tabs.length);
     }
     get activeContent(): Widget | undefined { return this._tabs[this._activeIndex]?.content; }
+
+    override mount(): void {
+        super.mount();
+        if (!this._contentMounted) {
+            this.activeContent?.mount();
+            this._contentMounted = true;
+        }
+    }
+
+    override unmount(): void {
+        if (this._contentMounted) {
+            this.activeContent?.unmount();
+            this._contentMounted = false;
+        }
+        super.unmount();
+    }
+
+    override destroy(): void {
+        super.destroy();
+        for (const tab of this._tabs) tab.content.destroy();
+        this._tabs = [];
+    }
 
     protected _renderSelf(screen: Screen): void {
         const { x, y, width, height } = this._rect;


### PR DESCRIPTION
## Summary

- mount and unmount the active tab content with the Tabs container
- transfer lifecycle ownership when the selected tab changes
- destroy all tab content widgets when the container is destroyed
- add tracked-widget lifecycle coverage

## Root cause

Tabs rendered content directly without registering it as a child or explicitly forwarding lifecycle operations.

## Validation

- `bun run build`
- `bun run typecheck`
- `bun vitest run packages/ui/src/Tabs.test.ts`

Closes #2609