### PR TITLE
Skip generated dirs in watcher fallback

### DIFF
--- a/packages/dev-server/src/watcher.test.ts
+++ b/packages/dev-server/src/watcher.test.ts
@@ -393,6 +393,27 @@ describe('FileWatcher', () => {
         expect(changeSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('skips generated directories during fallback traversal', () => {
+        vi.mocked(watch)
+            .mockImplementationOnce(() => {
+                throw new Error('recursive watch unavailable');
+            })
+            .mockReturnValue(mockWatcherEmitter as any);
+        vi.mocked(readdirSync).mockImplementation((dir) => {
+            if (String(dir).endsWith('src')) return ['components', 'node_modules', 'dist'] as any;
+            return [] as any;
+        });
+        vi.mocked(statSync).mockReturnValue({ isDirectory: () => true } as any);
+
+        const watcher = new FileWatcher(['./src']);
+
+        watcher.start();
+
+        expect(vi.mocked(watch)).toHaveBeenCalledTimes(3);
+        expect(vi.mocked(statSync)).toHaveBeenCalledTimes(1);
+        expect(vi.mocked(statSync).mock.calls[0][0]).toEqual(expect.stringContaining('components'));
+    });
+
     // ─── 13. Timestamp generation ─────────────────────────────────────────────
 
     it('attaches a timestamp within the expected execution range', () => {

--- a/packages/dev-server/src/watcher.ts
+++ b/packages/dev-server/src/watcher.ts
@@ -5,6 +5,15 @@
 import { watch, existsSync, readdirSync, statSync } from 'node:fs';
 import { resolve, extname, join } from 'node:path';
 
+const DEFAULT_IGNORED_DIRS = new Set([
+    '.git',
+    '.next',
+    '.turbo',
+    'coverage',
+    'dist',
+    'node_modules',
+]);
+
 /**
  * A single detected file change emitted by the {@link FileWatcher}.
  */
@@ -70,6 +79,7 @@ export class FileWatcher {
         this.watchDir(rootDir, rootDir, ac, false);
 
         for (const entry of readdirSync(rootDir)) {
+            if (DEFAULT_IGNORED_DIRS.has(entry)) continue;
             const child = join(rootDir, entry);
             if (statSync(child).isDirectory()) {
                 this.watchDirectoryTree(child, ac);


### PR DESCRIPTION
Summary
- skip generated and dependency folders during fallback directory traversal
- avoid creating fallback watchers under node_modules and dist
- add coverage for skipped fallback directories

Validation
- node_modules\.bin\vitest.exe run packages/dev-server/src/watcher.test.ts --watch=false

Closes #2838