### PR TITLE
Run parent guards for nested routes

### DIFF
--- a/packages/router/src/router.test.ts
+++ b/packages/router/src/router.test.ts
@@ -194,6 +194,33 @@ describe('Router', () => {
         expect(r.currentPath).toBe('/login');
     });
 
+    it('parent beforeEnter can block nested child navigation', () => {
+        const r = new Router();
+        const parentGuard = vi.fn().mockReturnValue(false);
+        r.addRoute('/admin', () => 'Admin', undefined, [
+            { path: 'users', component: () => 'Users' },
+        ], undefined, { beforeEnter: parentGuard });
+
+        r.push('/admin/users');
+
+        expect(parentGuard).toHaveBeenCalledWith('/admin/users');
+        expect(r.current).toBeNull();
+        expect(r.historyLength).toBe(0);
+    });
+
+    it('parent beforeEnter can redirect nested child navigation', () => {
+        const r = new Router();
+        r.addRoute('/login', () => 'Login');
+        r.addRoute('/admin', () => 'Admin', undefined, [
+            { path: 'users', component: () => 'Users' },
+        ], undefined, { beforeEnter: () => '/login' });
+
+        r.push('/admin/users');
+
+        expect(r.currentPath).toBe('/login');
+        expect(r.current?.route.path).toBe('/login');
+    });
+
     it('back() with beforeEnter redirect does not corrupt history', () => {
         const r = new Router();
         r.addRoute('/login', () => 'Login');

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -226,6 +226,16 @@ export class Router {
         return path;
     }
 
+    private _runBeforeEnterGuards(match: RouteMatch, path: string): boolean | string {
+        for (const route of match.chain) {
+            const result = route.beforeEnter?.(path);
+            if (result === false || typeof result === 'string') {
+                return result;
+            }
+        }
+        return true;
+    }
+
     /**
      * Core navigation execution with redirect resolution, guard evaluation,
      * history management, and hook dispatch. Used by push, replace, back, and forward.
@@ -284,7 +294,7 @@ export class Router {
             this._forwardStack = [];
         }
 
-        const guardResult = match.route.beforeEnter?.(resolvedPath);
+        const guardResult = this._runBeforeEnterGuards(match, resolvedPath);
 
         if (guardResult === false) {
             return;
@@ -375,7 +385,7 @@ export class Router {
             return;
         }
 
-        const guardResult = match.route.beforeEnter?.(prevPath);
+        const guardResult = this._runBeforeEnterGuards(match, prevPath);
 
         if (guardResult === false) {
             return;
@@ -428,7 +438,7 @@ export class Router {
             return;
         }
 
-        const guardResult = match.route.beforeEnter?.(nextPath);
+        const guardResult = this._runBeforeEnterGuards(match, nextPath);
 
         if (guardResult === false) {
             return;


### PR DESCRIPTION
## Summary
- evaluates nested route guards from parent to child before navigation
- keeps redirects and blocked navigations working for leaf routes
- adds coverage for parent guard blocking and redirecting child routes

## Validation
- node_modules\.bin\vitest.exe run packages/router/src/router.test.ts --watch=false

Closes #2832
