### PR TITLE
feat(ui): enhance CommandPalette with favorites, recent commands, and…

### DIFF
--- a/packages/ui/src/CommandPalette.test.ts
+++ b/packages/ui/src/CommandPalette.test.ts
@@ -1040,4 +1040,244 @@ describe('CommandPalette', () => {
             expect((cmds[0]!.action as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callCount);
         });
     });
+
+    // ── 33. Favorites ──────────────────────────────────
+
+    describe('favorites', () => {
+        it('starts with no favorites by default', () => {
+            const palette = new CommandPalette(makeCommands());
+            expect(palette.getFavorites()).toEqual([]);
+        });
+
+        it('accepts initial favorites via options', () => {
+            const palette = new CommandPalette(makeCommands(), { favorites: ['open', 'settings'] });
+            expect(palette.getFavorites()).toEqual(['open', 'settings']);
+            expect(palette.isFavorite('open')).toBe(true);
+            expect(palette.isFavorite('close')).toBe(false);
+        });
+
+        it('addFavorite adds an id and reports it', () => {
+            const palette = new CommandPalette(makeCommands());
+            palette.addFavorite('open');
+            expect(palette.isFavorite('open')).toBe(true);
+            expect(palette.getFavorites()).toEqual(['open']);
+        });
+
+        it('addFavorite is a no-op when already present', () => {
+            const palette = new CommandPalette(makeCommands(), { favorites: ['open'] });
+            palette.addFavorite('open');
+            expect(palette.getFavorites()).toEqual(['open']);
+        });
+
+        it('removeFavorite removes an id', () => {
+            const palette = new CommandPalette(makeCommands(), { favorites: ['open'] });
+            palette.removeFavorite('open');
+            expect(palette.isFavorite('open')).toBe(false);
+            expect(palette.getFavorites()).toEqual([]);
+        });
+
+        it('removeFavorite is a no-op when not present', () => {
+            const palette = new CommandPalette(makeCommands());
+            palette.removeFavorite('open');
+            expect(palette.getFavorites()).toEqual([]);
+        });
+
+        it('toggleFavorite adds then removes the same id', () => {
+            const palette = new CommandPalette(makeCommands());
+            palette.toggleFavorite('open');
+            expect(palette.isFavorite('open')).toBe(true);
+            palette.toggleFavorite('open');
+            expect(palette.isFavorite('open')).toBe(false);
+        });
+
+        it('getFavorites returns a copy, not the internal array', () => {
+            const palette = new CommandPalette(makeCommands(), { favorites: ['open'] });
+            const favs = palette.getFavorites();
+            favs.push('close');
+            expect(palette.getFavorites()).toEqual(['open']);
+        });
+
+        it('marks dirty when toggling a favorite', () => {
+            const palette = new CommandPalette(makeCommands());
+            const spy = vi.spyOn(palette as any, 'markDirty');
+            palette.toggleFavorite('open');
+            expect(spy).toHaveBeenCalled();
+        });
+
+        it('renders a Favorites section header when favorites exist', () => {
+            vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+            const palette = new CommandPalette(makeCommands(), { favorites: ['open'] });
+            palette.show();
+            const text = allText(renderPalette(palette));
+            expect(text).toContain('Favorites');
+            expect(text).toContain('Open File');
+        });
+
+        it('does not duplicate a favorited command in its category section', () => {
+            vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+            const cmds: Command[] = [
+                { id: 'open', label: 'Open File', category: 'File', action: vi.fn() },
+                { id: 'close', label: 'Close File', category: 'File', action: vi.fn() },
+            ];
+            const palette = new CommandPalette(cmds, { favorites: ['open'] });
+            palette.show();
+            const text = allText(renderPalette(palette));
+            const occurrences = text.split('Open File').length - 1;
+            expect(occurrences).toBe(1);
+        });
+
+        it('Ctrl+F toggles the favorite state of the selected command', () => {
+            const palette = new CommandPalette(makeCommands());
+            palette.show();
+            const ev = makeKey('f', { ctrl: true });
+            palette.handleKey(ev as any);
+            expect(ev._propagationStopped).toBe(true);
+            expect(palette.isFavorite('open')).toBe(true);
+        });
+
+        it('Ctrl+F toggles off an already-favorited selected command', () => {
+            const palette = new CommandPalette(makeCommands(), { favorites: ['open'] });
+            palette.show();
+            palette.handleKey(makeKey('f', { ctrl: true }) as any);
+            expect(palette.isFavorite('open')).toBe(false);
+        });
+    });
+
+    // ── 34. Recent Commands ────────────────────────────
+
+    describe('recent commands', () => {
+        it('starts with an empty recent list', () => {
+            const palette = new CommandPalette(makeCommands());
+            expect(palette.getRecent()).toEqual([]);
+        });
+
+        it('records a command after it is confirmed', () => {
+            const cmds = makeCommands();
+            const palette = new CommandPalette(cmds);
+            palette.show();
+            palette.handleKey(makeKey('enter') as any); // executes 'open'
+            expect(palette.getRecent()).toEqual(['open']);
+            expect(cmds[0]!.action).toHaveBeenCalledTimes(1);
+        });
+
+        it('orders recents most-recent-first', () => {
+            const cmds = makeCommands();
+            const palette = new CommandPalette(cmds);
+            palette.show();
+            palette.handleKey(makeKey('enter') as any); // open
+            palette.show();
+            palette.handleKey(makeKey('down') as any); // -> close
+            palette.handleKey(makeKey('enter') as any); // close
+            expect(palette.getRecent()).toEqual(['close', 'open']);
+        });
+
+        it('moves an already-recent command back to the front', () => {
+            const cmds = makeCommands();
+            const palette = new CommandPalette(cmds);
+            palette.show();
+            palette.handleKey(makeKey('enter') as any); // open
+            palette.show();
+            palette.handleKey(makeKey('down') as any);
+            palette.handleKey(makeKey('enter') as any); // close
+            palette.show();
+            palette.handleKey(makeKey('enter') as any); // open again
+            expect(palette.getRecent()).toEqual(['open', 'close']);
+        });
+
+        it('respects the recentLimit option', () => {
+            const cmds = makeCommands();
+            const palette = new CommandPalette(cmds, { recentLimit: 2 });
+            // Execute all three in order
+            palette.show(); palette.handleKey(makeKey('enter') as any); // open
+            palette.show(); palette.handleKey(makeKey('down') as any); palette.handleKey(makeKey('enter') as any); // close
+            palette.show(); palette.handleKey(makeKey('down') as any); palette.handleKey(makeKey('down') as any); palette.handleKey(makeKey('enter') as any); // settings
+            expect(palette.getRecent()).toEqual(['settings', 'close']);
+        });
+
+        it('clears the recent list', () => {
+            const cmds = makeCommands();
+            const palette = new CommandPalette(cmds);
+            palette.show();
+            palette.handleKey(makeKey('enter') as any);
+            expect(palette.getRecent()).toHaveLength(1);
+            palette.clearRecent();
+            expect(palette.getRecent()).toEqual([]);
+        });
+
+        it('does not record anything when confirming with no results', () => {
+            const cmds = makeCommands();
+            const palette = new CommandPalette(cmds);
+            palette.show();
+            for (const ch of 'zzzz') palette.insertChar(ch);
+            palette.handleKey(makeKey('enter') as any);
+            expect(palette.getRecent()).toEqual([]);
+        });
+
+        it('renders a Recent section when recents exist', () => {
+            vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+            const cmds = makeCommands();
+            const palette = new CommandPalette(cmds);
+            palette.show();
+            palette.handleKey(makeKey('enter') as any); // record 'open'
+            palette.show();
+            const text = allText(renderPalette(palette));
+            expect(text).toContain('Recent');
+            expect(text).toContain('Open File');
+        });
+
+        it('getRecent returns a copy, not the internal array', () => {
+            const cmds = makeCommands();
+            const palette = new CommandPalette(cmds);
+            palette.show();
+            palette.handleKey(makeKey('enter') as any);
+            const rec = palette.getRecent();
+            rec.push('close');
+            expect(palette.getRecent()).toEqual(['open']);
+        });
+    });
+
+    // ── 35. Favorites + Recent + Category integration ──
+
+    describe('favorites, recent, and categories together', () => {
+        it('shows Favorites above Recent above categories when query is empty', () => {
+            vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+            const cmds: Command[] = [
+                { id: 'open', label: 'Open File', category: 'File', action: vi.fn() },
+                { id: 'save', label: 'Save File', category: 'File', action: vi.fn() },
+                { id: 'theme', label: 'Toggle Theme', category: 'View', action: vi.fn() },
+            ];
+            const palette = new CommandPalette(cmds, { favorites: ['save'] });
+            palette.show();
+            // Execute 'open' so it appears in Recent
+            palette.handleKey(makeKey('enter') as any);
+            palette.show();
+            const text = allText(renderPalette(palette));
+            expect(text).toContain('Favorites');
+            expect(text).toContain('Recent');
+            expect(text).toContain('File');
+            const favIdx = text.indexOf('Favorites');
+            const recIdx = text.indexOf('Recent');
+            const fileIdx = text.indexOf('File');
+            expect(favIdx).toBeLessThan(recIdx);
+            expect(recIdx).toBeLessThan(fileIdx);
+        });
+
+        it('query mode hides Favorites/Recent and shows only matches grouped by category', () => {
+            vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+            const cmds: Command[] = [
+                { id: 'open', label: 'Open File', category: 'File', action: vi.fn() },
+                { id: 'save', label: 'Save File', category: 'File', action: vi.fn() },
+                { id: 'theme', label: 'Toggle Theme', category: 'View', action: vi.fn() },
+            ];
+            const palette = new CommandPalette(cmds, { favorites: ['save'] });
+            palette.show();
+            palette.handleKey(makeKey('enter') as any); // record recent
+            palette.show();
+            palette.insertChar('o'); // fuzzy: 'Open File'
+            const text = allText(renderPalette(palette));
+            expect(text).not.toContain('Favorites');
+            expect(text).not.toContain('Recent');
+            expect(text).toContain('Open File');
+        });
+    });
 });

--- a/packages/ui/src/CommandPalette.ts
+++ b/packages/ui/src/CommandPalette.ts
@@ -1,13 +1,32 @@
-// CommandPalette — fuzzy-search command launcher
+// CommandPalette — fuzzy-search command launcher with favorites and recents
 import { Widget } from '@termuijs/widgets';
 import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, getBorderChars, caps } from '@termuijs/core';
 
 export interface Command { id: string; label: string; shortcut?: string; action: () => void; category?: string; }
-export interface CommandPaletteOptions { placeholder?: string; borderColor?: Style['fg']; activeColor?: Style['fg']; maxVisible?: number; }
+export interface CommandPaletteOptions {
+    placeholder?: string;
+    borderColor?: Style['fg'];
+    activeColor?: Style['fg'];
+    maxVisible?: number;
+    /** Initial set of favorite command IDs. */
+    favorites?: Iterable<string>;
+    /** Maximum number of recent commands tracked. Default: 5. */
+    recentLimit?: number;
+    /** Label for the favorites section header. Default: 'Favorites'. */
+    favoritesLabel?: string;
+    /** Label for the recent commands section header. Default: 'Recent'. */
+    recentLabel?: string;
+}
+
+interface CommandSection {
+    title: string;
+    commands: Command[];
+}
 
 export class CommandPalette extends Widget {
     private _commands: Command[];
     private _filtered: Command[] = [];
+    private _sections: CommandSection[] = [];
     private _query = '';
     private _cursorPos = 0;
     private _selectedIndex = 0;
@@ -16,27 +35,87 @@ export class CommandPalette extends Widget {
     private _borderColor: Style['fg'];
     private _activeColor: Style['fg'];
     private _maxVisible: number;
+    private _favorites: string[];
+    private _recent: string[] = [];
+    private _recentLimit: number;
+    private _favoritesLabel: string;
+    private _recentLabel: string;
     focusable = true;
 
     constructor(commands: Command[], options: CommandPaletteOptions = {}) {
         super(mergeStyles(defaultStyle(), {}));
         this._commands = commands;
-        this._filtered = [...commands];
         this._placeholder = options.placeholder ?? 'Type a command...';
         this._borderColor = options.borderColor ?? { type: 'named', name: 'cyan' };
         this._activeColor = options.activeColor ?? { type: 'named', name: 'cyan' };
         this._maxVisible = options.maxVisible ?? 10;
+        this._favorites = options.favorites ? [...options.favorites] : [];
+        this._recentLimit = options.recentLimit ?? 5;
+        this._favoritesLabel = options.favoritesLabel ?? 'Favorites';
+        this._recentLabel = options.recentLabel ?? 'Recent';
+        this._filter();
     }
 
     get visible(): boolean { return this._visible; }
-    show(): void { this._visible = true; this._query = ''; this._cursorPos = 0; this._selectedIndex = 0; this._filtered = [...this._commands]; this.markDirty(); }
+    show(): void { this._visible = true; this._query = ''; this._cursorPos = 0; this._selectedIndex = 0; this._filter(); this.markDirty(); }
     hide(): void { this._visible = false; this.markDirty(); }
     toggle(): void { this._visible ? this.hide() : this.show(); }
     insertChar(ch: string): void { this._query = this._query.slice(0, this._cursorPos) + ch + this._query.slice(this._cursorPos); this._cursorPos++; this._filter(); this.markDirty(); }
     deleteBack(): void { if (this._cursorPos > 0) { this._query = this._query.slice(0, this._cursorPos - 1) + this._query.slice(this._cursorPos); this._cursorPos--; this._filter(); this.markDirty(); } }
     selectNext(): void { if (this._selectedIndex < this._filtered.length - 1) { this._selectedIndex++; this.markDirty(); } }
     selectPrev(): void { if (this._selectedIndex > 0) { this._selectedIndex--; this.markDirty(); } }
-    confirm(): void { const c = this._filtered[this._selectedIndex]; if (c) { this.hide(); c.action(); } }
+    confirm(): void { const c = this._filtered[this._selectedIndex]; if (c) { this._recordRecent(c.id); this.hide(); c.action(); } }
+
+    // ─── Favorites ──────────────────────────────────────
+
+    /** Returns a copy of the favorite command IDs in toggle order. */
+    getFavorites(): string[] { return [...this._favorites]; }
+    /** True when the command with the given id is a favorite. */
+    isFavorite(id: string): boolean { return this._favorites.includes(id); }
+    /** Add a command id to favorites. No-op if already present. */
+    addFavorite(id: string): void {
+        if (!this._favorites.includes(id)) {
+            this._favorites.push(id);
+            this._filter();
+            this.markDirty();
+        }
+    }
+    /** Remove a command id from favorites. No-op if not present. */
+    removeFavorite(id: string): void {
+        const i = this._favorites.indexOf(id);
+        if (i >= 0) {
+            this._favorites.splice(i, 1);
+            this._filter();
+            this.markDirty();
+        }
+    }
+    /** Toggle the favorite state of a command id. */
+    toggleFavorite(id: string): void {
+        const i = this._favorites.indexOf(id);
+        if (i >= 0) this._favorites.splice(i, 1);
+        else this._favorites.push(id);
+        this._filter();
+        this.markDirty();
+    }
+
+    // ─── Recent commands ────────────────────────────────
+
+    /** Returns a copy of recent command IDs, most-recent first. */
+    getRecent(): string[] { return [...this._recent]; }
+    /** Clears the recent commands history. */
+    clearRecent(): void {
+        if (this._recent.length === 0) return;
+        this._recent = [];
+        this._filter();
+        this.markDirty();
+    }
+
+    private _recordRecent(id: string): void {
+        const i = this._recent.indexOf(id);
+        if (i >= 0) this._recent.splice(i, 1);
+        this._recent.unshift(id);
+        if (this._recent.length > this._recentLimit) this._recent.length = this._recentLimit;
+    }
 
     /**
      * Handle a KeyEvent from @termuijs/core.
@@ -52,6 +131,7 @@ export class CommandPalette extends Widget {
      *   Enter           — confirm selected command
      *   Escape          — close
      *   Backspace       — delete last character
+     *   Ctrl+F          — toggle favorite on selected command
      *   any printable   — append character to query
      *
      * Ctrl+P is also handled while hidden so the palette can be opened.
@@ -73,6 +153,13 @@ export class CommandPalette extends Widget {
         if (key === 'escape' || (ctrl && key === 'c')) {
             event.stopPropagation();
             this.hide();
+            return;
+        }
+
+        if (ctrl && key === 'f') {
+            event.stopPropagation();
+            const c = this._filtered[this._selectedIndex];
+            if (c) this.toggleFavorite(c.id);
             return;
         }
 
@@ -108,13 +195,50 @@ export class CommandPalette extends Widget {
         }
     }
 
+    private _groupByCategory(commands: Command[]): CommandSection[] {
+        const grouped = new Map<string, Command[]>();
+        for (const cmd of commands) {
+            const category = cmd.category ?? 'General';
+            if (!grouped.has(category)) {
+                grouped.set(category, []);
+            }
+            grouped.get(category)!.push(cmd);
+        }
+        const sections: CommandSection[] = [];
+        for (const [category, cmds] of grouped) {
+            sections.push({ title: category, commands: cmds });
+        }
+        return sections;
+    }
+
     private _filter(): void {
         const q = this._query.toLowerCase();
-        if (!q) { this._filtered = [...this._commands]; } else {
-            this._filtered = this._commands.filter(c => { 
+        this._sections = [];
+        if (!q) {
+            // Favorites first
+            const favSet = new Set(this._favorites);
+            const favCmds = this._favorites
+                .map((id) => this._commands.find((c) => c.id === id))
+                .filter((c): c is Command => !!c);
+            if (favCmds.length) this._sections.push({ title: this._favoritesLabel, commands: favCmds });
+
+            // Recent next (excluding favorites so items aren't duplicated)
+            const recCmds = this._recent
+                .map((id) => this._commands.find((c) => c.id === id))
+                .filter((c): c is Command => !!c && !favSet.has(c.id));
+            if (recCmds.length) this._sections.push({ title: this._recentLabel, commands: recCmds });
+
+            // Remaining commands grouped by category
+            const rest = this._commands.filter((c) => !favSet.has(c.id) && !this._recent.includes(c.id));
+            this._sections.push(...this._groupByCategory(rest));
+        } else {
+            const filtered = this._commands.filter((c) => {
                 const l =
-    `${c.label} ${c.category ?? ''}`.toLowerCase(); let qi = 0; for (let i = 0; i < l.length && qi < q.length; i++) { if (l[i] === q[qi]) qi++; } return qi === q.length; });
+                    `${c.label} ${c.category ?? ''}`.toLowerCase(); let qi = 0; for (let i = 0; i < l.length && qi < q.length; i++) { if (l[i] === q[qi]) qi++; } return qi === q.length;
+            });
+            this._sections = this._groupByCategory(filtered);
         }
+        this._filtered = this._sections.flatMap((s) => s.commands);
         this._selectedIndex = 0;
     }
 
@@ -126,17 +250,19 @@ export class CommandPalette extends Widget {
         const backdropCh = caps.unicode ? '░' : ' ';
         for (let r = 0; r < height; r++) screen.writeString(x, y + r, backdropCh.repeat(width), { ...attrs, dim: true });
         // Box
-        const vis = this._filtered.slice(0, this._maxVisible);
-        const grouped = new Map<string, Command[]>();
-        for (const cmd of vis) {
-            const category = cmd.category ?? 'General';
-            if (!grouped.has(category)) {
-                grouped.set(category, []);
-            }
-            grouped.get(category)!.push(cmd);
-        }
         const bw = Math.min(60, width - 4);
-        const totalVisRows = grouped.size + vis.length;
+
+        // Build the visible sections, capping command rows at maxVisible.
+        let remaining = this._maxVisible;
+        const sectionsToRender: CommandSection[] = [];
+        for (const sec of this._sections) {
+            if (remaining <= 0) break;
+            const take = Math.min(sec.commands.length, remaining);
+            sectionsToRender.push({ title: sec.title, commands: sec.commands.slice(0, take) });
+            remaining -= take;
+        }
+
+        const totalVisRows = sectionsToRender.reduce((n, s) => n + 1 + s.commands.length, 0);
         const bh = Math.min(totalVisRows + 3, height - 2);
         const bx = x + Math.floor((width - bw) / 2);
         const by = y + 2;
@@ -154,39 +280,41 @@ export class CommandPalette extends Widget {
         screen.writeString(bx, by + 2, border.left + '─'.repeat(bw - 2) + border.right, ba);
         // Items
         let rowOffset = 0;
+        let flatIndex = 0;
 
-for (const [category, commands] of grouped) {
-    screen.writeString(
-        bx + 1,
-        by + 3 + rowOffset,
-        `[${category}]`,
-        { ...attrs, bold: true }
-    );
+        for (const section of sectionsToRender) {
+            screen.writeString(
+                bx + 1,
+                by + 3 + rowOffset,
+                `[${section.title}]`,
+                { ...attrs, bold: true }
+            );
+            rowOffset++;
 
-    rowOffset++;
+            for (const c of section.commands) {
+                const active = flatIndex === this._selectedIndex;
 
-    for (const c of commands) {
-        const active = rowOffset - 1 === this._selectedIndex;
+                const prefix = active ? (caps.unicode ? '❯ ' : '> ') : '  ';
+                const favMark = this.isFavorite(c.id) ? (caps.unicode ? ' ★' : ' *') : '';
+                const shortcutStr = c.shortcut ? `  ${c.shortcut}` : '';
+                const labelFull = prefix + c.label + shortcutStr + favMark;
+                const label = labelFull.slice(0, bw - 4).padEnd(bw - 4);
 
-        const prefix = active ? (caps.unicode ? '❯ ' : '> ') : '  ';
-        const shortcutStr = c.shortcut ? `  ${c.shortcut}` : '';
-        const labelFull = prefix + c.label + shortcutStr;
-        const label = labelFull.slice(0, bw - 4).padEnd(bw - 4);
+                screen.writeString(
+                    bx + 1,
+                    by + 3 + rowOffset,
+                    label,
+                    {
+                        ...attrs,
+                        fg: active ? this._activeColor : attrs.fg,
+                        bold: active,
+                    }
+                );
 
-        screen.writeString(
-            bx + 1,
-            by + 3 + rowOffset,
-            label,
-            {
-                ...attrs,
-                fg: active ? this._activeColor : attrs.fg,
-                bold: active,
+                rowOffset++;
+                flatIndex++;
             }
-        );
-
-        rowOffset++;
-    }
-}
+        }
         // Bottom
         const last = Math.min(by + 3 + totalVisRows, by + bh - 1);
         screen.writeString(bx, last, border.bottomLeft + border.bottom.repeat(bw - 2) + border.bottomRight, ba);

--- a/packages/widgets/src/input/CommandPalette.ts
+++ b/packages/widgets/src/input/CommandPalette.ts
@@ -21,6 +21,8 @@ export interface Command {
     label: string;
     description?: string;
     action: () => void;
+    /** Optional category used to group commands under a header. */
+    category?: string;
 }
 
 export interface CommandPaletteOptions {
@@ -201,7 +203,6 @@ export class CommandPalette extends Widget {
         if (width <= 0 || height <= 0) return;
 
         const attrs = styleToCellAttrs(this._style);
-        const maxVisible = this._options.maxVisible ?? 8;
         const placeholder = this._options.placeholder ?? 'Type to search...';
 
         // ── Row 0: query line ──────────────────────────
@@ -218,68 +219,94 @@ export class CommandPalette extends Widget {
             screen.setCell(x + c, y, { char: ' ', ...attrs });
         }
 
-        // ── Rows 1..N: command list ────────────────────
+        // ── Rows 1..N: command list, grouped by category ─
         const listStartRow = 1;
         const listHeight = height - listStartRow;
-        const visibleCount = Math.min(this._filtered.length, maxVisible, listHeight);
 
-        for (let i = 0; i < visibleCount; i++) {
-            const cmd = this._filtered[i];
-            const isSelected = i === this._selectedIndex;
-            const rowY = y + listStartRow + i;
+        // Group filtered commands by category, preserving filter order.
+        const sections: { title: string; commands: Command[] }[] = [];
+        const indexByCategory = new Map<string, number>();
+        for (const cmd of this._filtered) {
+            const title = cmd.category ?? 'General';
+            let idx = indexByCategory.get(title);
+            if (idx === undefined) {
+                idx = sections.length;
+                indexByCategory.set(title, idx);
+                sections.push({ title, commands: [] });
+            }
+            sections[idx].commands.push(cmd);
+        }
 
-            // Compose left part: prefix + label
-            const rowPrefix = isSelected ? '▸ ' : '  ';
-            const labelPart = rowPrefix + cmd.label;
+        let rowY = y + listStartRow;
+        let flatIndex = 0;
 
-            // Compose right part: description (dim, right-aligned)
-            const desc = cmd.description ?? '';
-            const descWidth = stringWidth(desc);
+        for (const section of sections) {
+            if (section.commands.length === 0) continue;
+            if (rowY >= y + listHeight) break;
 
-            // Available width for label (leave room for desc if it fits)
-            const gap = 1; // minimum space between label and desc
-            const labelMaxWidth = desc
-                ? Math.max(0, width - descWidth - gap)
-                : width;
+            // Category header
+            screen.writeString(x, rowY, truncate(`[${section.title}]`, width), { ...attrs, bold: true, dim: true });
+            rowY++;
 
-            const labelTruncated = truncate(labelPart, labelMaxWidth);
-            const labelWidth = stringWidth(labelTruncated);
+            for (const cmd of section.commands) {
+                if (rowY >= y + listHeight) break;
+                const isSelected = flatIndex === this._selectedIndex;
 
-            // Cell style for the row
-            const cellStyle = {
-                ...attrs,
-                bold: isSelected,
-                inverse: isSelected,
-            };
-            const dimStyle = {
-                ...attrs,
-                dim: true,
-                inverse: isSelected,
-            };
+                // Compose left part: prefix + label
+                const rowPrefix = isSelected ? '▸ ' : '  ';
+                const labelPart = rowPrefix + cmd.label;
 
-            // Write label
-            screen.writeString(x, rowY, labelTruncated, cellStyle);
+                // Compose right part: description (dim, right-aligned)
+                const desc = cmd.description ?? '';
+                const descWidth = stringWidth(desc);
 
-            // Fill gap between label and description
-            if (desc) {
-                const descX = x + width - descWidth;
-                // Fill blank between label end and desc start
-                for (let c = x + labelWidth; c < descX; c++) {
-                    screen.setCell(c, rowY, { char: ' ', ...cellStyle });
+                // Available width for label (leave room for desc if it fits)
+                const gap = 1; // minimum space between label and desc
+                const labelMaxWidth = desc
+                    ? Math.max(0, width - descWidth - gap)
+                    : width;
+
+                const labelTruncated = truncate(labelPart, labelMaxWidth);
+                const labelWidth = stringWidth(labelTruncated);
+
+                // Cell style for the row
+                const cellStyle = {
+                    ...attrs,
+                    bold: isSelected,
+                    inverse: isSelected,
+                };
+                const dimStyle = {
+                    ...attrs,
+                    dim: true,
+                    inverse: isSelected,
+                };
+
+                // Write label
+                screen.writeString(x, rowY, labelTruncated, cellStyle);
+
+                // Fill gap between label and description
+                if (desc) {
+                    const descX = x + width - descWidth;
+                    // Fill blank between label end and desc start
+                    for (let c = x + labelWidth; c < descX; c++) {
+                        screen.setCell(c, rowY, { char: ' ', ...cellStyle });
+                    }
+                    // Write description (right-aligned, dim)
+                    screen.writeString(descX, rowY, desc, dimStyle);
+                } else {
+                    // Fill remainder of row for inverse highlight
+                    for (let c = x + labelWidth; c < x + width; c++) {
+                        screen.setCell(c, rowY, { char: ' ', ...cellStyle });
+                    }
                 }
-                // Write description (right-aligned, dim)
-                screen.writeString(descX, rowY, desc, dimStyle);
-            } else {
-                // Fill remainder of row for inverse highlight
-                for (let c = x + labelWidth; c < x + width; c++) {
-                    screen.setCell(c, rowY, { char: ' ', ...cellStyle });
-                }
+
+                rowY++;
+                flatIndex++;
             }
         }
 
         // Clear any rows below the visible commands (in case widget was larger)
-        for (let i = visibleCount; i < listHeight; i++) {
-            const rowY = y + listStartRow + i;
+        for (; rowY < y + listHeight; rowY++) {
             for (let c = 0; c < width; c++) {
                 screen.setCell(x + c, rowY, { char: ' ', ...attrs });
             }


### PR DESCRIPTION
#2274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Favorites and Recent sections to the Command Palette.
  * Mark commands as favorites with `Ctrl+F`, manage favorites, and view recent commands.
  * Recent commands are ordered by usage and can be limited or cleared.
  * Commands are now grouped by category, with customizable section labels.
  * Favorites, recent items, and categories display in a clear priority order.
  * Favorite indicators and keyboard shortcuts are shown for command items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->