### PR TITLE
fix: only rollback the failing store in batch, not all stores

### DIFF
--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -128,8 +128,9 @@ function flushBatch(threw: boolean, immediate = false) {
                         listener(newState, prevState);
                     }
                 } catch (e) {
-                    for (const [, entry] of stores) {
-                        entry.rollback();
+                    const failedEntry = stores.find(([l]) => l === listeners);
+                    if (failedEntry) {
+                        failedEntry[1].rollback();
                     }
                     throw e;
                 }


### PR DESCRIPTION
## Description

When a batch of store updates includes multiple stores and one store's listener throws an error, the catch block rolls back ALL stores in the batch instead of just the failing store. This causes innocent stores to lose their state updates unnecessarily.

## Fix

Modified the catch block in `flushBatch` to only rollback the specific store whose listener threw the error, leaving other stores unaffected.

## Changes

- `packages/store/src/store.ts`: Changed catch block to find and rollback only the failing store entry instead of all stores

## Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] I have tested these changes locally
- [x] My commits follow the Conventional Commits format
- [x] I have starred the repo

Closes #2865

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during batched updates.
  * When a notification fails, only the affected update is rolled back, while other batched updates remain intact.
  * The original error continues to be reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->