### PR TITLE
fix: guard usePolling against overlapping and stale requests

### DIFF
--- a/packages/data/src/hooks/usePolling.test.ts
+++ b/packages/data/src/hooks/usePolling.test.ts
@@ -99,4 +99,65 @@ describe('usePolling', () => {
         expect(fn).toHaveBeenCalledTimes(3);
         expect((global as any).hookResult.data).toBe(3);
     });
+
+    it('Skips interval tick while a request is still in flight', async () => {
+        let resolveFirst!: (value: string) => void;
+        const fn = vi.fn().mockImplementationOnce(() => new Promise<string>(resolve => {
+            resolveFirst = resolve;
+        }));
+        render(createElement(TestComponent, { fn, interval: 1000 }));
+
+        await flushPromises();
+        expect(fn).toHaveBeenCalledTimes(1);
+
+        // Interval tick fires while the first request is still unresolved.
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(fn).toHaveBeenCalledTimes(1);
+
+        resolveFirst('first result');
+        await flushPromises();
+        expect((global as any).hookResult.data).toBe('first result');
+
+        // Next tick after resolution starts a new request.
+        fn.mockResolvedValueOnce('second result');
+        await vi.advanceTimersByTimeAsync(1000);
+        await flushPromises();
+        expect(fn).toHaveBeenCalledTimes(2);
+        expect((global as any).hookResult.data).toBe('second result');
+    });
+
+    it('Ignores manual refresh while a request is in flight', async () => {
+        let resolveFirst!: (value: string) => void;
+        const fn = vi.fn().mockImplementationOnce(() => new Promise<string>(resolve => {
+            resolveFirst = resolve;
+        }));
+        render(createElement(TestComponent, { fn, interval: 1000 }));
+
+        await flushPromises();
+        expect(fn).toHaveBeenCalledTimes(1);
+
+        (global as any).hookResult.refresh();
+        (global as any).hookResult.refresh();
+        expect(fn).toHaveBeenCalledTimes(1);
+
+        resolveFirst('done');
+        await flushPromises();
+        expect((global as any).hookResult.data).toBe('done');
+    });
+
+    it('Does not commit a resolved request that is no longer current after unmount', async () => {
+        let resolveFirst!: (value: string) => void;
+        const fn = vi.fn().mockImplementationOnce(() => new Promise<string>(resolve => {
+            resolveFirst = resolve;
+        }));
+        const { unmount } = render(createElement(TestComponent, { fn, interval: 1000 }));
+
+        await flushPromises();
+        unmount();
+
+        resolveFirst('late');
+        await flushPromises();
+
+        expect((global as any).hookResult.data).toBeNull();
+    });
 });

--- a/packages/data/src/hooks/usePolling.ts
+++ b/packages/data/src/hooks/usePolling.ts
@@ -29,18 +29,30 @@ export function usePolling<T>(
     const fnRef = useRef(fn);
     fnRef.current = fn;
 
+    const inFlightRef = useRef(false);
+    const requestIdRef = useRef(0);
+
     const execute = async () => {
+        if (inFlightRef.current) {
+            return;
+        }
+        inFlightRef.current = true;
+        const requestId = ++requestIdRef.current;
         try {
             const result = await fnRef.current();
-            if (mountedRef.current) {
+            if (mountedRef.current && requestId === requestIdRef.current) {
                 setData(result);
                 setError(null);
                 setLoading(false);
             }
         } catch (err) {
-            if (mountedRef.current) {
+            if (mountedRef.current && requestId === requestIdRef.current) {
                 setError(err instanceof Error ? err : new Error(String(err)));
                 setLoading(false);
+            }
+        } finally {
+            if (requestId === requestIdRef.current) {
+                inFlightRef.current = false;
             }
         }
     };
@@ -73,6 +85,8 @@ export function usePolling<T>(
 
         return () => {
             mountedRef.current = false;
+            inFlightRef.current = false;
+            requestIdRef.current++;
             clearInterval(timer);
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Description

`usePolling` starts a new `fn()` call on every interval tick and every manual `refresh()`, even if the previous call hasn't resolved yet. If an earlier request resolves after a later one, its result overwrites the fresher data. This adds an in-flight guard plus a monotonic request id so overlapping calls are skipped and stale responses can't win.

## Related Issue

Closes #2748

## Which package(s)?

@termuijs/data

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read `CONTRIBUTING.md`.
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.

## Notes for the Reviewer

`execute()` now bails out early if a request is already in flight, and on resolve/reject it only commits state if its request id still matches the latest one. Unmount bumps the request id so any response that lands after cleanup is ignored too. Added tests for skipped interval ticks, ignored manual refresh while in flight, and dropped post-unmount responses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented overlapping polling requests when a previous request is still in progress.
  * Ensured repeated refresh actions do not trigger duplicate requests.
  * Ignored outdated responses so they cannot overwrite newer results.
  * Prevented polling responses from updating state after the component is unmounted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->