### PR TITLE
Clip SearchInput prefix to width

### DIFF
--- a/packages/ui/src/SearchInput.test.ts
+++ b/packages/ui/src/SearchInput.test.ts
@@ -3,7 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { Screen, caps, createKeyEvent } from '@termuijs/core';
+import { Screen, caps, createKeyEvent, stringWidth } from '@termuijs/core';
 import { SearchInput } from './SearchInput.js';
 
 afterEach(() => {
@@ -131,6 +131,20 @@ describe('SearchInput', () => {
         expect(row[1]?.char).toBe(' ');
         // The icon and placeholder should start at x=2
         expect(row[2]?.char).not.toBe(' ');
+    });
+
+    it('clips the prefix to very narrow widths', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+        const input = new SearchInput({ placeholder: 'query' });
+        const screen = new Screen(1, 1);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        input.updateRect({ x: 0, y: 0, width: 1, height: 1 });
+        input.render(screen);
+
+        for (const call of writeSpy.mock.calls) {
+            expect(call[0] + stringWidth(String(call[2]))).toBeLessThanOrEqual(1);
+        }
     });
 
         it('clears the debounce timer when destroyed to prevent memory leaks', () => {

--- a/packages/ui/src/SearchInput.ts
+++ b/packages/ui/src/SearchInput.ts
@@ -118,6 +118,7 @@ export class SearchInput extends Widget {
         const icon = caps.unicode ? '🔍' : '/';
         const prefix = `${icon} `;
         const prefixWidth = stringWidth(prefix);
+        const visiblePrefix = truncate(prefix, width, '');
 
         const valueOrPlaceholder = this._value.length > 0
             ? this._value
@@ -130,8 +131,10 @@ export class SearchInput extends Widget {
         const available = Math.max(0, width - prefixWidth);
         const valueText = truncate(valueOrPlaceholder, available);
 
-        screen.writeString(x, y, prefix, attrs);
-        if (valueText.length > 0) {
+        if (visiblePrefix.length > 0) {
+            screen.writeString(x, y, visiblePrefix, attrs);
+        }
+        if (stringWidth(visiblePrefix) === prefixWidth && valueText.length > 0) {
             screen.writeString(x + prefixWidth, y, valueText, valueAttrs);
         }
     }


### PR DESCRIPTION
## Summary
- clips the SearchInput prefix before writing it
- skips value text unless the full prefix fits
- adds a width-one regression test

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/ui/src/SearchInput.test.ts

Closes #2670

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the search input display in extremely narrow layouts.
  * Ensured the search icon and entered text remain within the available screen width.
  * Prevented rendering content that could overflow the input area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->