### PR TITLE
Clip Stat label and value

### DIFF
--- a/packages/widgets/src/data/Stat.test.ts
+++ b/packages/widgets/src/data/Stat.test.ts
@@ -23,6 +23,21 @@ describe('Stat', () => {
         expect(row1).toBe('Value');
     });
 
+    it('clips label and value to the available width', async () => {
+        const { Screen, stringWidth } = await import('@termuijs/core');
+        const { Stat } = await import('./Stat.js');
+
+        const stat = new Stat('VeryLongLabel', 'VeryLongValue');
+        const screen = new Screen(5, 2);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+        stat.updateRect({ x: 0, y: 0, width: 5, height: 2 });
+        stat.render(screen);
+
+        for (const [x, , text] of writeSpy.mock.calls) {
+            expect(x + stringWidth(text)).toBeLessThanOrEqual(5);
+        }
+    });
+
     it('setValue updates rendered output', async () => {
         vi.stubEnv('NO_UNICODE', '');
         vi.stubEnv('TERM', '');

--- a/packages/widgets/src/data/Stat.ts
+++ b/packages/widgets/src/data/Stat.ts
@@ -1,4 +1,4 @@
-import { type Screen, type Style, type Color, styleToCellAttrs, stringWidth } from '@termuijs/core';
+import { type Screen, type Style, type Color, styleToCellAttrs, stringWidth, truncate } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 import { validateFinite } from './utils.js';
 
@@ -37,18 +37,20 @@ export class Stat extends Widget {
         if (width <= 0 || height <= 0) return;
 
         const attrs = styleToCellAttrs(this._style);
+        const label = truncate(this._label, width, '');
+        const value = truncate(this._value, width, '');
 
         // Row 0: label (bold)
-        screen.writeString(x, y, this._label, { ...attrs, bold: true });
+        screen.writeString(x, y, label, { ...attrs, bold: true });
 
         if (height < 2) return;
 
         // Row 1: value
-        screen.writeString(x, y + 1, this._value, { ...attrs, fg: this._valueColor });
+        screen.writeString(x, y + 1, value, { ...attrs, fg: this._valueColor });
 
         // Optional delta arrow
         if (this._delta !== undefined) {
-            const valueWidth = stringWidth(this._value);
+            const valueWidth = stringWidth(value);
             const arrowX = x + valueWidth + 1;
 
             if (arrowX >= x + width) return;


### PR DESCRIPTION
## Summary
- clips Stat label and value text to the content width
- positions the optional delta arrow from the visible value width
- adds narrow-width regression coverage

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/widgets/src/data/Stat.test.ts --watch=false

Closes #2711
