### PR TITLE
docs(jsx): document useKeymap duplicate-key dev warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ function App() {
 }
 ```
 
+Bindings across multiple `useKeymap` calls in the same component are additive, so it's possible to accidentally register the same key twice. In development, `useKeymap` detects this and logs a `console.warn` naming the key instead of silently letting the later registration win — see the [`@termuijs/jsx` README](./packages/jsx#usekeymap) for details.
+
 ### Focus management
 
 Four hooks for building keyboard-accessible interfaces:

--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -90,6 +90,19 @@ function App() {
 
 Modifier syntax: `ctrl+`, `alt+`, `shift+`, `meta+`. Combine them: `ctrl+shift+k`.
 
+**Duplicate keys:** because bindings across calls are additive, it's possible to accidentally register the same key twice (e.g. from two different hooks or conditionals). In non-production builds, `useKeymap` detects this — both within a single call and across multiple calls in the same component — and logs a `console.warn` naming the colliding key, since the second registration silently wins otherwise:
+
+\`\`\`tsx
+useKeymap([{ key: '/', action: () => openSearch() }])
+
+// Registered elsewhere in the same component, same key:
+useKeymap([{ key: '/', action: () => openFilter() }])
+// console.warn: [useKeymap] Duplicate keymap binding: "/|false|false|false"
+// registered more than once in the same component. Last registration wins.
+\`\`\`
+
+This is a warning, not an error — the app keeps running with the last handler active — but it flags the collision instead of leaving the first handler as silent dead code.
+
 ## useMotion
 
 Read the user's motion preference before starting animations.

--- a/packages/jsx/src/hooks.ts
+++ b/packages/jsx/src/hooks.ts
@@ -330,9 +330,11 @@ export interface KeyBinding {
 }
 
 /**
- * useKeymap — declarative keybindings with optional conflict detection.
+ * useKeymap — declarative keybindings with automatic duplicate-key detection.
  *
- * Supports multiple calls per component — handlers are chained via prevOnInput.
+ * Supports multiple calls per component — bindings are additive, and handlers
+ * are chained via prevOnInput. The most recently registered handler for a key
+ * wins if the same key is bound more than once.
  *
  * ```tsx
  * useKeymap([
@@ -340,6 +342,23 @@ export interface KeyBinding {
  *     { key: 'r', ctrl: true, action: refresh, description: 'Refresh' },
  * ]);
  * ```
+ *
+ * In non-production builds, registering the same key twice — whether inside a
+ * single `useKeymap` call or across multiple calls in the same component —
+ * logs a `console.warn` so the collision isn't silent:
+ *
+ * ```tsx
+ * useKeymap([{ key: '/', action: () => openSearch() }]);
+ * useKeymap([{ key: '/', action: () => openFilter() }]);
+ * // [useKeymap] Duplicate keymap binding: "/|false|false|false" registered
+ * // more than once in the same component. Last registration wins.
+ * ```
+ *
+ * This check runs once per render (state is reset in `setCurrentFiber`), so it
+ * flags real same-render collisions without accumulating stale warnings across
+ * re-renders. It is a `console.warn`, not a thrown error — the last binding
+ * still wins at runtime, this only makes the overwrite visible during
+ * development.
  */
 export function useKeymap(bindings: KeyBinding[]): void {
     const fiber = currentFiber();


### PR DESCRIPTION
Closes #2729

## Context
Issue #2729 reports that the README says multiple `useKeymap` calls in
one component are additive, but there's no warning when two calls
register the same key — leaving one handler silently dead.

## What I found
Digging into `packages/jsx/src/hooks.ts`, this detection **already
exists** — it was added in #1830. `useKeymap` tracks bindings per
render via `fiber._keymapKeys` and logs a `console.warn` in
non-production builds whenever a key collides, both within a single
call and across multiple calls in the same component. There's also
existing test coverage in `hooks.test.ts` for this exact behavior.

So the runtime behavior in #2729 is not actually missing — what's
missing is that **none of the docs mention it**. The README's
"additive" claim with no follow-up about collisions is exactly the gap
the issue is describing.

## What this PR changes (docs only, no logic changes)
- `packages/jsx/src/hooks.ts`: expanded the `useKeymap` JSDoc to
  describe the duplicate-key warning and show the exact console.warn
  message format.
- `packages/jsx/README.md`: added a "Duplicate keys" section under
  `useKeymap` with a runnable example.
- `README.md`: added a short pointer from the root useKeymap section
  to the detailed explanation.

## Testing
Docs-only change — no runtime code touched. Existing tests in
`packages/jsx/src/hooks.test.ts`
(`describe('useKeymap — cross-call duplicate detection (dev-mode)')`)
already cover the warning behavior being documented here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented that multiple keymap declarations are additive.
  * Added guidance about duplicate key bindings and development-time console warnings.
  * Clarified that the latest registration takes precedence while the application continues running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->