### PR TITLE
Clip Select rows at narrow widths

### DIFF
--- a/packages/ui/src/Select.test.ts
+++ b/packages/ui/src/Select.test.ts
@@ -3,6 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi } from 'vitest';
+import { Screen, stringWidth } from '@termuijs/core';
 import { Select } from './Select.js';
 
 const OPTIONS = [
@@ -84,5 +85,30 @@ describe('Select', () => {
         sel.selectNext(); // index 1 = banana
         sel.confirm();
         expect(onSelect).toHaveBeenCalledWith(OPTIONS[1], 1);
+    });
+
+    it('clips the closed label to narrow widths', () => {
+        const sel = new Select([{ label: 'Watermelon', value: 'watermelon' }]);
+        const screen = new Screen(1, 1);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        sel.updateRect({ x: 0, y: 0, width: 1, height: 1 });
+        sel.render(screen);
+
+        expect(stringWidth(String(writeSpy.mock.calls[0][2]))).toBeLessThanOrEqual(1);
+    });
+
+    it('clips open option rows to narrow widths', () => {
+        const sel = new Select([{ label: 'Watermelon', value: 'watermelon' }]);
+        const screen = new Screen(1, 2);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        sel.updateRect({ x: 0, y: 0, width: 1, height: 2 });
+        sel.open();
+        sel.render(screen);
+
+        for (const call of writeSpy.mock.calls) {
+            expect(stringWidth(String(call[2]))).toBeLessThanOrEqual(1);
+        }
     });
 });

--- a/packages/ui/src/Select.ts
+++ b/packages/ui/src/Select.ts
@@ -1,6 +1,6 @@
 // Select — single-item dropdown selector
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Screen, mergeStyles, defaultStyle, styleToCellAttrs, caps } from '@termuijs/core';
+import { type Style, type Screen, mergeStyles, defaultStyle, styleToCellAttrs, caps, truncate } from '@termuijs/core';
 import { firstEnabledIndex, nextEnabledIndex, previousEnabledIndex } from './navigation.js';
 
 export interface SelectOption { label: string; value: string; disabled?: boolean; }
@@ -88,13 +88,13 @@ export class Select extends Widget {
         const sel = this.selectedOption;
         const label = sel ? sel.label : this._placeholder;
         const prefix = this._isOpen ? (caps.unicode ? '▼ ' : 'v ') : (caps.unicode ? '▶ ' : '> ');
-        screen.writeString(x, y, prefix + label.slice(0, width - 2), { ...attrs, fg: this._activeColor });
+        screen.writeString(x, y, truncate(prefix + label, width, ''), { ...attrs, fg: this._activeColor });
         if (this._isOpen) {
             for (let i = 0; i < this._options.length; i++) {
                 const o = this._options[i];
                 const isSel = i === this._selectedIndex;
                 const m = isSel ? (caps.unicode ? '● ' : '* ') : '  ';
-                screen.writeString(x, y + 1 + i, m + o.label.slice(0, width - 2), {
+                screen.writeString(x, y + 1 + i, truncate(m + o.label, width, ''), {
                     ...attrs,
                     fg: o.disabled ? { type: 'named' as const, name: 'brightBlack' as const } : isSel ? this._activeColor : attrs.fg,
                     bold: isSel, dim: o.disabled,


### PR DESCRIPTION
﻿## Summary
- truncates closed and open Select rows to the widget width
- avoids negative label slice budgets at very narrow widths
- adds regression coverage for one-column rendering

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/ui/src/Select.test.ts

Closes #2626
