### PR TITLE
Use grapheme editing in PathInput

### DIFF
--- a/packages/ui/src/PathInput.test.ts
+++ b/packages/ui/src/PathInput.test.ts
@@ -314,6 +314,18 @@ describe('PathInput — backspace', () => {
         input.deleteBack();
         expect(input.value).toBe('abc');
     });
+
+    it('removes one grapheme cluster at a time', () => {
+        const input = new PathInput();
+        input.value = 'e\u0301👍🏽';
+        input.moveCursorEnd();
+
+        input.deleteBack();
+        expect(input.value).toBe('e\u0301');
+
+        input.deleteBack();
+        expect(input.value).toBe('');
+    });
 });
 
 // ─────────────────────────────────────────────────────
@@ -345,6 +357,17 @@ describe('PathInput — delete key', () => {
         input.moveCursorEnd();
         input.deleteForward();
         expect(input.value).toBe('abc');
+    });
+
+    it('deletes the grapheme cluster under the cursor', () => {
+        const input = new PathInput();
+        input.value = 'a👍🏽b';
+        input.moveCursorHome();
+        input.moveCursorRight();
+
+        input.deleteForward();
+
+        expect(input.value).toBe('ab');
     });
 });
 

--- a/packages/ui/src/PathInput.ts
+++ b/packages/ui/src/PathInput.ts
@@ -12,7 +12,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Screen, type KeyEvent, styleToCellAttrs, truncate, caps } from '@termuijs/core';
+import { type Style, type Screen, type KeyEvent, styleToCellAttrs, truncate, caps, splitGraphemes } from '@termuijs/core';
 
 export interface PathInputOptions {
     placeholder?: string;
@@ -61,8 +61,8 @@ export class PathInput extends Widget {
     get value(): string { return this._value; }
 
     set value(v: string) {
-        this._value = v.slice(0, this._maxLength);
-        this._cursorPos = Math.min(this._cursorPos, this._value.length);
+        this._value = splitGraphemes(v).slice(0, this._maxLength).join('');
+        this._cursorPos = Math.min(this._cursorPos, this._graphemes().length);
         this._dismissCompletions();
     }
 
@@ -132,17 +132,16 @@ export class PathInput extends Widget {
         }
 
         this._value = this._completions[this._completionIndex];
-        this._cursorPos = this._value.length;
+        this._cursorPos = this._graphemes().length;
         this._onChange?.(this._value);
         this.markDirty();
     }
 
     insertChar(char: string): void {
-        if (this._value.length >= this._maxLength) return;
-        this._value =
-            this._value.slice(0, this._cursorPos) +
-            char +
-            this._value.slice(this._cursorPos);
+        const graphemes = this._graphemes();
+        if (graphemes.length >= this._maxLength) return;
+        graphemes.splice(this._cursorPos, 0, char);
+        this._value = graphemes.join('');
         this._cursorPos++;
         this._dismissCompletions();
         this._onChange?.(this._value);
@@ -151,9 +150,9 @@ export class PathInput extends Widget {
 
     deleteBack(): void {
         if (this._cursorPos > 0) {
-            this._value =
-                this._value.slice(0, this._cursorPos - 1) +
-                this._value.slice(this._cursorPos);
+            const graphemes = this._graphemes();
+            graphemes.splice(this._cursorPos - 1, 1);
+            this._value = graphemes.join('');
             this._cursorPos--;
             this._dismissCompletions();
             this._onChange?.(this._value);
@@ -162,10 +161,10 @@ export class PathInput extends Widget {
     }
 
     deleteForward(): void {
-        if (this._cursorPos < this._value.length) {
-            this._value =
-                this._value.slice(0, this._cursorPos) +
-                this._value.slice(this._cursorPos + 1);
+        const graphemes = this._graphemes();
+        if (this._cursorPos < graphemes.length) {
+            graphemes.splice(this._cursorPos, 1);
+            this._value = graphemes.join('');
             this._dismissCompletions();
             this._onChange?.(this._value);
             this.markDirty();
@@ -173,11 +172,15 @@ export class PathInput extends Widget {
     }
 
     moveCursorLeft(): void { this._cursorPos = Math.max(0, this._cursorPos - 1); this.markDirty(); }
-    moveCursorRight(): void { this._cursorPos = Math.min(this._value.length, this._cursorPos + 1); this.markDirty(); }
+    moveCursorRight(): void { this._cursorPos = Math.min(this._graphemes().length, this._cursorPos + 1); this.markDirty(); }
     moveCursorHome(): void { this._cursorPos = 0; this.markDirty(); }
-    moveCursorEnd(): void { this._cursorPos = this._value.length; this.markDirty(); }
+    moveCursorEnd(): void { this._cursorPos = this._graphemes().length; this.markDirty(); }
     submit(): void { this._dismissCompletions(); this._onSubmit?.(this._value); }
     clear(): void { this._value = ''; this._cursorPos = 0; this._dismissCompletions(); this._onChange?.(''); this.markDirty(); }
+
+    private _graphemes(): string[] {
+        return splitGraphemes(this._value);
+    }
 
     /**
      * Handle key events. Call this from your input loop.


### PR DESCRIPTION
## Summary
- treats PathInput cursor positions as grapheme indexes
- updates insert, backspace, delete, and cursor movement to preserve composed characters
- adds regression coverage for composed and emoji path text

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/ui/src/PathInput.test.ts

Closes #2671

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text editing to handle combined characters and emoji sequences as single characters.
  * Backspace and forward-delete now remove one complete visible character at a time.
  * Cursor movement and input length limits now correctly account for grapheme clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->