### PR TITLE
Normalize Pagination total pages

### DIFF
--- a/packages/ui/src/Pagination.test.ts
+++ b/packages/ui/src/Pagination.test.ts
@@ -46,4 +46,18 @@ describe('Pagination', () => {
         expect(p2.page).toBe(5);
         expect(onChange).not.toHaveBeenCalled();
     });
+
+    it('normalizes NaN totalPages to one page', () => {
+        const p = new Pagination(3, NaN);
+
+        expect(p.totalPages).toBe(1);
+        expect(p.page).toBe(1);
+    });
+
+    it('normalizes infinite totalPages to one page', () => {
+        const p = new Pagination(3, Infinity);
+
+        expect(p.totalPages).toBe(1);
+        expect(p.page).toBe(1);
+    });
 });

--- a/packages/ui/src/Pagination.ts
+++ b/packages/ui/src/Pagination.ts
@@ -14,13 +14,17 @@ export class Pagination extends Widget {
 
     constructor(page: number, totalPages: number, options: PaginationOptions = {}) {
         super(mergeStyles(defaultStyle(), { height: 1 }));
-        this._totalPages = Math.max(1, Math.floor(totalPages));
+        this._totalPages = this._normalizeTotalPages(totalPages);
         this._page = this._clamp(Math.floor(page));
         this._onChange = options.onChange;
     }
 
     get page(): number { return this._page; }
     get totalPages(): number { return this._totalPages; }
+
+    private _normalizeTotalPages(n: number): number {
+        return Number.isFinite(n) ? Math.max(1, Math.floor(n)) : 1;
+    }
 
     private _clamp(n: number): number {
         if (isNaN(n) || !isFinite(n)) return 1;


### PR DESCRIPTION
﻿## Summary
- normalizes non-finite totalPages values to one page
- keeps page clamping finite for NaN and Infinity totals
- adds regression coverage for invalid total counts

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/ui/src/Pagination.test.ts

Closes #2625
