### PR TITLE
fix: use ref to track latest asyncFn in useAsync to prevent stale closure

### DIFF
--- a/packages/jsx/src/hooks.ts
+++ b/packages/jsx/src/hooks.ts
@@ -753,13 +753,16 @@ export function useAsync<T>(
 
     // Track a version counter to ignore stale responses
     const versionRef = useRef(0);
+    // Always call the latest asyncFn to avoid stale closure
+    const asyncFnRef = useRef(asyncFn);
+    asyncFnRef.current = asyncFn;
 
     const refetch = useCallback(() => {
         const version = ++versionRef.current;
         setLoading(true);
         setError(null);
 
-        asyncFn()
+        asyncFnRef.current()
             .then((result) => {
                 // Only update if this is still the latest request
                 if (versionRef.current === version) {


### PR DESCRIPTION
## Description

The `useAsync` hook captures `asyncFn` in a closure via `useCallback`. When the component re-renders with a new `asyncFn` prop, the `refetch` callback still uses the stale original function, causing it to fetch stale data or fail.

## Fix

Added a ref to track the latest `asyncFn` function. The ref is updated on every render, and `refetch` always calls the current function from the ref instead of the captured closure.

## Changes

- `packages/jsx/src/hooks.ts`: Added `asyncFnRef` to track latest function, modified `refetch` to call `asyncFnRef.current()` instead of captured `asyncFn`

## Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] I have tested these changes locally
- [x] My commits follow the Conventional Commits format
- [x] I have starred the repo

Closes #2868