### PR TITLE
Add deterministic recorder clock

### DIFF
--- a/packages/testing/src/recorder.test.ts
+++ b/packages/testing/src/recorder.test.ts
@@ -63,6 +63,37 @@ describe('ScreenRecorder', () => {
         expect(recorder.getFrames()[0].timestamp).toBe(0);
     });
 
+    it('supports an injected clock for deterministic timestamps', () => {
+        let currentTime = 10_000;
+        const recorder = new ScreenRecorder({ now: () => currentTime });
+
+        recorder.recordFrame('first');
+        currentTime += 250;
+        recorder.recordFrame('second');
+
+        expect(recorder.getFrames()).toEqual([
+            { timestamp: 0, buffer: 'first' },
+            { timestamp: 250, buffer: 'second' },
+        ]);
+
+        const header = JSON.parse(recorder.toAsciicast({ title: 'Stable' }).split('\n')[0]);
+        expect(header.timestamp).toBe(10);
+    });
+
+    it('resets the injected clock baseline on clear()', () => {
+        let currentTime = 1_000;
+        const recorder = new ScreenRecorder({ now: () => currentTime });
+
+        recorder.recordFrame('before');
+        currentTime = 1_500;
+        recorder.clear();
+        recorder.recordFrame('after');
+
+        expect(recorder.getFrames()).toEqual([
+            { timestamp: 0, buffer: 'after' },
+        ]);
+    });
+
     it('respects enabled flag and environment variable RECORD_DISABLED', () => {
         // Disabled via option
         const recorder1 = new ScreenRecorder({ enabled: false });

--- a/packages/testing/src/recorder.ts
+++ b/packages/testing/src/recorder.ts
@@ -6,22 +6,31 @@ export interface FrameData {
     buffer: string;
 }
 
+export interface ScreenRecorderOptions {
+    maxFrames?: number;
+    enabled?: boolean;
+    now?: () => number;
+}
+
 /**
  * ScreenRecorder — recording utility for terminal output frames.
  * Can export in asciicast v2 format for asciinema compatibility, or as SVG.
  */
 export class ScreenRecorder {
     private frames: FrameData[] = [];
-    private startTime: number = Date.now();
+    private startTime: number;
     private maxFrames?: number;
     private enabled = true;
+    private now: () => number;
 
-    constructor(options?: { maxFrames?: number; enabled?: boolean }) {
+    constructor(options?: ScreenRecorderOptions) {
         const maxFrames = options?.maxFrames;
         if (maxFrames !== undefined && (!Number.isInteger(maxFrames) || maxFrames <= 0)) {
             throw new Error("maxFrames must be a positive integer");
         }
         this.maxFrames = maxFrames;
+        this.now = options?.now ?? Date.now;
+        this.startTime = this.now();
         // Enabled by default unless set to false or RECORD_DISABLED=1 env is present
         this.enabled = options?.enabled ?? (process.env.RECORD_DISABLED !== '1');
     }
@@ -57,7 +66,7 @@ export class ScreenRecorder {
             this.frames.shift(); // Remove oldest frame
         }
         this.frames.push({
-            timestamp: Date.now() - this.startTime,
+            timestamp: this.now() - this.startTime,
             buffer
         });
     }
@@ -76,7 +85,7 @@ export class ScreenRecorder {
      */
     public clear(): void {
         this.frames = [];
-        this.startTime = Date.now();
+        this.startTime = this.now();
     }
 
     /**


### PR DESCRIPTION
Summary
- add an optional now() clock to ScreenRecorder options
- use the injected clock for frame offsets, cast headers, and clear baselines
- add deterministic timestamp coverage

Validation
- node_modules\.bin\vitest.exe run packages/testing/src/recorder.test.ts --watch=false

Closes #2883
