### PR TITLE
Add router transition cancellation

### DIFF
--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -11,6 +11,7 @@ export type {
     RouteMatch,
     RouteParams,
     QueryParams,
+    NavigationGuardContext,
     LazyLoader,
     BeforeEnterGuard,
     AfterEnterGuard,

--- a/packages/router/src/route.ts
+++ b/packages/router/src/route.ts
@@ -4,9 +4,15 @@
 
 export type LazyLoader = () => Promise<any>;
 
-export type BeforeEnterGuard = (to: string) => boolean | string;
+export interface NavigationGuardContext {
+    id: number;
+    signal: AbortSignal;
+    isStale: () => boolean;
+}
 
-export type AfterEnterGuard = (to: string) => void;
+export type BeforeEnterGuard = (to: string, context?: NavigationGuardContext) => boolean | string;
+
+export type AfterEnterGuard = (to: string, context?: NavigationGuardContext) => void;
 
 export type RouteMeta = Record<string, unknown>;
 

--- a/packages/router/src/router.test.ts
+++ b/packages/router/src/router.test.ts
@@ -212,7 +212,7 @@ describe('Router', () => {
 
         r.push('/admin/users');
 
-        expect(parentGuard).toHaveBeenCalledWith('/admin/users');
+        expect(parentGuard.mock.calls[0][0]).toBe('/admin/users');
         expect(r.current).toBeNull();
         expect(r.historyLength).toBe(0);
     });
@@ -259,6 +259,39 @@ describe('Router', () => {
         r.push('/home');
         
         expect(spy).toHaveBeenCalled();
+    });
+
+    it('keeps the newest route when a guard starts another navigation', () => {
+        const r = new Router();
+        const navFn = vi.fn();
+        r.addRoute('/old', () => 'Old', undefined, {
+            beforeEnter: () => {
+                r.push('/new');
+                return true;
+            },
+        });
+        r.addRoute('/new', () => 'New');
+        r.events.on('navigate', navFn);
+
+        r.push('/old');
+
+        expect(r.currentPath).toBe('/new');
+        expect(r.current?.route.path).toBe('/new');
+        expect(navFn).toHaveBeenCalledTimes(1);
+        expect(navFn.mock.calls[0][0].match.route.path).toBe('/new');
+    });
+
+    it('passes abortable navigation context to guards and afterEnter hooks', () => {
+        const r = new Router();
+        const guard = vi.fn().mockReturnValue(true);
+        const after = vi.fn();
+        r.addRoute('/a', () => 'A', undefined, { beforeEnter: guard, afterEnter: after });
+
+        r.push('/a');
+
+        expect(guard.mock.calls[0][1]).toMatchObject({ id: 1 });
+        expect(guard.mock.calls[0][1].signal.aborted).toBe(false);
+        expect(after.mock.calls[0][1].isStale()).toBe(false);
     });
 
     it('initialPath sets current match once a matching route is registered', () => {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -4,7 +4,7 @@
 
 import { EventEmitter } from '@termuijs/core';
 import { createElement, ErrorBoundary, unmountAll, type VNode, getCurrentApp } from '@termuijs/jsx';
-import { type Route, type RouteMatch, type RouteParams, type RouteMeta, type QueryParams, type RedirectTarget, matchRoute, compilePattern, serializeQuery } from './route.js';
+import { type NavigationGuardContext, type Route, type RouteMatch, type RouteParams, type RouteMeta, type QueryParams, type RedirectTarget, matchRoute, compilePattern, serializeQuery } from './route.js';
 import { RouterContext } from './hooks.js';
 
 function defaultErrorScreen(err: Error): VNode {
@@ -22,6 +22,7 @@ export interface NavigateEvent {
     match: RouteMatch;
     screen: VNode;
     direction?: 'push' | 'replace' | 'back' | 'forward';
+    navigation: NavigationGuardContext;
 }
 
 export interface RouterEvents {
@@ -47,6 +48,9 @@ export class Router {
     private _maxHistory: number;
     private _notFound?: (path: string) => VNode;
     private _pendingInitialPath: string | null = null;
+    private _navigationId = 0;
+    private _activeNavigationId = 0;
+    private _activeNavigationController: AbortController | null = null;
     public autoUnmount = true;
     readonly events = new EventEmitter<RouterEvents>();
 
@@ -226,9 +230,24 @@ export class Router {
         return path;
     }
 
-    private _runBeforeEnterGuards(match: RouteMatch, path: string): boolean | string {
+    private _beginNavigation(): NavigationGuardContext {
+        this._activeNavigationController?.abort();
+        const controller = new AbortController();
+        const id = ++this._navigationId;
+        this._activeNavigationId = id;
+        this._activeNavigationController = controller;
+
+        return {
+            id,
+            signal: controller.signal,
+            isStale: () => this._activeNavigationId !== id || controller.signal.aborted,
+        };
+    }
+
+    private _runBeforeEnterGuards(match: RouteMatch, path: string, navigation: NavigationGuardContext): boolean | string {
         for (const route of match.chain) {
-            const result = route.beforeEnter?.(path);
+            const result = route.beforeEnter?.(path, navigation);
+            if (navigation.isStale()) return false;
             if (result === false || typeof result === 'string') {
                 return result;
             }
@@ -246,12 +265,16 @@ export class Router {
             modifyHistory?: 'push' | 'replace' | 'none';
             clearForwardStack?: boolean;
             direction?: 'push' | 'replace' | 'back' | 'forward';
+            navigation?: NavigationGuardContext;
         } = {},
     ): void {
+        const navigation = options.navigation ?? this._beginNavigation();
         const resolvedPath = this._resolveRedirect(path);
+        if (navigation.isStale()) return;
         if (!resolvedPath) return;
 
         const match = matchRoute(resolvedPath, this._routes);
+        if (navigation.isStale()) return;
 
         if (!match) {
             if (this._notFound) {
@@ -282,7 +305,8 @@ export class Router {
                 if (this.autoUnmount) unmountAll();
                 const screen = this.wrapScreen(notFoundMatch);
                 const emitEvent = direction === 'back' ? 'back' : 'navigate';
-                this.events.emit(emitEvent, { match: notFoundMatch, screen, direction });
+                if (navigation.isStale()) return;
+                this.events.emit(emitEvent, { match: notFoundMatch, screen, direction, navigation });
                 return;
             }
 
@@ -294,14 +318,15 @@ export class Router {
             this._forwardStack = [];
         }
 
-        const guardResult = this._runBeforeEnterGuards(match, resolvedPath);
+        const guardResult = this._runBeforeEnterGuards(match, resolvedPath, navigation);
+        if (navigation.isStale()) return;
 
         if (guardResult === false) {
             return;
         }
 
         if (typeof guardResult === 'string') {
-            this._executeNavigation(guardResult, { ...options, clearForwardStack: false });
+            this._executeNavigation(guardResult, { ...options, clearForwardStack: false, navigation });
             return;
         }
 
@@ -328,9 +353,10 @@ export class Router {
         const screen = this.wrapScreen(match);
 
         const emitEvent = direction === 'back' ? 'back' : 'navigate';
-        this.events.emit(emitEvent, { match, screen, direction });
+        if (navigation.isStale()) return;
+        this.events.emit(emitEvent, { match, screen, direction, navigation });
 
-        match.route.afterEnter?.(resolvedPath);
+        match.route.afterEnter?.(resolvedPath, navigation);
     }
 
     private _applyInitialPathIfPending(): void {
@@ -366,6 +392,7 @@ export class Router {
 
         const prevPath = this._history[this._history.length - 2];
         const match = prevPath ? matchRoute(prevPath, this._routes) : null;
+        const navigation = this._beginNavigation();
 
         if (!match) {
             if (this._notFound && prevPath) {
@@ -385,7 +412,8 @@ export class Router {
             return;
         }
 
-        const guardResult = this._runBeforeEnterGuards(match, prevPath);
+        const guardResult = this._runBeforeEnterGuards(match, prevPath, navigation);
+        if (navigation.isStale()) return;
 
         if (guardResult === false) {
             return;
@@ -396,7 +424,7 @@ export class Router {
             if (poppedPath) {
                 this._forwardStack.push(poppedPath);
             }
-            this._executeNavigation(guardResult, { clearForwardStack: false, direction: 'back' });
+            this._executeNavigation(guardResult, { clearForwardStack: false, direction: 'back', navigation });
             return;
         }
 
@@ -411,9 +439,10 @@ export class Router {
         if (this.autoUnmount) unmountAll();
         const screen = this.wrapScreen(match);
 
-        this.events.emit('back', { match, screen, direction: 'back' });
+        if (navigation.isStale()) return;
+        this.events.emit('back', { match, screen, direction: 'back', navigation });
 
-        match.route.afterEnter?.(prevPath);
+        match.route.afterEnter?.(prevPath, navigation);
     }
 
     /** Move forward one step with full lifecycle (beforeEnter, afterEnter, redirects) */
@@ -421,6 +450,7 @@ export class Router {
         if (this._forwardStack.length === 0) return;
 
         const nextPath = this._forwardStack[this._forwardStack.length - 1];
+        const navigation = this._beginNavigation();
 
         const match = matchRoute(nextPath, this._routes);
         if (!match) {
@@ -438,7 +468,8 @@ export class Router {
             return;
         }
 
-        const guardResult = this._runBeforeEnterGuards(match, nextPath);
+        const guardResult = this._runBeforeEnterGuards(match, nextPath, navigation);
+        if (navigation.isStale()) return;
 
         if (guardResult === false) {
             return;
@@ -450,6 +481,7 @@ export class Router {
                 modifyHistory: 'push',
                 clearForwardStack: false,
                 direction: 'forward',
+                navigation,
             });
             return;
         }
@@ -461,9 +493,10 @@ export class Router {
         if (fwdApp) fwdApp.focus.clearFocus();
         if (this.autoUnmount) unmountAll();
         const screen = this.wrapScreen(match);
-        this.events.emit('navigate', { match, screen, direction: 'forward' });
+        if (navigation.isStale()) return;
+        this.events.emit('navigate', { match, screen, direction: 'forward', navigation });
 
-        match.route.afterEnter?.(nextPath);
+        match.route.afterEnter?.(nextPath, navigation);
     }
 
     /** Move delta steps: negative is back, positive is forward */
@@ -540,5 +573,11 @@ export class Router {
     /** All registered routes */
     get routes(): Route[] {
         return [...this._routes];
+    }
+
+    cancelPendingNavigation(): void {
+        this._activeNavigationController?.abort();
+        this._activeNavigationController = null;
+        this._activeNavigationId = ++this._navigationId;
     }
 }


### PR DESCRIPTION
Summary
- Add navigation IDs and abort signals to router transitions.
- Prevent stale guard-driven navigations from committing after a newer transition starts.
- Expose cancelPendingNavigation for callers that need to stop an in-flight transition.

Validation
- npx.cmd vitest run packages/router/src/router.test.ts packages/router/src/redirect.test.ts packages/router/src/hooks.test.ts

Closes #2902
