### PR TITLE
Constrain Popover title width

### DIFF
--- a/packages/ui/src/Popover.test.ts
+++ b/packages/ui/src/Popover.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { Screen, caps } from '@termuijs/core';
+import { Screen, caps, stringWidth } from '@termuijs/core';
 import { Text } from '@termuijs/widgets';
 import { Popover } from './Popover.js';
 
@@ -30,6 +30,7 @@ describe('Popover Widget', () => {
     });
 
     it('renders a bordered panel and wrapped content when open', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
         const pop = new Popover(new Text('hi there'), {}, { title: 'Info' });
         pop.updateRect({ x: 0, y: 0, width: 30, height: 10 });
         
@@ -95,5 +96,20 @@ describe('Popover Widget', () => {
         
         // The text should still successfully render on the screen
         expect(rows).toContain('anchored');
+    });
+
+    it('clips long titles to the popover border width', () => {
+        const pop = new Popover(new Text('x'), {}, {
+            title: 'A very long title that should not widen the border',
+        });
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        pop.updateRect({ x: 0, y: 0, width: 30, height: 10 });
+        pop.open();
+        pop.render(screen);
+
+        const topBorderWrite = writeSpy.mock.calls.find(call => call[1] === 1);
+        expect(topBorderWrite).toBeDefined();
+        expect(stringWidth(String(topBorderWrite?.[2]))).toBe(10);
     });
 });

--- a/packages/ui/src/Popover.ts
+++ b/packages/ui/src/Popover.ts
@@ -4,7 +4,9 @@ import {
     type Screen,
     type KeyEvent,
     caps,
-    styleToCellAttrs
+    styleToCellAttrs,
+    stringWidth,
+    truncate,
 } from '@termuijs/core';
 
 export type PopoverPlacement = 'top' | 'bottom' | 'left' | 'right';
@@ -124,9 +126,9 @@ export class Popover extends Widget {
         }
 
         // ── 2. Top Border with Title ──
-        const titleStr = this.opts.title ? ` ${this.opts.title} ` : '';
         const innerWidth = Math.max(0, width - 2);
-        const fill = Math.max(0, innerWidth - titleStr.length);
+        const titleStr = this.opts.title ? truncate(` ${this.opts.title} `, innerWidth, '') : '';
+        const fill = Math.max(0, innerWidth - stringWidth(titleStr));
         const leftFill = Math.floor(fill / 2);
         const rightFill = fill - leftFill;
 


### PR DESCRIPTION
## Summary
- clips Popover titles to the available inner border width
- keeps the top border at the panel width for long titles
- adds focused regression coverage for long titles

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/ui/src/Popover.test.ts

Closes #2651