### PR TITLE
Clip WelcomeScreen keymap hints

### DIFF
--- a/packages/ui/src/WelcomeScreen.test.ts
+++ b/packages/ui/src/WelcomeScreen.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { Screen } from '@termuijs/core';
+import { describe, it, expect, vi } from 'vitest';
+import { Screen, stringWidth } from '@termuijs/core';
 import { WelcomeScreen } from './WelcomeScreen.js';
 
 function render(widget: WelcomeScreen, w = 40, h = 15): string {
@@ -40,5 +40,26 @@ describe('WelcomeScreen', () => {
   it('renders with no subtitle/tagline/keymap', () => {
     const ws = new WelcomeScreen({ title: 'X' });
     expect(() => render(ws)).not.toThrow();
+  });
+
+  it('clips long keymap hints to the screen width', () => {
+    const ws = new WelcomeScreen({
+      title: 'HI',
+      keymap: [
+        { key: 'Enter', action: 'Start the very long onboarding workflow' },
+        { key: 'Escape', action: 'Cancel everything' },
+      ],
+    });
+    const screen = new Screen(12, 8);
+    const writeSpy = vi.spyOn(screen, 'writeString');
+
+    ws.updateRect({ x: 0, y: 0, width: 12, height: 8 });
+    ws.render(screen);
+
+    for (const call of writeSpy.mock.calls) {
+      if (call[1] === 7) {
+        expect(call[0] + stringWidth(String(call[2]))).toBeLessThanOrEqual(12);
+      }
+    }
   });
 });

--- a/packages/ui/src/WelcomeScreen.ts
+++ b/packages/ui/src/WelcomeScreen.ts
@@ -78,7 +78,7 @@ export class WelcomeScreen extends Widget {
             const keymapRow = y + height - 1;
             if (keymapRow > row) {
                 const parts = this._keymap.map(({ key, action }) => `[${key}] ${action}`);
-                const hint = parts.join('  ');
+                const hint = truncate(parts.join('  '), width, '');
                 const hintX = x + Math.max(0, Math.floor((width - stringWidth(hint)) / 2));
                 screen.writeString(hintX, keymapRow, hint, { ...attrs, dim: true });
             }


### PR DESCRIPTION
## Summary
- clips WelcomeScreen keymap hints before centering them
- prevents long bottom-row hints from exceeding the screen width
- adds a focused long-keymap regression test

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/ui/src/WelcomeScreen.test.ts

Closes #2674