### PR TITLE
fix(ui): edit text by grapheme cluster

### DIFF
--- a/packages/ui/src/Combobox.test.ts
+++ b/packages/ui/src/Combobox.test.ts
@@ -24,6 +24,19 @@ describe('Combobox', () => {
         vi.restoreAllMocks();
     });
 
+    it('backspace removes one complete grapheme cluster', () => {
+        const cb = new Combobox([
+            { label: 'é', value: 'accented' },
+            { label: 'Other', value: 'other' },
+        ]);
+        cb.handleKey(makeKey('e'));
+        cb.handleKey(makeKey('\u0301'));
+
+        cb.handleKey(makeKey('backspace'));
+
+        expect(cb.filtered).toHaveLength(2);
+    });
+
     it('initializes with empty value and no selection', () => {
         const cb = new Combobox([
             { label: 'Apple', value: 'a' },

--- a/packages/ui/src/Combobox.ts
+++ b/packages/ui/src/Combobox.ts
@@ -9,7 +9,8 @@ import {
     styleToCellAttrs,
     caps,
     stringWidth,
-    truncate
+    truncate,
+    splitGraphemes
 } from '@termuijs/core';
 import { nextEnabledIndex, previousEnabledIndex } from './navigation.js';
 
@@ -111,7 +112,7 @@ export class Combobox extends Widget {
                 return;
             }
         
-            this._inputValue = this._inputValue.slice(0, -1);
+            this._inputValue = splitGraphemes(this._inputValue).slice(0, -1).join('');
             this._isOpen = true;
             this._selectedIndex = -1;
             this.markDirty();

--- a/packages/ui/src/CommandPalette.test.ts
+++ b/packages/ui/src/CommandPalette.test.ts
@@ -65,6 +65,20 @@ describe('CommandPalette', () => {
         vi.restoreAllMocks();
     });
 
+    it('backspace removes one complete grapheme cluster', () => {
+        const palette = new CommandPalette([
+            { id: 'accented', label: 'é', action: vi.fn() },
+            { id: 'other', label: 'Other', action: vi.fn() },
+        ]);
+        palette.show();
+        palette.insertChar('é');
+
+        palette.deleteBack();
+
+        expect(allText(renderPalette(palette))).not.toContain('�');
+        expect(allText(renderPalette(palette))).toContain('Type a command...');
+    });
+
     // ── 1. Initial State ──────────────────────────────
 
     describe('initial state', () => {

--- a/packages/ui/src/CommandPalette.ts
+++ b/packages/ui/src/CommandPalette.ts
@@ -1,6 +1,6 @@
 // CommandPalette — fuzzy-search command launcher
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, getBorderChars, caps } from '@termuijs/core';
+import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, getBorderChars, caps, splitGraphemes } from '@termuijs/core';
 
 export interface Command { id: string; label: string; shortcut?: string; action: () => void; category?: string; }
 export interface CommandPaletteOptions { placeholder?: string; borderColor?: Style['fg']; activeColor?: Style['fg']; maxVisible?: number; }
@@ -32,8 +32,24 @@ export class CommandPalette extends Widget {
     show(): void { this._visible = true; this._query = ''; this._cursorPos = 0; this._selectedIndex = 0; this._filtered = [...this._commands]; this.markDirty(); }
     hide(): void { this._visible = false; this.markDirty(); }
     toggle(): void { this._visible ? this.hide() : this.show(); }
-    insertChar(ch: string): void { this._query = this._query.slice(0, this._cursorPos) + ch + this._query.slice(this._cursorPos); this._cursorPos++; this._filter(); this.markDirty(); }
-    deleteBack(): void { if (this._cursorPos > 0) { this._query = this._query.slice(0, this._cursorPos - 1) + this._query.slice(this._cursorPos); this._cursorPos--; this._filter(); this.markDirty(); } }
+    insertChar(ch: string): void {
+        const query = splitGraphemes(this._query);
+        const inserted = splitGraphemes(ch);
+        query.splice(this._cursorPos, 0, ...inserted);
+        this._query = query.join('');
+        this._cursorPos += inserted.length;
+        this._filter();
+        this.markDirty();
+    }
+    deleteBack(): void {
+        if (this._cursorPos === 0) return;
+        const query = splitGraphemes(this._query);
+        query.splice(this._cursorPos - 1, 1);
+        this._query = query.join('');
+        this._cursorPos--;
+        this._filter();
+        this.markDirty();
+    }
     selectNext(): void { if (this._selectedIndex < this._filtered.length - 1) { this._selectedIndex++; this.markDirty(); } }
     selectPrev(): void { if (this._selectedIndex > 0) { this._selectedIndex--; this.markDirty(); } }
     confirm(): void { const c = this._filtered[this._selectedIndex]; if (c) { this.hide(); c.action(); } }

--- a/packages/ui/src/EmailInput.test.ts
+++ b/packages/ui/src/EmailInput.test.ts
@@ -46,6 +46,25 @@ function renderRow(input: EmailInput, width = 40): string {
 // ─────────────────────────────────────────────────────
 
 describe('EmailInput', () => {
+
+    it('backspace removes one complete grapheme cluster', () => {
+        const input = new EmailInput();
+        input.insertChar('e\u0301');
+
+        input.deleteBack();
+
+        expect(input.getValue()).toBe('');
+    });
+
+    it('deleteForward removes one complete grapheme cluster', () => {
+        const input = new EmailInput();
+        input.insertChar('👨‍👩‍👧‍👦');
+        input.moveCursorHome();
+
+        input.deleteForward();
+
+        expect(input.getValue()).toBe('');
+    });
     afterEach(() => {
         vi.restoreAllMocks();
     });

--- a/packages/ui/src/EmailInput.ts
+++ b/packages/ui/src/EmailInput.ts
@@ -8,7 +8,7 @@
 // ─────────────────────────────────────────────────────
 
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Color, type Screen, type KeyEvent, styleToCellAttrs, truncate, mergeStyles, defaultStyle } from '@termuijs/core';
+import { type Style, type Color, type Screen, type KeyEvent, styleToCellAttrs, truncate, mergeStyles, defaultStyle, splitGraphemes, stringWidth } from '@termuijs/core';
 
 export interface EmailInputOptions {
     placeholder?: string;
@@ -56,29 +56,29 @@ export class EmailInput extends Widget {
     }
 
     insertChar(char: string): void {
-        this._raw =
-            this._raw.slice(0, this._cursorPos) +
-            char +
-            this._raw.slice(this._cursorPos);
-        this._cursorPos++;
+        const graphemes = splitGraphemes(this._raw);
+        const inserted = splitGraphemes(char);
+        graphemes.splice(this._cursorPos, 0, ...inserted);
+        this._raw = graphemes.join('');
+        this._cursorPos += inserted.length;
         this._notify();
     }
 
     deleteBack(): void {
         if (this._cursorPos > 0) {
-            this._raw =
-                this._raw.slice(0, this._cursorPos - 1) +
-                this._raw.slice(this._cursorPos);
+            const graphemes = splitGraphemes(this._raw);
+            graphemes.splice(this._cursorPos - 1, 1);
+            this._raw = graphemes.join('');
             this._cursorPos--;
             this._notify();
         }
     }
 
     deleteForward(): void {
-        if (this._cursorPos < this._raw.length) {
-            this._raw =
-                this._raw.slice(0, this._cursorPos) +
-                this._raw.slice(this._cursorPos + 1);
+        const graphemes = splitGraphemes(this._raw);
+        if (this._cursorPos < graphemes.length) {
+            graphemes.splice(this._cursorPos, 1);
+            this._raw = graphemes.join('');
             this._notify();
         }
     }
@@ -89,7 +89,7 @@ export class EmailInput extends Widget {
     }
     
     moveCursorRight(): void { 
-        this._cursorPos = Math.min(this._raw.length, this._cursorPos + 1); 
+        this._cursorPos = Math.min(splitGraphemes(this._raw).length, this._cursorPos + 1);
         this.markDirty(); 
     }
     
@@ -99,7 +99,7 @@ export class EmailInput extends Widget {
     }
     
     moveCursorEnd(): void { 
-        this._cursorPos = this._raw.length; 
+        this._cursorPos = splitGraphemes(this._raw).length;
         this.markDirty(); 
     }
 
@@ -112,7 +112,7 @@ export class EmailInput extends Widget {
         
         if (match) {
             this._raw = this._raw.slice(0, atIndex + 1) + match;
-            this._cursorPos = this._raw.length;
+            this._cursorPos = splitGraphemes(this._raw).length;
             this._notify();
         }
     }
@@ -151,14 +151,14 @@ export class EmailInput extends Widget {
             return;
         }
 
-        const display = this._raw;
+        const display = splitGraphemes(this._raw);
         const visibleWidth = width - 1;
-        let scrollX = 0;
-        if (this._cursorPos > visibleWidth) {
-            scrollX = this._cursorPos - visibleWidth;
+        let scrollIndex = 0;
+        while (stringWidth(display.slice(scrollIndex, this._cursorPos).join('')) > visibleWidth) {
+            scrollIndex++;
         }
 
-        const visibleText = display.slice(scrollX, scrollX + visibleWidth);
+        const visibleText = truncate(display.slice(scrollIndex).join(''), visibleWidth, '');
         
         // Show error indicator if invalid and not empty
         const isError = this._raw.length > 0 && !this.isValid();
@@ -167,11 +167,10 @@ export class EmailInput extends Widget {
         screen.writeString(x, y, visibleText, renderAttrs);
 
         if (this.isFocused) {
-            const cursorScreenPos = x + this._cursorPos - scrollX;
+            const cursorOffset = stringWidth(display.slice(scrollIndex, this._cursorPos).join(''));
+            const cursorScreenPos = x + cursorOffset;
             if (cursorScreenPos >= x && cursorScreenPos < x + width) {
-                const cursorChar = this._cursorPos < display.length
-                    ? display[this._cursorPos]
-                    : ' ';
+                const cursorChar = display[this._cursorPos] ?? ' ';
                 screen.setCell(cursorScreenPos, y, {
                     char: cursorChar,
                     ...renderAttrs,


### PR DESCRIPTION
## Summary

- make CommandPalette insertion and backspace grapheme-aware
- make Combobox backspace remove one user-perceived character
- make EmailInput cursor movement, insertion, deletion, and rendering use grapheme boundaries
- add combining-mark and joined-emoji regression coverage

## Impact

Text editing no longer leaves partial surrogate pairs, combining sequences, or joined emoji in affected inputs.

## Validation

- `bun run build`
- `bun run typecheck`
- `bun vitest run packages/ui/src/CommandPalette.test.ts`
- focused Combobox grapheme test
- `bun vitest run packages/ui/src/EmailInput.test.ts`

Closes #2610