### PR TITLE
Preserve spaces in recorder SVG export

### DIFF
--- a/packages/testing/src/recorder.test.ts
+++ b/packages/testing/src/recorder.test.ts
@@ -133,6 +133,17 @@ describe('ScreenRecorder', () => {
         expect(svg).toContain('</svg>');
     });
 
+    it('preserves repeated spaces in SVG text rows', () => {
+        const recorder = new ScreenRecorder();
+        recorder.recordFrame('Name    Value\nleft      right');
+
+        const svg = recorder.toSVG();
+
+        expect(svg).toContain('xml:space="preserve"');
+        expect(svg).toContain('Name    Value');
+        expect(svg).toContain('left      right');
+    });
+
     it('validates maxFrames option as a positive integer', () => {
         expect(() => new ScreenRecorder({ maxFrames: 0 })).toThrow('maxFrames must be a positive integer');
         expect(() => new ScreenRecorder({ maxFrames: -5 })).toThrow('maxFrames must be a positive integer');

--- a/packages/testing/src/recorder.ts
+++ b/packages/testing/src/recorder.ts
@@ -145,7 +145,7 @@ export class ScreenRecorder {
                 .replace(/>/g, '&gt;')
                 .replace(/"/g, '&quot;')
                 .replace(/'/g, '&apos;');
-            svgLines += `  <text x="15" y="${yOffset}" fill="#DCDCCC" font-family="Courier, monospace" font-size="14">${escapedLine}</text>\n`;
+            svgLines += `  <text x="15" y="${yOffset}" fill="#DCDCCC" font-family="Courier, monospace" font-size="14" xml:space="preserve">${escapedLine}</text>\n`;
             yOffset += 18;
         }
 


### PR DESCRIPTION
Summary
- add whitespace preservation to SVG text rows
- keep repeated terminal spaces intact in exported frames
- add regression coverage for aligned text output

Validation
- node_modules\.bin\vitest.exe run packages/testing/src/recorder.test.ts --watch=false

Closes #2877
