### PR TITLE
Clip Stopwatch label to width

### DIFF
--- a/packages/widgets/src/display/Stopwatch.test.ts
+++ b/packages/widgets/src/display/Stopwatch.test.ts
@@ -3,7 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { Screen } from '@termuijs/core';
+import { Screen, stringWidth } from '@termuijs/core';
 import { Stopwatch } from './Stopwatch.js';
 
 /** Helper: create a Stopwatch, give it a rect, render to a screen, return both. */
@@ -48,6 +48,19 @@ describe('Stopwatch – rendering', () => {
 
     it('renders nothing when the content rect has zero width', () => {
         expect(() => renderStopwatch(0, {}, 0, 1)).not.toThrow();
+    });
+
+    it('clips the formatted label to narrow widths', () => {
+        const sw = new Stopwatch();
+        const screen = new Screen(3, 1);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        sw.updateRect({ x: 0, y: 0, width: 3, height: 1 });
+        sw.render(screen);
+
+        for (const call of writeSpy.mock.calls) {
+            expect(call[0] + stringWidth(String(call[2]))).toBeLessThanOrEqual(3);
+        }
     });
 });
 

--- a/packages/widgets/src/display/Stopwatch.ts
+++ b/packages/widgets/src/display/Stopwatch.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets — Stopwatch widget
 // ─────────────────────────────────────────────────────
 
-import { type Screen, type Style, styleToCellAttrs } from '@termuijs/core';
+import { type Screen, type Style, styleToCellAttrs, truncate } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
 export interface StopwatchOptions {
@@ -148,7 +148,7 @@ export class Stopwatch extends Widget {
         const attrs = styleToCellAttrs(this._style);
         const label = this._format(this.getElapsed());
 
-        screen.writeString(x, y, label, attrs);
+        screen.writeString(x, y, truncate(label, width, ''), attrs);
     }
 
     setInterval(interval: number): void {


### PR DESCRIPTION
## Summary
- clips the Stopwatch formatted label to the widget width
- adds a narrow-width rendering regression test

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/widgets/src/display/Stopwatch.test.ts

Closes #2654