### PR TITLE
fix: add VirtualList.invalidateCache() for stale row data

### DIFF
--- a/packages/widgets/src/input/VirtualList.test.ts
+++ b/packages/widgets/src/input/VirtualList.test.ts
@@ -277,6 +277,47 @@ describe('VirtualList', () => {
         });
     });
 
+    describe('invalidateCache', () => {
+        it('rerenders updated row content after mutable data changes', () => {
+            const rows = ['alpha'];
+            const list = new VirtualList({
+                totalItems: rows.length,
+                renderItem: (i) => rows[i],
+                springScroll: false,
+                showScrollbar: false,
+                style: { width: 20, height: 3 },
+            });
+            const node = list.getLayoutNode();
+            computeLayout(node, 20, 3);
+            list.syncLayout();
+
+            const screen = new Screen(20, 3);
+            list.render(screen);
+            const rowText = (row: number) => screen.back[row].map(c => c.char).join('').trim();
+            expect(rowText(1)).toContain('alpha');
+
+            // Mutate the backing data without replacing the render function.
+            rows[0] = 'beta';
+            list.markDirty();
+            list.render(screen);
+
+            // Cache is keyed by index/selection/focus only, so the stale
+            // "alpha" row is served until the cache is invalidated.
+            expect(rowText(1)).toContain('alpha');
+
+            list.invalidateCache();
+            list.render(screen);
+            expect(rowText(1)).toContain('beta');
+        });
+
+        it('marks the widget dirty so a subsequent render reflects the invalidation', () => {
+            const list = createList(10);
+            const markDirtySpy = vi.spyOn(list, 'markDirty');
+            list.invalidateCache();
+            expect(markDirtySpy).toHaveBeenCalled();
+        });
+    });
+
     describe('render cache eviction', () => {
         it('evicts old entries outside visible range after scroll', () => {
             const list = new VirtualList({

--- a/packages/widgets/src/input/VirtualList.ts
+++ b/packages/widgets/src/input/VirtualList.ts
@@ -121,6 +121,21 @@ export class VirtualList extends Widget {
         this.markDirty();
     }
 
+    /**
+     * Invalidate the render cache without replacing the render function.
+     *
+     * The cache only tracks index, selection, and focus state, so if
+     * `renderItem` closes over mutable data (e.g., an external array) and
+     * that data changes, previously rendered rows are reused unchanged.
+     * Call this after mutating that backing data so the next `render()`
+     * re-invokes `renderItem` for every visible row instead of serving
+     * stale cached content.
+     */
+    invalidateCache(): void {
+        this._clearCache();
+        this.markDirty();
+    }
+
     /** Move selection up by one */
     selectPrev(): void {
         if (this._selectedIndex > 0) {


### PR DESCRIPTION
## Description

`VirtualList`'s render cache keys entries on index/selection/focus only, so if `renderItem` closes over mutable external data, changing that data and calling `markDirty()` still serves the old cached row. Adds a public `invalidateCache()` method to clear the cache without forcing callers to replace the render function.

## Related Issue

Closes #2751

## Which package(s)?

@termuijs/widgets

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read `CONTRIBUTING.md`.
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.

## Notes for the Reviewer

Reused the existing private `_clearCache()` rather than duplicating logic, and kept `setRenderItem`/`setTotalItems`/`setStyle` untouched since those already clear the cache on their own paths. `invalidateCache()` just gives callers an explicit way to do the same thing when the render function itself hasn't changed but the data it reads has. Test reproduces the repro from the issue (mutate a backing array, confirm stale row without invalidation, confirm fresh row after calling `invalidateCache()`).
