### PR TITLE
Align ScalePrompt end labels by cell width

### DIFF
--- a/packages/ui/src/ScalePrompt.test.ts
+++ b/packages/ui/src/ScalePrompt.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { Screen, createKeyEvent } from '@termuijs/core';
+import { Screen, createKeyEvent, stringWidth } from '@termuijs/core';
 import { ScalePrompt } from './ScalePrompt.js';
 
 function renderScalePrompt(prompt: ScalePrompt, width = 40, height = 3): Screen {
@@ -124,5 +124,19 @@ describe('ScalePrompt', () => {
         expect(prompt.getValue()).toBe(1);
         expect(rendered).toContain('[1]');
         expect(rendered).toContain('5');
+    });
+
+    it('clips and aligns end labels by cell width', () => {
+        const prompt = new ScalePrompt(undefined, {
+            endLabels: ['你好', '世界'],
+        });
+        const screen = new Screen(5, 3);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+        prompt.updateRect({ x: 0, y: 0, width: 5, height: 3 });
+        prompt.render(screen);
+
+        for (const [x, , text] of writeSpy.mock.calls) {
+            expect(x + stringWidth(text)).toBeLessThanOrEqual(5);
+        }
     });
 });

--- a/packages/ui/src/ScalePrompt.ts
+++ b/packages/ui/src/ScalePrompt.ts
@@ -1,5 +1,5 @@
 import { Widget } from '@termuijs/widgets';
-import { type Color, type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs } from '@termuijs/core';
+import { type Color, type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, stringWidth, truncate } from '@termuijs/core';
 
 export interface ScalePromptOptions {
     max?: number;
@@ -91,12 +91,15 @@ export class ScalePrompt extends Widget {
 
         if (row < height && this._endLabels) {
             const [leftLabel, rightLabel] = this._endLabels;
-            const leftText = leftLabel.slice(0, width);
-            const rightText = rightLabel.slice(0, width);
-            const rightX = x + Math.max(0, width - rightText.length);
+            const leftText = truncate(leftLabel, width, '');
+            const rightWidth = Math.max(0, width - stringWidth(leftText));
+            const rightText = truncate(rightLabel, rightWidth, '');
+            const rightX = x + Math.max(0, width - stringWidth(rightText));
 
             screen.writeString(x, y + row, leftText, attrs);
-            screen.writeString(rightX, y + row, rightText, attrs);
+            if (rightText) {
+                screen.writeString(rightX, y + row, rightText, attrs);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- clips ScalePrompt end labels by terminal cell width
- positions the right label using measured cell width
- avoids overlap with the left label in narrow layouts

## Validation
- npx.cmd --yes bun@1.3.14 vitest run packages/ui/src/ScalePrompt.test.ts --watch=false

Closes #2715
