### PR TITLE
Clip RangeInput fixed text in narrow widths

### DIFF
--- a/packages/widgets/src/input/RangeInput.test.ts
+++ b/packages/widgets/src/input/RangeInput.test.ts
@@ -23,6 +23,20 @@ describe('RangeInput', () => {
         expect(r.getHigh()).toBe(100);
     });
 
+    it('clips fixed text when no track fits', async () => {
+        const { Screen, stringWidth } = await import('@termuijs/core');
+        const { RangeInput } = await import('./RangeInput.js');
+        const r = new RangeInput('VeryLongLabel', {}, { low: 20, high: 80 });
+        const screen = new Screen(6, 1);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+        r.updateRect({ x: 0, y: 0, width: 6, height: 1 });
+        r.render(screen);
+
+        for (const [x, , text] of writeSpy.mock.calls) {
+            expect(x + stringWidth(text)).toBeLessThanOrEqual(6);
+        }
+    });
+
     it('constructs with custom low and high and clamps them', async () => {
         const { RangeInput } = await import('./RangeInput.js');
         const r = new RangeInput('Price', {}, { min: 10, max: 90, low: 30, high: 70 });

--- a/packages/widgets/src/input/RangeInput.ts
+++ b/packages/widgets/src/input/RangeInput.ts
@@ -7,6 +7,7 @@ import {
     styleToCellAttrs,
     caps,
     stringWidth,
+    truncate,
 } from '@termuijs/core';
 
 export interface RangeInputOptions {
@@ -131,11 +132,20 @@ export class RangeInput extends Widget {
         const leftCapWidth = stringWidth(leftCap);
         const rightCapWidth = stringWidth(rightCap);
         const valueWidth = stringWidth(valueStr);
+        const fixedWidth = labelWidth + leftCapWidth + rightCapWidth + valueWidth;
 
         const trackWidth = Math.max(
             0,
-            width - labelWidth - leftCapWidth - rightCapWidth - valueWidth,
+            width - fixedWidth,
         );
+
+        if (trackWidth === 0 && fixedWidth > width) {
+            screen.writeString(x, y, truncate(`${labelStr}${leftCap}${rightCap}${valueStr}`, width, ''), {
+                ...attrs,
+                bold: true,
+            });
+            return;
+        }
 
         // Render label
         screen.writeString(x, y, labelStr, { ...attrs, bold: true });


### PR DESCRIPTION
## Summary
- renders a clipped RangeInput fallback when fixed text leaves no track space
- preserves existing range track rendering when width allows
- adds narrow-width regression coverage

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/widgets/src/input/RangeInput.test.ts --watch=false

Closes #2710
