### PR TITLE
test(widgets): add missing DragAndDrop unit tests

### DIFF
--- a/packages/widgets/src/layout/DragAndDrop.test.ts
+++ b/packages/widgets/src/layout/DragAndDrop.test.ts
@@ -3,7 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { KeyEvent, MouseEvent as TermMouseEvent } from '@termuijs/core';
+import { Screen, type KeyEvent, type MouseEvent as TermMouseEvent } from '@termuijs/core';
 import { DragState, DraggableWidget, DroppableWidget } from './DragAndDrop.js';
 
 function keyEvent(key: string): KeyEvent {
@@ -122,6 +122,19 @@ describe('DraggableWidget', () => {
         widget.handleKey(keyEvent('space'));
 
         expect(onDragEnd).toHaveBeenCalledOnce();
+    });
+
+    it('renders transparently and does not modify the screen output', () => {
+        const drag = new DraggableWidget({ id: 'drag-5' });
+        const screen = new Screen(10, 10);
+        drag.updateRect({ x: 0, y: 0, width: 5, height: 5 });
+        drag.render(screen);
+
+        for (let r = 0; r < 5; r++) {
+            for (let c = 0; c < 5; c++) {
+                expect(screen.back[r][c].char).toBe(' ');
+            }
+        }
     });
 });
 
@@ -277,5 +290,18 @@ describe('DroppableWidget', () => {
         widget.handleMouse(mouseEvent('mouseleave'));
 
         expect(onDragLeave).not.toHaveBeenCalled();
+    });
+
+    it('renders transparently and does not modify the screen output', () => {
+        const drop = new DroppableWidget({ id: 'drop-3' });
+        const screen = new Screen(10, 10);
+        drop.updateRect({ x: 0, y: 0, width: 5, height: 5 });
+        drop.render(screen);
+
+        for (let r = 0; r < 5; r++) {
+            for (let c = 0; c < 5; c++) {
+                expect(screen.back[r][c].char).toBe(' ');
+            }
+        }
     });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

This PR adds the missing unit test coverage for the DragAndDrop layout widget (`packages/widgets/src/layout/DragAndDrop.ts`). It includes robust Vitest coverage verifying that both `DraggableWidget` and `DroppableWidget` render transparently by asserting the output screen's characters are unmodified.

## Related Issue

Closes #2567

## Which package(s)?

@termuijs/widgets

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/daed37c5-b1cd-491d-a0bf-f46a00e1c44c`

## Screenshots / Recordings (UI changes)

N/A - Test suite additions only.

## Notes for the Reviewer

Rebased the branch onto the latest `upstream/main` and resolved merge conflicts with the baseline tests that were merged in separate PRs (#2193 & #2296). Added robust assertions for screen character verification to verify transparency, addressing the CodeRabbit review suggestion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming draggable and droppable widgets render transparently without altering the underlying screen content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->