### PR TITLE
Clip Timer label to width

### DIFF
--- a/packages/widgets/src/display/Timer.test.ts
+++ b/packages/widgets/src/display/Timer.test.ts
@@ -3,7 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { Screen } from '@termuijs/core';
+import { Screen, stringWidth } from '@termuijs/core';
 import { Timer } from './Timer.js';
 
 /** Helper: create a Timer, give it a rect, render to a screen, return both. */
@@ -56,6 +56,19 @@ describe('Timer – rendering', () => {
 
     it('renders nothing when the content rect has zero width', () => {
         expect(() => renderTimer({ duration: 30_000 }, {}, 0, 1)).not.toThrow();
+    });
+
+    it('clips the formatted label to narrow widths', () => {
+        const timer = new Timer({ duration: 61_000 });
+        const screen = new Screen(3, 1);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        timer.updateRect({ x: 0, y: 0, width: 3, height: 1 });
+        timer.render(screen);
+
+        for (const call of writeSpy.mock.calls) {
+            expect(call[0] + stringWidth(String(call[2]))).toBeLessThanOrEqual(3);
+        }
     });
 });
 

--- a/packages/widgets/src/display/Timer.ts
+++ b/packages/widgets/src/display/Timer.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets — Timer widget
 // ─────────────────────────────────────────────────────
 
-import { type Screen, type Style, styleToCellAttrs } from '@termuijs/core';
+import { type Screen, type Style, styleToCellAttrs, truncate } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
 export interface TimerOptions {
@@ -182,6 +182,6 @@ export class Timer extends Widget {
         const attrs = styleToCellAttrs(this._style);
         const label = this._format(this._remaining);
 
-        screen.writeString(x, y, label, attrs);
+        screen.writeString(x, y, truncate(label, width, ''), attrs);
     }
 }


### PR DESCRIPTION
## Summary
- clips Timer countdown labels to the widget width
- adds a narrow-width rendering regression test

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/widgets/src/display/Timer.test.ts

Closes #2655