### PR TITLE
fix(ui): isolate notification snapshots

### DIFF
--- a/packages/ui/src/NotificationCenter.test.ts
+++ b/packages/ui/src/NotificationCenter.test.ts
@@ -72,6 +72,36 @@ describe('NotificationStore', () => {
         store.reset();
     });
 
+    it('does not expose its internal array or notification objects', () => {
+        store.push('Original');
+        const snapshot = store.notifications;
+
+        snapshot[0].message = 'Changed';
+        snapshot.push({
+            id: 'external',
+            message: 'Injected',
+            type: 'info',
+            createdAt: Date.now(),
+        });
+
+        expect(store.notifications.map((notification) => notification.message)).toEqual(['Original']);
+    });
+
+    it('isolates notification snapshots between subscribers', () => {
+        const observed: string[][] = [];
+        store.subscribe((snapshot) => {
+            snapshot[0].message = 'Changed by first subscriber';
+        });
+        store.subscribe((snapshot) => {
+            observed.push(snapshot.map((notification) => notification.message));
+        });
+
+        store.push('Original');
+
+        expect(observed).toEqual([['Original']]);
+        expect(store.notifications[0].message).toBe('Original');
+    });
+
     afterEach(() => {
         store.reset();
         vi.useRealTimers();

--- a/packages/ui/src/NotificationCenter.ts
+++ b/packages/ui/src/NotificationCenter.ts
@@ -76,11 +76,13 @@ export class NotificationStore {
     }
 
     get notifications(): Notification[] {
-        return this._notifications;
+        return this._notifications.map((notification) => ({ ...notification }));
     }
 
     private _emit(): void {
-        for (const fn of this._subs) fn(this._notifications);
+        for (const fn of this._subs) {
+            fn(this._notifications.map((notification) => ({ ...notification })));
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- return cloned notification arrays and objects from the public getter
- provide each subscriber with an independent snapshot
- add regression tests for getter and subscriber mutation

## Root cause

NotificationStore exposed its internal array and objects directly, allowing callers and subscribers to mutate state without store methods or emissions.

## Validation

- `bun run build`
- `bun run typecheck`
- `bun vitest run packages/ui/src/NotificationCenter.test.ts`

Closes #2611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification state isolation by preventing external changes from modifying stored notifications.
  * Ensured subscribers receive independent notification snapshots, so changes in one view do not affect others.

* **Tests**
  * Added coverage verifying notification data remains protected from unintended mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->