### PR TITLE
Bubble testing mouse events

### DIFF
--- a/packages/testing/src/render.mouse.test.ts
+++ b/packages/testing/src/render.mouse.test.ts
@@ -4,7 +4,7 @@ import { createElement } from "@termuijs/jsx";
 import { render } from "./render.js";
 
 describe("mouse target resolution", () => {
-    it("dispatches clicks to the deepest matching widget", () => {
+    it("bubbles mouse events from the deepest matching widget", () => {
         // render() reconciles a VNode into a real Widget tree, so the tree under
         // test has to be built through createElement() rather than by constructing
         // Widget instances directly (those never enter the reconciled tree).
@@ -22,9 +22,27 @@ describe("mouse target resolution", () => {
         parent.events.on("mouse", parentMouse);
         child.events.on("mouse", childMouse);
 
-        t.click(5, 5);
+        t.fireMouse(5, 5);
 
-        expect(childMouse).toHaveBeenCalled();
+        expect(childMouse).toHaveBeenCalledTimes(1);
+        expect(parentMouse).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops bubbling when a mouse handler stops propagation", () => {
+        const t = render(createElement("box", null, createElement("box", null)));
+
+        const parent = (t.container as any)._children[0] as Box; // as any: Widget._children is protected; needed to reach the reconciled widget under test
+        const child = (parent as any)._children[0] as Box; // as any: Widget._children is protected; needed to reach the reconciled child widget under test
+
+        const parentMouse = vi.fn();
+        const childMouse = vi.fn((event: any) => event.stopPropagation());
+
+        parent.events.on("mouse", parentMouse);
+        child.events.on("mouse", childMouse);
+
+        t.fireMouse(5, 5);
+
+        expect(childMouse).toHaveBeenCalledTimes(1);
         expect(parentMouse).not.toHaveBeenCalled();
     });
 });

--- a/packages/testing/src/render.ts
+++ b/packages/testing/src/render.ts
@@ -453,11 +453,23 @@ export function render(
 
         fireMouse(x: number, y: number, init?: Partial<MouseEvent>) {
             // Normalize the mouse event
-            const event: MouseEvent = {
+            const event = {
+                ...init,
                 x,
                 y,
                 type: init?.type ?? 'mousedown',
                 button: init?.button ?? 'left',
+                stopPropagation() {
+                    this._propagationStopped = true;
+                },
+                preventDefault() {
+                    this._defaultPrevented = true;
+                },
+            } as MouseEvent & {
+                _propagationStopped?: boolean;
+                _defaultPrevented?: boolean;
+                stopPropagation(): void;
+                preventDefault(): void;
             };
 
             // Hit-test the widget tree
@@ -491,13 +503,17 @@ export function render(
                 return false;
             });
 
-            if (target) {
+            let current: Widget | null | undefined = target;
+            while (current) {
                 // Dispatch to the widget
-                if (typeof (target as any).handleMouse === 'function') { // as any: handleMouse not on Widget base type but implemented on interactive subclasses
-                    (target as any).handleMouse(event); // as any: handleMouse not on Widget base type but implemented on interactive subclasses
+                if (typeof (current as any).handleMouse === 'function') { // as any: handleMouse not on Widget base type but implemented on interactive subclasses
+                    (current as any).handleMouse(event); // as any: handleMouse not on Widget base type but implemented on interactive subclasses
                 } else {
-                    target.events.emit('mouse', event);
+                    current.events.emit('mouse', event);
                 }
+
+                if (event._propagationStopped) break;
+                current = current.parent;
             }
 
             // Re-render and flush any sync state updates


### PR DESCRIPTION
Summary
- bubble test-renderer mouse events from target to parent widgets
- add propagation controls to synthetic mouse events
- cover bubbling and stopped propagation

Validation
- node_modules\.bin\vitest.exe run packages/testing/src/render.mouse.test.ts --watch=false

Closes #2840

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mouse events now bubble from the deepest matching widget through its parents.
  * Mouse handlers can stop event propagation or prevent the default action.

* **Bug Fixes**
  * Improved mouse target resolution and event handling for nested widgets.
  * Corrected behavior when propagation is stopped by a child widget.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->