### PR TITLE
Keep Switch track within bounds

### DIFF
--- a/packages/ui/src/Switch.test.ts
+++ b/packages/ui/src/Switch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { Screen, caps } from '@termuijs/core';
+import { Screen, caps, stringWidth } from '@termuijs/core';
 import { Switch } from './Switch.js';
 
 describe('Switch', () => {
@@ -96,5 +96,33 @@ describe('Switch', () => {
             .join('');
 
         expect(row).toContain('O');
+    });
+
+    it('keeps the label and track within the widget width', () => {
+        const sw = new Switch({
+            label: 'Very long wireless label',
+            defaultValue: true,
+        });
+
+        sw.updateRect({
+            x: 0,
+            y: 0,
+            width: 5,
+            height: 1,
+        });
+
+        const screen = new Screen(5, 1);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+        const setCellSpy = vi.spyOn(screen, 'setCell');
+
+        sw.render(screen);
+
+        for (const call of writeSpy.mock.calls) {
+            expect(call[0] + stringWidth(String(call[2]))).toBeLessThanOrEqual(5);
+        }
+
+        for (const call of setCellSpy.mock.calls) {
+            expect(call[0]).toBeLessThan(5);
+        }
     });
 });

--- a/packages/ui/src/Switch.ts
+++ b/packages/ui/src/Switch.ts
@@ -6,6 +6,7 @@ import {
     defaultStyle,
     styleToCellAttrs,
     stringWidth,
+    truncate,
     caps,
     prefersReducedMotion,
 } from '@termuijs/core';
@@ -127,13 +128,23 @@ export class Switch extends Widget {
         }
 
         let cursorX = x;
+        const right = x + width;
 
         if (this._label) {
-            screen.writeString(cursorX, y, `${this._label} `, attrs);
-            cursorX += stringWidth(`${this._label} `);
+            const labelWidth = Math.max(0, width - 3);
+            const label = truncate(`${this._label} `, labelWidth, '');
+
+            if (label.length > 0) {
+                screen.writeString(cursorX, y, label, attrs);
+                cursorX += stringWidth(label);
+            }
         }
 
         for (let i = 0; i < 3; i++) {
+            if (cursorX + i >= right) {
+                break;
+            }
+
             const isKnob = i === knobPos;
             const isOn = this._value;
             screen.setCell(cursorX + i, y, {


### PR DESCRIPTION
## Summary
- reserves room for the Switch track when rendering labels
- clips long labels to the available width
- adds a narrow-width regression test

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/ui/src/Switch.test.ts

Closes #2628