### PR TITLE
Clip TimePicker rendering to width

### DIFF
--- a/packages/ui/src/TimePicker.test.ts
+++ b/packages/ui/src/TimePicker.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { Screen, createKeyEvent } from "@termuijs/core";
+import { describe, it, expect, vi } from "vitest";
+import { Screen, createKeyEvent, stringWidth } from "@termuijs/core";
 import { TimePicker } from "./TimePicker.js";
 
 describe("TimePicker", () => {
@@ -64,5 +64,33 @@ describe("TimePicker", () => {
         picker.handleKey(createKeyEvent({ key: "right", raw: Buffer.from(""), ctrl: false, alt: false, shift: false }));
         picker.handleKey(createKeyEvent({ key: "up", raw: Buffer.from(""), ctrl: false, alt: false, shift: false }));
         expect(picker.value.getHours()).toBe(2); // 14 - 12 = 2 (AM)
+    });
+
+    it("clips 12-hour rendering to narrow widths", () => {
+        const screen = new Screen(4, 3);
+        const writeSpy = vi.spyOn(screen, "writeString");
+        const d = new Date(2020, 1, 1, 14, 30);
+        const picker = new TimePicker({ value: d, use24Hour: false });
+
+        picker.updateRect({ x: 0, y: 0, width: 4, height: 3 });
+        picker.render(screen);
+
+        for (const call of writeSpy.mock.calls) {
+            expect(call[0] + stringWidth(String(call[2]))).toBeLessThanOrEqual(4);
+        }
+    });
+
+    it("clips 24-hour rendering to narrow widths", () => {
+        const screen = new Screen(3, 3);
+        const writeSpy = vi.spyOn(screen, "writeString");
+        const d = new Date(2020, 1, 1, 14, 30);
+        const picker = new TimePicker({ value: d, use24Hour: true });
+
+        picker.updateRect({ x: 0, y: 0, width: 3, height: 3 });
+        picker.render(screen);
+
+        for (const call of writeSpy.mock.calls) {
+            expect(call[0] + stringWidth(String(call[2]))).toBeLessThanOrEqual(3);
+        }
     });
 });

--- a/packages/ui/src/TimePicker.ts
+++ b/packages/ui/src/TimePicker.ts
@@ -1,5 +1,5 @@
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs } from '@termuijs/core';
+import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, stringWidth, truncate } from '@termuijs/core';
 
 export interface TimePickerOptions {
     value?: Date;
@@ -106,24 +106,55 @@ export class TimePicker extends Widget {
         const totalWidth = 2 + 1 + 2 + (this._use24Hour ? 0 : 3);
         const startX = x + Math.max(0, Math.floor((width - totalWidth) / 2));
         const centerY = y + Math.floor(height / 2);
+        const right = x + width;
 
-        screen.writeString(startX, centerY, hStr, {
-            ...attrs,
-            inverse: this.isFocused && this._activeSegment === 0
-        });
-
-        screen.writeString(startX + 2, centerY, ":", attrs);
-
-        screen.writeString(startX + 3, centerY, mStr, {
-            ...attrs,
-            inverse: this.isFocused && this._activeSegment === 1
-        });
+        const segments = [
+            {
+                text: hStr,
+                active: this._activeSegment === 0,
+            },
+            {
+                text: ":",
+                active: false,
+            },
+            {
+                text: mStr,
+                active: this._activeSegment === 1,
+            },
+        ];
 
         if (!this._use24Hour) {
-            screen.writeString(startX + 5, centerY, ampmStr, {
-                ...attrs,
-                inverse: this.isFocused && this._activeSegment === 2
+            segments.push({
+                text: ampmStr,
+                active: this._activeSegment === 2,
             });
+        }
+
+        let col = startX;
+
+        for (const segment of segments) {
+            const remaining = right - col;
+
+            if (remaining <= 0) {
+                break;
+            }
+
+            const visible = truncate(segment.text, remaining, '');
+
+            if (visible.length === 0) {
+                break;
+            }
+
+            screen.writeString(col, centerY, visible, {
+                ...attrs,
+                inverse: this.isFocused && segment.active
+            });
+
+            col += stringWidth(visible);
+
+            if (stringWidth(segment.text) > remaining) {
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- clips TimePicker time segments to the content width
- preserves active segment styling for visible text
- adds narrow-width regression coverage for 12-hour and 24-hour modes

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/ui/src/TimePicker.test.ts

Closes #2631