### PR TITLE
Add incremental layout invalidation reasons

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,7 +33,7 @@ export type { ChordMatcherOptions, Chord } from './input/ChordMatcher.js';
 export { LiveRender } from './renderer/live-render.js';
 // ── Layout ────────────────────────────────────────────
 export { computeLayout, createLayoutNode, invalidateLayout } from './layout/LayoutEngine.js';
-export type { LayoutNode } from './layout/LayoutEngine.js';
+export type { LayoutDirtyReason, LayoutInvalidationOptions, LayoutNode } from './layout/LayoutEngine.js';
 export { emptyRect, containsPoint, shrinkRect, intersectRect, unionRect } from './layout/Rect.js';
 export type { Rect, Size } from './layout/Rect.js';
 export { Pos } from './layout/pos.js';

--- a/packages/core/src/layout/LayoutEngine.test.ts
+++ b/packages/core/src/layout/LayoutEngine.test.ts
@@ -196,6 +196,37 @@ describe('layout cache invalidation', () => {
         expect(root._dirty).toBe(true);
         expect(childA._dirty).toBe(true);
         expect(childB._dirty).toBe(true);
+        expect(root._dirtyReason).toBe('subtree');
+        expect(childA._dirtyReason).toBe('subtree');
+    });
+
+    it('supports local invalidation without dirtying descendants', () => {
+        const leaf = makeNode('leaf');
+        const child = makeNode('child', { height: 10 }, [leaf]);
+        const root = makeNode('root', {}, [child]);
+
+        computeLayout(root, 80, 24);
+        invalidateLayout(child, { reason: 'local' });
+
+        expect(child._dirty).toBe(true);
+        expect(child._dirtyReason).toBe('local');
+        expect(leaf._dirty).toBe(false);
+    });
+
+    it('walks clean ancestors to recompute a dirty nested child', () => {
+        const leaf = makeNode('leaf', { height: 2 });
+        const child = makeNode('child', { height: 10 }, [leaf]);
+        const root = makeNode('root', {}, [child]);
+
+        computeLayout(root, 80, 24);
+        leaf.style.height = 6;
+        invalidateLayout(leaf, { reason: 'local' });
+        computeLayout(root, 80, 24);
+
+        expect(leaf.computed.height).toBe(6);
+        expect(root._dirty).toBe(false);
+        expect(child._dirty).toBe(false);
+        expect(leaf._dirty).toBe(false);
     });
 
     it('clean subtree with dirty parent still recomputes parent', () => {
@@ -208,6 +239,7 @@ describe('layout cache invalidation', () => {
 
         // Mark only the parent dirty
         parent._dirty = true;
+        parent._dirtyReason = 'local';
         computeLayout(parent, 80, 24);
         // After layout, all should be clean again
         expect(parent._dirty).toBe(false);

--- a/packages/core/src/layout/LayoutEngine.test.ts
+++ b/packages/core/src/layout/LayoutEngine.test.ts
@@ -210,7 +210,18 @@ describe('layout cache invalidation', () => {
 
         expect(child._dirty).toBe(true);
         expect(child._dirtyReason).toBe('local');
+        expect(root._hasDirtyDescendant).toBe(true);
         expect(leaf._dirty).toBe(false);
+    });
+
+    it('ignores paint-only invalidation for layout work', () => {
+        const root = makeNode('root');
+        computeLayout(root, 80, 24);
+
+        invalidateLayout(root, { reason: 'paint' });
+
+        expect(root._dirty).toBe(false);
+        expect(root._dirtyReason).toBeUndefined();
     });
 
     it('walks clean ancestors to recompute a dirty nested child', () => {
@@ -225,6 +236,7 @@ describe('layout cache invalidation', () => {
 
         expect(leaf.computed.height).toBe(6);
         expect(root._dirty).toBe(false);
+        expect(root._hasDirtyDescendant).toBe(false);
         expect(child._dirty).toBe(false);
         expect(leaf._dirty).toBe(false);
     });

--- a/packages/core/src/layout/LayoutEngine.ts
+++ b/packages/core/src/layout/LayoutEngine.ts
@@ -25,6 +25,7 @@ export interface LayoutNode {
     computed: Rect;
     /** Dirty flag — true when this node needs to be re-laid-out. Foundation for layout caching. */
     _dirty: boolean;
+    _dirtyReason?: LayoutDirtyReason;
     /** Last container dimensions used — separate from computed so manual computed edits don't confuse sizeChanged detection */
     _lastContainerWidth: number;
     _lastContainerHeight: number;
@@ -37,6 +38,13 @@ export interface LayoutNode {
     _dragging?: boolean;
 }
 
+export type LayoutDirtyReason = 'paint' | 'local' | 'children' | 'subtree' | 'container';
+
+export interface LayoutInvalidationOptions {
+    reason?: LayoutDirtyReason;
+    cascade?: boolean;
+}
+
 /**
  * Create a LayoutNode with default values.
  */
@@ -47,6 +55,7 @@ export function createLayoutNode(id: string, style: Style, children: LayoutNode[
         children,
         computed: { x: 0, y: 0, width: 0, height: 0 },
         _dirty: true,
+        _dirtyReason: 'subtree',
         _lastContainerWidth: 0,
         _lastContainerHeight: 0,
         _lastComputedWidth: 0,
@@ -71,6 +80,9 @@ export function createLayoutNode(id: string, style: Style, children: LayoutNode[
  */
 export function computeLayout(root: LayoutNode, containerWidth: number, containerHeight: number): void {
     const sizeChanged = root._lastContainerWidth !== containerWidth || root._lastContainerHeight !== containerHeight;
+    if (sizeChanged) {
+        markLayoutDirty(root, 'container');
+    }
     if (!sizeChanged && !root._dirty && !hasDirtyChild(root)) {
         return;
     }
@@ -82,11 +94,29 @@ export function computeLayout(root: LayoutNode, containerWidth: number, containe
     root.computed.width = containerWidth;
     root.computed.height = containerHeight;
 }
-export function invalidateLayout(node: LayoutNode): void {
-    node._dirty = true;
+export function invalidateLayout(node: LayoutNode, options: LayoutInvalidationOptions = {}): void {
+    const reason = options.reason ?? 'subtree';
+    const cascade = options.cascade ?? (reason === 'subtree' || reason === 'container');
+    markLayoutDirty(node, reason);
+    if (!cascade) return;
     for (const child of node.children) {
-        invalidateLayout(child);
+        invalidateLayout(child, { reason, cascade: true });
     }
+}
+function markLayoutDirty(node: LayoutNode, reason: LayoutDirtyReason): void {
+    node._dirty = true;
+    node._dirtyReason = mergeDirtyReason(node._dirtyReason, reason);
+}
+function mergeDirtyReason(current: LayoutDirtyReason | undefined, next: LayoutDirtyReason): LayoutDirtyReason {
+    const priority: Record<LayoutDirtyReason, number> = {
+        paint: 0,
+        local: 1,
+        children: 2,
+        subtree: 3,
+        container: 4,
+    };
+    if (!current || priority[next] > priority[current]) return next;
+    return current;
 }
 function hasDirtyChild(node: LayoutNode): boolean {
     if (node._dirty) return true;
@@ -100,6 +130,7 @@ function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, p
     // Note: node.computed.width/height are written by the parent before this call,
     // so comparing against them detects non-dirty nodes whose allocated size changed.
     if (!node._dirty &&
+        !hasDirtyChild(node) &&
         node._lastComputedWidth === node.computed.width &&
         node._lastComputedHeight === node.computed.height) {
         return;
@@ -132,6 +163,7 @@ function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, p
 
     if (node.children.length === 0) {
         node._dirty = false;
+        node._dirtyReason = undefined;
         node._lastComputedWidth = node.computed.width;
         node._lastComputedHeight = node.computed.height;
         return;
@@ -334,6 +366,7 @@ function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, p
         }
 
         node._dirty = false;
+        node._dirtyReason = undefined;
         node._lastComputedWidth = node.computed.width;
         node._lastComputedHeight = node.computed.height;
         return;
@@ -379,6 +412,7 @@ function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, p
             visibleIndex++;
         }
         node._dirty = false;
+        node._dirtyReason = undefined;
         node._lastComputedWidth = node.computed.width;
         node._lastComputedHeight = node.computed.height;
         return;
@@ -580,6 +614,7 @@ function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, p
 
     // Mark this node clean after layout is complete (used by future caching logic)
     node._dirty = false;
+    node._dirtyReason = undefined;
     node._lastComputedWidth = node.computed.width;
     node._lastComputedHeight = node.computed.height;
 }

--- a/packages/core/src/layout/LayoutEngine.ts
+++ b/packages/core/src/layout/LayoutEngine.ts
@@ -26,6 +26,8 @@ export interface LayoutNode {
     /** Dirty flag — true when this node needs to be re-laid-out. Foundation for layout caching. */
     _dirty: boolean;
     _dirtyReason?: LayoutDirtyReason;
+    _hasDirtyDescendant?: boolean;
+    _parent?: LayoutNode;
     /** Last container dimensions used — separate from computed so manual computed edits don't confuse sizeChanged detection */
     _lastContainerWidth: number;
     _lastContainerHeight: number;
@@ -49,7 +51,7 @@ export interface LayoutInvalidationOptions {
  * Create a LayoutNode with default values.
  */
 export function createLayoutNode(id: string, style: Style, children: LayoutNode[] = []): LayoutNode {
-    return {
+    const node: LayoutNode = {
         id,
         style,
         children,
@@ -63,6 +65,10 @@ export function createLayoutNode(id: string, style: Style, children: LayoutNode[
         _draggable: false,
         _dragging: false,
     };
+    for (const child of children) {
+        child._parent = node;
+    }
+    return node;
 }
 
 /**
@@ -83,7 +89,7 @@ export function computeLayout(root: LayoutNode, containerWidth: number, containe
     if (sizeChanged) {
         markLayoutDirty(root, 'container');
     }
-    if (!sizeChanged && !root._dirty && !hasDirtyChild(root)) {
+    if (!sizeChanged && !root._dirty && !root._hasDirtyDescendant) {
         return;
     }
     root._lastContainerWidth = containerWidth;
@@ -100,12 +106,19 @@ export function invalidateLayout(node: LayoutNode, options: LayoutInvalidationOp
     markLayoutDirty(node, reason);
     if (!cascade) return;
     for (const child of node.children) {
+        child._parent = node;
         invalidateLayout(child, { reason, cascade: true });
     }
 }
 function markLayoutDirty(node: LayoutNode, reason: LayoutDirtyReason): void {
+    if (reason === 'paint') return;
     node._dirty = true;
     node._dirtyReason = mergeDirtyReason(node._dirtyReason, reason);
+    let parent = node._parent;
+    while (parent) {
+        parent._hasDirtyDescendant = true;
+        parent = parent._parent;
+    }
 }
 function mergeDirtyReason(current: LayoutDirtyReason | undefined, next: LayoutDirtyReason): LayoutDirtyReason {
     const priority: Record<LayoutDirtyReason, number> = {
@@ -118,19 +131,12 @@ function mergeDirtyReason(current: LayoutDirtyReason | undefined, next: LayoutDi
     if (!current || priority[next] > priority[current]) return next;
     return current;
 }
-function hasDirtyChild(node: LayoutNode): boolean {
-    if (node._dirty) return true;
-    for (const child of node.children) {
-        if (hasDirtyChild(child)) return true;
-    }
-    return false;
-}
 function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, precomputed = false): void {
     // Skip only if not dirty AND dimensions are unchanged since last layout pass.
     // Note: node.computed.width/height are written by the parent before this call,
     // so comparing against them detects non-dirty nodes whose allocated size changed.
     if (!node._dirty &&
-        !hasDirtyChild(node) &&
+        !node._hasDirtyDescendant &&
         node._lastComputedWidth === node.computed.width &&
         node._lastComputedHeight === node.computed.height) {
         return;
@@ -164,6 +170,7 @@ function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, p
     if (node.children.length === 0) {
         node._dirty = false;
         node._dirtyReason = undefined;
+        node._hasDirtyDescendant = false;
         node._lastComputedWidth = node.computed.width;
         node._lastComputedHeight = node.computed.height;
         return;
@@ -367,6 +374,7 @@ function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, p
 
         node._dirty = false;
         node._dirtyReason = undefined;
+        node._hasDirtyDescendant = false;
         node._lastComputedWidth = node.computed.width;
         node._lastComputedHeight = node.computed.height;
         return;
@@ -413,6 +421,7 @@ function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, p
         }
         node._dirty = false;
         node._dirtyReason = undefined;
+        node._hasDirtyDescendant = false;
         node._lastComputedWidth = node.computed.width;
         node._lastComputedHeight = node.computed.height;
         return;
@@ -615,6 +624,7 @@ function layoutNode(node: LayoutNode, availWidth: number, availHeight: number, p
     // Mark this node clean after layout is complete (used by future caching logic)
     node._dirty = false;
     node._dirtyReason = undefined;
+    node._hasDirtyDescendant = false;
     node._lastComputedWidth = node.computed.width;
     node._lastComputedHeight = node.computed.height;
 }


### PR DESCRIPTION
Summary
- Add typed layout dirty reasons and invalidation options.
- Preserve full subtree invalidation by default while allowing local invalidation for nested layout trees.
- Ensure clean ancestors still walk dirty descendants during layout recomputation.

Validation
- npx.cmd vitest run packages/core/src/layout/LayoutEngine.test.ts

Closes #2901
