### PR TITLE
Guard QuizPrompt feedback row

### DIFF
--- a/packages/ui/src/QuizPrompt.test.ts
+++ b/packages/ui/src/QuizPrompt.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Screen } from '@termuijs/core';
 import { QuizPrompt } from './QuizPrompt.js';
 
 const SAMPLE_QUESTIONS = [
@@ -99,6 +100,20 @@ describe('QuizPrompt', () => {
         const result = quiz.getResult();
         expect(result.total).toBe(1);
         expect(result.answers).toEqual([0]);
+    });
+
+    it('does not render feedback below a short layout', () => {
+        const quiz = new QuizPrompt(SAMPLE_QUESTIONS);
+        quiz['_selectedIndex'] = 0;
+        quiz['_feedback'] = 'wrong';
+        const screen = new Screen(40, 5);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+        quiz.updateRect({ x: 0, y: 0, width: 40, height: 3 });
+        quiz.render(screen);
+
+        for (const [, row] of writeSpy.mock.calls) {
+            expect(row).toBeLessThan(3);
+        }
     });
 
     it('clears pending feedback timeout when destroyed', () => {

--- a/packages/ui/src/QuizPrompt.ts
+++ b/packages/ui/src/QuizPrompt.ts
@@ -162,6 +162,8 @@ export class QuizPrompt extends Widget {
         }
         
         // Render feedback message
+        if (row >= height) return;
+
         if (this._feedback === 'correct') {
             screen.writeString(x, y + row, '✓ Correct!'.slice(0, width), { ...attrs, fg: this._correctColor });
         } else if (this._feedback === 'wrong') {


### PR DESCRIPTION
## Summary
- skips QuizPrompt feedback rendering when the short layout has no row left
- preserves existing feedback behavior when space is available
- adds short-layout regression coverage

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/ui/src/QuizPrompt.test.ts --watch=false

Closes #2714
