### PR TITLE
feat(ui, widgets): enhance Rating and Calendar widgets with precision, labels, and shortcuts

### DIFF
--- a/packages/ui/src/Rating.test.ts
+++ b/packages/ui/src/Rating.test.ts
@@ -182,4 +182,65 @@ describe('Rating', () => {
         const { rating } = renderRating({ value: 4 });
         expect(rating.getValue()).toBe(4);
     });
+
+    it('supports precision stepping 0.5 and renders half-star glyph', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+
+        const { rating, screen } = renderRating({ precision: 0.5, value: 2.5, max: 5 });
+        const rendered = screen.back[0].map((c: { char: string }) => c.char).join('');
+        expect(rendered).toContain('★★½☆☆');
+
+        rating.handleKey(key('right'));
+        expect(rating.getValue()).toBe(3.0);
+
+        rating.handleKey(key('down'));
+        expect(rating.getValue()).toBe(2.5);
+    });
+
+    it('ignores key interaction when readonly is true', () => {
+        const { rating } = renderRating({ value: 2, readonly: true });
+        expect(rating.readonly).toBe(true);
+
+        rating.handleKey(key('right'));
+        expect(rating.getValue()).toBe(2);
+
+        rating.handleKey(key('3'));
+        expect(rating.getValue()).toBe(2);
+
+        rating.setReadonly(false);
+        rating.handleKey(key('3'));
+        expect(rating.getValue()).toBe(3);
+    });
+
+    it('supports direct digit key shortcuts 0-9', () => {
+        const { rating } = renderRating({ value: 0, max: 5 });
+
+        rating.handleKey(key('4'));
+        expect(rating.getValue()).toBe(4);
+
+        rating.handleKey(key('0'));
+        expect(rating.getValue()).toBe(0);
+    });
+
+    it('renders numerical label when showLabel is true', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
+
+        const { rating, screen } = renderRating({ value: 3, max: 5, showLabel: true }, 30);
+        expect(rating.showLabel).toBe(true);
+
+        const rendered = screen.back[0].map((c: { char: string }) => c.char).join('');
+        expect(rendered).toContain('★★★☆☆ (3/5)');
+    });
+
+    it('triggers onChange callback when value changes', () => {
+        const onChange = vi.fn();
+        const { rating } = renderRating({ value: 1, onChange });
+
+        rating.handleKey(key('right'));
+        expect(onChange).toHaveBeenCalledWith(2);
+
+        rating.setValue(4);
+        expect(onChange).toHaveBeenCalledWith(4);
+    });
 });
+

--- a/packages/ui/src/Rating.ts
+++ b/packages/ui/src/Rating.ts
@@ -25,10 +25,22 @@ export interface RatingOptions {
     value?: number;
     /** Filled star character. Default: '★' with ASCII fallback '*' */
     filledChar?: string;
+    /** Half star character. Default: '½' with ASCII fallback '*' */
+    halfStarChar?: string;
     /** Empty star character. Default: '☆' with ASCII fallback '-' */
     emptyChar?: string;
     /** Color for filled stars */
     filledColor?: Color;
+    /** Color for empty stars */
+    emptyColor?: Color;
+    /** Step precision (0.5 or 1). Default: 1 */
+    precision?: 0.5 | 1;
+    /** Show numerical label e.g. (3/5). Default: false */
+    showLabel?: boolean;
+    /** Disable user interaction if true. Default: false */
+    readonly?: boolean;
+    /** Callback when rating value changes */
+    onChange?: (value: number) => void;
     /** Callback when the user confirms a rating via enter */
     onSelect?: (value: number) => void;
 }
@@ -46,9 +58,16 @@ export class Rating extends Widget {
     private _value: number;
     private _max: number;
     private _filledChar?: string;
+    private _halfStarChar?: string;
     private _emptyChar?: string;
     private _filledColor?: Color;
+    private _emptyColor?: Color;
+    private _precision: 0.5 | 1;
+    private _showLabel: boolean;
+    private _readonly: boolean;
 
+    /** Callback when rating value changes. */
+    onChange?: (value: number) => void;
     /** Callback when the user confirms a rating via enter. */
     onSelect?: (value: number) => void;
 
@@ -57,16 +76,24 @@ export class Rating extends Widget {
     constructor(style: Partial<Style> = {}, opts: RatingOptions = {}) {
         const rawMax = opts.max ?? 5;
         const max = Number.isFinite(rawMax) ? Math.max(Math.floor(rawMax), 1) : 5;
+        const precision = opts.precision === 0.5 ? 0.5 : 1;
         const rawValue = opts.value ?? 0;
         const value = Number.isFinite(rawValue) ? rawValue : 0;
+        const snapped = Math.round(value / precision) * precision;
 
         super(mergeStyles(defaultStyle(), { ...style, height: 1 }));
 
         this._max = max;
-        this._value = Math.max(0, Math.min(value, max));
+        this._precision = precision;
+        this._value = Math.max(0, Math.min(snapped, max));
         this._filledChar = opts.filledChar;
+        this._halfStarChar = opts.halfStarChar;
         this._emptyChar = opts.emptyChar;
         this._filledColor = opts.filledColor;
+        this._emptyColor = opts.emptyColor;
+        this._showLabel = opts.showLabel ?? false;
+        this._readonly = opts.readonly ?? false;
+        this.onChange = opts.onChange;
         this.onSelect = opts.onSelect;
     }
 
@@ -82,14 +109,64 @@ export class Rating extends Widget {
         return this._max;
     }
 
+    /** Step precision (0.5 or 1). */
+    get precision(): 0.5 | 1 {
+        return this._precision;
+    }
+
+    /** Whether the rating is read-only. */
+    get readonly(): boolean {
+        return this._readonly;
+    }
+
+    /** Whether numerical label is enabled. */
+    get showLabel(): boolean {
+        return this._showLabel;
+    }
+
     // ── Public methods ────────────────────────────────
 
-    /** Set the rating value (clamped to 0..max). Calls markDirty(). */
+    setReadonly(readonly: boolean): void {
+        if (this._readonly === readonly) return;
+        this._readonly = readonly;
+        this.markDirty();
+    }
+
+    setPrecision(precision: 0.5 | 1): void {
+        if (this._precision === precision) return;
+        this._precision = precision;
+        this.setValue(this._value);
+    }
+
+    setShowLabel(show: boolean): void {
+        if (this._showLabel === show) return;
+        this._showLabel = show;
+        this.markDirty();
+    }
+
+    setEmptyColor(color?: Color): void {
+        this._emptyColor = color;
+        this.markDirty();
+    }
+
+    setFilledColor(color?: Color): void {
+        this._filledColor = color;
+        this.markDirty();
+    }
+
+    setHalfStarChar(char: string): void {
+        this._halfStarChar = char;
+        this.markDirty();
+    }
+
+    /** Set the rating value (clamped & snapped to precision). Calls markDirty(). */
     setValue(value: number): void {
         const finiteValue = Number.isFinite(value) ? value : 0;
-        const clamped = Math.max(0, Math.min(finiteValue, this._max));
+        const snapped = Math.round(finiteValue / this._precision) * this._precision;
+        const clamped = Math.max(0, Math.min(snapped, this._max));
         if (clamped === this._value) return;
         this._value = clamped;
+        this.onChange?.(this._value);
         this.markDirty();
     }
 
@@ -101,12 +178,16 @@ export class Rating extends Widget {
     // ── Key handling ──────────────────────────────────
 
     handleKey(event: KeyEvent): void {
+        if (this._readonly) return;
+
         switch (event.key) {
             case 'right':
-                this.setValue(this._value + 1);
+            case 'up':
+                this.setValue(this._value + this._precision);
                 break;
             case 'left':
-                this.setValue(this._value - 1);
+            case 'down':
+                this.setValue(this._value - this._precision);
                 break;
             case 'home':
                 this.setValue(0);
@@ -116,6 +197,14 @@ export class Rating extends Widget {
                 break;
             case 'enter':
                 this.onSelect?.(this._value);
+                break;
+            default:
+                if (event.key.length === 1 && event.key >= '0' && event.key <= '9') {
+                    const num = parseInt(event.key, 10);
+                    if (num <= this._max) {
+                        this.setValue(num);
+                    }
+                }
                 break;
         }
     }
@@ -128,14 +217,37 @@ export class Rating extends Widget {
 
         const attrs = styleToCellAttrs(this.style);
 
-        const filled = this._filledChar ?? (caps.unicode ? '★' : '*');
-        const empty = this._emptyChar ?? (caps.unicode ? '☆' : '-');
+        const filledChar = this._filledChar ?? (caps.unicode ? '★' : '*');
+        const halfChar = this._halfStarChar ?? (caps.unicode ? '½' : '*');
+        const emptyChar = this._emptyChar ?? (caps.unicode ? '☆' : '-');
 
-        let text = '';
+        let currentX = x;
+        const maxX = x + width;
+
         for (let i = 0; i < this._max; i++) {
-            text += i < this._value ? filled : empty;
+            if (currentX >= maxX) break;
+
+            const starVal = i + 1;
+            let charToRender = emptyChar;
+            let fgColor = this._emptyColor;
+
+            if (this._value >= starVal) {
+                charToRender = filledChar;
+                fgColor = this._filledColor;
+            } else if (this._value >= starVal - 0.5) {
+                charToRender = halfChar;
+                fgColor = this._filledColor;
+            }
+
+            const cellAttrs = fgColor ? { ...attrs, fg: fgColor } : attrs;
+            screen.writeString(currentX, y, charToRender, cellAttrs);
+            currentX += charToRender.length;
         }
 
-        screen.writeString(x, y, text.slice(0, width), attrs);
+        if (this._showLabel && currentX < maxX) {
+            const label = ` (${this._value}/${this._max})`;
+            screen.writeString(currentX, y, label.slice(0, maxX - currentX), attrs);
+        }
     }
 }
+

--- a/packages/widgets/src/data/Calendar.test.ts
+++ b/packages/widgets/src/data/Calendar.test.ts
@@ -204,4 +204,89 @@ describe('Calendar', () => {
         cal.setMonth(2027, 0);
         expect(cal.isDirty).toBe(true);
     });
+
+    it('supports setSelectedDate and updates current month if needed', () => {
+        const cal = new Calendar({ width: 30, height: 10 }, { date: new Date(2026, 5, 2) });
+        const onMonthChange = vi.fn();
+        const cal2 = new Calendar({ width: 30, height: 10 }, { date: new Date(2026, 5, 2), onMonthChange });
+
+        cal.setSelectedDate(new Date(2026, 7, 15));
+        expect(cal.getSelectedDate().getMonth()).toBe(7);
+        expect(cal.getSelectedDate().getDate()).toBe(15);
+
+        cal2.setSelectedDate(new Date(2026, 7, 15));
+        expect(onMonthChange).toHaveBeenCalledWith(2026, 7);
+    });
+
+    it('navigates months with pageup and pagedown keys', () => {
+        const onMonthChange = vi.fn();
+        const cal = new Calendar({ width: 30, height: 10 }, { date: new Date(2026, 5, 15), onMonthChange });
+
+        cal.handleKey(key('pageup'));
+        expect(onMonthChange).toHaveBeenCalledWith(2026, 4);
+
+        cal.handleKey(key('pagedown'));
+        expect(onMonthChange).toHaveBeenCalledWith(2026, 5);
+    });
+
+    it('jumps to start and end of month with home and end keys', () => {
+        const cal = new Calendar({ width: 30, height: 10 }, { date: new Date(2026, 5, 15) });
+
+        cal.handleKey(key('home'));
+        expect(cal.getSelectedDate().getDate()).toBe(1);
+
+        cal.handleKey(key('end'));
+        expect(cal.getSelectedDate().getDate()).toBe(30); // June has 30 days
+    });
+
+    it('renders highlighted dates with highlightColor', () => {
+        const highlightColor = { type: 'named' as const, name: 'yellow' as const };
+        const highlightedDate = new Date(2026, 5, 15);
+        const cal = new Calendar(
+            { width: 30, height: 10 },
+            { date: new Date(2026, 5, 1), highlightedDates: [highlightedDate], highlightColor }
+        );
+        cal.updateRect({ x: 0, y: 0, width: 30, height: 10 });
+        const screen = new Screen(30, 10);
+        cal.render(screen);
+
+        const rows = screen.back.map(row => row.map(cell => cell.char).join(''));
+        expect(rows[0]).toContain('June 2026');
+
+        // Find cell corresponding to 15th
+        let foundCell = false;
+        for (const row of screen.back) {
+            for (let c = 0; c < row.length - 1; c++) {
+                if (row[c].char === '1' && row[c + 1].char === '5') {
+                    expect(row[c + 1].fg).toEqual(highlightColor);
+                    foundCell = true;
+                    break;
+                }
+            }
+        }
+        expect(foundCell).toBe(true);
+    });
+
+    it('respects minDate, maxDate, and disabledDates constraints', () => {
+        const minDate = new Date(2026, 5, 5);
+        const maxDate = new Date(2026, 5, 20);
+        const disabledDate = new Date(2026, 5, 10);
+        const cal = new Calendar(
+            { width: 30, height: 10 },
+            { date: new Date(2026, 5, 5), minDate, maxDate, disabledDates: [disabledDate] }
+        );
+
+        // Trying to move left past minDate should be blocked
+        cal.handleKey(key('left'));
+        expect(cal.getSelectedDate().getDate()).toBe(5);
+
+        // Setting a disabled date should be ignored
+        cal.setSelectedDate(disabledDate);
+        expect(cal.getSelectedDate().getDate()).toBe(5);
+
+        // Trying to set date past maxDate should be ignored
+        cal.setSelectedDate(new Date(2026, 5, 25));
+        expect(cal.getSelectedDate().getDate()).toBe(5);
+    });
 });
+

--- a/packages/widgets/src/data/Calendar.ts
+++ b/packages/widgets/src/data/Calendar.ts
@@ -9,7 +9,13 @@ export interface CalendarOptions {
     date?: Date;
     selectedColor?: Color;
     todayColor?: Color;
+    highlightColor?: Color;
+    highlightedDates?: Date[];
+    minDate?: Date;
+    maxDate?: Date;
+    disabledDates?: Date[];
     onSelect?: (date: Date) => void;
+    onMonthChange?: (year: number, month: number) => void;
 }
 
 const MONTH_NAMES = [
@@ -22,30 +28,120 @@ export class Calendar extends Widget {
     private _currentMonth: Date;
     private _selectedColor: Color;
     private _todayColor: Color;
+    private _highlightColor: Color;
+    private _highlightedDatesSet: Set<number> = new Set();
+    private _disabledDatesSet: Set<number> = new Set();
+    private _minDate?: Date;
+    private _maxDate?: Date;
     private _onSelect?: (date: Date) => void;
+    private _onMonthChange?: (year: number, month: number) => void;
     focusable = true;
 
     constructor(style: Partial<Style> = {}, opts: CalendarOptions = {}) {
         super(style);
-        this._selectedDate = opts.date ? new Date(opts.date) : new Date();
-        this._selectedDate.setHours(0, 0, 0, 0);
-
+        this._selectedDate = opts.date ? this._normalizeDate(opts.date) : this._normalizeDate(new Date());
         this._currentMonth = new Date(this._selectedDate.getFullYear(), this._selectedDate.getMonth(), 1);
         this._currentMonth.setHours(0, 0, 0, 0);
 
         this._selectedColor = opts.selectedColor ?? { type: 'named', name: 'cyan' };
         this._todayColor = opts.todayColor ?? { type: 'named', name: 'green' };
+        this._highlightColor = opts.highlightColor ?? { type: 'named', name: 'yellow' };
+
+        if (opts.minDate) this._minDate = this._normalizeDate(opts.minDate);
+        if (opts.maxDate) this._maxDate = this._normalizeDate(opts.maxDate);
+
+        if (opts.highlightedDates) {
+            this._setDatesSet(this._highlightedDatesSet, opts.highlightedDates);
+        }
+        if (opts.disabledDates) {
+            this._setDatesSet(this._disabledDatesSet, opts.disabledDates);
+        }
+
         this._onSelect = opts.onSelect;
+        this._onMonthChange = opts.onMonthChange;
     }
 
-    setMonth(year: number, month: number): void {
-        this._currentMonth = new Date(year, month, 1);
-        this._currentMonth.setHours(0, 0, 0, 0);
-        this.markDirty();
+    private _normalizeDate(d: Date): Date {
+        const normalized = new Date(d);
+        normalized.setHours(0, 0, 0, 0);
+        return normalized;
+    }
+
+    private _setDatesSet(targetSet: Set<number>, dates: Date[]): void {
+        targetSet.clear();
+        for (const date of dates) {
+            targetSet.add(this._normalizeDate(date).getTime());
+        }
+    }
+
+    setSelectedDate(date: Date): void {
+        const norm = this._normalizeDate(date);
+        if (this._isDateDisabled(norm)) return;
+
+        this._selectedDate = norm;
+        if (
+            norm.getMonth() !== this._currentMonth.getMonth() ||
+            norm.getFullYear() !== this._currentMonth.getFullYear()
+        ) {
+            this.setMonth(norm.getFullYear(), norm.getMonth());
+        } else {
+            this.markDirty();
+        }
     }
 
     getSelectedDate(): Date {
         return new Date(this._selectedDate);
+    }
+
+    setMonth(year: number, month: number): void {
+        const newMonth = new Date(year, month, 1);
+        newMonth.setHours(0, 0, 0, 0);
+        const changed =
+            newMonth.getFullYear() !== this._currentMonth.getFullYear() ||
+            newMonth.getMonth() !== this._currentMonth.getMonth();
+
+        this._currentMonth = newMonth;
+        if (changed) {
+            this._onMonthChange?.(this._currentMonth.getFullYear(), this._currentMonth.getMonth());
+        }
+        this.markDirty();
+    }
+
+    changeMonth(months: number): void {
+        this.setMonth(this._currentMonth.getFullYear(), this._currentMonth.getMonth() + months);
+    }
+
+    setHighlightedDates(dates: Date[]): void {
+        this._setDatesSet(this._highlightedDatesSet, dates);
+        this.markDirty();
+    }
+
+    setHighlightColor(color: Color): void {
+        this._highlightColor = color;
+        this.markDirty();
+    }
+
+    setMinDate(date?: Date): void {
+        this._minDate = date ? this._normalizeDate(date) : undefined;
+        this.markDirty();
+    }
+
+    setMaxDate(date?: Date): void {
+        this._maxDate = date ? this._normalizeDate(date) : undefined;
+        this.markDirty();
+    }
+
+    setDisabledDates(dates: Date[]): void {
+        this._setDatesSet(this._disabledDatesSet, dates);
+        this.markDirty();
+    }
+
+    private _isDateDisabled(date: Date): boolean {
+        const time = date.getTime();
+        if (this._minDate && time < this._minDate.getTime()) return true;
+        if (this._maxDate && time > this._maxDate.getTime()) return true;
+        if (this._disabledDatesSet.has(time)) return true;
+        return false;
     }
 
     handleKey(event: KeyEvent): void {
@@ -62,8 +158,26 @@ export class Calendar extends Widget {
             case 'down':
                 this._moveSelection(7);
                 break;
+            case 'pageup':
+                this.changeMonth(-1);
+                break;
+            case 'pagedown':
+                this.changeMonth(1);
+                break;
+            case 'home': {
+                const firstDay = new Date(this._currentMonth.getFullYear(), this._currentMonth.getMonth(), 1);
+                this.setSelectedDate(firstDay);
+                break;
+            }
+            case 'end': {
+                const lastDay = new Date(this._currentMonth.getFullYear(), this._currentMonth.getMonth() + 1, 0);
+                this.setSelectedDate(lastDay);
+                break;
+            }
             case 'enter':
-                this._onSelect?.(new Date(this._selectedDate));
+                if (!this._isDateDisabled(this._selectedDate)) {
+                    this._onSelect?.(new Date(this._selectedDate));
+                }
                 break;
         }
     }
@@ -71,16 +185,20 @@ export class Calendar extends Widget {
     private _moveSelection(days: number): void {
         const newDate = new Date(this._selectedDate);
         newDate.setDate(newDate.getDate() + days);
-        this._selectedDate = newDate;
+        const norm = this._normalizeDate(newDate);
+
+        if (this._isDateDisabled(norm)) return;
+
+        this._selectedDate = norm;
 
         if (
-            newDate.getMonth() !== this._currentMonth.getMonth() ||
-            newDate.getFullYear() !== this._currentMonth.getFullYear()
+            norm.getMonth() !== this._currentMonth.getMonth() ||
+            norm.getFullYear() !== this._currentMonth.getFullYear()
         ) {
-            this._currentMonth = new Date(newDate.getFullYear(), newDate.getMonth(), 1);
-            this._currentMonth.setHours(0, 0, 0, 0);
+            this.setMonth(norm.getFullYear(), norm.getMonth());
+        } else {
+            this.markDirty();
         }
-        this.markDirty();
     }
 
     protected _renderSelf(screen: Screen): void {
@@ -115,8 +233,7 @@ export class Calendar extends Widget {
         const gridStartY = y + 2;
         const maxWeeks = 6;
 
-        const today = new Date();
-        today.setHours(0, 0, 0, 0);
+        const today = this._normalizeDate(new Date());
 
         for (let w = 0; w < maxWeeks; w++) {
             const rowY = gridStartY + w;
@@ -133,16 +250,30 @@ export class Calendar extends Widget {
                     const cellDate = new Date(year, month, dayVal);
                     cellDate.setHours(0, 0, 0, 0);
 
-                    const isSelected = cellDate.getTime() === this._selectedDate.getTime();
-                    const isToday = cellDate.getTime() === today.getTime();
+                    const time = cellDate.getTime();
+                    const isSelected = time === this._selectedDate.getTime();
+                    const isToday = time === today.getTime();
+                    const isHighlighted = this._highlightedDatesSet.has(time);
+                    const isDisabled = this._isDateDisabled(cellDate);
 
-                    if (isSelected) {
+                    if (isDisabled) {
+                        screen.writeString(colX, rowY, label, {
+                            ...attrs,
+                            dim: true,
+                        });
+                    } else if (isSelected) {
                         screen.writeString(colX, rowY, label, {
                             ...attrs,
                             fg: this._selectedColor,
                             bold: true,
                             inverse: this.isFocused,
                             underline: !this.isFocused,
+                        });
+                    } else if (isHighlighted) {
+                        screen.writeString(colX, rowY, label, {
+                            ...attrs,
+                            fg: this._highlightColor,
+                            bold: true,
                         });
                     } else if (isToday) {
                         screen.writeString(colX, rowY, label, {
@@ -161,3 +292,4 @@ export class Calendar extends Widget {
         }
     }
 }
+


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. -->

## Description

This PR solves issue #2872 by enhancing the `Rating` widget in `@termuijs/ui` and adding calendar improvements in `@termuijs/widgets`:

1. **Rating Widget Enhancements (Fixes #2872):**
   - **Half-Star Precision (`precision: 0.5 | 1`):** Stepping in `0.5` increments with unicode half-star rendering (`★★★½☆`).
   - **Numerical Labels (`showLabel`):** Appends rating label e.g. `★★★★☆ (4/5)`.
   - **Read-Only Mode (`readonly`):** Disables interactive key input when active.
   - **Direct Digit Shortcuts (`0`-`9`):** Number keys jump directly to rating values.
   - **Custom Empty Star Color (`emptyColor`):** Styles unselected stars distinctly.
   - **Value Change Callback (`onChange`):** Triggered on value update.

2. **Calendar Widget Enhancements:**
   - Programmatic state control (`setSelectedDate`, `changeMonth`).
   - Expanded keyboard navigation (`pageup`/`pagedown` month shifting, `home`/`end` day jumping).
   - Date event highlighting (`highlightedDates`, `highlightColor`).
   - Boundary & date constraints (`minDate`, `maxDate`, `disabledDates`).
   - Month-change listener callback (`onMonthChange`).

## Related Issue

Closes #2872

## Which package(s)?

`@termuijs/ui`, `@termuijs/widgets`

## Type of Change

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [x] 🎨 Design / UX (`type:design`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/karthikj5453`

## Screenshots / Recordings (UI changes)

```text
--- Rating Output ---
Half Star (value=3.5/5)    -> "★★★½☆"
With Label (showLabel=true)-> "★★★★☆ (4/5)"
Digit Key "4"              -> "★★★★☆"

--- Calendar Output ---
  ┌─           ◀ June 2026 ▶            ─┌   
  │         Su Mo Tu We Th Fr Sa         │   
                1  2  3  4  5  6             
             7  8  9 10 11 12 13             
            14 [15] 16 17 18 19 20           
            21 22 23 24 25 26 27             
            28 29 30                         
