### PR TITLE
Clip ThemeSwitcher names by cell width

### DIFF
--- a/packages/ui/src/ThemeSwitcher.test.ts
+++ b/packages/ui/src/ThemeSwitcher.test.ts
@@ -3,7 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi } from 'vitest';
-import { Screen, caps } from '@termuijs/core';
+import { Screen, caps, stringWidth } from '@termuijs/core';
 import { ThemeSwitcher } from './ThemeSwitcher.js';
 
 function rowText(screen: Screen, row: number): string {
@@ -131,5 +131,19 @@ describe('ThemeSwitcher', () => {
         expect(row1).toContain('*> Light');
         
         vi.restoreAllMocks();
+    });
+
+    it('clips wide theme names to the widget width', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+        const ts = new ThemeSwitcher({ themes: ['你好你好'], activeTheme: '你好你好' });
+        const screen = new Screen(6, 1);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        ts.updateRect({ x: 0, y: 0, width: 6, height: 1 });
+        ts.render(screen);
+
+        for (const call of writeSpy.mock.calls) {
+            expect(call[0] + stringWidth(String(call[2]))).toBeLessThanOrEqual(6);
+        }
     });
 });

--- a/packages/ui/src/ThemeSwitcher.ts
+++ b/packages/ui/src/ThemeSwitcher.ts
@@ -7,7 +7,7 @@
 // ─────────────────────────────────────────────────────
 
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, caps } from '@termuijs/core';
+import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, caps, truncate } from '@termuijs/core';
 
 export interface ThemeSwitcherOptions {
     themes?: string[];
@@ -138,7 +138,7 @@ export class ThemeSwitcher extends Widget {
             const formattedName = themeName.charAt(0).toUpperCase() + themeName.slice(1);
             const lineText = `${prefix} ${formattedName}`;
 
-            screen.writeString(x, y + i, lineText.slice(0, width), {
+            screen.writeString(x, y + i, truncate(lineText, width, ''), {
                 ...attrs,
                 fg: isSelected ? this._activeColor : attrs.fg,
                 bold: isSelected || isActive,


### PR DESCRIPTION
## Summary
- truncates ThemeSwitcher rows by terminal cell width
- preserves existing active and selected styling
- adds a wide-character regression test

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/ui/src/ThemeSwitcher.test.ts

Closes #2673