### PR TITLE
Add terminal capability negotiation

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,19 @@ export type { FrameStats } from './terminal/Renderer.js';
 export { LayerManager } from './terminal/LayerManager.js';
 export type { Layer } from './terminal/LayerManager.js';
 export { caps, prefersReducedMotion, shouldUseColor, prefersHighContrast } from './terminal/env-caps.js';
+export {
+    detectTerminalCapabilities,
+    getTerminalCapabilities,
+    setTerminalCapabilitiesForTests,
+} from './terminal/capabilities.js';
+export type {
+    TerminalCapabilities,
+    TerminalCapabilityEnv,
+    TerminalCapabilityOptions,
+    TerminalColorLevel,
+    TerminalBackground,
+    TerminalKeybindingMode,
+} from './terminal/capabilities.js';
 export { BOX, BRAILLE_SPIN, BLOCK } from './terminal/ascii-map.js';
 
 // ── Renderer ──────────────────────────────────────────

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,7 +11,7 @@ export { Renderer } from './terminal/Renderer.js';
 export type { FrameStats } from './terminal/Renderer.js';
 export { LayerManager } from './terminal/LayerManager.js';
 export type { Layer } from './terminal/LayerManager.js';
-export { caps, prefersReducedMotion, shouldUseColor, prefersHighContrast } from './terminal/env-caps.js';
+export { caps, prefersReducedMotion, shouldUseColor, prefersHighContrast, resetCapsOverridesForTests } from './terminal/env-caps.js';
 export {
     detectTerminalCapabilities,
     getTerminalCapabilities,

--- a/packages/core/src/terminal/capabilities.test.ts
+++ b/packages/core/src/terminal/capabilities.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ColorDepth } from '../style/Color.js';
+import {
+    detectTerminalCapabilities,
+    getTerminalCapabilities,
+    setTerminalCapabilitiesForTests,
+    type TerminalCapabilities,
+} from './capabilities.js';
+
+describe('detectTerminalCapabilities', () => {
+    it('honors NO_COLOR and TERM=dumb as hard fallbacks', () => {
+        const capabilities = detectTerminalCapabilities({
+            env: { NO_COLOR: '1', FORCE_COLOR: '3', TERM: 'xterm-256color' },
+            isTTY: true,
+            platform: 'linux',
+        });
+
+        expect(capabilities.color).toMatchObject({
+            enabled: false,
+            depth: ColorDepth.None,
+            level: 'none',
+            ansi256: false,
+            truecolor: false,
+        });
+
+        const dumb = detectTerminalCapabilities({ env: { TERM: 'dumb' }, isTTY: true, platform: 'linux' });
+        expect(dumb.escapeSequences).toEqual({ csi: false, osc: false });
+        expect(dumb.screen.alternateBuffer).toBe(false);
+        expect(dumb.mouse.supported).toBe(false);
+    });
+
+    it('negotiates color levels from FORCE_COLOR, COLORTERM, and TERM', () => {
+        expect(detectTerminalCapabilities({ env: { FORCE_COLOR: '1' }, platform: 'linux' }).color.level).toBe('basic');
+        expect(detectTerminalCapabilities({ env: { FORCE_COLOR: '2' }, platform: 'linux' }).color.level).toBe('ansi256');
+        expect(detectTerminalCapabilities({ env: { FORCE_COLOR: '3' }, platform: 'linux' }).color.level).toBe('truecolor');
+        expect(detectTerminalCapabilities({ env: { COLORTERM: '24bit' }, platform: 'linux' }).color.truecolor).toBe(true);
+        expect(detectTerminalCapabilities({ env: { TERM: 'screen-256color' }, platform: 'linux' }).color.ansi256).toBe(true);
+    });
+
+    it('tracks unicode width, mouse support, background, and keybinding fallbacks', () => {
+        const capabilities = detectTerminalCapabilities({
+            env: {
+                TERM: 'xterm-256color',
+                TERMUI_AMBIGUOUS_WIDTH: '2',
+                COLORFGBG: '0;15',
+                TERMUI_KEYBINDINGS: 'vim',
+            },
+            platform: 'linux',
+        });
+
+        expect(capabilities.unicode).toEqual({ enabled: true, ambiguousWidth: 2 });
+        expect(capabilities.mouse).toEqual({ supported: true, sgr: true });
+        expect(capabilities.background).toBe('light');
+        expect(capabilities.keybindingMode).toBe('vim');
+    });
+
+    it('disables unicode on Windows unless explicitly handled by callers', () => {
+        const capabilities = detectTerminalCapabilities({
+            env: { TERM: 'xterm-256color' },
+            platform: 'win32',
+        });
+
+        expect(capabilities.unicode.enabled).toBe(false);
+    });
+});
+
+describe('getTerminalCapabilities', () => {
+    afterEach(() => {
+        setTerminalCapabilitiesForTests(null);
+    });
+
+    it('allows tests to install a deterministic negotiated profile', () => {
+        const profile: TerminalCapabilities = detectTerminalCapabilities({
+            env: { FORCE_COLOR: '3', TERMUI_MOUSE: '1' },
+            platform: 'linux',
+        });
+
+        setTerminalCapabilitiesForTests(profile);
+
+        expect(getTerminalCapabilities()).toBe(profile);
+    });
+});

--- a/packages/core/src/terminal/capabilities.ts
+++ b/packages/core/src/terminal/capabilities.ts
@@ -1,0 +1,166 @@
+import { ColorDepth } from '../style/Color.js';
+
+export type TerminalColorLevel = 'none' | 'basic' | 'ansi256' | 'truecolor';
+export type TerminalBackground = 'light' | 'dark';
+export type TerminalKeybindingMode = 'default' | 'vim' | 'emacs';
+
+export interface TerminalCapabilityEnv {
+    [key: string]: string | undefined;
+}
+
+export interface TerminalCapabilities {
+    color: {
+        enabled: boolean;
+        depth: ColorDepth;
+        level: TerminalColorLevel;
+        ansi256: boolean;
+        truecolor: boolean;
+    };
+    unicode: {
+        enabled: boolean;
+        ambiguousWidth: 1 | 2;
+    };
+    mouse: {
+        supported: boolean;
+        sgr: boolean;
+    };
+    screen: {
+        alternateBuffer: boolean;
+    };
+    escapeSequences: {
+        csi: boolean;
+        osc: boolean;
+    };
+    motion: boolean;
+    ci: boolean;
+    background: TerminalBackground;
+    keybindingMode: TerminalKeybindingMode;
+}
+
+export interface TerminalCapabilityOptions {
+    env?: TerminalCapabilityEnv;
+    isTTY?: boolean;
+    platform?: NodeJS.Platform | string;
+}
+
+let overrideCapabilities: TerminalCapabilities | null = null;
+
+function parseColorDepth(env: TerminalCapabilityEnv, isTTY: boolean): ColorDepth {
+    if (env.NO_COLOR !== undefined || env.TERM === 'dumb') {
+        return ColorDepth.None;
+    }
+
+    if (env.FORCE_COLOR !== undefined) {
+        const level = Number.parseInt(env.FORCE_COLOR, 10);
+        if (level === 0) return ColorDepth.None;
+        if (level === 1) return ColorDepth.Basic;
+        if (level === 2) return ColorDepth.Ansi256;
+        if (level >= 3) return ColorDepth.TrueColor;
+        return ColorDepth.Basic;
+    }
+
+    const colorterm = env.COLORTERM?.toLowerCase();
+    if (colorterm === 'truecolor' || colorterm === '24bit') {
+        return ColorDepth.TrueColor;
+    }
+
+    const term = env.TERM ?? '';
+    if (term.includes('256color') || term.includes('256')) {
+        return ColorDepth.Ansi256;
+    }
+
+    if (env.TERM_PROGRAM === 'iTerm.app' || env.TERM_PROGRAM === 'Hyper') {
+        return ColorDepth.TrueColor;
+    }
+
+    return isTTY ? ColorDepth.Basic : ColorDepth.None;
+}
+
+function colorLevel(depth: ColorDepth): TerminalColorLevel {
+    if (depth >= ColorDepth.TrueColor) return 'truecolor';
+    if (depth >= ColorDepth.Ansi256) return 'ansi256';
+    if (depth >= ColorDepth.Basic) return 'basic';
+    return 'none';
+}
+
+function detectBackground(env: TerminalCapabilityEnv): TerminalBackground {
+    if (env.TERM_BACKGROUND === 'light') return 'light';
+    if (env.TERM_BACKGROUND === 'dark') return 'dark';
+
+    const colorfgbg = env.COLORFGBG;
+    if (colorfgbg) {
+        const parts = colorfgbg.split(';');
+        const bg = Number.parseInt(parts[parts.length - 1], 10);
+        if (!Number.isNaN(bg)) return bg < 8 ? 'dark' : 'light';
+    }
+
+    return 'dark';
+}
+
+function keybindingMode(env: TerminalCapabilityEnv): TerminalKeybindingMode {
+    const mode = env.TERMUI_KEYBINDINGS;
+    return mode === 'vim' || mode === 'emacs' ? mode : 'default';
+}
+
+function supportsMouse(env: TerminalCapabilityEnv): boolean {
+    if (env.TERM === 'dumb' || env.TERMUI_MOUSE === '0' || env.NO_MOUSE === '1') {
+        return false;
+    }
+    if (env.TERMUI_MOUSE === '1') return true;
+
+    const term = env.TERM ?? '';
+    return /xterm|screen|tmux|rxvt|kitty|wezterm|alacritty|foot/i.test(term);
+}
+
+function supportsOsc(env: TerminalCapabilityEnv): boolean {
+    if (env.TERM === 'dumb') return false;
+    if (env.TERMUI_OSC === '0') return false;
+    return true;
+}
+
+export function detectTerminalCapabilities(options: TerminalCapabilityOptions = {}): TerminalCapabilities {
+    const env = options.env ?? process.env;
+    const isTTY = options.isTTY ?? !!process.stdout?.isTTY;
+    const platform = options.platform ?? process.platform;
+    const depth = parseColorDepth(env, isTTY);
+    const level = colorLevel(depth);
+    const dumb = env.TERM === 'dumb';
+    const unicodeEnabled = !dumb && !env.NO_UNICODE && platform !== 'win32';
+
+    return {
+        color: {
+            enabled: depth !== ColorDepth.None,
+            depth,
+            level,
+            ansi256: depth >= ColorDepth.Ansi256,
+            truecolor: depth >= ColorDepth.TrueColor,
+        },
+        unicode: {
+            enabled: unicodeEnabled,
+            ambiguousWidth: env.TERMUI_AMBIGUOUS_WIDTH === '2' ? 2 : 1,
+        },
+        mouse: {
+            supported: supportsMouse(env),
+            sgr: supportsMouse(env) && !dumb,
+        },
+        screen: {
+            alternateBuffer: !dumb && env.TERMUI_ALT_SCREEN !== '0',
+        },
+        escapeSequences: {
+            csi: !dumb,
+            osc: supportsOsc(env),
+        },
+        motion: !env.NO_MOTION && !env.CI,
+        ci: !!env.CI,
+        background: detectBackground(env),
+        keybindingMode: keybindingMode(env),
+    };
+}
+
+export function getTerminalCapabilities(): TerminalCapabilities {
+    return overrideCapabilities ?? detectTerminalCapabilities();
+}
+
+export function setTerminalCapabilitiesForTests(capabilities: TerminalCapabilities | null): void {
+    overrideCapabilities = capabilities;
+}

--- a/packages/core/src/terminal/env-caps.test.ts
+++ b/packages/core/src/terminal/env-caps.test.ts
@@ -3,7 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { caps, prefersReducedMotion } from './env-caps.js';
+import { caps, prefersReducedMotion, resetCapsOverridesForTests } from './env-caps.js';
 
 // caps is evaluated at module load time, so each test must:
 // 1. vi.stubEnv() to set env vars
@@ -14,6 +14,7 @@ describe('env-caps', () => {
     beforeEach(() => {
         vi.unstubAllEnvs();
         vi.resetModules();
+        resetCapsOverridesForTests();
     });
 
     it('caps.color is false when NO_COLOR=1', async () => {
@@ -88,6 +89,12 @@ describe('env-caps', () => {
         const { ColorDepth } = await import('../style/Color.js');
         expect(caps.colorDepth).toBe(ColorDepth.None);
         expect(caps.color).toBe(false);
+    });
+
+    it('caps.unicode remains assignable for tests that force ASCII fallback', () => {
+        caps.unicode = false;
+        expect(caps.unicode).toBe(false);
+        resetCapsOverridesForTests();
     });
 });
 

--- a/packages/core/src/terminal/env-caps.ts
+++ b/packages/core/src/terminal/env-caps.ts
@@ -1,4 +1,5 @@
-import { ColorDepth, detectColorDepth } from '../style/Color.js';
+import { ColorDepth } from '../style/Color.js';
+import { getTerminalCapabilities } from './capabilities.js';
 
 /**
  * Terminal capability detection hub.
@@ -10,40 +11,31 @@ import { ColorDepth, detectColorDepth } from '../style/Color.js';
 export const caps = {
   /** Detected color depth (None, ANSI16, ANSI256, TrueColor). */
   get colorDepth(): ColorDepth {
-    return detectColorDepth();
+    return getTerminalCapabilities().color.depth;
   },
   /** Whether color output is enabled. Returns false when NO_COLOR or TERM=dumb. */
   get color(): boolean {
-    if (process.env.NO_COLOR !== undefined) return false;
-    if (process.env.TERM === 'dumb') return false;
-    return this.colorDepth !== ColorDepth.None;
+    return getTerminalCapabilities().color.enabled;
   },
   /** Whether Unicode characters are supported. Disabled by NO_UNICODE or TERM=dumb. */
-  unicode: !process.env.NO_UNICODE && process.env.TERM !== 'dumb',
+  get unicode(): boolean {
+    return getTerminalCapabilities().unicode.enabled;
+  },
   /** Whether animations are enabled. Disabled by NO_MOTION or CI environments. */
-  motion:  !process.env.NO_MOTION && !process.env.CI,
+  get motion(): boolean {
+    return getTerminalCapabilities().motion;
+  },
   /** Whether running inside a CI system (CI=1). */
-  ci:      !!process.env.CI,
+  get ci(): boolean {
+    return getTerminalCapabilities().ci;
+  },
   /** Terminal background color (light/dark). Checks TERM_BACKGROUND then COLORFGBG. */
   get background(): 'light' | 'dark' {
-    // Explicit override takes priority over terminal heuristics.
-    if (process.env.TERM_BACKGROUND === 'light') return 'light';
-    if (process.env.TERM_BACKGROUND === 'dark') return 'dark';
-
-    const colorfgbg = process.env.COLORFGBG;
-    if (colorfgbg) {
-      const parts = colorfgbg.split(';');
-      const bg = parseInt(parts[parts.length - 1], 10);
-      if (!Number.isNaN(bg)) return bg < 8 ? 'dark' : 'light';
-    }
-
-    return 'dark';
+    return getTerminalCapabilities().background;
   },
   /** Keyboard navigation mode: 'default' (arrow keys), 'vim' (hjkl), or 'emacs' (C-n/p). */
   get keybindingMode(): 'vim' | 'emacs' | 'default' {
-    const mode = process.env.TERMUI_KEYBINDINGS;
-    if (mode === 'vim' || mode === 'emacs') return mode;
-    return 'default';
+    return getTerminalCapabilities().keybindingMode;
   },
 } as const;
 

--- a/packages/core/src/terminal/env-caps.ts
+++ b/packages/core/src/terminal/env-caps.ts
@@ -1,6 +1,16 @@
 import { ColorDepth } from '../style/Color.js';
 import { getTerminalCapabilities } from './capabilities.js';
 
+const capsOverrides: Partial<{
+  colorDepth: ColorDepth;
+  color: boolean;
+  unicode: boolean;
+  motion: boolean;
+  ci: boolean;
+  background: 'light' | 'dark';
+  keybindingMode: 'vim' | 'emacs' | 'default';
+}> = {};
+
 /**
  * Terminal capability detection hub.
  *
@@ -11,33 +21,67 @@ import { getTerminalCapabilities } from './capabilities.js';
 export const caps = {
   /** Detected color depth (None, ANSI16, ANSI256, TrueColor). */
   get colorDepth(): ColorDepth {
+    if (capsOverrides.colorDepth !== undefined) return capsOverrides.colorDepth;
     return getTerminalCapabilities().color.depth;
+  },
+  set colorDepth(value: ColorDepth) {
+    capsOverrides.colorDepth = value;
   },
   /** Whether color output is enabled. Returns false when NO_COLOR or TERM=dumb. */
   get color(): boolean {
+    if (capsOverrides.color !== undefined) return capsOverrides.color;
     return getTerminalCapabilities().color.enabled;
+  },
+  set color(value: boolean) {
+    capsOverrides.color = value;
   },
   /** Whether Unicode characters are supported. Disabled by NO_UNICODE or TERM=dumb. */
   get unicode(): boolean {
+    if (capsOverrides.unicode !== undefined) return capsOverrides.unicode;
     return getTerminalCapabilities().unicode.enabled;
+  },
+  set unicode(value: boolean) {
+    capsOverrides.unicode = value;
   },
   /** Whether animations are enabled. Disabled by NO_MOTION or CI environments. */
   get motion(): boolean {
+    if (capsOverrides.motion !== undefined) return capsOverrides.motion;
     return getTerminalCapabilities().motion;
+  },
+  set motion(value: boolean) {
+    capsOverrides.motion = value;
   },
   /** Whether running inside a CI system (CI=1). */
   get ci(): boolean {
+    if (capsOverrides.ci !== undefined) return capsOverrides.ci;
     return getTerminalCapabilities().ci;
+  },
+  set ci(value: boolean) {
+    capsOverrides.ci = value;
   },
   /** Terminal background color (light/dark). Checks TERM_BACKGROUND then COLORFGBG. */
   get background(): 'light' | 'dark' {
+    if (capsOverrides.background !== undefined) return capsOverrides.background;
     return getTerminalCapabilities().background;
+  },
+  set background(value: 'light' | 'dark') {
+    capsOverrides.background = value;
   },
   /** Keyboard navigation mode: 'default' (arrow keys), 'vim' (hjkl), or 'emacs' (C-n/p). */
   get keybindingMode(): 'vim' | 'emacs' | 'default' {
+    if (capsOverrides.keybindingMode !== undefined) return capsOverrides.keybindingMode;
     return getTerminalCapabilities().keybindingMode;
   },
+  set keybindingMode(value: 'vim' | 'emacs' | 'default') {
+    capsOverrides.keybindingMode = value;
+  },
 } as const;
+
+export function resetCapsOverridesForTests(): void {
+  for (const key of Object.keys(capsOverrides) as Array<keyof typeof capsOverrides>) {
+    delete capsOverrides[key];
+  }
+}
 
 /**
  * Returns `true` when animation should be suppressed.


### PR DESCRIPTION
Summary
- Add a negotiated terminal capability profile for color, Unicode, mouse, alternate screen, escape sequences, motion, background, and keybindings.
- Rewire the existing caps API to read from the negotiated profile while keeping current imports compatible.
- Add deterministic test overrides for package-level checks.

Validation
- npx.cmd vitest run packages/core/src/terminal/capabilities.test.ts packages/core/src/terminal/env-caps.test.ts

Closes #2900
