### PR TITLE
Clip error overlay writes to screen bounds

### DIFF
--- a/packages/dev-server/src/error-overlay.test.ts
+++ b/packages/dev-server/src/error-overlay.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { Screen } from '@termuijs/core';
+import { describe, it, expect, vi } from 'vitest';
+import { Screen, stringWidth } from '@termuijs/core';
 import { parseErrorStack, ErrorOverlay } from './error-overlay.js';
 
 // ─────────────────────────────────────────────────────
@@ -284,16 +284,27 @@ describe('ErrorOverlay rendering — long error messages', () => {
         expect(textOutput).toContain('DEV-SERVER RUNTIME / COMPILE ERROR');
     });
 
-    it('keeps rows within bounds on very narrow screens', () => {
-        const rawTrace = `Error: ${'C'.repeat(200)}\n    at /app/src/main.ts:1:1`;
+    it('clips every write to the visible screen bounds on very narrow screens', () => {
+        const rawTrace = `Error: ${'C'.repeat(200)} ❌\n    at /app/src/main.ts:1:1`;
         const screen = new Screen(4, 6);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+        const setCellSpy = vi.spyOn(screen, 'setCell');
         const overlay = new ErrorOverlay(rawTrace);
 
         overlay.render(screen);
 
-        expect(screen.back).toHaveLength(6);
-        for (const row of screen.back) {
-            expect(row).toHaveLength(4);
+        for (const [x, y, text] of writeSpy.mock.calls) {
+            expect(x).toBeGreaterThanOrEqual(0);
+            expect(y).toBeGreaterThanOrEqual(0);
+            expect(y).toBeLessThan(screen.rows);
+            expect(x + stringWidth(String(text))).toBeLessThanOrEqual(screen.cols);
+        }
+
+        for (const [x, y] of setCellSpy.mock.calls) {
+            expect(x).toBeGreaterThanOrEqual(0);
+            expect(x).toBeLessThan(screen.cols);
+            expect(y).toBeGreaterThanOrEqual(0);
+            expect(y).toBeLessThan(screen.rows);
         }
     });
 });

--- a/packages/dev-server/src/error-overlay.test.ts
+++ b/packages/dev-server/src/error-overlay.test.ts
@@ -283,6 +283,19 @@ describe('ErrorOverlay rendering — long error messages', () => {
         const textOutput = screen.back.map(row => row.map(c => c.char).join('')).join('\n');
         expect(textOutput).toContain('DEV-SERVER RUNTIME / COMPILE ERROR');
     });
+
+    it('keeps rows within bounds on very narrow screens', () => {
+        const rawTrace = `Error: ${'C'.repeat(200)}\n    at /app/src/main.ts:1:1`;
+        const screen = new Screen(4, 6);
+        const overlay = new ErrorOverlay(rawTrace);
+
+        overlay.render(screen);
+
+        expect(screen.back).toHaveLength(6);
+        for (const row of screen.back) {
+            expect(row).toHaveLength(4);
+        }
+    });
 });
 
 // 8. ErrorOverlay rendering with missing location data

--- a/packages/dev-server/src/error-overlay.ts
+++ b/packages/dev-server/src/error-overlay.ts
@@ -120,6 +120,20 @@ export class ErrorOverlay implements RootWidget {
     render(screen: Screen): void {
         const { cols, rows } = screen;
         if (cols <= 0 || rows <= 0) return;
+        const writeClipped = (
+            x: number,
+            y: number,
+            text: string,
+            attrs?: Parameters<Screen['writeString']>[3],
+        ) => {
+            if (y < 0 || y >= rows || x >= cols) return;
+
+            const startX = Math.max(0, x);
+            const available = cols - startX;
+            if (available <= 0) return;
+
+            screen.writeString(startX, y, text.slice(0, available), attrs);
+        };
 
         // Clear screen with a consistent background
         for (let y = 0; y < rows; y++) {
@@ -134,7 +148,7 @@ export class ErrorOverlay implements RootWidget {
 
         // 1. Draw top banner
         const bannerText = '  ❌ DEV-SERVER RUNTIME / COMPILE ERROR  ';
-        screen.writeString(0, 0, bannerText.padEnd(cols, ' '), {
+        writeClipped(0, 0, bannerText.padEnd(cols, ' '), {
             fg: { type: 'named', name: 'white' },
             bg: { type: 'named', name: 'red' },
             bold: true,
@@ -142,11 +156,11 @@ export class ErrorOverlay implements RootWidget {
 
         // 2. Draw error header (Name: message)
         let currentLine = 2;
-        screen.writeString(2, currentLine, `${this._error.name}:`, {
+        writeClipped(2, currentLine, `${this._error.name}:`, {
             fg: { type: 'named', name: 'red' },
             bold: true,
         });
-        screen.writeString(2 + this._error.name.length + 2, currentLine, this._error.message, {
+        writeClipped(2 + this._error.name.length + 2, currentLine, this._error.message, {
             fg: { type: 'named', name: 'white' },
             bold: true,
         });
@@ -155,14 +169,14 @@ export class ErrorOverlay implements RootWidget {
         // 3. Draw primary error location
         if (this._error.file) {
             const locText = `Location: ${this._error.file}:${this._error.line ?? 0}:${this._error.column ?? 0}`;
-            screen.writeString(2, currentLine, locText, {
+            writeClipped(2, currentLine, locText, {
                 fg: { type: 'named', name: 'yellow' },
             });
             currentLine += 2;
         }
 
         // 4. Draw stack trace header
-        screen.writeString(2, currentLine, 'Stack Trace:', {
+        writeClipped(2, currentLine, 'Stack Trace:', {
             fg: { type: 'named', name: 'brightBlack' },
             underline: true,
         });
@@ -182,12 +196,12 @@ export class ErrorOverlay implements RootWidget {
                 ? { fg: { type: 'named' as const, name: 'brightBlack' as const } }
                 : { fg: { type: 'named' as const, name: 'white' as const } };
 
-            screen.writeString(4, currentLine, line.slice(0, cols - 6), style);
+            writeClipped(4, currentLine, line, style);
             currentLine++;
         }
 
         if (this._error.rawStack.length > visibleTrace.length) {
-            screen.writeString(
+            writeClipped(
                 4,
                 currentLine,
                 `... and ${this._error.rawStack.length - visibleTrace.length} more frames`,
@@ -197,7 +211,7 @@ export class ErrorOverlay implements RootWidget {
 
         // 6. Draw bottom footer
         const footerText = '  🔄 Watching for changes... (Save a file to auto-reload)  ';
-        screen.writeString(0, rows - 1, footerText.padEnd(cols, ' '), {
+        writeClipped(0, rows - 1, footerText.padEnd(cols, ' '), {
             fg: { type: 'named', name: 'black' },
             bg: { type: 'named', name: 'brightBlack' },
             bold: true,

--- a/packages/dev-server/src/error-overlay.ts
+++ b/packages/dev-server/src/error-overlay.ts
@@ -2,7 +2,7 @@
 // @termuijs/dev-server — Full-screen Error Overlay
 // ─────────────────────────────────────────────────────
 
-import { Screen, type LayoutNode, type RootWidget, stripAnsi, createLayoutNode, defaultStyle } from '@termuijs/core';
+import { Screen, type LayoutNode, type RootWidget, stripAnsi, createLayoutNode, defaultStyle, truncate } from '@termuijs/core';
 
 export interface ParsedError {
     name: string;
@@ -132,7 +132,7 @@ export class ErrorOverlay implements RootWidget {
             const available = cols - startX;
             if (available <= 0) return;
 
-            screen.writeString(startX, y, text.slice(0, available), attrs);
+            screen.writeString(startX, y, truncate(text, available, ''), attrs);
         };
 
         // Clear screen with a consistent background


### PR DESCRIPTION
Summary
- route overlay writes through a clipped screen helper
- avoid writing past row bounds on narrow terminals
- add coverage for very narrow overlay rendering

Validation
- node_modules\.bin\vitest.exe run packages/dev-server/src/error-overlay.test.ts --watch=false

Closes #2839