### PR TITLE
Guard Wizard error row rendering

### DIFF
--- a/packages/ui/src/Wizard.test.ts
+++ b/packages/ui/src/Wizard.test.ts
@@ -144,4 +144,17 @@ describe('Wizard', () => {
         wizard.handleKey({ key: 'enter', ctrl: false, alt: false } as any);
         expect(onCompleteMock).toHaveBeenCalledWith(['john_doe', 'postgres://db']);
     });
+
+    it('does not write the error-clearing row outside height-one layouts', () => {
+        const wizard = new Wizard(makeSteps());
+        const screen = new Screen(40, 1);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        wizard.updateRect({ x: 0, y: 0, width: 40, height: 1 });
+        wizard.render(screen);
+
+        for (const call of writeSpy.mock.calls) {
+            expect(call[1]).toBeLessThan(1);
+        }
+    });
 });

--- a/packages/ui/src/Wizard.ts
+++ b/packages/ui/src/Wizard.ts
@@ -226,22 +226,25 @@ export class Wizard extends Widget {
             { ...attrs, bold: true }
         );
 
-        // Write validation error if present on row 1 of the content area
-        if (this._error) {
-            screen.writeString(
-                x + border,
-                y + border + 1,
-                truncate(this._error, contentWidth),
-                { ...attrs, fg: { type: 'named', name: 'red' } }
-            );
-        } else {
-            // Write blank line to clear any old error
-            screen.writeString(
-                x + border,
-                y + border + 1,
-                ' '.repeat(contentWidth),
-                attrs
-            );
+        const errorRow = y + border + 1;
+        if (errorRow < y + height) {
+            // Write validation error if present on row 1 of the content area
+            if (this._error) {
+                screen.writeString(
+                    x + border,
+                    errorRow,
+                    truncate(this._error, contentWidth),
+                    { ...attrs, fg: { type: 'named', name: 'red' } }
+                );
+            } else {
+                // Write blank line to clear any old error
+                screen.writeString(
+                    x + border,
+                    errorRow,
+                    ' '.repeat(contentWidth),
+                    attrs
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- skips Wizard error-row rendering when the layout is too short
- keeps the clearing row inside the widget bounds
- adds a height-one regression test

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/ui/src/Wizard.test.ts

Closes #2677