### PR TITLE
Constrain Timeline title rendering

### DIFF
--- a/packages/widgets/src/display/Timeline.test.ts
+++ b/packages/widgets/src/display/Timeline.test.ts
@@ -3,7 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi } from 'vitest';
-import { Screen, caps } from '@termuijs/core';
+import { Screen, caps, stringWidth } from '@termuijs/core';
 import { Timeline, type TimelineItem } from './Timeline.js';
 
 function renderList(
@@ -114,4 +114,25 @@ describe('Timeline', () => {
         expect(rowText(nextScreen, 0)).toContain('New');
     });
 
+    it('clips long titles before right-aligned time text', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+        const widget = new Timeline([
+            {
+                title: 'A very long deployment step name',
+                time: '12:34',
+                status: 'active',
+            },
+        ]);
+        const screen = new Screen(16, 1);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        widget.updateRect({ x: 0, y: 0, width: 16, height: 1 });
+        widget.render(screen);
+
+        for (const call of writeSpy.mock.calls) {
+            expect(call[0] + stringWidth(String(call[2]))).toBeLessThanOrEqual(16);
+        }
+
+        expect(rowText(screen, 0)).toContain('12:34');
+    });
 });

--- a/packages/widgets/src/display/Timeline.ts
+++ b/packages/widgets/src/display/Timeline.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets — Timeline widget
 // ─────────────────────────────────────────────────────
 
-import { type Screen, type Style, type Color, styleToCellAttrs, caps } from '@termuijs/core';
+import { type Screen, type Style, type Color, styleToCellAttrs, caps, stringWidth, truncate } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
 export type TimelineStatus = 'done' | 'active' | 'pending';
@@ -90,33 +90,45 @@ export class Timeline extends Widget {
                     : { type: 'named', name: 'white' };
 
             // Connector + icon portion: e.g. "├─ ● "
-            const iconX = x + connector.length;
+            const right = x + width;
+            const connectorWidth = stringWidth(connector);
+            const iconX = x + connectorWidth;
             const titleX = iconX + 2;
 
-            screen.writeString(x, y + i, connector, {
+            screen.writeString(x, y + i, truncate(connector, width, ''), {
                 ...attrs,
                 fg: statusColor,
                 bold: isActive,
                 dim: isPending,
             });
 
-            screen.setCell(iconX, y + i, {
-                char: icon,
-                fg: statusColor,
-                bold: isActive,
-                dim: isPending,
-            });
+            if (iconX < right) {
+                screen.setCell(iconX, y + i, {
+                    char: icon,
+                    fg: statusColor,
+                    bold: isActive,
+                    dim: isPending,
+                });
+            }
 
-            screen.writeString(titleX, y + i, item.title, {
-                ...attrs,
-                bold: isActive,
-                dim: isPending,
-            });
+            const timeStr = item.time ? ` ${item.time}` : '';
+            const timeWidth = stringWidth(timeStr);
+            const timeX = timeStr ? x + width - timeWidth : right;
+            const titleWidth = Math.max(
+                0,
+                (timeStr && timeX > titleX ? timeX : right) - titleX,
+            );
+
+            if (titleWidth > 0) {
+                screen.writeString(titleX, y + i, truncate(item.title, titleWidth, ''), {
+                    ...attrs,
+                    bold: isActive,
+                    dim: isPending,
+                });
+            }
 
             // Time — dimmed right-aligned
-            if (item.time) {
-                const timeStr = ` ${item.time}`;
-                const timeX = x + width - timeStr.length;
+            if (timeStr) {
                 if (timeX > titleX) {
                     screen.writeString(timeX, y + i, timeStr, {
                         ...attrs,


### PR DESCRIPTION
## Summary
- reserves space for Timeline time labels before writing titles
- clips long titles to the available row width
- guards narrow connector and icon rendering

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/widgets/src/display/Timeline.test.ts

Closes #2649

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Timeline rendering for long titles and right-aligned times.
  * Prevented content from exceeding the available display width.
  * Preserved time visibility while truncating titles and connectors as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->