### PR TITLE
Validate Stopwatch intervals

### DIFF
--- a/packages/widgets/src/display/Stopwatch.test.ts
+++ b/packages/widgets/src/display/Stopwatch.test.ts
@@ -175,6 +175,22 @@ describe('Stopwatch – destroy()', () => {
 
 // ── 7. setInterval() mutation behavior ───────────────────────────────────
 describe('Stopwatch – setInterval()', () => {
+    it('rejects invalid constructor intervals', () => {
+        expect(() => new Stopwatch({ interval: 0 })).toThrow(/interval/);
+        expect(() => new Stopwatch({ interval: -1 })).toThrow(/interval/);
+        expect(() => new Stopwatch({ interval: Number.NaN })).toThrow(/interval/);
+        expect(() => new Stopwatch({ interval: Infinity })).toThrow(/interval/);
+    });
+
+    it('rejects invalid setInterval values', () => {
+        const sw = new Stopwatch({ interval: 10 });
+
+        expect(() => sw.setInterval(0)).toThrow(/interval/);
+        expect(() => sw.setInterval(-1)).toThrow(/interval/);
+        expect(() => sw.setInterval(Number.NaN)).toThrow(/interval/);
+        expect(() => sw.setInterval(Infinity)).toThrow(/interval/);
+    });
+
     it('setInterval marks widget dirty', () => {
         const sw = new Stopwatch({ interval: 10 });
 

--- a/packages/widgets/src/display/Stopwatch.ts
+++ b/packages/widgets/src/display/Stopwatch.ts
@@ -36,7 +36,7 @@ export class Stopwatch extends Widget {
 
     constructor(options: StopwatchOptions = {}, style: Partial<Style> = {}) {
         super({ height: 1, ...style });
-        this._interval = options.interval ?? 10;
+        this._interval = Stopwatch._validateInterval(options.interval ?? 10);
     }
 
     // ── Public API ──────────────────────────────────────────────────────
@@ -152,6 +152,8 @@ export class Stopwatch extends Widget {
     }
 
     setInterval(interval: number): void {
+        interval = Stopwatch._validateInterval(interval);
+
         if (interval === this._interval) return;
     
         this._interval = interval;
@@ -166,6 +168,14 @@ export class Stopwatch extends Widget {
     
     getInterval(): number {
         return this._interval;
+    }
+
+    private static _validateInterval(interval: number): number {
+        if (!Number.isFinite(interval) || interval <= 0) {
+            throw new Error('Stopwatch interval must be a finite positive number');
+        }
+
+        return interval;
     }
 
 }


### PR DESCRIPTION
## Summary
- validates Stopwatch constructor intervals
- validates setInterval values before rescheduling
- adds coverage for zero, negative, NaN, and infinite intervals

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/widgets/src/display/Stopwatch.test.ts

Closes #2653