### PR TITLE
Validate useConf app names

### DIFF
--- a/packages/adapters/src/conf/index.test.ts
+++ b/packages/adapters/src/conf/index.test.ts
@@ -114,4 +114,29 @@ describe('useConf', () => {
       'useConf() requires the optional peer dependency `conf`.'
     )
   })
+
+  it('rejects app names with path traversal or separators', () => {
+    const unsafeNames = [
+      '../outside',
+      '/tmp/outside',
+      'nested/app',
+      'nested\\app',
+      '.hidden',
+    ]
+
+    for (const appName of unsafeNames) {
+      expect(() => useConf(appName, { theme: 'dark' })).toThrow(
+        'useConf() appName must contain only letters, numbers, dots, underscores, and hyphens'
+      )
+    }
+  })
+
+  it('accepts simple app identifiers with dots, underscores, and hyphens', () => {
+    tempHomeDirectory = mkdtempSync(join(tmpdir(), 'termui-conf-'))
+    setHomeDirectory(tempHomeDirectory)
+
+    const [config] = useConf('my-app_1.test', { theme: 'dark' })
+
+    expect(config).toEqual({ theme: 'dark' })
+  })
 })

--- a/packages/adapters/src/conf/index.ts
+++ b/packages/adapters/src/conf/index.ts
@@ -34,6 +34,12 @@ export function _setCustomLoader(loader: (() => any) | null): void {
   customLoader = loader
 }
 
+function assertValidAppName(appName: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(appName)) {
+    throw new Error('useConf() appName must contain only letters, numbers, dots, underscores, and hyphens, and must start with a letter or number.')
+  }
+}
+
 function resolveConfConstructor(): ConfConstructor {
   try {
     const loaded = customLoader
@@ -89,6 +95,8 @@ function createStore<T extends Record<string, unknown>>(appName: string, default
 }
 
 export function useConf<T extends Record<string, unknown>>(appName: string, defaults: T): UseConfResult<T> {
+  assertValidAppName(appName)
+
   // The cache is keyed by app name, so callers are responsible for reusing a consistent config shape per app.
   const cachedStore = configStores.get(appName) as ConfStore<T> | undefined
   const store = cachedStore ?? createStore(appName, defaults)


### PR DESCRIPTION
Summary
- validate useConf app names before path construction
- reject traversal, absolute path, and separator-based names
- cover accepted identifier characters and unsafe inputs

Validation
- node_modules\.bin\vitest.exe run packages/adapters/src/conf/index.test.ts --watch=false

Closes #2879
