### PR TITLE
Constrain ThinkingBlock rendering

### DIFF
--- a/packages/widgets/src/display/ThinkingBlock.test.ts
+++ b/packages/widgets/src/display/ThinkingBlock.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import * as core from '@termuijs/core';
 import * as motion from '@termuijs/motion';
-import { Screen, type KeyEvent, caps } from '@termuijs/core';
+import { Screen, type KeyEvent, caps, stringWidth } from '@termuijs/core';
 import { ThinkingBlock } from './ThinkingBlock.js';
 
 const key = (k: string): KeyEvent => ({ key: k, ctrl: false, alt: false, shift: false, raw: Buffer.alloc(0), stopPropagation: () => {}, preventDefault: () => {} });
@@ -167,6 +167,36 @@ describe('ThinkingBlock', () => {
         const screen = render(block);
 
         expect(screen.back[0]?.[0]?.char).toBe('[');
+    });
+
+    it('clips collapsed text to the widget width', () => {
+        const block = new ThinkingBlock();
+        const screen = new Screen(4, 1);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        block.updateRect({ x: 0, y: 0, width: 4, height: 1 });
+        block.render(screen);
+
+        for (const call of writeSpy.mock.calls) {
+            expect(call[0] + stringWidth(String(call[2]))).toBeLessThanOrEqual(4);
+        }
+    });
+
+    it('keeps expanded rendering inside a narrow widget', () => {
+        const block = new ThinkingBlock({
+            thinking: 'Narrow content should stay inside the available box',
+        });
+        const screen = new Screen(3, 3);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        block.handleKey(key('enter'));
+        block.updateRect({ x: 0, y: 0, width: 3, height: 3 });
+        block.render(screen);
+
+        for (const call of writeSpy.mock.calls) {
+            expect(call[0] + stringWidth(String(call[2]))).toBeLessThanOrEqual(3);
+            expect(call[1]).toBeLessThan(3);
+        }
     });
 
 });

--- a/packages/widgets/src/display/ThinkingBlock.ts
+++ b/packages/widgets/src/display/ThinkingBlock.ts
@@ -8,6 +8,7 @@ import {
     type KeyEvent,
     styleToCellAttrs,
     wordWrap,
+    truncate,
     caps,
     prefersReducedMotion,
 } from '@termuijs/core';
@@ -99,15 +100,20 @@ export class ThinkingBlock extends Widget {
 
     protected _renderSelf(screen: Screen): void {
         const rect = this._getContentRect();
+
+        if (rect.width <= 0 || rect.height <= 0) {
+            return;
+        }
+
         const attrs = styleToCellAttrs(this._style);
 
         if (!this._expanded) {
             const text = `[thinking${this._streaming ? this._dots : ''}]`;
-            screen.writeString(rect.x, rect.y, text, attrs);
+            screen.writeString(rect.x, rect.y, truncate(text, rect.width, ''), attrs);
             return;
         }
 
-        const boxWidth = Math.max(4, rect.width);
+        const boxWidth = rect.width;
 
         const tl = caps.unicode ? '┌' : '+';
         const tr = caps.unicode ? '┐' : '+';
@@ -115,6 +121,11 @@ export class ThinkingBlock extends Widget {
         const br = caps.unicode ? '┘' : '+';
         const h = caps.unicode ? '─' : '-';
         const v = caps.unicode ? '│' : '|';
+
+        if (boxWidth === 1) {
+            screen.writeString(rect.x, rect.y, tl, attrs);
+            return;
+        }
 
         if (
             this._cachedBorderWidth !== boxWidth ||
@@ -137,7 +148,8 @@ export class ThinkingBlock extends Widget {
             attrs,
         );
 
-        const wrapWidth = Math.max(1, boxWidth - 4);
+        const contentWidth = Math.max(0, boxWidth - 4);
+        const wrapWidth = Math.max(1, contentWidth);
 
         if (this._cachedWrapWidth !== wrapWidth || this._wrappedLines.length === 0) {
             const wrapped = wordWrap(
@@ -168,7 +180,7 @@ export class ThinkingBlock extends Widget {
             screen.writeString(
                 rect.x + 2,
                 rect.y + i + 1,
-                line,
+                truncate(line, contentWidth, ''),
                 attrs,
             );
 
@@ -180,11 +192,13 @@ export class ThinkingBlock extends Widget {
             );
         }
 
-        screen.writeString(
-            rect.x,
-            rect.y + limit + 1,
-            this._bottomBorder,
-            attrs,
-        );
+        if (limit + 1 < rect.height) {
+            screen.writeString(
+                rect.x,
+                rect.y + limit + 1,
+                this._bottomBorder,
+                attrs,
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- clips collapsed ThinkingBlock text to the widget width
- keeps expanded borders and content inside narrow rectangles
- adds narrow-width regression coverage

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/widgets/src/display/ThinkingBlock.test.ts

Closes #2629