### PR TITLE
Clear notification dismiss timers

### DIFF
--- a/packages/ui/src/NotificationCenter.test.ts
+++ b/packages/ui/src/NotificationCenter.test.ts
@@ -154,6 +154,42 @@ describe('NotificationStore', () => {
         expect(store.notifications).toEqual([]);
     });
 
+    it('clears an auto-dismiss timer when a timed notification is dismissed manually', () => {
+        const subscriber = vi.fn();
+        store.subscribe(subscriber);
+
+        const id = store.push('Manual', 'info', 1000);
+        store.dismiss(id);
+        subscriber.mockClear();
+
+        vi.advanceTimersByTime(1000);
+
+        expect(store.notifications).toEqual([]);
+        expect(subscriber).not.toHaveBeenCalled();
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('dismissAll() clears pending auto-dismiss timers', () => {
+        store.push('One', 'info', 1000);
+        store.push('Two', 'success', 2000);
+
+        store.dismissAll();
+        vi.advanceTimersByTime(2000);
+
+        expect(store.notifications).toEqual([]);
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('reset() clears pending auto-dismiss timers', () => {
+        store.push('Before reset', 'warning', 1000);
+
+        store.reset();
+        vi.advanceTimersByTime(1000);
+
+        expect(store.notifications).toEqual([]);
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
     it('does not schedule auto-dismiss for durationMs 0 or undefined', () => {
         store.push('Zero', 'info', 0);
         store.push('Forever', 'success');

--- a/packages/ui/src/NotificationCenter.ts
+++ b/packages/ui/src/NotificationCenter.ts
@@ -30,6 +30,7 @@ export class NotificationStore {
     private static _instance: NotificationStore;
     private _notifications: Notification[] = [];
     private _subs: Set<(notifications: Notification[]) => void> = new Set();
+    private _dismissTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
     static getInstance(): NotificationStore {
         if (!NotificationStore._instance) {
@@ -45,12 +46,14 @@ export class NotificationStore {
         this._emit();
 
         if (durationMs && durationMs > 0) {
-            setTimeout(() => this.dismiss(id), durationMs);
+            const timer = setTimeout(() => this.dismiss(id), durationMs);
+            this._dismissTimers.set(id, timer);
         }
         return id;
     }
 
     dismiss(id: string): void {
+        this._clearDismissTimer(id);
         const prev = this._notifications;
         this._notifications = this._notifications.filter(n => n.id !== id);
         if (this._notifications.length !== prev.length) {
@@ -60,12 +63,14 @@ export class NotificationStore {
 
     dismissAll(): void {
         if (this._notifications.length > 0) {
+            this._clearAllDismissTimers();
             this._notifications = [];
             this._emit();
         }
     }
 
     reset(): void {
+        this._clearAllDismissTimers();
         this._notifications = [];
         this._subs.clear();
     }
@@ -83,6 +88,21 @@ export class NotificationStore {
         for (const fn of this._subs) {
             fn(this._notifications.map((notification) => ({ ...notification })));
         }
+    }
+
+    private _clearDismissTimer(id: string): void {
+        const timer = this._dismissTimers.get(id);
+        if (!timer) return;
+
+        clearTimeout(timer);
+        this._dismissTimers.delete(id);
+    }
+
+    private _clearAllDismissTimers(): void {
+        for (const timer of this._dismissTimers.values()) {
+            clearTimeout(timer);
+        }
+        this._dismissTimers.clear();
     }
 }
 


### PR DESCRIPTION
Summary
- track auto-dismiss timers per notification
- clear timers on manual dismiss, dismissAll, and reset
- add fake-timer coverage for cleanup paths

Validation
- node_modules\.bin\vitest.exe run packages/ui/src/NotificationCenter.test.ts --watch=false

Closes #2874


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timed notifications so their automatic dismissal timers are properly canceled when notifications are dismissed manually, cleared in bulk, or reset.
  * Prevented delayed updates from firing after notifications have already been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->