### PR TITLE
Make file watcher start idempotent

### DIFF
--- a/packages/dev-server/src/watcher.test.ts
+++ b/packages/dev-server/src/watcher.test.ts
@@ -307,6 +307,25 @@ describe('FileWatcher', () => {
         expect(vi.mocked(watch)).toHaveBeenCalledTimes(dirs.length);
     });
 
+    it('does not register duplicate watchers when start is called twice', () => {
+        const watcher = new FileWatcher(['./src']);
+
+        watcher.start();
+        watcher.start();
+
+        expect(vi.mocked(watch)).toHaveBeenCalledTimes(1);
+    });
+
+    it('can start again after stop', () => {
+        const watcher = new FileWatcher(['./src']);
+
+        watcher.start();
+        watcher.stop();
+        watcher.start();
+
+        expect(vi.mocked(watch)).toHaveBeenCalledTimes(2);
+    });
+
     it('handles events from multiple directories independently', () => {
         // Use separate emitters per directory
         const emitters = [new EventEmitter(), new EventEmitter(), new EventEmitter()];

--- a/packages/dev-server/src/watcher.ts
+++ b/packages/dev-server/src/watcher.ts
@@ -37,6 +37,7 @@ export class FileWatcher {
     private _onChangeCallbacks: Array<(change: FileChange) => void> = [];
     private _onErrorCallbacks: Array<(err: Error) => void> = [];
     private _debounceTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+    private _started = false;
 
     constructor(dirs: string[]) {
         this._dirs = dirs.map(d => resolve(d));
@@ -49,6 +50,9 @@ export class FileWatcher {
 
     /** Begin watching all configured directories, debouncing rapid changes. */
     start(): void {
+        if (this._started) return;
+        this._started = true;
+
         for (const dir of this._dirs) {
             if (!existsSync(dir)) continue;
             const ac = new AbortController();
@@ -114,6 +118,7 @@ export class FileWatcher {
     stop(): void {
         for (const ac of this._abortControllers) ac.abort();
         this._abortControllers = [];
+        this._started = false;
         for (const timer of this._debounceTimers.values()) clearTimeout(timer);
         this._debounceTimers.clear();
     }


### PR DESCRIPTION
Summary
- prevent duplicate native watchers from repeated start calls
- allow watchers to restart after stop
- add lifecycle coverage for both paths

Validation
- node_modules\.bin\vitest.exe run packages/dev-server/src/watcher.test.ts --watch=false

Closes #2837