### PR TITLE
Abort pending infinite query page fetches

### DIFF
--- a/packages/data/src/hooks.ts
+++ b/packages/data/src/hooks.ts
@@ -536,7 +536,7 @@ export function useFetch<T = unknown>(url: string, options?: UseFetchOptions): U
 
 export interface InfiniteQueryOptions<T, P> {
     /** Called with a page param; resolves to one page of data. */
-    queryFn: (pageParam: P) => Promise<T>;
+    queryFn: (pageParam: P, signal?: AbortSignal) => Promise<T>;
     /** Param used for the very first page fetch. */
     initialPageParam: P;
     /**
@@ -574,6 +574,7 @@ export function useInfiniteQuery<T, P = number>(
     // Each effect run creates a fresh controller and aborts the previous one on
     // cleanup, so stale promise callbacks see `signal.aborted === true` and bail.
     const abortControllerRef = useRef<AbortController | null>(null);
+    const pageAbortControllerRef = useRef<AbortController | null>(null);
 
     // Generation counter for fetchNextPage: incremented when the main effect
     // re-runs (queryFn / initialPageParam changed), so any in-flight
@@ -587,6 +588,7 @@ export function useInfiniteQuery<T, P = number>(
     useEffect(() => {
         // Abort any previous in-flight fetch from the last effect run.
         abortControllerRef.current?.abort();
+        pageAbortControllerRef.current?.abort();
         const controller = new AbortController();
         abortControllerRef.current = controller;
 
@@ -596,7 +598,7 @@ export function useInfiniteQuery<T, P = number>(
         setLoading(true);
         loadingRef.current = true;
 
-        queryFn(initialPageParam)
+        queryFn(initialPageParam, controller.signal)
             .then(page => {
                 if (controller.signal.aborted) return;
                 setPages([page]);
@@ -614,6 +616,8 @@ export function useInfiniteQuery<T, P = number>(
         return () => {
             generationRef.current += 1;
             controller.abort();
+            pageAbortControllerRef.current?.abort();
+            pageAbortControllerRef.current = null;
         };
     }, [queryFn, initialPageParam]);
 
@@ -633,18 +637,26 @@ export function useInfiniteQuery<T, P = number>(
         // Capture the current generation; if the main effect re-runs before
         // this promise settles, the generation will have changed and we skip.
         const myGeneration = generationRef.current;
+        const controller = new AbortController();
+        pageAbortControllerRef.current = controller;
 
         setLoading(true);
-        queryFn(nextParam)
+        queryFn(nextParam, controller.signal)
             .then(page => {
-                if (myGeneration !== generationRef.current) return;
+                if (myGeneration !== generationRef.current || controller.signal.aborted) return;
+                if (pageAbortControllerRef.current === controller) {
+                    pageAbortControllerRef.current = null;
+                }
                 loadingRef.current = false;
                 setPages(prev => [...prev, page]);
                 setError(null);
                 setLoading(false);
             })
             .catch(err => {
-                if (myGeneration !== generationRef.current) return;
+                if (pageAbortControllerRef.current === controller) {
+                    pageAbortControllerRef.current = null;
+                }
+                if (myGeneration !== generationRef.current || controller.signal.aborted) return;
                 loadingRef.current = false;
                 setError(err instanceof Error ? err : new Error(String(err)));
                 setLoading(false);

--- a/packages/data/src/useFetch.test.ts
+++ b/packages/data/src/useFetch.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { invalidate, clearCache, getCache, isFresh, setCache } from "./cache.js";
 import { render } from "@termuijs/testing";
 import { h, useState } from "@termuijs/jsx";
-import { useFetch, UseFetchOptions, __resetSharedAbortControllersForTests } from "./hooks.js";
+import { useFetch, useInfiniteQuery, UseFetchOptions, __resetSharedAbortControllersForTests } from "./hooks.js";
 
 const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0));
 
@@ -340,5 +340,46 @@ describe("useFetch caching", () => {
     expect(global.fetch).toHaveBeenCalledTimes(2);
 
     unmount();
+  });
+});
+
+describe("useInfiniteQuery", () => {
+  it("aborts a pending next-page request on unmount", async () => {
+    const signals: AbortSignal[] = [];
+    let currentResult: ReturnType<typeof useInfiniteQuery<number, number>>;
+
+    const queryFn = vi.fn((page: number, signal?: AbortSignal) => {
+      if (signal) signals.push(signal);
+
+      if (page === 1) {
+        return Promise.resolve(page);
+      }
+
+      return new Promise<number>(() => {
+        // The cleanup path should abort this pending next-page request.
+      });
+    });
+
+    function TestComponent() {
+      currentResult = useInfiniteQuery({
+        queryFn,
+        initialPageParam: 1,
+        getNextPageParam: page => page + 1,
+      });
+
+      return h("text", null, currentResult.loading ? "loading" : "done");
+    }
+
+    const screen = render(h(TestComponent, {}));
+
+    await flushPromises();
+    currentResult!.fetchNextPage();
+
+    expect(signals).toHaveLength(2);
+    expect(signals[1].aborted).toBe(false);
+
+    screen.unmount();
+
+    expect(signals[1].aborted).toBe(true);
   });
 });

--- a/packages/data/src/useInfiniteQuery.test.tsx
+++ b/packages/data/src/useInfiniteQuery.test.tsx
@@ -38,7 +38,7 @@ describe('useInfiniteQuery', () => {
         expect(result!.loading).toBe(true);
         expect(result!.pages).toHaveLength(0);
         expect(queryFn).toHaveBeenCalledTimes(1);
-        expect(queryFn).toHaveBeenCalledWith(1);
+        expect(queryFn).toHaveBeenCalledWith(1, expect.any(AbortSignal));
 
         await flush();
 
@@ -88,7 +88,7 @@ describe('useInfiniteQuery', () => {
         expect(result!.pages).toHaveLength(2);
         expect(result!.pages[1]).toEqual({ items: ['b'], next: null });
         expect(queryFn).toHaveBeenCalledTimes(2);
-        expect(queryFn).toHaveBeenNthCalledWith(2, 2);
+        expect(queryFn).toHaveBeenNthCalledWith(2, 2, expect.any(AbortSignal));
     });
 
     it('hasNextPage becomes false at the end', async () => {


### PR DESCRIPTION
Summary
- abort pending next-page requests when infinite queries unmount or restart
- pass AbortSignal into infinite query fetch functions
- add coverage for pending next-page cleanup

Validation
- node_modules\.bin\vitest.exe run packages/data/src/useFetch.test.ts --watch=false

Closes #2835


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for canceling in-progress infinite-query page requests.
  * Query functions can now receive an abort signal for request cancellation.

* **Bug Fixes**
  * Prevented canceled or stale page requests from updating application state after unmounting or newer requests.

* **Tests**
  * Added coverage confirming that active page requests are aborted correctly and receive abort signals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->