### PR TITLE
Clip SetupFlow header width

### DIFF
--- a/packages/ui/src/SetupFlow.test.ts
+++ b/packages/ui/src/SetupFlow.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { Screen } from '@termuijs/core';
+import { Screen, stringWidth } from '@termuijs/core';
 import { Box } from '@termuijs/widgets';
 import { SetupFlow } from './SetupFlow.js';
 
@@ -116,5 +116,22 @@ describe('SetupFlow', () => {
     });
     const out = render(flow);
     expect(out).toContain('SuperApp');
+  });
+
+  it('clips long app names in the header', () => {
+    const flow = new SetupFlow({
+      appName: 'SuperLongApplicationName',
+      steps: [makeStep('Step 1')],
+      onComplete: () => {},
+    });
+    const screen = new Screen(8, 5);
+    const writeSpy = vi.spyOn(screen, 'writeString');
+
+    flow.updateRect({ x: 0, y: 0, width: 8, height: 5 });
+    flow.render(screen);
+
+    const headerWrite = writeSpy.mock.calls.find(call => call[1] === 0);
+    expect(headerWrite).toBeDefined();
+    expect(Number(headerWrite?.[0]) + stringWidth(String(headerWrite?.[2]))).toBeLessThanOrEqual(8);
   });
 });

--- a/packages/ui/src/SetupFlow.ts
+++ b/packages/ui/src/SetupFlow.ts
@@ -86,7 +86,7 @@ export class SetupFlow extends Widget {
         let row = y;
 
         // ── Header ────────────────────────────────────
-        const header = ` Setup: ${this._appName} `;
+        const header = truncate(` Setup: ${this._appName} `, width, '');
         const headerX = x + Math.max(0, Math.floor((width - stringWidth(header)) / 2));
         screen.writeString(headerX, row, header, { ...attrs, bold: true });
         row++;


### PR DESCRIPTION
## Summary
- clips the SetupFlow header before centering
- prevents long app names from exceeding narrow layout widths
- adds a focused header-width regression test

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/ui/src/SetupFlow.test.ts

Closes #2675