### PR TITLE
Clip MultiProgress label column

### DIFF
--- a/packages/widgets/src/feedback/MultiProgress.test.ts
+++ b/packages/widgets/src/feedback/MultiProgress.test.ts
@@ -191,6 +191,20 @@ describe('MultiProgress — edge cases', () => {
         expect(rows.some(r => r.trim().length > 0)).toBe(true);
     });
 
+    it('clips the label column to the widget width', () => {
+        const mp = new MultiProgress({
+            items: [{ label: 'VeryLongLabel', value: 0.5 }],
+            labelWidth: 12,
+            showValues: false,
+        });
+        const screen = new Screen(5, 1);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+        mp.updateRect({ x: 0, y: 0, width: 5, height: 1 });
+        mp.render(screen);
+
+        expect(writeSpy.mock.calls[0]?.[2]).toHaveLength(5);
+    });
+
     it('setItems() clamps all values in new items', () => {
         const mp = new MultiProgress({ items: [{ label: 'A', value: 0.5 }] });
         const newItems: ProgressItem[] = [

--- a/packages/widgets/src/feedback/MultiProgress.ts
+++ b/packages/widgets/src/feedback/MultiProgress.ts
@@ -138,11 +138,12 @@ export class MultiProgress extends Widget {
             let colX = x;
 
             // 1. Render label (left-aligned, truncated/padded to labelWidth)
-            const label = item.label.length > this._labelWidth
-                ? item.label.substring(0, this._labelWidth)
-                : item.label.padEnd(this._labelWidth);
+            const labelWidth = Math.min(this._labelWidth, width);
+            const label = item.label.length > labelWidth
+                ? item.label.substring(0, labelWidth)
+                : item.label.padEnd(labelWidth);
             screen.writeString(colX, rowY, label, attrs);
-            colX += this._labelWidth;
+            colX += labelWidth;
 
             // 2. Space after label
             if (colX < x + width) {


### PR DESCRIPTION
## Summary
- caps the MultiProgress label column at the available widget width
- keeps existing label padding behavior when there is enough room
- adds narrow-width regression coverage

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/widgets/src/feedback/MultiProgress.test.ts --watch=false

Closes #2708


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved progress widget label rendering to respect the configured width.
  * Added proper support for wide Unicode characters, preventing labels from overflowing their boundaries.
  * Preserved consistent alignment between labels and progress bars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->