### PR TITLE
Ignore invalid workspace restore data

### DIFF
--- a/packages/widgets/src/layout/Workspace.test.ts
+++ b/packages/widgets/src/layout/Workspace.test.ts
@@ -82,4 +82,46 @@ describe('Workspace', () => {
 
         expect(workspace.getWorkspaceNames()).toEqual([]);
     });
+
+    it('restores layouts from storage', () => {
+        const saved = new Map<string, string>();
+        const storage = {
+            save: (name: string, data: string) => saved.set(name, data),
+            load: (name: string) => saved.get(name) ?? null,
+        };
+        const source = new Workspace();
+        source.saveLayout('default', { id: 'default', panels: [{ id: 'main' }] });
+        source.save(storage);
+
+        const restored = new Workspace();
+        restored.restore(storage);
+
+        expect(restored.loadLayout('default')).toEqual({ id: 'default', panels: [{ id: 'main' }] });
+    });
+
+    it('ignores corrupt stored layout data without throwing', () => {
+        const workspace = new Workspace();
+        workspace.saveLayout('default', { id: 'default', panels: [] });
+        const storage = {
+            save: () => {},
+            load: () => '{',
+        };
+
+        expect(() => workspace.restore(storage)).not.toThrow();
+        expect(workspace.loadLayout('default')).toEqual({ id: 'default', panels: [] });
+    });
+
+    it('ignores stored layout data with the wrong shape', () => {
+        const workspace = new Workspace();
+        workspace.saveLayout('default', { id: 'default', panels: [] });
+        const storage = {
+            save: () => {},
+            load: () => JSON.stringify([['broken', { id: 'broken' }]]),
+        };
+
+        workspace.restore(storage);
+
+        expect(workspace.getWorkspaceNames()).toEqual(['default']);
+        expect(workspace.loadLayout('broken')).toBeUndefined();
+    });
 });

--- a/packages/widgets/src/layout/Workspace.ts
+++ b/packages/widgets/src/layout/Workspace.ts
@@ -17,6 +17,34 @@ export interface WorkspaceOptions {
     defaultWorkspace?: string;
 }
 
+function isWorkspaceLayout(value: unknown): value is WorkspaceLayout {
+    return typeof value === "object"
+        && value !== null
+        && typeof (value as WorkspaceLayout).id === "string"
+        && Array.isArray((value as WorkspaceLayout).panels);
+}
+
+function parseLayouts(data: string): Map<string, WorkspaceLayout> | null {
+    try {
+        const parsed = JSON.parse(data);
+        if (!Array.isArray(parsed)) return null;
+
+        const layouts = new Map<string, WorkspaceLayout>();
+        for (const entry of parsed) {
+            if (!Array.isArray(entry) || entry.length !== 2) return null;
+
+            const [name, layout] = entry;
+            if (typeof name !== "string" || !isWorkspaceLayout(layout)) return null;
+
+            layouts.set(name, layout);
+        }
+
+        return layouts;
+    } catch {
+        return null;
+    }
+}
+
 export class Workspace {
     private layouts = new Map<string, WorkspaceLayout>();
     private activeWorkspace: string;
@@ -67,8 +95,9 @@ export class Workspace {
 
         if (!data) return;
 
-        this.layouts = new Map(
-            JSON.parse(data)
-        );
+        const layouts = parseLayouts(data);
+        if (!layouts) return;
+
+        this.layouts = layouts;
     }
 }


### PR DESCRIPTION
Summary
- validate persisted workspace data before replacing layouts
- ignore corrupt or wrong-shaped stored payloads safely
- add restore coverage for valid and invalid data

Validation
- node_modules\.bin\vitest.exe run packages/widgets/src/layout/Workspace.test.ts --watch=false

Closes #2878
