### PR TITLE
Clip Slider fixed text in narrow widths

### DIFF
--- a/packages/widgets/src/input/Slider.test.ts
+++ b/packages/widgets/src/input/Slider.test.ts
@@ -13,6 +13,21 @@ describe("Slider", () => {
     expect(slider.getValue()).toBe(0);
   });
 
+  it("clips fixed text when no track fits", async () => {
+    const { Screen, stringWidth } = await import("@termuijs/core");
+    const { Slider } = await import("./Slider.js");
+
+    const slider = new Slider("VeryLongLabel", {}, { showValue: true, value: 50 });
+    const screen = new Screen(6, 1);
+    const writeSpy = vi.spyOn(screen, "writeString");
+    slider.updateRect({ x: 0, y: 0, width: 6, height: 1 });
+    slider.render(screen);
+
+    for (const [x, , text] of writeSpy.mock.calls) {
+      expect(x + stringWidth(text)).toBeLessThanOrEqual(6);
+    }
+  });
+
   it("constructs with custom initial value and clamps it", async () => {
     const { Slider } = await import("./Slider.js");
 

--- a/packages/widgets/src/input/Slider.ts
+++ b/packages/widgets/src/input/Slider.ts
@@ -5,6 +5,7 @@ import {
   type KeyEvent,
   styleToCellAttrs,
   stringWidth,
+  truncate,
   caps,
 } from "@termuijs/core";
 import { Widget } from "../base/Widget.js";
@@ -91,6 +92,14 @@ export class Slider extends Widget {
       0,
       width - prefixWidth - suffixWidth
     );
+
+    if (trackWidth === 0 && prefixWidth + suffixWidth > width) {
+      screen.writeString(x, y, truncate(`${prefix}${suffix}`, width, ""), {
+        ...attrs,
+        bold: true,
+      });
+      return;
+    }
 
     const ratio =
       (this._value - this._min) /


### PR DESCRIPTION
## Summary
- renders a clipped Slider fallback when the fixed label/value text leaves no track space
- keeps the existing track rendering path when enough width is available
- adds narrow-width regression coverage

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/widgets/src/input/Slider.test.ts --watch=false

Closes #2709
