### PR TITLE
Clip LinearPrompt rows at narrow widths

### DIFF
--- a/packages/ui/src/LinearPrompt.test.ts
+++ b/packages/ui/src/LinearPrompt.test.ts
@@ -3,7 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { Screen, createKeyEvent } from '@termuijs/core';
+import { Screen, createKeyEvent, stringWidth } from '@termuijs/core';
 import { LinearPrompt, type LinearPromptOption } from './LinearPrompt.js';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -538,6 +538,18 @@ describe('LinearPrompt — rendering constraints', () => {
     it('width smaller than the 2-char marker renders safely', () => {
         const prompt = new LinearPrompt(basicOptions, { question: 'Q' });
         expect(() => renderPrompt(prompt, 1, basicOptions.length + 2)).not.toThrow();
+    });
+
+    it('clips option rows when width is smaller than the marker', () => {
+        const prompt = new LinearPrompt(basicOptions, { question: 'Q' });
+        const screen = new Screen(1, 4);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+        prompt.updateRect({ x: 0, y: 0, width: 1, height: 4 });
+        prompt.render(screen);
+
+        for (const [x, , text] of writeSpy.mock.calls) {
+            expect(x + stringWidth(text)).toBeLessThanOrEqual(1);
+        }
     });
 
     it('very long labels do not overflow the row buffer', () => {

--- a/packages/ui/src/LinearPrompt.ts
+++ b/packages/ui/src/LinearPrompt.ts
@@ -1,6 +1,6 @@
 // LinearPrompt — screen-reader-friendly linear prompt rendering
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs } from '@termuijs/core';
+import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, truncate } from '@termuijs/core';
 
 export interface LinearPromptOption {
     label: string;
@@ -98,7 +98,7 @@ export class LinearPrompt extends Widget {
         let currentY = y;
 
         // Render question
-        screen.writeString(x, currentY, this._question.slice(0, width), attrs);
+        screen.writeString(x, currentY, truncate(this._question, width, ''), attrs);
         currentY++;
 
         // Render options sequentially without positioning codes
@@ -106,12 +106,11 @@ export class LinearPrompt extends Widget {
             const opt = this._options[i];
             const isSel = i === this._selectedIndex;
             const marker = isSel ? '> ' : '  ';
-            const label = opt.label.slice(0, width - 2);
 
             screen.writeString(
                 x,
                 currentY,
-                marker + label,
+                truncate(marker + opt.label, width, ''),
                 {
                     ...attrs,
                     fg: opt.disabled


### PR DESCRIPTION
## Summary
- clips LinearPrompt question and option rows by terminal cell width
- avoids negative slice behavior when width is smaller than the option marker
- adds width-one regression coverage

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/ui/src/LinearPrompt.test.ts --watch=false

Closes #2713
