### PR TITLE
Skip Toast rendering in narrow rects

### DIFF
--- a/packages/ui/src/Toast.test.ts
+++ b/packages/ui/src/Toast.test.ts
@@ -50,4 +50,18 @@ describe('Toast', () => {
         vi.advanceTimersByTime(1);
         expect(markDirty).toHaveBeenCalledTimes(1);
     });
+
+    it('skips rendering when the rect is too narrow for a toast body', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+        const toast = new Toast({ durationMs: 1000 });
+        const screen = new Screen(1, 3);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        toast.updateRect({ x: 0, y: 0, width: 1, height: 3 });
+        toast.info('Saved');
+        toast.render(screen);
+
+        expect(writeSpy).not.toHaveBeenCalled();
+    });
 });

--- a/packages/ui/src/Toast.ts
+++ b/packages/ui/src/Toast.ts
@@ -78,6 +78,8 @@ export class Toast extends Widget {
     this._messages = this._messages.filter(m => m.expireAt > now);
     if (this._messages.length === 0) return;
     const { x, y, width, height } = this._rect;
+    if (width <= 2 || height <= 0) return;
+
     const visible = this._messages.slice(-this._maxVisible);
     const tw = Math.min(40, width - 2);
     const isRight = this._position.includes('right');


### PR DESCRIPTION
## Summary
- skips Toast rendering when the widget is too narrow for a toast body
- prevents negative toast width and off-rect start positions
- adds a narrow-rect regression test

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/ui/src/Toast.test.ts

Closes #2652