### PR TITLE
Clip AreaChart labels by cell width

### DIFF
--- a/packages/widgets/src/data/AreaChart.test.ts
+++ b/packages/widgets/src/data/AreaChart.test.ts
@@ -3,7 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { caps, Screen } from '@termuijs/core';
+import { caps, Screen, stringWidth } from '@termuijs/core';
 import { AreaChart } from './AreaChart.js';
 
 afterEach(() => {
@@ -119,5 +119,21 @@ describe('AreaChart', () => {
         expect(countCharInGrid(withLine, '#')).toBeGreaterThanOrEqual(
             countCharInGrid(withoutLine, '#'),
         );
+    });
+
+    it('clips wide labels by cell width', () => {
+        const widget = new AreaChart({}, {
+            xLabel: '你好你好',
+            yLabel: '你好你好',
+        });
+        widget.setData([]);
+        const screen = new Screen(5, 3);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+        widget.updateRect({ x: 0, y: 0, width: 5, height: 3 });
+        widget.render(screen);
+
+        for (const [x, , text] of writeSpy.mock.calls) {
+            expect(x + stringWidth(text)).toBeLessThanOrEqual(5);
+        }
     });
 });

--- a/packages/widgets/src/data/AreaChart.ts
+++ b/packages/widgets/src/data/AreaChart.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets — AreaChart widget
 // ─────────────────────────────────────────────────────
 
-import { type Screen, type Style, type Color, styleToCellAttrs, caps, stringWidth, BRAILLE_DOTS, BRAILLE_OFFSET } from '@termuijs/core';
+import { type Screen, type Style, type Color, styleToCellAttrs, caps, stringWidth, truncate, BRAILLE_DOTS, BRAILLE_OFFSET } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 import { filterFinite } from './utils.js';
 
@@ -146,13 +146,14 @@ export class AreaChart extends Widget {
         const plotHeight = height - topLabelRows - bottomLabelRows;
 
         if (this._yLabel) {
-            screen.writeString(x, y, this._yLabel.slice(0, width), attrs);
+            screen.writeString(x, y, truncate(this._yLabel, width, ''), attrs);
         }
 
         if (this._xLabel) {
-            const labelWidth = stringWidth(this._xLabel);
+            const xLabel = truncate(this._xLabel, width, '');
+            const labelWidth = stringWidth(xLabel);
             const labelX = x + Math.max(0, width - labelWidth);
-            screen.writeString(labelX, y + height - 1, this._xLabel.slice(0, width), attrs);
+            screen.writeString(labelX, y + height - 1, xLabel, attrs);
         }
 
         if (plotHeight <= 0 || this._data.length === 0) return;


### PR DESCRIPTION
## Summary
- truncates AreaChart labels by terminal cell width
- aligns the x-axis label after clipping
- adds wide-character regression coverage

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/widgets/src/data/AreaChart.test.ts --watch=false

Closes #2679
