### PR TITLE
feat(jsx): add usePrevious hook

### DIFF
--- a/packages/jsx/src/hooks/usePrevious.test.ts
+++ b/packages/jsx/src/hooks/usePrevious.test.ts
@@ -1,0 +1,77 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/jsx — Tests for usePrevious hook
+// ─────────────────────────────────────────────────────
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+    createFiber, setCurrentFiber, clearCurrentFiber,
+    setRequestRender, runEffects, destroyFiber,
+} from '../hooks.js';
+import { usePrevious } from './usePrevious.js';
+
+function renderWithFiber<T>(fiber: ReturnType<typeof createFiber>, fn: () => T): T {
+    setCurrentFiber(fiber);
+    const result = fn();
+    clearCurrentFiber();
+    runEffects(fiber);
+    return result;
+}
+
+describe('usePrevious', () => {
+    beforeEach(() => {
+        setRequestRender(() => {});
+    });
+
+    afterEach(() => {
+        clearCurrentFiber();
+    });
+
+    it('returns undefined on the first render', () => {
+        const fiber = createFiber();
+
+        const prev = renderWithFiber(fiber, () => usePrevious('first'));
+        expect(prev).toBeUndefined();
+
+        destroyFiber(fiber);
+    });
+
+    it('returns the value from the previous render after a second render', () => {
+        const fiber = createFiber();
+
+        renderWithFiber(fiber, () => usePrevious('first'));
+        const prev = renderWithFiber(fiber, () => usePrevious('second'));
+
+        expect(prev).toBe('first');
+
+        destroyFiber(fiber);
+    });
+
+    it('tracks the previous value across multiple renders', () => {
+        const fiber = createFiber();
+
+        renderWithFiber(fiber, () => usePrevious(1));
+        let prev = renderWithFiber(fiber, () => usePrevious(2));
+        expect(prev).toBe(1);
+
+        prev = renderWithFiber(fiber, () => usePrevious(3));
+        expect(prev).toBe(2);
+
+        prev = renderWithFiber(fiber, () => usePrevious(4));
+        expect(prev).toBe(3);
+
+        destroyFiber(fiber);
+    });
+
+    it('works with object values', () => {
+        const fiber = createFiber();
+
+        const objA = { id: 1 };
+        const objB = { id: 2 };
+
+        renderWithFiber(fiber, () => usePrevious(objA));
+        const prev = renderWithFiber(fiber, () => usePrevious(objB));
+
+        expect(prev).toBe(objA);
+
+        destroyFiber(fiber);
+    });
+});

--- a/packages/jsx/src/hooks/usePrevious.ts
+++ b/packages/jsx/src/hooks/usePrevious.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from '../hooks.js';
+
+/**
+ * usePrevious — returns the value held during the previous render.
+ *
+ * Returns `undefined` on the first render.
+ *
+ * ```tsx
+ * function Counter() {
+ *     const [count, setCount] = useState(0);
+ *     const prevCount = usePrevious(count);
+ *
+ *     return <Text>Now: {count}, Before: {prevCount ?? '—'}</Text>;
+ * }
+ * ```
+ */
+export function usePrevious<T>(value: T): T | undefined {
+    const ref = useRef<T | undefined>(undefined);
+
+    useEffect(() => {
+        ref.current = value;
+    });
+
+    return ref.current;
+}

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -113,4 +113,5 @@ export { useSet } from './hooks/useSet.js';
 export type { UseSetActions } from './hooks/useSet.js';
 export { useThrottle } from './hooks/useThrottle.js';
 export { useViewMeta } from './hooks/useViewMeta.js';
+export { usePrevious } from './hooks/usePrevious.js';
 export type { ViewMeta, ViewMetaCursor, ViewMetaMouseMode } from './hooks/useViewMeta.js';


### PR DESCRIPTION
Resolves #2794

Adds a usePrevious hook to @termuijs/jsx that returns the value from the previous render, matching conventions used by other hooks in the package (e.g. useDebounce). Includes tests using the renderWithFiber pattern; full test suite (5848 tests) and typecheck across all 42 packages pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `usePrevious` hook that provides the value from the prior render.
  * Exported the hook for use through the public JSX API.

* **Tests**
  * Added coverage for initial, repeated, multi-render, and object-reference behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->