### PR TITLE
Clamp popover within screen bounds

### DIFF
--- a/packages/ui/src/Popover.test.ts
+++ b/packages/ui/src/Popover.test.ts
@@ -98,6 +98,40 @@ describe('Popover Widget', () => {
         expect(rows).toContain('anchored');
     });
 
+    it('clamps bottom placement when the anchor is near the bottom-right edge', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+        const pop = new Popover(
+            new Text('edge text'),
+            {},
+            { anchor: { x: 29, y: 9 }, placement: 'bottom' }
+        );
+
+        pop.updateRect({ x: 0, y: 0, width: 30, height: 10 });
+        pop.open();
+        pop.render(screen);
+
+        const rows = getScreenText();
+        expect(rows).toContain('edge');
+        expect(rows.split('\n')[9]).toContain('+');
+    });
+
+    it('clamps top placement when the anchor is above the available panel height', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+        const pop = new Popover(
+            new Text('top edge'),
+            {},
+            { anchor: { x: 2, y: 0 }, placement: 'top' }
+        );
+
+        pop.updateRect({ x: 0, y: 0, width: 30, height: 10 });
+        pop.open();
+        pop.render(screen);
+
+        const rows = getScreenText();
+        expect(rows).toContain('top edge');
+        expect(rows.split('\n')[0]).toContain('+');
+    });
+
     it('clips long titles to the popover border width', () => {
         const pop = new Popover(new Text('x'), {}, {
             title: 'A very long title that should not widen the border',

--- a/packages/ui/src/Popover.ts
+++ b/packages/ui/src/Popover.ts
@@ -100,8 +100,8 @@ export class Popover extends Widget {
         const anchorY = this.opts.anchor?.y ?? this._rect.y;
         
         const contentRect = this.content.rect;
-        const width = Math.max(10, contentRect.width + 2); 
-        const height = Math.max(3, contentRect.height + 2);
+        const width = Math.min(Math.max(10, contentRect.width + 2), screen.cols);
+        const height = Math.min(Math.max(3, contentRect.height + 2), screen.rows);
 
         let px = anchorX;
         let py = anchorY;
@@ -112,6 +112,9 @@ export class Popover extends Widget {
             case 'left': px = anchorX - width; break;
             case 'right': px = anchorX + 1; break;
         }
+
+        px = Math.min(Math.max(0, px), Math.max(0, screen.cols - width));
+        py = Math.min(Math.max(0, py), Math.max(0, screen.rows - height));
 
         const attrs = styleToCellAttrs(this.style);
         const bAttrs = { ...attrs, fg: this.opts.borderColor || attrs.fg };


### PR DESCRIPTION
Summary
- cap popover panel size to the current screen
- clamp positioned panels within visible terminal bounds
- add edge-anchor coverage for top and bottom placements

Validation
- node_modules\.bin\vitest.exe run packages/ui/src/Popover.test.ts --watch=false

Closes #2880
