### PR TITLE
Preserve throttled value on interval change

### DIFF
--- a/packages/jsx/src/hooks/useThrottle.test.ts
+++ b/packages/jsx/src/hooks/useThrottle.test.ts
@@ -93,6 +93,30 @@ describe('useThrottle', () => {
         destroyFiber(fiber);
     });
 
+    it('emits a pending value after intervalMs changes', () => {
+        const fiber = createFiber();
+
+        let throttled = renderWithFiber(fiber, () => useThrottle('a', 500));
+        expect(throttled).toBe('a');
+
+        vi.advanceTimersByTime(50);
+        throttled = renderWithFiber(fiber, () => useThrottle('b', 500));
+        expect(throttled).toBe('a');
+
+        throttled = renderWithFiber(fiber, () => useThrottle('b', 100));
+        expect(throttled).toBe('a');
+
+        vi.advanceTimersByTime(99);
+        throttled = renderWithFiber(fiber, () => useThrottle('b', 100));
+        expect(throttled).toBe('a');
+
+        vi.advanceTimersByTime(1);
+        throttled = renderWithFiber(fiber, () => useThrottle('b', 100));
+        expect(throttled).toBe('b');
+
+        destroyFiber(fiber);
+    });
+
     it('emits the first change immediately if called after intervalMs has passed since mount', () => {
         const fiber = createFiber();
 

--- a/packages/jsx/src/hooks/useThrottle.ts
+++ b/packages/jsx/src/hooks/useThrottle.ts
@@ -14,6 +14,7 @@ export function useThrottle<T>(value: T, intervalMs: number): T {
     const latestValueRef = useRef<T>(value);
     const lastEmittedValueRef = useRef<T>(value);
     const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const intervalRef = useRef(intervalMs);
     latestValueRef.current = value;
     const runTimeout = () => {
         timeoutRef.current = setTimeout(() => {
@@ -28,14 +29,28 @@ export function useThrottle<T>(value: T, intervalMs: number): T {
     };
     // Effect to handle value updates and start throttle timer
     useEffect(() => {
+        const intervalChanged = intervalRef.current !== intervalMs;
+        const hasPendingValue = latestValueRef.current !== lastEmittedValueRef.current;
+        intervalRef.current = intervalMs;
+
+        if (intervalChanged && timeoutRef.current !== null) {
+            clearTimeout(timeoutRef.current);
+            timeoutRef.current = null;
+
+            if (hasPendingValue) {
+                runTimeout();
+            }
+            return;
+        }
+
         if (!timeoutRef.current) {
             // Emits the initial value change immediately
             lastEmittedValueRef.current = value;
             setThrottledValue(value);
             runTimeout();
         }
-    }, [value]);
-    // Effect to clean up the timer on unmount or interval changes
+    }, [value, intervalMs]);
+    // Effect to clean up the timer on unmount
     useEffect(() => {
         return () => {
             if (timeoutRef.current !== null) {
@@ -43,6 +58,6 @@ export function useThrottle<T>(value: T, intervalMs: number): T {
                 timeoutRef.current = null;
             }
         };
-    }, [intervalMs]);
+    }, []);
     return throttledValue;
 }


### PR DESCRIPTION
Summary
- restart pending throttle timers when intervalMs changes
- keep immediate updates when no throttle window is active
- add coverage for pending values across interval changes

Validation
- node_modules\.bin\vitest.exe run packages/jsx/src/hooks/useThrottle.test.ts --watch=false

Closes #2875


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved throttling behavior when the configured interval changes.
  * Ensured pending values are released according to the newly configured interval.
  * Updated timer handling to prevent stale delays after configuration changes.

* **Tests**
  * Added coverage for changing throttle intervals between renders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->