### PR TITLE
Fix SurveyPrompt grapheme deletion

### DIFF
--- a/packages/ui/src/SurveyPrompt.test.ts
+++ b/packages/ui/src/SurveyPrompt.test.ts
@@ -115,4 +115,18 @@ describe("SurveyPrompt", () => {
             name: "Bob",
         });
     });
+
+    it("backspace removes one grapheme from text answers", () => {
+        const prompt = new SurveyPrompt(QUESTIONS);
+
+        for (const key of "Cafe\u0301") {
+            prompt.handleKey({ key, ctrl: false, alt: false } as any);
+        }
+        prompt.handleKey({ key: "backspace", ctrl: false, alt: false } as any);
+        prompt.handleKey({ key: "enter", ctrl: false, alt: false } as any);
+
+        expect(prompt.getAnswers()).toEqual({
+            name: "Caf",
+        });
+    });
 });

--- a/packages/ui/src/SurveyPrompt.ts
+++ b/packages/ui/src/SurveyPrompt.ts
@@ -7,6 +7,7 @@ import {
     defaultStyle,
     styleToCellAttrs,
     caps,
+    splitGraphemes,
 } from "@termuijs/core";
 
 export interface SurveyQuestion {
@@ -71,7 +72,7 @@ export class SurveyPrompt extends Widget {
         if (question.type === "text") {
             switch (event.key) {
                 case "backspace":
-                    this._textBuffer = this._textBuffer.slice(0, -1);
+                    this._textBuffer = splitGraphemes(this._textBuffer).slice(0, -1).join("");
                     this.markDirty();
                     break;
 


### PR DESCRIPTION
﻿## Summary
- deletes text-answer input by grapheme cluster on backspace
- adds regression coverage for combining-mark answers

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/ui/src/SurveyPrompt.test.ts

Closes #2623


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text input backspace behavior to remove complete characters, including characters made up of combining marks.
  * Added coverage to verify accented text is handled correctly when editing survey responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->