### PR TITLE
Clip notifications by cell width

### DIFF
--- a/packages/ui/src/NotificationCenter.test.ts
+++ b/packages/ui/src/NotificationCenter.test.ts
@@ -3,7 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { Screen, caps } from '@termuijs/core';
+import { Screen, caps, stringWidth } from '@termuijs/core';
 
 vi.mock('@termuijs/jsx', async () => {
     const actual = await vi.importActual<typeof import('@termuijs/jsx')>('@termuijs/jsx');
@@ -298,6 +298,20 @@ describe('NotificationCenter rendering and lifecycle', () => {
         const lines = renderLines(center, 12, 4, { x: 0, y: 0, width: 12, height: 4 });
         expect(lines[1]).toContain(' i abcdef');
         expect(lines.join('\n')).not.toContain('klmnopqrstuvwxyz');
+    });
+
+    it('truncates and pads wide notification text by terminal cell width', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+        const center = new NotificationCenter({ width: 10 });
+        const localScreen = new Screen(30, 10);
+        const writeSpy = vi.spyOn(localScreen, 'writeString');
+
+        store.push('部署完成 ok', 'info');
+        center.updateRect({ x: 0, y: 0, width: 30, height: 10 });
+        center.render(localScreen);
+
+        const rowText = String(writeSpy.mock.calls[0][2]);
+        expect(stringWidth(rowText)).toBe(10);
     });
 
     it.each([

--- a/packages/ui/src/NotificationCenter.ts
+++ b/packages/ui/src/NotificationCenter.ts
@@ -6,7 +6,7 @@
 
 import { Widget } from '@termuijs/widgets';
 import { useState, useEffect, registerCleanup } from '@termuijs/jsx';
-import { caps, type Screen } from '@termuijs/core';
+import { caps, stringWidth, truncate, type Screen } from '@termuijs/core';
 import type { Color } from '@termuijs/core';
 
 // Auto-register cleanup for test isolation
@@ -199,7 +199,8 @@ export class NotificationCenter extends Widget {
                 : TYPE_ICONS[notif.type].ascii;
 
             const raw = `${icon} ${notif.message}`;
-            const label = ` ${raw} `.slice(0, tw).padEnd(tw);
+            const clipped = truncate(` ${raw} `, tw, '');
+            const label = clipped + ' '.repeat(Math.max(0, tw - stringWidth(clipped)));
 
             screen.writeString(sx, sy + i, label, {
                 fg: TYPE_COLORS[notif.type],


### PR DESCRIPTION
Summary
- format notification rows with terminal cell width helpers
- avoid code-unit truncation for wide characters
- add coverage for wide notification text in narrow rows

Validation
- node_modules\.bin\vitest.exe run packages/ui/src/NotificationCenter.test.ts --watch=false

Closes #2881
