### PR TITLE
Bound LinearPrompt rendering by height

### DIFF
--- a/packages/ui/src/LinearPrompt.test.ts
+++ b/packages/ui/src/LinearPrompt.test.ts
@@ -527,6 +527,18 @@ describe('LinearPrompt — rendering constraints', () => {
         }).not.toThrow();
     });
 
+    it('does not render options past the assigned height', () => {
+        const prompt = new LinearPrompt(basicOptions, { question: 'Q' });
+        const screen = new Screen(20, 4);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+        prompt.updateRect({ x: 0, y: 1, width: 20, height: 1 });
+        prompt.render(screen);
+
+        for (const [, row] of writeSpy.mock.calls) {
+            expect(row).toBeLessThan(2);
+        }
+    });
+
     it('width smaller than option text renders safely (no overflow)', () => {
         const prompt = new LinearPrompt(
             [{ label: 'VeryLongOptionLabel', value: 'x' }],

--- a/packages/ui/src/LinearPrompt.ts
+++ b/packages/ui/src/LinearPrompt.ts
@@ -91,8 +91,8 @@ export class LinearPrompt extends Widget {
     }
 
     protected _renderSelf(screen: Screen): void {
-        const { x, y, width } = this._rect;
-        if (width <= 0) return;
+        const { x, y, width, height } = this._rect;
+        if (width <= 0 || height <= 0) return;
 
         const attrs = styleToCellAttrs(this.style);
         let currentY = y;
@@ -102,7 +102,7 @@ export class LinearPrompt extends Widget {
         currentY++;
 
         // Render options sequentially without positioning codes
-        for (let i = 0; i < this._options.length; i++) {
+        for (let i = 0; i < this._options.length && currentY < y + height; i++) {
             const opt = this._options[i];
             const isSel = i === this._selectedIndex;
             const marker = isSel ? '> ' : '  ';


### PR DESCRIPTION
## Summary
- stops LinearPrompt option rendering at the assigned height
- preserves question and option styling for visible rows
- adds short-layout regression coverage

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/ui/src/LinearPrompt.test.ts --watch=false

Closes #2712
