### PR TITLE
Keep Transfer panes inside narrow width

### DIFF
--- a/packages/ui/src/Transfer.test.ts
+++ b/packages/ui/src/Transfer.test.ts
@@ -189,6 +189,7 @@ describe('Transfer', () => {
     });
 
     it('overwrites unused lines with blank spaces', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
         const screen = new Screen(21, 5);
         const transfer = new Transfer(ITEMS); // 3 items
         transfer.updateRect({ x: 0, y: 0, width: 21, height: 5 }); // 5 height viewport
@@ -199,5 +200,20 @@ describe('Transfer', () => {
 
         const row4 = screen.back[4].map(c => c.char).join('');
         expect(row4).toBe('          │          ');
+    });
+
+    it('does not write pane content outside a width-one rect', () => {
+        const screen = new Screen(1, 1);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+        const setCellSpy = vi.spyOn(screen, 'setCell');
+        const transfer = new Transfer(ITEMS);
+
+        transfer.updateRect({ x: 0, y: 0, width: 1, height: 1 });
+        transfer.render(screen);
+
+        expect(writeSpy).not.toHaveBeenCalled();
+        for (const call of setCellSpy.mock.calls) {
+            expect(call[0]).toBeLessThan(1);
+        }
     });
 });

--- a/packages/ui/src/Transfer.ts
+++ b/packages/ui/src/Transfer.ts
@@ -189,7 +189,7 @@ export class Transfer extends Widget {
 
         for (let i = 0; i < height; i++) {
             // 1. Left pane (source)
-            if (i < this._sourceItems.length) {
+            if (leftPaneWidth > 0 && i < this._sourceItems.length) {
                 const o = this._sourceItems[i];
                 const active = this._activePane === 'source' && i === this._sourceCursorIndex;
                 const text = (active ? indicator : noIndicator) + o.label;
@@ -200,7 +200,7 @@ export class Transfer extends Widget {
                     bold: active,
                     dim: o.disabled,
                 });
-            } else {
+            } else if (leftPaneWidth > 0) {
                 screen.writeString(x, y + i, ' '.repeat(leftPaneWidth), attrs);
             }
 
@@ -211,7 +211,7 @@ export class Transfer extends Widget {
             });
 
             // 3. Right pane (target)
-            if (i < this._targetItems.length) {
+            if (rightPaneWidth > 0 && dividerX + 1 < x + width && i < this._targetItems.length) {
                 const o = this._targetItems[i];
                 const active = this._activePane === 'target' && i === this._targetCursorIndex;
                 const text = (active ? indicator : noIndicator) + o.label;
@@ -222,7 +222,7 @@ export class Transfer extends Widget {
                     bold: active,
                     dim: o.disabled,
                 });
-            } else {
+            } else if (rightPaneWidth > 0 && dividerX + 1 < x + width) {
                 screen.writeString(dividerX + 1, y + i, ' '.repeat(rightPaneWidth), attrs);
             }
         }


### PR DESCRIPTION
## Summary
- skips pane writes when Transfer has no room for that pane
- keeps divider writes inside width-one rectangles
- adds a width-one regression test

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/ui/src/Transfer.test.ts

Closes #2656