### PR TITLE
Add context selector subscriptions

### DIFF
--- a/packages/jsx/src/context.test.ts
+++ b/packages/jsx/src/context.test.ts
@@ -2,10 +2,10 @@
 // Tests — Context API (createContext / useContext)
 // ─────────────────────────────────────────────────────
 
-import { describe, it, expect, beforeEach } from 'vitest';
-import { createContext, useContext } from './context.js';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createContext, useContext, useContextSelector } from './context.js';
 import {
-    createFiber, setCurrentFiber, clearCurrentFiber,
+    createFiber, setCurrentFiber, clearCurrentFiber, setRequestRender,
     type Fiber,
 } from './hooks.js';
 
@@ -32,6 +32,7 @@ describe('useContext', () => {
     });
 
     afterEach(() => {
+        setRequestRender(null);
         clearCurrentFiber();
     });
 
@@ -103,6 +104,38 @@ describe('useContext', () => {
         ctx.Provider({ value: 'custom', children: undefined as any });
 
         expect(fiber.contextValues.get(ctx._id)).toBe('custom');
+    });
+
+    it('useContextSelector returns a selected value', () => {
+        const ctx = createContext({ count: 0, label: 'idle' });
+        fiber.contextValues.set(ctx._id, { count: 2, label: 'ready' });
+
+        expect(useContextSelector(ctx, value => value.label)).toBe('ready');
+    });
+
+    it('selector subscriptions skip updates when the selected value is unchanged', async () => {
+        const ctx = createContext({ count: 0, label: 'idle' });
+        const provider = createFiber();
+        const consumer = createFiber(provider);
+        const render = vi.fn();
+        setRequestRender(render);
+
+        setCurrentFiber(provider);
+        ctx.Provider({ value: { count: 0, label: 'idle' }, children: undefined as any });
+
+        setCurrentFiber(consumer);
+        expect(useContextSelector(ctx, value => value.count)).toBe(0);
+
+        setCurrentFiber(provider);
+        ctx.Provider({ value: { count: 0, label: 'busy' }, children: undefined as any });
+        await Promise.resolve();
+
+        expect(render).not.toHaveBeenCalled();
+
+        ctx.Provider({ value: { count: 1, label: 'busy' }, children: undefined as any });
+        await Promise.resolve();
+
+        expect(render).toHaveBeenCalledOnce();
     });
 });
 

--- a/packages/jsx/src/context.test.ts
+++ b/packages/jsx/src/context.test.ts
@@ -137,6 +137,21 @@ describe('useContext', () => {
 
         expect(render).toHaveBeenCalledOnce();
     });
+
+    it('reuses selector subscriptions for the same fiber across renders', () => {
+        const ctx = createContext({ count: 0 });
+        const provider = createFiber();
+        const consumer = createFiber(provider);
+
+        setCurrentFiber(provider);
+        ctx.Provider({ value: { count: 0 }, children: undefined as any });
+
+        setCurrentFiber(consumer);
+        expect(useContextSelector(ctx, value => value.count)).toBe(0);
+        expect(useContextSelector(ctx, value => value.count)).toBe(0);
+
+        expect(provider.contextSubscribers?.get(ctx._id)?.size).toBe(1);
+    });
 });
 
 // Need afterEach import

--- a/packages/jsx/src/context.ts
+++ b/packages/jsx/src/context.ts
@@ -98,8 +98,9 @@ function subscribeToContext<T, S>(
         provider.contextSubscribers.set(id, subs);
     }
 
-    const existing = [...subs].find(sub => sub.fiber === consumer && sub.selector === selector);
+    const existing = [...subs].find(sub => sub.fiber === consumer);
     if (existing) {
+        existing.selector = selector;
         existing.selectedValue = selectedValue;
         existing.equalityFn = equalityFn as ContextEqualityFn<any> | undefined;
         return;

--- a/packages/jsx/src/context.ts
+++ b/packages/jsx/src/context.ts
@@ -1,121 +1,120 @@
-// ─────────────────────────────────────────────────────
-// @termuijs/jsx — Context API
-//
-// React-style context for sharing state down the
-// component tree without prop drilling.
-//
-// Usage:
-//   const ThemeCtx = createContext(defaultTheme);
-//
-//   function App() {
-//       return (
-//           <ThemeCtx.Provider value={darkTheme}>
-//               <Dashboard />
-//           </ThemeCtx.Provider>
-//       );
-//   }
-//
-//   function StatusBar() {
-//       const theme = useContext(ThemeCtx);
-//   }
-// ─────────────────────────────────────────────────────
-
-import { currentFiber, scheduleRender, type Fiber } from './hooks.js';
+import { currentFiber, scheduleRender, type ContextSubscription, type Fiber } from './hooks.js';
 import type { VNode, FC } from './vnode.js';
 
-// ── Context ──
-
-/**
- * A Context object created by `createContext()`.
- * Contains a Provider component and the default value.
- */
 export interface Context<T> {
-    /** Internal symbol — used to look up the value in the fiber tree */
     readonly _id: symbol;
-    /** Provider component — wrap your tree to supply a value */
     readonly Provider: FC<{ value: T; children?: VNode | VNode[] }>;
-    /** The default value returned when no Provider is found */
     readonly defaultValue: T;
 }
 
-/**
- * Create a new context with a default value.
- *
- * ```tsx
- * const ThemeContext = createContext({ bg: 'black', fg: 'white' });
- * ```
- */
+export type ContextSelector<T, S> = (value: T) => S;
+export type ContextEqualityFn<S> = (a: S, b: S) => boolean;
+
 export function createContext<T>(defaultValue: T): Context<T> {
     const id = Symbol('context');
 
-    // The Provider is a functional component that stores
-    // the value on the current fiber's contextValues map.
-    // It renders its children transparently.
     const Provider: FC<{ value: T; children?: VNode | VNode[] }> = ({ value, children }) => {
         const fiber = currentFiber();
         const oldValue = fiber.contextValues.get(id);
         const hasOldValue = fiber.contextValues.has(id);
         fiber.contextValues.set(id, value);
 
-        // If value changed, trigger render on all subscribers
         if (hasOldValue && !Object.is(oldValue, value)) {
             const subs = fiber.contextSubscribers?.get(id);
             if (subs) {
                 for (const sub of subs) {
-                    scheduleRender(sub);
+                    if (!sub.selector) {
+                        scheduleRender(sub.fiber);
+                        continue;
+                    }
+
+                    const nextSelected = sub.selector(value);
+                    const equal = sub.equalityFn ?? Object.is;
+                    if (!equal(sub.selectedValue, nextSelected)) {
+                        sub.selectedValue = nextSelected;
+                        scheduleRender(sub.fiber);
+                    }
                 }
             }
         }
 
-        // Return children as-is (single child or fragment)
         if (Array.isArray(children)) {
             return { type: Symbol.for('termui.fragment'), children } as any;
         }
         return (children ?? null) as VNode;
     };
 
-    // Tag the Provider so reconciler knows it's special
     (Provider as any).displayName = 'Context.Provider';
 
     return Object.freeze({ _id: id, Provider, defaultValue });
 }
 
-/**
- * Consume a context value from the nearest Provider ancestor.
- * If no Provider is found, returns the default value.
- *
- * ```tsx
- * function StatusBar() {
- *     const theme = useContext(ThemeContext);
- *     return <Text color={theme.fg}>{theme.label}</Text>;
- * }
- * ```
- */
 export function useContext<T>(context: Context<T>): T {
+    return readContext(context, value => value, undefined, false);
+}
+
+export function useContextSelector<T, S>(
+    context: Context<T>,
+    selector: ContextSelector<T, S>,
+    equalityFn: ContextEqualityFn<S> = Object.is,
+): S {
+    return readContext(context, selector, equalityFn, true);
+}
+
+function readContext<T, S>(
+    context: Context<T>,
+    selector: ContextSelector<T, S>,
+    equalityFn: ContextEqualityFn<S> | undefined,
+    selected: boolean,
+): S {
     const fiber = currentFiber();
 
-    // Walk up the fiber tree to find the nearest Provider
     let current: Fiber | undefined = fiber;
     while (current) {
         if (current.contextValues.has(context._id)) {
-            // Track subscription for re-renders
-            if (!current.contextSubscribers) current.contextSubscribers = new Map();
-            let subs = current.contextSubscribers.get(context._id);
-            if (!subs) {
-                subs = new Set();
-                current.contextSubscribers.set(context._id, subs);
-            }
-            subs.add(fiber);
-            
-            // Register dependency on consumer fiber for teardown
-            if (!fiber.contextDependencies) fiber.contextDependencies = new Set();
-            fiber.contextDependencies.add(subs);
-
-            return current.contextValues.get(context._id) as T;
+            const value = current.contextValues.get(context._id) as T;
+            const selectedValue = selector(value);
+            subscribeToContext(current, context._id, fiber, selected ? selector : undefined, selectedValue, equalityFn);
+            return selectedValue;
         }
         current = current.parent;
     }
 
-    // No Provider found — return default
-    return context.defaultValue;
+    return selector(context.defaultValue);
+}
+
+function subscribeToContext<T, S>(
+    provider: Fiber,
+    id: symbol,
+    consumer: Fiber,
+    selector: ContextSelector<T, S> | undefined,
+    selectedValue: S,
+    equalityFn: ContextEqualityFn<S> | undefined,
+): void {
+    if (!provider.contextSubscribers) provider.contextSubscribers = new Map();
+    let subs = provider.contextSubscribers.get(id);
+    if (!subs) {
+        subs = new Set();
+        provider.contextSubscribers.set(id, subs);
+    }
+
+    const existing = [...subs].find(sub => sub.fiber === consumer && sub.selector === selector);
+    if (existing) {
+        existing.selectedValue = selectedValue;
+        existing.equalityFn = equalityFn as ContextEqualityFn<any> | undefined;
+        return;
+    }
+
+    const subscription: ContextSubscription = {
+        fiber: consumer,
+        providerSubscribers: subs,
+        selector,
+        selectedValue,
+        equalityFn: equalityFn as ContextEqualityFn<any> | undefined,
+    };
+
+    subs.add(subscription);
+
+    if (!consumer.contextDependencies) consumer.contextDependencies = new Set();
+    consumer.contextDependencies.add(subscription);
 }

--- a/packages/jsx/src/hooks.ts
+++ b/packages/jsx/src/hooks.ts
@@ -20,6 +20,14 @@ export interface ChildFiberEntry {
     component: FC<any>;
 }
 
+export interface ContextSubscription {
+    fiber: Fiber;
+    providerSubscribers: Set<ContextSubscription>;
+    selector?: (value: any) => any;
+    selectedValue?: any;
+    equalityFn?: (a: any, b: any) => boolean;
+}
+
 export interface Fiber {
     id: number;
     hooks: HookState[];
@@ -32,8 +40,8 @@ export interface Fiber {
     intervals: ReturnType<typeof setInterval>[];
     /** Context values provided by this fiber's component */
     contextValues: Map<symbol, any>;
-    contextSubscribers?: Map<symbol, Set<Fiber>>;
-    contextDependencies?: Set<Set<Fiber>>;
+    contextSubscribers?: Map<symbol, Set<ContextSubscription>>;
+    contextDependencies?: Set<ContextSubscription>;
     /** Parent fiber for context lookup */
     parent?: Fiber;
     // ── ErrorBoundary fields ──
@@ -669,8 +677,8 @@ export function destroyFiber(fiber: Fiber): void {
     fiber.contextValues.clear();
     
     if (fiber.contextDependencies) {
-        for (const subs of fiber.contextDependencies) {
-            subs.delete(fiber);
+        for (const sub of fiber.contextDependencies) {
+            sub.providerSubscribers.delete(sub);
         }
         fiber.contextDependencies.clear();
     }

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -54,8 +54,8 @@ export type { SuspenseProps } from './Suspense.js';
 export { lazy } from './lazy.js';
 
 // ── Context ──
-export { createContext, useContext } from './context.js';
-export type { Context } from './context.js';
+export { createContext, useContext, useContextSelector } from './context.js';
+export type { Context, ContextEqualityFn, ContextSelector } from './context.js';
 
 // ── Memoization ──
 export { memo } from './memo.js';


### PR DESCRIPTION
Summary
- Add useContextSelector with optional equality comparison.
- Store context subscriptions with selector metadata so provider updates only schedule affected consumers.
- Update fiber teardown to remove selector subscription records cleanly.

Validation
- npx.cmd vitest run packages/jsx/src/context.test.ts packages/jsx/src/reconciler.test.ts

Closes #2903
