### PR TITLE
fix(core): forward gap parameter to resolveConstraints in LayoutEngine (#2394)

### DIFF
--- a/packages/core/src/layout/LayoutEngine.test.ts
+++ b/packages/core/src/layout/LayoutEngine.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { computeLayout, createLayoutNode, invalidateLayout } from '../layout/LayoutEngine.js';
+import { Constraint } from './constraint.js';
 import type { Style } from '../style/Style.js';
 
 function makeNode(id: string, style: Partial<Style> = {}, children: ReturnType<typeof createLayoutNode>[] = []) {
@@ -105,6 +106,26 @@ describe('computeLayout', () => {
 
         expect(root.children[0].computed.y).toBe(0);
         expect(root.children[1].computed.y).toBe(4); // 3 + 1 gap
+    });
+
+    it('respects gap when using constraints', () => {
+        const root = makeNode('root', {
+            flexDirection: 'column',
+            gap: 2,
+            constraints: [
+                Constraint.Length(3),
+                Constraint.Length(4),
+            ]
+        }, [
+            makeNode('a'),
+            makeNode('b'),
+        ]);
+        computeLayout(root, 80, 24);
+
+        expect(root.children[0].computed.y).toBe(0);
+        expect(root.children[0].computed.height).toBe(3);
+        expect(root.children[1].computed.y).toBe(5); // 3 + 2 gap
+        expect(root.children[1].computed.height).toBe(4);
     });
 
     it('centers children with justifyContent: center', () => {

--- a/packages/core/src/layout/LayoutEngine.ts
+++ b/packages/core/src/layout/LayoutEngine.ts
@@ -349,7 +349,7 @@ function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, p
         else if (style.justifyContent === 'center') flexJustify = Flex.Center;
         else if (style.justifyContent === 'flex-end') flexJustify = Flex.End;
         
-        const results = resolveConstraints(mainAvail, style.constraints, flexJustify);
+        const results = resolveConstraints(mainAvail, style.constraints, flexJustify, gap);
         
         let visibleIndex = 0;
         for (let i = 0; i < node.children.length; i++) {


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

Forwards the `gap` style parameter to the `resolveConstraints` function in the 1D layout constraints phase. This ensures that constraint-resolved child elements respect the configured gap spacing instead of overlapping or touching.

## Related Issue

Closes #2394

## Which package(s)?

@termuijs/core

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [ ] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/Rakshak05`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->
N/A (Layout calculation fix, covered by automated test cases)

## Notes for the Reviewer

Added a dedicated test case in `LayoutEngine.test.ts` to assert that constraint-resolved layout children correctly space out according to the configured `gap` parameter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layout calculations so gaps are correctly applied when child sizes are defined by constraints.
  * Improved positioning and sizing of children in column-based layouts with fixed spacing.

* **Tests**
  * Added coverage to verify constrained child dimensions and offsets include the configured gap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->