### PR TITLE
Keep EmptyState content inside bounds

### DIFF
--- a/packages/widgets/src/feedback/EmptyState.test.ts
+++ b/packages/widgets/src/feedback/EmptyState.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { Screen } from '@termuijs/core';
+import { Screen, stringWidth, caps } from '@termuijs/core';
 import { EmptyState } from './EmptyState.js';
 
 afterEach(() => {
@@ -12,6 +12,7 @@ function row(screen: Screen, y: number): string {
 
 describe('EmptyState', () => {
     it('renders icon + title centered', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
         const es = new EmptyState('No items');
         es.updateRect({ x: 0, y: 0, width: 30, height: 5 });
         const screen = new Screen(30, 5);
@@ -163,6 +164,7 @@ describe('EmptyState', () => {
     });
     
     it('setIcon updates rendered icon', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
         const es = new EmptyState('No data');
     
         es.setIcon('📦');
@@ -225,4 +227,20 @@ describe('EmptyState', () => {
         });
     });
 
+    it('keeps long content writes inside the widget rect', () => {
+        const es = new EmptyState('Very long empty state title', {}, {
+            description: 'A description that is also too long',
+            hint: 'Press something eventually',
+        });
+        const screen = new Screen(6, 1);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        es.updateRect({ x: 0, y: 0, width: 6, height: 1 });
+        es.render(screen);
+
+        for (const call of writeSpy.mock.calls) {
+            expect(call[0] + stringWidth(String(call[2]))).toBeLessThanOrEqual(6);
+            expect(call[1]).toBeLessThan(1);
+        }
+    });
 });

--- a/packages/widgets/src/feedback/EmptyState.ts
+++ b/packages/widgets/src/feedback/EmptyState.ts
@@ -1,4 +1,4 @@
-import { type Screen, type Style, styleToCellAttrs, stringWidth, caps } from '@termuijs/core';
+import { type Screen, type Style, styleToCellAttrs, stringWidth, caps, truncate } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
 export interface EmptyStateOptions {
@@ -80,23 +80,33 @@ export class EmptyState extends Widget {
         const contentLines = 1 + 1 + (hasDesc ? 1 : 0);
         const startRow = y + Math.max(0, Math.floor((mainHeight - contentLines) / 2));
 
-        const iconX = x + Math.max(0, Math.floor((width - stringWidth(this._icon)) / 2));
-        screen.writeString(iconX, startRow, this._icon, attrs);
+        const renderLine = (
+            row: number,
+            text: string,
+            lineAttrs = attrs,
+        ): void => {
+            if (row < y || row >= y + height) return;
+
+            const visible = truncate(text, width, '');
+            if (visible.length === 0) return;
+
+            const lineX = x + Math.max(0, Math.floor((width - stringWidth(visible)) / 2));
+            screen.writeString(lineX, row, visible, lineAttrs);
+        };
+
+        renderLine(startRow, this._icon, attrs);
 
         const titleStr = this._title;
-        const titleX = x + Math.max(0, Math.floor((width - stringWidth(titleStr)) / 2));
-        screen.writeString(titleX, startRow + 1, titleStr, { ...attrs, bold: true });
+        renderLine(startRow + 1, titleStr, { ...attrs, bold: true });
 
         if (hasDesc) {
             const descStr = this._description;
-            const descX = x + Math.max(0, Math.floor((width - stringWidth(descStr)) / 2));
-            screen.writeString(descX, startRow + 2, descStr, { ...attrs, dim: true });
+            renderLine(startRow + 2, descStr, { ...attrs, dim: true });
         }
 
         if (hasHint) {
             const hintStr = this._hint;
-            const hintX = x + Math.max(0, Math.floor((width - stringWidth(hintStr)) / 2));
-            screen.writeString(hintX, hintRow, hintStr, { ...attrs, dim: true });
+            renderLine(hintRow, hintStr, { ...attrs, dim: true });
         }
     }
 }


### PR DESCRIPTION
## Summary
- clips EmptyState icon, title, description, and hint lines to the widget width
- skips writes when computed rows fall outside the widget height
- makes Unicode icon expectations deterministic in the focused test file

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/widgets/src/feedback/EmptyState.test.ts

Closes #2650