### PR TITLE
fix: abort in-flight useFetch requests on cleanup

### DIFF
--- a/packages/data/src/hooks.ts
+++ b/packages/data/src/hooks.ts
@@ -369,6 +369,38 @@ export interface UseFetchResult<T> {
     loading: boolean;
 }
 
+// Ref-counted AbortControllers keyed by cache key. Multiple useFetch
+// instances requesting the same key share one in-flight fetch (via
+// fetchShared); the underlying request is only aborted once every
+// subscriber for that key has released it (unmounted or moved on to a
+// different url/key).
+interface SharedAbortEntry {
+    controller: AbortController;
+    refCount: number;
+}
+
+const sharedAbortControllers = new Map<string, SharedAbortEntry>();
+
+function acquireAbortController(key: string): AbortController {
+    let entry = sharedAbortControllers.get(key);
+    if (!entry) {
+        entry = { controller: new AbortController(), refCount: 0 };
+        sharedAbortControllers.set(key, entry);
+    }
+    entry.refCount += 1;
+    return entry.controller;
+}
+
+function releaseAbortController(key: string): void {
+    const entry = sharedAbortControllers.get(key);
+    if (!entry) return;
+    entry.refCount -= 1;
+    if (entry.refCount <= 0) {
+        entry.controller.abort();
+        sharedAbortControllers.delete(key);
+    }
+}
+
 /**
  * useFetch — reactive fetch hook with caching.
  *
@@ -427,13 +459,15 @@ export function useFetch<T = unknown>(url: string, options?: UseFetchOptions): U
 
         setLoading(true);
 
+        const controller = acquireAbortController(cacheKey);
+
         /**
          * Attempt the fetch and, on failure, schedule a retry using
          * exponential backoff. `attempt` is zero-based and controls the
          * backoff multiplier `retryDelay * 2 ** attempt`.
          */
         const fetchWithRetry = (attempt: number) => {
-            fetchShared<T>(cacheKey, () => fetch(url)
+            fetchShared<T>(cacheKey, () => fetch(url, { signal: controller.signal })
                 .then(res => {
                     if (!res.ok) throw new Error(`HTTP Error ${res.status}`);
                     return res.json() as Promise<T>;
@@ -449,6 +483,11 @@ export function useFetch<T = unknown>(url: string, options?: UseFetchOptions): U
             })
             .catch(err => {
                 if (!isMounted) return;
+
+                // The request was aborted because this hook instance unmounted
+                // or moved on to a different url/key. There is nothing left to
+                // report — the cleanup below already handles this case.
+                if (err instanceof Error && err.name === 'AbortError') return;
 
                 if (attempt < retry) {
                     clearRetryTimer();
@@ -473,6 +512,7 @@ export function useFetch<T = unknown>(url: string, options?: UseFetchOptions): U
         return () => {
             isMounted = false;
             clearRetryTimer();
+            releaseAbortController(cacheKey);
         };
     }, [url, staleTime, retry, retryDelay, cacheKey]);
 

--- a/packages/data/src/hooks.ts
+++ b/packages/data/src/hooks.ts
@@ -402,6 +402,19 @@ function releaseAbortController(key: string): void {
 }
 
 /**
+ * Test-only helper to reset the module-scoped shared abort controller
+ * registry between test cases. Not part of the public API — not re-exported
+ * from index.ts. A test that misses an unmount/cleanup step could otherwise
+ * leave a stale refCount behind for later cases in the same process.
+ */
+export function __resetSharedAbortControllersForTests(): void {
+    for (const entry of sharedAbortControllers.values()) {
+        entry.controller.abort();
+    }
+    sharedAbortControllers.clear();
+}
+
+/**
  * useFetch — reactive fetch hook with caching.
  *
  * @param url - The URL to fetch.

--- a/packages/data/src/useFetch.test.ts
+++ b/packages/data/src/useFetch.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { invalidate, clearCache, getCache, isFresh, setCache } from "./cache.js";
 import { render } from "@termuijs/testing";
-import { h } from "@termuijs/jsx";
+import { h, useState } from "@termuijs/jsx";
 import { useFetch, UseFetchOptions } from "./hooks.js";
 
 const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0));
@@ -168,6 +168,109 @@ describe("useFetch caching", () => {
     expect(global.fetch).toHaveBeenCalledTimes(2);
 
     unmount();
+  });
+
+  it("aborts the in-flight request on unmount", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    global.fetch = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      capturedSignal = init?.signal;
+      return new Promise(() => {
+        // never resolves; unmount should abort it instead
+      });
+    }) as unknown as typeof global.fetch;
+
+    const { unmount } = renderFetch("test-url-abort-unmount", { staleTime: 1000 });
+
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal?.aborted).toBe(false);
+
+    unmount();
+
+    expect(capturedSignal?.aborted).toBe(true);
+  });
+
+  it("aborts the in-flight request when the key changes", async () => {
+    const signals: AbortSignal[] = [];
+    global.fetch = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      if (init?.signal) signals.push(init.signal);
+      return new Promise(() => {
+        // never resolves
+      });
+    }) as unknown as typeof global.fetch;
+
+    let setKey: (key: string) => void = () => {};
+
+    function TestComponent() {
+      const [key, updateKey] = useState("initial");
+      setKey = updateKey;
+      const result = useFetch("test-url-abort-key", { key });
+      return h("text", null, result.loading ? "loading" : "done");
+    }
+
+    render(h(TestComponent, {}));
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0].aborted).toBe(false);
+
+    setKey("changed");
+    await flushPromises();
+
+    expect(signals[0].aborted).toBe(true);
+    expect(signals).toHaveLength(2);
+    expect(signals[1].aborted).toBe(false);
+  });
+
+  it("ignores AbortError and does not set it as a user-visible error", async () => {
+    global.fetch = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          const err = new Error("The operation was aborted.");
+          err.name = "AbortError";
+          reject(err);
+        });
+      });
+    }) as unknown as typeof global.fetch;
+
+    let currentResult: any;
+    let setKey: (key: string) => void = () => {};
+
+    function TestComponent() {
+      const [key, updateKey] = useState("initial");
+      setKey = updateKey;
+      currentResult = useFetch("test-url-abort-error", { key });
+      return h("text", null, currentResult.loading ? "loading" : "done");
+    }
+
+    render(h(TestComponent, {}));
+
+    setKey("changed");
+    await flushPromises();
+
+    expect(currentResult.error).toBeNull();
+  });
+
+  it("does not cache a response after the request was aborted", async () => {
+    let rejectFetch!: (err: Error) => void;
+    global.fetch = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        rejectFetch = reject;
+        init?.signal?.addEventListener("abort", () => {
+          const err = new Error("The operation was aborted.");
+          err.name = "AbortError";
+          reject(err);
+        });
+      });
+    }) as unknown as typeof global.fetch;
+
+    const { unmount } = renderFetch("test-url-abort-cache", { staleTime: 1000 });
+    unmount();
+    await flushPromises();
+
+    expect(isFresh("test-url-abort-cache")).toBe(false);
+    expect(getCache("test-url-abort-cache")).toBeUndefined();
+
+    // avoid an unhandled rejection warning from the never-otherwise-settled promise
+    rejectFetch(Object.assign(new Error("aborted"), { name: "AbortError" }));
   });
 
   it("refetches when the key changes while URL cache is fresh", async () => {

--- a/packages/data/src/useFetch.test.ts
+++ b/packages/data/src/useFetch.test.ts
@@ -2,12 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { invalidate, clearCache, getCache, isFresh, setCache } from "./cache.js";
 import { render } from "@termuijs/testing";
 import { h, useState } from "@termuijs/jsx";
-import { useFetch, UseFetchOptions } from "./hooks.js";
+import { useFetch, UseFetchOptions, __resetSharedAbortControllersForTests } from "./hooks.js";
 
 const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0));
 
 function renderFetch(url: string, options?: UseFetchOptions) {
-  let currentResult: any;
+  let currentResult: any; // useFetch's generic result shape varies per call site in this helper
 
   function TestComponent(props: { url: string; options?: UseFetchOptions }) {
     currentResult = useFetch(props.url, props.options);
@@ -39,13 +39,14 @@ describe("useFetch caching", () => {
       ok: true,
       status: 200,
       json: async () => ({ status: "ok" }),
-    } as unknown) as typeof global.fetch;
+    } as unknown) as typeof global.fetch; // partial Response mock doesn't implement the full interface
   });
 
   afterEach(() => {
     global.fetch = originalFetch;
     vi.restoreAllMocks();
     clearCache();
+    __resetSharedAbortControllersForTests();
   });
 
   it("first fetch populates cache", async () => {
@@ -177,7 +178,7 @@ describe("useFetch caching", () => {
       return new Promise(() => {
         // never resolves; unmount should abort it instead
       });
-    }) as unknown as typeof global.fetch;
+    }) as unknown as typeof global.fetch; // mock signature narrower than fetch's overloads
 
     const { unmount } = renderFetch("test-url-abort-unmount", { staleTime: 1000 });
 
@@ -196,7 +197,7 @@ describe("useFetch caching", () => {
       return new Promise(() => {
         // never resolves
       });
-    }) as unknown as typeof global.fetch;
+    }) as unknown as typeof global.fetch; // mock signature narrower than fetch's overloads
 
     let setKey: (key: string) => void = () => {};
 
@@ -229,9 +230,9 @@ describe("useFetch caching", () => {
           reject(err);
         });
       });
-    }) as unknown as typeof global.fetch;
+    }) as unknown as typeof global.fetch; // mock signature narrower than fetch's overloads
 
-    let currentResult: any;
+    let currentResult: any; // useFetch's generic result shape varies per call site in this test
     let setKey: (key: string) => void = () => {};
 
     function TestComponent() {
@@ -250,17 +251,15 @@ describe("useFetch caching", () => {
   });
 
   it("does not cache a response after the request was aborted", async () => {
-    let rejectFetch!: (err: Error) => void;
     global.fetch = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
       return new Promise((_resolve, reject) => {
-        rejectFetch = reject;
         init?.signal?.addEventListener("abort", () => {
           const err = new Error("The operation was aborted.");
           err.name = "AbortError";
           reject(err);
         });
       });
-    }) as unknown as typeof global.fetch;
+    }) as unknown as typeof global.fetch; // mock signature narrower than fetch's overloads
 
     const { unmount } = renderFetch("test-url-abort-cache", { staleTime: 1000 });
     unmount();
@@ -268,9 +267,59 @@ describe("useFetch caching", () => {
 
     expect(isFresh("test-url-abort-cache")).toBe(false);
     expect(getCache("test-url-abort-cache")).toBeUndefined();
+  });
 
-    // avoid an unhandled rejection warning from the never-otherwise-settled promise
-    rejectFetch(Object.assign(new Error("aborted"), { name: "AbortError" }));
+  it("does not populate the cache when a response resolves after unmount", async () => {
+    // Unlike the AbortError case above, this exercises the isMounted guard in
+    // the success branch directly: the underlying promise is unaffected by
+    // abort() (it ignores the signal) and still resolves successfully, but
+    // after the consumer has already unmounted.
+    let resolveFetch!: (value: unknown) => void;
+    global.fetch = vi.fn().mockImplementation(() => {
+      return new Promise(resolve => {
+        resolveFetch = resolve;
+      });
+    }) as unknown as typeof global.fetch; // mock signature narrower than fetch's overloads
+
+    const { unmount } = renderFetch("test-url-success-after-unmount", { staleTime: 1000 });
+    unmount();
+
+    resolveFetch({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: "late" }),
+    });
+    await flushPromises();
+
+    expect(isFresh("test-url-success-after-unmount")).toBe(false);
+    expect(getCache("test-url-success-after-unmount")).toBeUndefined();
+  });
+
+  it("does not schedule fetch after unmount when a retry was pending", async () => {
+    vi.useFakeTimers();
+
+    let callCount = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      callCount++;
+      return Promise.reject(new Error("network error"));
+    }) as unknown as typeof global.fetch; // mock signature narrower than fetch's overloads
+
+    const { unmount } = renderFetch("test-url-retry-cleanup", {
+      retry: 2,
+      retryDelay: 300,
+    });
+
+    // Let the first attempt fail and the retry timer get scheduled.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(callCount).toBe(1);
+
+    unmount();
+
+    // Advance well past the retry delay — cleanup must have cleared the timer.
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(callCount).toBe(1);
+
+    vi.useRealTimers();
   });
 
   it("refetches when the key changes while URL cache is fresh", async () => {


### PR DESCRIPTION
## Description

`useFetch` prevented state updates after unmount via an `isMounted` flag but never canceled the underlying network request, so requests kept running even after a component unmounted or `url`/`key` changed. This passes an `AbortController` signal into `fetch` and aborts it on cleanup.

## Related Issue

Closes #2749

## Which package(s)?

@termuijs/data

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read `CONTRIBUTING.md`.
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.

## Notes for the Reviewer

`fetchShared()` dedupes requests by cache key across multiple `useFetch` consumers, so a single unmount can't just abort unconditionally — it would cancel a request another instance still needs. I kept `fetchShared` itself untouched and instead added a small ref-counted controller map in `hooks.ts` keyed by the same cache key: each effect run acquires the controller (bumping refcount) and releases it on cleanup, aborting only when the last subscriber releases it. `AbortError` is caught and swallowed rather than surfaced through `error`, and the retry loop also respects it. Added tests for unmount abort, key-change abort, and making sure an aborted response doesn't populate the cache or set a visible error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation of in-flight data requests when components unmount or request keys change.
  * Prevented cancellation errors from appearing as user-visible errors.
  * Ensured canceled requests do not populate or refresh cached data.
  * Coordinated shared requests so they are canceled only after all subscribers release them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->