### PR TITLE
Validate ScalePrompt max option

### DIFF
--- a/packages/ui/src/ScalePrompt.test.ts
+++ b/packages/ui/src/ScalePrompt.test.ts
@@ -98,4 +98,31 @@ describe('ScalePrompt', () => {
         expect(onSelect).toHaveBeenCalledTimes(1);
         expect(onSelect).toHaveBeenCalledWith(3);
     });
+
+    it('falls back to a finite max when max is NaN', () => {
+        const prompt = new ScalePrompt(undefined, { max: NaN });
+
+        prompt.handleKey(createKeyEvent({
+            key: 'right',
+            ctrl: false,
+            alt: false,
+            shift: false,
+            raw: Buffer.from('right'),
+        }));
+
+        expect(prompt.getValue()).toBe(2);
+        const screen = renderScalePrompt(prompt);
+        const rendered = screen.back[0].map((cell) => cell.char).join('');
+        expect(rendered).toContain('5');
+    });
+
+    it('falls back to a finite max when max is infinite', () => {
+        const prompt = new ScalePrompt(undefined, { max: Infinity });
+        const screen = renderScalePrompt(prompt);
+        const rendered = screen.back[0].map((cell) => cell.char).join('');
+
+        expect(prompt.getValue()).toBe(1);
+        expect(rendered).toContain('[1]');
+        expect(rendered).toContain('5');
+    });
 });

--- a/packages/ui/src/ScalePrompt.ts
+++ b/packages/ui/src/ScalePrompt.ts
@@ -22,7 +22,8 @@ export class ScalePrompt extends Widget {
     constructor(style?: Partial<Style>, opts: ScalePromptOptions = {}) {
         super(mergeStyles(defaultStyle(), { height: 3, flexGrow: 1, ...style }));
 
-        this._max = Math.max(1, Math.floor(opts.max ?? 5));
+        const rawMax = opts.max ?? 5;
+        this._max = Number.isFinite(rawMax) ? Math.max(1, Math.floor(rawMax)) : 5;
         this._value = 1;
         this._question = opts.question;
         this._endLabels = opts.endLabels;


### PR DESCRIPTION
﻿## Summary
- normalizes non-finite max values to the default scale size
- keeps ScalePrompt value clamping finite after invalid constructor input
- adds regression coverage for NaN and Infinity max values

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/ui/src/ScalePrompt.test.ts

Closes #2624
