### PR TITLE
fix: restore key handlers after remount

### DIFF
--- a/packages/ui/src/ConfirmDialog.ts
+++ b/packages/ui/src/ConfirmDialog.ts
@@ -20,6 +20,7 @@ export class ConfirmDialog extends Widget {
     private _visible = false;
     private _onConfirm?: () => void;
     private _onCancel?: () => void;
+    private readonly _keyHandler = (event: KeyEvent): void => this.handleKey(event);
     focusable = true;
 
     constructor(options: ConfirmDialogOptions) {
@@ -30,7 +31,13 @@ export class ConfirmDialog extends Widget {
         this._borderColor = options.borderColor ?? { type: 'named', name: 'yellow' };
         this._onConfirm = options.onConfirm;
         this._onCancel = options.onCancel;
-        this.events.on('key', (event) => this.handleKey(event));
+        this.events.on('key', this._keyHandler);
+    }
+
+    override mount(): void {
+        super.mount();
+        this.events.off('key', this._keyHandler);
+        this.events.on('key', this._keyHandler);
     }
 
     get visible(): boolean { return this._visible; }

--- a/packages/ui/src/Form.ts
+++ b/packages/ui/src/Form.ts
@@ -28,6 +28,7 @@ export class Form extends Widget {
     private _onComplete?: (values: Record<string, string>) => void;
     focusable = true;
     public signal?: AbortSignal;
+    private readonly _keyHandler = (event: KeyEvent): void => this.handleKey(event);
 
     constructor(fields: FormField[], options: FormOptions = {}) {
         super(mergeStyles(defaultStyle(), { height: fields.length * 2 + 1, flexGrow: 1 }));
@@ -40,7 +41,13 @@ export class Form extends Widget {
         for (const f of fields) this._values.set(f.name, '');
         // Wire key events from the App/event system into this widget's handlers.
         // Minimal: only route printable chars and backspace to existing methods.
-        this.events.on('key', (event: KeyEvent) => this.handleKey(event));
+        this.events.on('key', this._keyHandler);
+    }
+
+    override mount(): void {
+        super.mount();
+        this.events.off('key', this._keyHandler);
+        this.events.on('key', this._keyHandler);
     }
 
     get values(): Record<string, string> { const r: Record<string, string> = {}; for (const [k, v] of this._values) r[k] = v; return r; }

--- a/packages/ui/src/PasswordInput.ts
+++ b/packages/ui/src/PasswordInput.ts
@@ -19,6 +19,7 @@ export class PasswordInput extends Widget {
     private _onSubmit?: (value: string) => void;
     private _vimMode: VimMode = process.env.TERMUI_KEYBINDINGS === 'vim' ? 'normal' : 'insert';
     focusable = true;
+    private readonly _keyHandler = (event: KeyEvent): void => this.handleKey(event);
 
     // '●' in unicode terminals, '*' in ASCII fallback
     private get _maskChar(): string {
@@ -35,7 +36,13 @@ export class PasswordInput extends Widget {
         this._onChange = options.onChange;
         this._onSubmit = options.onSubmit;
 
-        this.events.on('key', (event: KeyEvent) => this.handleKey(event));
+        this.events.on('key', this._keyHandler);
+    }
+
+    override mount(): void {
+        super.mount();
+        this.events.off('key', this._keyHandler);
+        this.events.on('key', this._keyHandler);
     }
 
     /** The actual (unmasked) value. */

--- a/packages/ui/src/Wizard.ts
+++ b/packages/ui/src/Wizard.ts
@@ -34,6 +34,7 @@ export class Wizard extends Widget {
     private _error = '';
     private _onComplete?: (stepData: unknown[]) => void;
     focusable = true;
+    private readonly _keyHandler = (event: KeyEvent): void => this.handleKey(event);
 
     constructor(steps: WizardStep[], options: WizardOptions = {}) {
         const topPadding = 2;
@@ -62,7 +63,13 @@ export class Wizard extends Widget {
         }
 
         // Register default key listener
-        this.events.on('key', (event) => this.handleKey(event));
+        this.events.on('key', this._keyHandler);
+    }
+
+    override mount(): void {
+        super.mount();
+        this.events.off('key', this._keyHandler);
+        this.events.on('key', this._keyHandler);
     }
 
     get currentStepIndex(): number {

--- a/packages/ui/src/remount-key-handlers.test.ts
+++ b/packages/ui/src/remount-key-handlers.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Box } from '@termuijs/widgets';
+import { type KeyEvent } from '@termuijs/core';
+import { ConfirmDialog } from './ConfirmDialog.js';
+import { Form } from './Form.js';
+import { PasswordInput } from './PasswordInput.js';
+import { Wizard } from './Wizard.js';
+
+function key(keyName: string): KeyEvent {
+    return {
+        key: keyName,
+        shift: false,
+        ctrl: false,
+        alt: false,
+        raw: Buffer.alloc(0),
+        stopPropagation() {},
+        preventDefault() {},
+    };
+}
+
+function remount(widget: { mount(): void; unmount(): void }): void {
+    widget.mount();
+    widget.unmount();
+    widget.mount();
+}
+
+describe('UI key handlers after remount', () => {
+    it('restores ConfirmDialog key handling', () => {
+        const onCancel = vi.fn();
+        const dialog = new ConfirmDialog({ message: 'Continue?', onCancel });
+        remount(dialog);
+        dialog.show();
+
+        dialog.events.emit('key', key('escape'));
+
+        expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('restores Form key handling', () => {
+        const form = new Form([{ name: 'name', label: 'Name', type: 'text' }]);
+        remount(form);
+
+        form.events.emit('key', key('a'));
+
+        expect(form.values).toEqual({ name: 'a' });
+    });
+
+    it('restores PasswordInput key handling', () => {
+        const input = new PasswordInput();
+        remount(input);
+
+        input.events.emit('key', key('a'));
+
+        expect(input.value).toBe('a');
+    });
+
+    it('restores Wizard key handling', () => {
+        const wizard = new Wizard([
+            { title: 'One', render: () => new Box() },
+            { title: 'Two', render: () => new Box() },
+        ]);
+        remount(wizard);
+
+        wizard.events.emit('key', key('right'));
+
+        expect(wizard.currentStepIndex).toBe(1);
+    });
+});

--- a/packages/widgets/src/data/Table.ts
+++ b/packages/widgets/src/data/Table.ts
@@ -87,6 +87,8 @@ export class Table extends Widget {
     private _focusedHeaderIndex = 0;
     private _tableOnSort?: (colIndex: number, direction: 'asc' | 'desc') => void;
     private _sortState: { colIndex: number; direction: 'asc' | 'desc' } | null = null;
+    private readonly _keyHandler = (event: KeyEvent): void => this.handleKey(event);
+    private readonly _mouseHandler = (event: MouseEvent): void => this.handleMouse(event);
 
     constructor(
         columnsOrProps: TableColumn[] | TableProps,
@@ -123,9 +125,19 @@ export class Table extends Widget {
         this._onStateChange = onStateChange;
         this._tableOnSort = options.onSort;
 
-        this.events.on('key', this.handleKey.bind(this));
+        this.events.on('key', this._keyHandler);
         if (this._resizable) {
-            this.events.on('mouse', this.handleMouse.bind(this));
+            this.events.on('mouse', this._mouseHandler);
+        }
+    }
+
+    override mount(): void {
+        super.mount();
+        this.events.off('key', this._keyHandler);
+        this.events.on('key', this._keyHandler);
+        if (this._resizable) {
+            this.events.off('mouse', this._mouseHandler);
+            this.events.on('mouse', this._mouseHandler);
         }
     }
 

--- a/packages/widgets/src/input/List.ts
+++ b/packages/widgets/src/input/List.ts
@@ -49,6 +49,8 @@ export class List extends Widget {
     private _reorderable = false;
     private _searchBuffer = '';
     private _searchTimeout: ReturnType<typeof setTimeout> | null = null;
+    private readonly _keyHandler = (event: KeyEvent): void => this.handleKey(event);
+    private readonly _mouseHandler = (event: MouseEvent): void => this.handleMouse(event);
 
 
     constructor(
@@ -78,8 +80,16 @@ export class List extends Widget {
         }
 
         this.focusable = true;
-        this.events.on('key', this.handleKey.bind(this));
-        this.events.on('mouse', (event) => this.handleMouse(event));
+        this.events.on('key', this._keyHandler);
+        this.events.on('mouse', this._mouseHandler);
+    }
+
+    override mount(): void {
+        super.mount();
+        this.events.off('key', this._keyHandler);
+        this.events.off('mouse', this._mouseHandler);
+        this.events.on('key', this._keyHandler);
+        this.events.on('mouse', this._mouseHandler);
     }
 
     // ── Getters ───────────────────────────────────────

--- a/packages/widgets/src/input/TextInput.ts
+++ b/packages/widgets/src/input/TextInput.ts
@@ -36,6 +36,7 @@ export class TextInput extends Widget {
     public signal?: AbortSignal;
 
     private _raw: boolean;
+    private readonly _keyHandler = (event: KeyEvent): void => this.handleKey(event);
 
     constructor(
         style: Partial<Style> = {},
@@ -74,7 +75,13 @@ export class TextInput extends Widget {
 
         this.focusable = true;
 
-        this.events.on('key', (event: KeyEvent) => this.handleKey(event));
+        this.events.on('key', this._keyHandler);
+    }
+
+    override mount(): void {
+        super.mount();
+        this.events.off('key', this._keyHandler);
+        this.events.on('key', this._keyHandler);
     }
 
     get value(): string {

--- a/packages/widgets/src/remount-key-handlers.test.ts
+++ b/packages/widgets/src/remount-key-handlers.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { type KeyEvent } from '@termuijs/core';
+import { List } from './input/List.js';
+import { TextInput } from './input/TextInput.js';
+import { Table } from './data/Table.js';
+
+function key(keyName: string): KeyEvent {
+    return {
+        key: keyName,
+        shift: false,
+        ctrl: false,
+        alt: false,
+        raw: Buffer.alloc(0),
+        stopPropagation() {},
+        preventDefault() {},
+    };
+}
+
+function remount(widget: { mount(): void; unmount(): void }): void {
+    widget.mount();
+    widget.unmount();
+    widget.mount();
+}
+
+describe('widget key handlers after remount', () => {
+    it('restores List key handling', () => {
+        const list = new List([
+            { label: 'One', value: 'one' },
+            { label: 'Two', value: 'two' },
+        ]);
+        remount(list);
+
+        list.events.emit('key', key('down'));
+
+        expect(list.selectedIndex).toBe(1);
+    });
+
+    it('restores TextInput key handling', () => {
+        const input = new TextInput();
+        remount(input);
+
+        input.events.emit('key', key('a'));
+
+        expect(input.value).toBe('a');
+    });
+
+    it('restores Table key handling', () => {
+        const table = new Table(
+            [{ header: 'Name', key: 'name' }],
+            [{ name: 'One' }, { name: 'Two' }],
+        );
+        remount(table);
+
+        table.events.emit('key', key('down'));
+
+        expect(table.selectedRow).toBe(1);
+    });
+});


### PR DESCRIPTION
## Summary
- keep stable key and mouse event handlers for affected UI and widget components
- re-register handlers when components are mounted again
- add regression coverage for remounting ConfirmDialog, Form, PasswordInput, Wizard, List, TextInput, and Table

## Validation
- `bun run build`
- `bun vitest run packages/ui/src/remount-key-handlers.test.ts packages/widgets/src/remount-key-handlers.test.ts --reporter=dot`
- `bun run typecheck`

Closes #2612

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored keyboard interactions for dialogs, forms, password fields, wizards, lists, text inputs, and tables after components are remounted.
  * Prevented duplicate or lost keyboard and mouse event handling during repeated mount and unmount cycles.
  * Ensured resizable tables continue to manage mouse interactions reliably.

* **Tests**
  * Added coverage for keyboard behavior and state updates following component remounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->