### PR TITLE
Clear pending batches on store destroy

### DIFF
--- a/packages/store/src/store.test.ts
+++ b/packages/store/src/store.test.ts
@@ -271,6 +271,25 @@ describe('batch', () => {
         expect(spy).not.toHaveBeenCalled()
     })
 
+    it('destroy clears pending batched updates for that store', async () => {
+        const useStore = createStore((set) => ({
+            count: 0,
+            setCount: (count: number) => set({ count }),
+        }))
+        const spy = vi.fn()
+        useStore.subscribe(spy)
+
+        batch(() => {
+            useStore.getState().setCount(1)
+        })
+
+        useStore.destroy()
+        await new Promise(resolve => queueMicrotask(resolve))
+
+        expect(useStore.getState().count).toBe(0)
+        expect(spy).not.toHaveBeenCalled()
+    })
+
     it('batch preserves listener notification order for unchanged keys', async () => {
         const useStore = createStore((set) => ({
             a: 1,

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -494,6 +494,7 @@ export function createStore<T extends object>(
     };
 
     const destroy = (): void => {
+        _batchStores.delete(listeners);
         listeners.clear();
         if (writeTimeout) {
             clearTimeout(writeTimeout);


### PR DESCRIPTION
Summary
- remove destroyed stores from pending batch work
- keep queued batch microtasks from committing destroyed store updates
- add regression coverage for destroy during a pending batch

Validation
- node_modules\.bin\vitest.exe run packages/store/src/store.test.ts --watch=false

Closes #2841

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where pending batched updates could still affect a store after it was destroyed.
  - Destroyed stores now remain unchanged, and their subscribers are not notified by queued updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->