### PR TITLE
Fix BasicAuthPrompt grapheme deletion

### DIFF
--- a/packages/ui/src/BasicAuthPrompt.test.ts
+++ b/packages/ui/src/BasicAuthPrompt.test.ts
@@ -313,6 +313,25 @@ describe("BasicAuthPrompt – multiple backspaces on username", () => {
         pressBackspace(widget);
         expect(widget.getCredentials().password).toBe("");
     });
+
+    it("removes one grapheme from username input", () => {
+        const widget = new BasicAuthPrompt();
+
+        typeInto(widget, "Cafe\u0301");
+        pressBackspace(widget);
+
+        expect(widget.getCredentials().username).toBe("Caf");
+    });
+
+    it("removes one grapheme from password input", () => {
+        const widget = new BasicAuthPrompt();
+        pressEnter(widget);
+
+        typeInto(widget, "Cafe\u0301");
+        pressBackspace(widget);
+
+        expect(widget.getCredentials().password).toBe("Caf");
+    });
 });
 
 // ─── 2. Backspace on empty fields ─────────────────────────────────────────────

--- a/packages/ui/src/BasicAuthPrompt.ts
+++ b/packages/ui/src/BasicAuthPrompt.ts
@@ -1,5 +1,5 @@
 import { Widget } from "@termuijs/widgets";
-import { type Style, type KeyEvent, Screen, caps, truncate } from "@termuijs/core";
+import { type Style, type KeyEvent, Screen, caps, truncate, splitGraphemes } from "@termuijs/core";
 
 export interface BasicAuthCredentials {
     username: string;
@@ -45,9 +45,9 @@ export class BasicAuthPrompt extends Widget {
     }
     private deleteBackward(): void {
         if (this._activeField === "username") {
-            this._username = this._username.slice(0, -1);
+            this._username = splitGraphemes(this._username).slice(0, -1).join("");
         } else {
-            this._password = this._password.slice(0, -1);
+            this._password = splitGraphemes(this._password).slice(0, -1).join("");
         }
         this.markDirty();
     }


### PR DESCRIPTION
﻿## Summary
- deletes username and password input by grapheme cluster on backspace
- adds regression coverage for combining-mark input in both fields

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/ui/src/BasicAuthPrompt.test.ts

Closes #2622


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backspace behavior in the Basic Authentication prompt.
  * Backspace now removes one complete user-perceived character, including characters made from combining accents, in both username and password fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->