### PR TITLE
Avoid replaying leading debounce flush

### DIFF
--- a/packages/core/src/utils/debounce.test.ts
+++ b/packages/core/src/utils/debounce.test.ts
@@ -99,4 +99,38 @@ describe('debounce', () => {
 
         vi.useRealTimers();
     });
+
+    it('flushes a pending trailing call immediately', () => {
+        vi.useFakeTimers();
+        const fn = vi.fn();
+        const debounced = debounce(fn, 100);
+
+        debounced('pending');
+        debounced.flush();
+
+        expect(fn).toHaveBeenCalledTimes(1);
+        expect(fn).toHaveBeenCalledWith('pending');
+
+        vi.advanceTimersByTime(100);
+        expect(fn).toHaveBeenCalledTimes(1);
+
+        vi.useRealTimers();
+    });
+
+    it('does not replay a leading-edge call when flushed', () => {
+        vi.useFakeTimers();
+        const fn = vi.fn();
+        const debounced = debounce(fn, 100, { leading: true });
+
+        debounced('leading');
+        debounced.flush();
+
+        expect(fn).toHaveBeenCalledTimes(1);
+        expect(fn).toHaveBeenCalledWith('leading');
+
+        vi.advanceTimersByTime(100);
+        expect(fn).toHaveBeenCalledTimes(1);
+
+        vi.useRealTimers();
+    });
 });

--- a/packages/core/src/utils/debounce.ts
+++ b/packages/core/src/utils/debounce.ts
@@ -41,19 +41,24 @@ export function debounce<T extends (...args: unknown[]) => void>(
         timer = setTimeout(() => {
             timer = undefined;
             if (!options?.leading) func(...(lastArgs as Parameters<T>));
+            lastArgs = undefined;
         }, wait);
     } as T & { cancel: () => void; flush: () => void };
 
     debounced.cancel = () => {
         clearTimeout(timer);
         timer = undefined;
+        lastArgs = undefined;
     };
 
     debounced.flush = () => {
         if (timer) {
             clearTimeout(timer);
             timer = undefined;
-            func(...(lastArgs as Parameters<T>));
+            if (!options?.leading && lastArgs) {
+                func(...lastArgs);
+            }
+            lastArgs = undefined;
         }
     };
 


### PR DESCRIPTION
Summary
- prevent flush from replaying calls already emitted on the leading edge
- clear stored arguments after cancel, flush, or timer completion
- add coverage for trailing flush and leading flush behavior

Validation
- node_modules\.bin\vitest.exe run packages/core/src/utils/debounce.test.ts --watch=false

Closes #2876
