### PR TITLE
Bound MultiProgress rendering by height

### DIFF
--- a/packages/widgets/src/feedback/MultiProgress.test.ts
+++ b/packages/widgets/src/feedback/MultiProgress.test.ts
@@ -191,6 +191,28 @@ describe('MultiProgress — edge cases', () => {
         expect(rows.some(r => r.trim().length > 0)).toBe(true);
     });
 
+    it('does not render rows past the assigned height', () => {
+        const mp = new MultiProgress({
+            items: [
+                { label: 'One', value: 0.2 },
+                { label: 'Two', value: 0.4 },
+                { label: 'Three', value: 0.6 },
+            ],
+        });
+        const screen = new Screen(30, 4);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+        const setCellSpy = vi.spyOn(screen, 'setCell');
+        mp.updateRect({ x: 0, y: 1, width: 30, height: 1 });
+        mp.render(screen);
+
+        for (const [, row] of writeSpy.mock.calls) {
+            expect(row).toBeLessThan(2);
+        }
+        for (const [, row] of setCellSpy.mock.calls) {
+            expect(row).toBeLessThan(2);
+        }
+    });
+
     it('setItems() clamps all values in new items', () => {
         const mp = new MultiProgress({ items: [{ label: 'A', value: 0.5 }] });
         const newItems: ProgressItem[] = [

--- a/packages/widgets/src/feedback/MultiProgress.ts
+++ b/packages/widgets/src/feedback/MultiProgress.ts
@@ -122,7 +122,7 @@ export class MultiProgress extends Widget {
 
     protected _renderSelf(screen: Screen): void {
         const rect = this._getContentRect();
-        const { x, y, width } = rect;
+        const { x, y, width, height } = rect;
         if (width <= 0) return;
 
         const attrs = styleToCellAttrs(this._style);
@@ -132,7 +132,7 @@ export class MultiProgress extends Widget {
         const emptyChar = caps.unicode ? '░' : BLOCK.empty; // '░' or ' '
 
         // Render each item on its own row
-        for (let i = 0; i < this._items.length; i++) {
+        for (let i = 0; i < this._items.length && i < height; i++) {
             const item = this._items[i];
             const rowY = y + i;
             let colX = x;


### PR DESCRIPTION
## Summary
- stops MultiProgress rendering once the assigned height is exhausted
- keeps existing row layout unchanged for visible items
- adds a regression for writes below the widget rect

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/widgets/src/feedback/MultiProgress.test.ts --watch=false

Closes #2707
