### PR TITLE
Clip Tabs rendering to width

### DIFF
--- a/packages/ui/src/Tabs.test.ts
+++ b/packages/ui/src/Tabs.test.ts
@@ -2,10 +2,10 @@
 // @termuijs/ui — Tests for Tabs component
 // ─────────────────────────────────────────────────────
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Tabs } from './Tabs.js';
 import { Box, Text, Widget } from '@termuijs/widgets';
-import { Screen } from '@termuijs/core';
+import { Screen, stringWidth } from '@termuijs/core';
 
 const makeTabs = () => new Tabs([
     { label: 'Home', content: new Box() },
@@ -166,5 +166,23 @@ describe('Tabs', () => {
 
         expect(first.destroys).toBe(1);
         expect(second.destroys).toBe(1);
+    });
+
+    it('clips tab labels and separators to the widget width', () => {
+        const tabs = new Tabs([
+            { label: 'VeryLongHomeLabel', content: new Box() },
+            { label: 'Settings', content: new Box() },
+        ], { border: 'none' });
+        const screen = new Screen(8, 3);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        tabs.updateRect({ x: 0, y: 0, width: 8, height: 3 });
+        tabs.render(screen);
+
+        for (const call of writeSpy.mock.calls) {
+            if (call[1] === 0) {
+                expect(call[0] + stringWidth(String(call[2]))).toBeLessThanOrEqual(8);
+            }
+        }
     });
 });

--- a/packages/ui/src/Tabs.ts
+++ b/packages/ui/src/Tabs.ts
@@ -1,6 +1,6 @@
 // Tabs — tabbed container with keyboard switching
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Screen, mergeStyles, defaultStyle, styleToCellAttrs, caps } from '@termuijs/core';
+import { type Style, type Screen, mergeStyles, defaultStyle, styleToCellAttrs, caps, stringWidth, truncate } from '@termuijs/core';
 
 export interface Tab { label: string; content: Widget; }
 export interface TabsOptions {
@@ -12,8 +12,8 @@ export interface TabsOptions {
 export class Tabs extends Widget {
     private _tabs: Tab[] = [];
     private _activeIndex = 0;
-    private _activeColor: Style['fg'];
-    private _inactiveColor: Style['fg'];
+    private _activeColor: NonNullable<Style['fg']>;
+    private _inactiveColor: NonNullable<Style['fg']>;
     private _contentMounted = false;
     focusable = true;
 
@@ -70,17 +70,28 @@ export class Tabs extends Widget {
         if (width <= 0 || height <= 0) return;
         const attrs = styleToCellAttrs(this.style);
         let col = x;
+        const right = x + width;
+        const writeSegment = (text: string, segmentAttrs = attrs): boolean => {
+            const remaining = right - col;
+            if (remaining <= 0) return false;
+            const visible = truncate(text, remaining, '');
+            if (visible.length === 0) return false;
+            screen.writeString(col, y, visible, segmentAttrs);
+            col += stringWidth(visible);
+            return stringWidth(text) <= remaining;
+        };
         for (let i = 0; i < this._tabs.length; i++) {
             const tab = this._tabs[i];
             const isActive = i === this._activeIndex;
             const label = isActive ? ` ${caps.unicode ? '●' : '*'} ${tab.label} ` : `   ${tab.label} `;
-            screen.writeString(col, y, label, {
+            if (!writeSegment(label, {
                 ...attrs,
                 fg: isActive ? this._activeColor : this._inactiveColor,
                 bold: isActive, dim: !isActive,
-            });
-            col += label.length;
-            if (i < this._tabs.length - 1) { screen.writeString(col, y, caps.unicode ? '│' : '|', { ...attrs, dim: true }); col++; }
+            })) {
+                break;
+            }
+            if (i < this._tabs.length - 1 && !writeSegment(caps.unicode ? '│' : '|', { ...attrs, dim: true })) break;
         }
         if (height > 1) screen.writeString(x, y + 1, '─'.repeat(width), { ...attrs, dim: true });
 


### PR DESCRIPTION
## Summary
- clips tab labels and separators to the widget width
- stops rendering once the tab bar has no remaining columns
- adds a narrow-width regression test

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/ui/src/Tabs.test.ts

Closes #2648

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab rendering in narrow panels by truncating labels to fit available width.
  * Prevented tab separators and labels from extending beyond the widget boundaries.
  * Improved handling of wide characters when calculating tab display space.

* **Tests**
  * Added coverage to verify tab content stays within its configured width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->