### PR TITLE
Preserve repeated query params

### DIFF
--- a/packages/router/src/route.test.ts
+++ b/packages/router/src/route.test.ts
@@ -27,6 +27,13 @@ describe('route - Query Utilities', () => {
                 'key space': 'value',
             });
         });
+
+        it('preserves repeated query parameters as arrays', () => {
+            expect(parseQuery('tag=ui&tag=data&sort=asc')).toEqual({
+                tag: ['ui', 'data'],
+                sort: 'asc',
+            });
+        });
     });
 
     describe('serializeQuery', () => {
@@ -45,6 +52,12 @@ describe('route - Query Utilities', () => {
         it('URL-encodes parameters during serialization', () => {
             expect(serializeQuery({ hello: 'world!', 'key space': 'value' })).toBe(
                 'hello=world%21&key+space=value'
+            );
+        });
+
+        it('serializes array values as repeated query parameters', () => {
+            expect(serializeQuery({ tag: ['ui', 'data'], sort: 'asc' })).toBe(
+                'tag=ui&tag=data&sort=asc'
             );
         });
     });
@@ -173,5 +186,10 @@ describe('route - matchRoute', () => {
         const match = matchRoute('/about?tab=settings&theme=dark', routes);
         expect(match?.route.meta?.name).toBe('about');
         expect(match?.query).toEqual({ tab: 'settings', theme: 'dark' });
+    });
+
+    it('preserves repeated query parameters in route match', () => {
+        const match = matchRoute('/about?tag=ui&tag=data', routes);
+        expect(match?.query).toEqual({ tag: ['ui', 'data'] });
     });
 });

--- a/packages/router/src/route.ts
+++ b/packages/router/src/route.ts
@@ -15,15 +15,37 @@ export interface RouteParams {
 }
 
 export interface QueryParams {
-    [key: string]: string;
+    [key: string]: string | string[];
 }
 
 export function parseQuery(queryString: string): QueryParams {
-    return Object.fromEntries(new URLSearchParams(queryString));
+    const params = new URLSearchParams(queryString);
+    const result: QueryParams = {};
+    for (const [key, value] of params) {
+        const existing = result[key];
+        if (existing === undefined) {
+            result[key] = value;
+        } else if (Array.isArray(existing)) {
+            existing.push(value);
+        } else {
+            result[key] = [existing, value];
+        }
+    }
+    return result;
 }
 
 export function serializeQuery(query: QueryParams): string {
-    return new URLSearchParams(query).toString();
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(query)) {
+        if (Array.isArray(value)) {
+            for (const item of value) {
+                params.append(key, item);
+            }
+        } else {
+            params.append(key, value);
+        }
+    }
+    return params.toString();
 }
 
 export type RedirectTarget =
@@ -159,7 +181,7 @@ export function matchRoute(path: string, routes: Route[]): RouteMatch | null {
 
     const match = matchNested(pathname, routes);
     if (match) {
-        match.query = Object.fromEntries(new URLSearchParams(queryString));
+        match.query = parseQuery(queryString);
         return match;
     }
     return null;

--- a/packages/router/src/router.test.ts
+++ b/packages/router/src/router.test.ts
@@ -68,6 +68,15 @@ describe('Router', () => {
         expect(r.params.id).toBe('42');
     });
 
+    it('push serializes array query values as repeated params', () => {
+        const r = new Router();
+        r.addRoute('/search', () => 'Search');
+        r.push('/search', { query: { tag: ['ui', 'data'] } });
+
+        expect(r.currentPath).toBe('/search?tag=ui&tag=data');
+        expect(r.query).toEqual({ tag: ['ui', 'data'] });
+    });
+
     it('navigate event fires on push', () => {
         const r = new Router();
         r.addRoute('/home', () => 'Home');

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -4,7 +4,7 @@
 
 import { EventEmitter } from '@termuijs/core';
 import { createElement, ErrorBoundary, unmountAll, type VNode, getCurrentApp } from '@termuijs/jsx';
-import { type Route, type RouteMatch, type RouteParams, type RouteMeta, type QueryParams, type RedirectTarget, matchRoute, compilePattern } from './route.js';
+import { type Route, type RouteMatch, type RouteParams, type RouteMeta, type QueryParams, type RedirectTarget, matchRoute, compilePattern, serializeQuery } from './route.js';
 import { RouterContext } from './hooks.js';
 
 function defaultErrorScreen(err: Error): VNode {
@@ -334,7 +334,7 @@ export class Router {
     push(path: string, options?: { query?: QueryParams }): void {
         let targetPath = path;
         if (options?.query) {
-            const qs = new URLSearchParams(options.query).toString();
+            const qs = serializeQuery(options.query);
             if (qs) targetPath += (targetPath.includes('?') ? '&' : '?') + qs;
         }
         this._executeNavigation(targetPath, { clearForwardStack: true, direction: 'push' });
@@ -344,7 +344,7 @@ export class Router {
     replace(path: string, options?: { query?: QueryParams }): void {
         let targetPath = path;
         if (options?.query) {
-            const qs = new URLSearchParams(options.query).toString();
+            const qs = serializeQuery(options.query);
             if (qs) targetPath += (targetPath.includes('?') ? '&' : '?') + qs;
         }
         this._executeNavigation(targetPath, { modifyHistory: 'replace', direction: 'replace' });


### PR DESCRIPTION
## Summary
- preserves repeated query params as arrays when parsing routes
- serializes array query values as repeated keys in router navigation
- adds coverage for parsing, serialization, matching, and push navigation

## Validation
- node_modules\.bin\vitest.exe run packages/router/src/route.test.ts packages/router/src/router.test.ts --watch=false

Closes #2834
