### PR TITLE
Add typed theme token compiler

### DIFF
--- a/packages/tss/src/index.ts
+++ b/packages/tss/src/index.ts
@@ -30,6 +30,7 @@ export type {
   CompiledThemeTokens,
   ThemeTokenCompileOptions,
   ThemeTokenDiagnostic,
+  ThemeTokenInput,
   ThemeTokenName,
 } from './token-compiler.js';
 

--- a/packages/tss/src/index.ts
+++ b/packages/tss/src/index.ts
@@ -25,6 +25,13 @@ export { BUILTIN_THEMES, getBuiltinThemeNames, getBuiltinTheme, getAllBuiltinThe
 // Design Tokens
 export { systemTheme, defaultDark, defaultLight, detectDark, tokensToTSS } from './tokens.js';
 export type { ThemeTokens } from './tokens.js';
+export { compileThemeTokens, validateThemeTokens } from './token-compiler.js';
+export type {
+  CompiledThemeTokens,
+  ThemeTokenCompileOptions,
+  ThemeTokenDiagnostic,
+  ThemeTokenName,
+} from './token-compiler.js';
 
 // Named ThemeTokens
 export {

--- a/packages/tss/src/token-compiler.test.ts
+++ b/packages/tss/src/token-compiler.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { compileThemeTokens, validateThemeTokens } from './token-compiler.js';
+import { defaultDark } from './tokens.js';
+
+describe('compileThemeTokens', () => {
+    it('compiles typed tokens into variables and a stable @theme block', () => {
+        const compiled = compileThemeTokens(defaultDark, { name: 'terminal-dark' });
+
+        expect(compiled.name).toBe('terminal-dark');
+        expect(compiled.variables['--primary']).toBe(defaultDark.primary);
+        expect(compiled.tss).toContain('@theme terminal-dark');
+        expect(compiled.tss.split('\n')[1]).toBe(`  --bg: ${defaultDark.bg};`);
+    });
+
+    it('resolves aliases before validation and output', () => {
+        const compiled = compileThemeTokens(
+            { ...defaultDark, background: '#101010' },
+            { name: 'aliased', aliases: { background: 'bg' }, allowExtraTokens: true },
+        );
+
+        expect(compiled.tokens.bg).toBe('#101010');
+        expect(compiled.variables['--bg']).toBe('#101010');
+    });
+
+    it('throws readable diagnostics for invalid token input', () => {
+        expect(() => compileThemeTokens({ bg: '#000' }, { name: 'bad' }))
+            .toThrow(/Missing required theme token: fg/);
+    });
+});
+
+describe('validateThemeTokens', () => {
+    it('reports unknown tokens unless extras are allowed', () => {
+        const diagnostics = validateThemeTokens({ ...defaultDark, card: '#111111' });
+        expect(diagnostics.some(diagnostic => diagnostic.code === 'unknown-token')).toBe(true);
+
+        const filtered = validateThemeTokens({ ...defaultDark, card: '#111111' }, { allowExtraTokens: true });
+        expect(filtered.some(diagnostic => diagnostic.code === 'unknown-token')).toBe(false);
+    });
+});

--- a/packages/tss/src/token-compiler.test.ts
+++ b/packages/tss/src/token-compiler.test.ts
@@ -22,6 +22,23 @@ describe('compileThemeTokens', () => {
         expect(compiled.variables['--bg']).toBe('#101010');
     });
 
+    it('resolves nested semantic and component aliases', () => {
+        const compiled = compileThemeTokens(
+            { ...defaultDark, buttonBackground: '#181818' },
+            {
+                name: 'semantic-chain',
+                aliases: {
+                    buttonBackground: 'surface',
+                    surface: 'bg',
+                },
+                allowExtraTokens: true,
+            },
+        );
+
+        expect(compiled.tokens.bg).toBe('#181818');
+        expect(compiled.variables['--bg']).toBe('#181818');
+    });
+
     it('throws readable diagnostics for invalid token input', () => {
         expect(() => compileThemeTokens({ bg: '#000' }, { name: 'bad' }))
             .toThrow(/Missing required theme token: fg/);
@@ -43,5 +60,20 @@ describe('validateThemeTokens', () => {
         });
 
         expect(diagnostics.some(diagnostic => diagnostic.code === 'invalid-alias')).toBe(true);
+    });
+
+    it('reports circular aliases with the full cycle path', () => {
+        const diagnostics = validateThemeTokens(defaultDark, {
+            aliases: {
+                surface: 'panel',
+                panel: 'surface',
+            },
+        });
+
+        expect(diagnostics).toContainEqual({
+            code: 'circular-alias',
+            token: 'surface',
+            message: 'Circular alias detected: surface -> panel -> surface',
+        });
     });
 });

--- a/packages/tss/src/token-compiler.test.ts
+++ b/packages/tss/src/token-compiler.test.ts
@@ -36,4 +36,12 @@ describe('validateThemeTokens', () => {
         const filtered = validateThemeTokens({ ...defaultDark, card: '#111111' }, { allowExtraTokens: true });
         expect(filtered.some(diagnostic => diagnostic.code === 'unknown-token')).toBe(false);
     });
+
+    it('reports aliases without a valid target', () => {
+        const diagnostics = validateThemeTokens(defaultDark, {
+            aliases: { accent: undefined },
+        });
+
+        expect(diagnostics.some(diagnostic => diagnostic.code === 'invalid-alias')).toBe(true);
+    });
 });

--- a/packages/tss/src/token-compiler.ts
+++ b/packages/tss/src/token-compiler.ts
@@ -5,7 +5,7 @@ export type ThemeTokenInput = ThemeTokens | Record<string, string | undefined>;
 
 export interface ThemeTokenCompileOptions {
     name: string;
-    aliases?: Partial<Record<string, ThemeTokenName>>;
+    aliases?: Partial<Record<string, string | undefined>>;
     allowExtraTokens?: boolean;
 }
 
@@ -17,7 +17,7 @@ export interface CompiledThemeTokens {
 }
 
 export interface ThemeTokenDiagnostic {
-    code: 'missing-token' | 'unknown-token' | 'invalid-alias';
+    code: 'missing-token' | 'unknown-token' | 'invalid-alias' | 'circular-alias';
     token: string;
     message: string;
 }
@@ -35,12 +35,15 @@ const REQUIRED_TOKENS: ThemeTokenName[] = [
     'highlight',
 ];
 
+const REQUIRED_TOKEN_SET = new Set<string>(REQUIRED_TOKENS);
+
 export function validateThemeTokens(
     input: ThemeTokenInput,
     options: Pick<ThemeTokenCompileOptions, 'aliases' | 'allowExtraTokens'> = {},
 ): ThemeTokenDiagnostic[] {
     const diagnostics: ThemeTokenDiagnostic[] = [];
-    const normalized = normalizeTokenKeys(input, options.aliases ?? {});
+    const aliases = options.aliases ?? {};
+    const normalized = normalizeTokenKeys(input, aliases);
 
     for (const key of REQUIRED_TOKENS) {
         if (!normalized[key]) {
@@ -53,8 +56,8 @@ export function validateThemeTokens(
     }
 
     for (const key of Object.keys(input)) {
-        const mapped = options.aliases?.[key] ?? key;
-        if (!REQUIRED_TOKENS.includes(mapped as ThemeTokenName)) {
+        const resolved = resolveTokenName(key, aliases);
+        if (!resolved.token) {
             diagnostics.push({
                 code: 'unknown-token',
                 token: key,
@@ -63,12 +66,21 @@ export function validateThemeTokens(
         }
     }
 
-    for (const [alias, target] of Object.entries(options.aliases ?? {})) {
-        if (!target || !REQUIRED_TOKENS.includes(target)) {
+    for (const alias of Object.keys(aliases)) {
+        const resolved = resolveTokenName(alias, aliases);
+        if (resolved.cycle) {
+            diagnostics.push({
+                code: 'circular-alias',
+                token: alias,
+                message: `Circular alias detected: ${resolved.cycle.join(' -> ')}`,
+            });
+            continue;
+        }
+        if (!resolved.token) {
             diagnostics.push({
                 code: 'invalid-alias',
                 token: alias,
-                message: `Alias ${alias} points to an unknown token: ${target}`,
+                message: `Alias ${alias} points to an unknown token: ${resolved.invalidTarget}`,
             });
         }
     }
@@ -87,10 +99,31 @@ export function compileThemeTokens(
         throw new Error(diagnostics.map(diagnostic => diagnostic.message).join('\n'));
     }
 
-    const tokens = normalizeTokenKeys(input, options.aliases ?? {}) as ThemeTokens;
-    const variables = Object.fromEntries(
-        REQUIRED_TOKENS.map(token => [`--${token}`, tokens[token]]),
-    ) as Record<`--${ThemeTokenName}`, string>;
+    const normalized = normalizeTokenKeys(input, options.aliases ?? {});
+    const tokens: ThemeTokens = {
+        bg: requireToken(normalized, 'bg'),
+        fg: requireToken(normalized, 'fg'),
+        primary: requireToken(normalized, 'primary'),
+        secondary: requireToken(normalized, 'secondary'),
+        success: requireToken(normalized, 'success'),
+        warning: requireToken(normalized, 'warning'),
+        error: requireToken(normalized, 'error'),
+        muted: requireToken(normalized, 'muted'),
+        border: requireToken(normalized, 'border'),
+        highlight: requireToken(normalized, 'highlight'),
+    };
+    const variables: CompiledThemeTokens['variables'] = {
+        '--bg': tokens.bg,
+        '--fg': tokens.fg,
+        '--primary': tokens.primary,
+        '--secondary': tokens.secondary,
+        '--success': tokens.success,
+        '--warning': tokens.warning,
+        '--error': tokens.error,
+        '--muted': tokens.muted,
+        '--border': tokens.border,
+        '--highlight': tokens.highlight,
+    };
     const tss = `@theme ${options.name} {\n` +
         REQUIRED_TOKENS.map(token => `  --${token}: ${tokens[token]};`).join('\n') +
         '\n}';
@@ -105,15 +138,47 @@ export function compileThemeTokens(
 
 function normalizeTokenKeys(
     input: ThemeTokenInput,
-    aliases: Partial<Record<string, ThemeTokenName>>,
+    aliases: Partial<Record<string, string | undefined>>,
 ): Partial<ThemeTokens> {
     const output: Partial<ThemeTokens> = {};
     for (const [key, value] of Object.entries(input)) {
         if (value === undefined) continue;
-        const mapped = aliases[key] ?? key;
-        if (REQUIRED_TOKENS.includes(mapped as ThemeTokenName)) {
-            output[mapped as ThemeTokenName] = value;
+        const mapped = resolveTokenName(key, aliases).token;
+        if (mapped) {
+            output[mapped] = value;
         }
     }
     return output;
+}
+
+function isThemeTokenName(value: string | undefined): value is ThemeTokenName {
+    return typeof value === 'string' && REQUIRED_TOKEN_SET.has(value);
+}
+
+function resolveTokenName(
+    name: string,
+    aliases: Partial<Record<string, string | undefined>>,
+    path: string[] = [],
+): { token?: ThemeTokenName; invalidTarget?: string; cycle?: string[] } {
+    if (path.includes(name)) {
+        return { cycle: [...path.slice(path.indexOf(name)), name] };
+    }
+
+    const hasAlias = Object.prototype.hasOwnProperty.call(aliases, name);
+    const target = hasAlias ? aliases[name] : name;
+    if (isThemeTokenName(target)) {
+        return { token: target };
+    }
+    if (!target || !Object.prototype.hasOwnProperty.call(aliases, target)) {
+        return { invalidTarget: String(target) };
+    }
+    return resolveTokenName(target, aliases, [...path, name]);
+}
+
+function requireToken(tokens: Partial<ThemeTokens>, name: ThemeTokenName): string {
+    const value = tokens[name];
+    if (!value) {
+        throw new Error(`Missing required theme token: ${name}`);
+    }
+    return value;
 }

--- a/packages/tss/src/token-compiler.ts
+++ b/packages/tss/src/token-compiler.ts
@@ -1,6 +1,7 @@
 import type { ThemeTokens } from './tokens.js';
 
 export type ThemeTokenName = keyof ThemeTokens;
+export type ThemeTokenInput = ThemeTokens | Record<string, string | undefined>;
 
 export interface ThemeTokenCompileOptions {
     name: string;
@@ -35,7 +36,7 @@ const REQUIRED_TOKENS: ThemeTokenName[] = [
 ];
 
 export function validateThemeTokens(
-    input: Record<string, string>,
+    input: ThemeTokenInput,
     options: Pick<ThemeTokenCompileOptions, 'aliases' | 'allowExtraTokens'> = {},
 ): ThemeTokenDiagnostic[] {
     const diagnostics: ThemeTokenDiagnostic[] = [];
@@ -63,7 +64,7 @@ export function validateThemeTokens(
     }
 
     for (const [alias, target] of Object.entries(options.aliases ?? {})) {
-        if (!REQUIRED_TOKENS.includes(target)) {
+        if (!target || !REQUIRED_TOKENS.includes(target)) {
             diagnostics.push({
                 code: 'invalid-alias',
                 token: alias,
@@ -78,7 +79,7 @@ export function validateThemeTokens(
 }
 
 export function compileThemeTokens(
-    input: Record<string, string>,
+    input: ThemeTokenInput,
     options: ThemeTokenCompileOptions,
 ): CompiledThemeTokens {
     const diagnostics = validateThemeTokens(input, options);
@@ -103,11 +104,12 @@ export function compileThemeTokens(
 }
 
 function normalizeTokenKeys(
-    input: Record<string, string>,
+    input: ThemeTokenInput,
     aliases: Partial<Record<string, ThemeTokenName>>,
 ): Partial<ThemeTokens> {
     const output: Partial<ThemeTokens> = {};
     for (const [key, value] of Object.entries(input)) {
+        if (value === undefined) continue;
         const mapped = aliases[key] ?? key;
         if (REQUIRED_TOKENS.includes(mapped as ThemeTokenName)) {
             output[mapped as ThemeTokenName] = value;

--- a/packages/tss/src/token-compiler.ts
+++ b/packages/tss/src/token-compiler.ts
@@ -1,0 +1,117 @@
+import type { ThemeTokens } from './tokens.js';
+
+export type ThemeTokenName = keyof ThemeTokens;
+
+export interface ThemeTokenCompileOptions {
+    name: string;
+    aliases?: Partial<Record<string, ThemeTokenName>>;
+    allowExtraTokens?: boolean;
+}
+
+export interface CompiledThemeTokens {
+    name: string;
+    tokens: ThemeTokens;
+    variables: Record<`--${ThemeTokenName}`, string>;
+    tss: string;
+}
+
+export interface ThemeTokenDiagnostic {
+    code: 'missing-token' | 'unknown-token' | 'invalid-alias';
+    token: string;
+    message: string;
+}
+
+const REQUIRED_TOKENS: ThemeTokenName[] = [
+    'bg',
+    'fg',
+    'primary',
+    'secondary',
+    'success',
+    'warning',
+    'error',
+    'muted',
+    'border',
+    'highlight',
+];
+
+export function validateThemeTokens(
+    input: Record<string, string>,
+    options: Pick<ThemeTokenCompileOptions, 'aliases' | 'allowExtraTokens'> = {},
+): ThemeTokenDiagnostic[] {
+    const diagnostics: ThemeTokenDiagnostic[] = [];
+    const normalized = normalizeTokenKeys(input, options.aliases ?? {});
+
+    for (const key of REQUIRED_TOKENS) {
+        if (!normalized[key]) {
+            diagnostics.push({
+                code: 'missing-token',
+                token: key,
+                message: `Missing required theme token: ${key}`,
+            });
+        }
+    }
+
+    for (const key of Object.keys(input)) {
+        const mapped = options.aliases?.[key] ?? key;
+        if (!REQUIRED_TOKENS.includes(mapped as ThemeTokenName)) {
+            diagnostics.push({
+                code: 'unknown-token',
+                token: key,
+                message: `Unknown theme token: ${key}`,
+            });
+        }
+    }
+
+    for (const [alias, target] of Object.entries(options.aliases ?? {})) {
+        if (!REQUIRED_TOKENS.includes(target)) {
+            diagnostics.push({
+                code: 'invalid-alias',
+                token: alias,
+                message: `Alias ${alias} points to an unknown token: ${target}`,
+            });
+        }
+    }
+
+    return options.allowExtraTokens
+        ? diagnostics.filter(diagnostic => diagnostic.code !== 'unknown-token')
+        : diagnostics;
+}
+
+export function compileThemeTokens(
+    input: Record<string, string>,
+    options: ThemeTokenCompileOptions,
+): CompiledThemeTokens {
+    const diagnostics = validateThemeTokens(input, options);
+    if (diagnostics.length > 0) {
+        throw new Error(diagnostics.map(diagnostic => diagnostic.message).join('\n'));
+    }
+
+    const tokens = normalizeTokenKeys(input, options.aliases ?? {}) as ThemeTokens;
+    const variables = Object.fromEntries(
+        REQUIRED_TOKENS.map(token => [`--${token}`, tokens[token]]),
+    ) as Record<`--${ThemeTokenName}`, string>;
+    const tss = `@theme ${options.name} {\n` +
+        REQUIRED_TOKENS.map(token => `  --${token}: ${tokens[token]};`).join('\n') +
+        '\n}';
+
+    return {
+        name: options.name,
+        tokens,
+        variables,
+        tss,
+    };
+}
+
+function normalizeTokenKeys(
+    input: Record<string, string>,
+    aliases: Partial<Record<string, ThemeTokenName>>,
+): Partial<ThemeTokens> {
+    const output: Partial<ThemeTokens> = {};
+    for (const [key, value] of Object.entries(input)) {
+        const mapped = aliases[key] ?? key;
+        if (REQUIRED_TOKENS.includes(mapped as ThemeTokenName)) {
+            output[mapped as ThemeTokenName] = value;
+        }
+    }
+    return output;
+}


### PR DESCRIPTION
Summary
- Add a typed theme token compiler with required-token validation.
- Support token aliases, extra-token filtering, deterministic variable output, and readable diagnostics.
- Export compiler types and helpers from the TSS package entrypoint.

Validation
- npx.cmd vitest run packages/tss/src/token-compiler.test.ts packages/tss/src/tokens.test.ts packages/tss/src/index.test.ts

Closes #2904


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added theme token validation and compilation APIs to the public surface.
  - Supports token aliases (including recursive alias resolution), required-token checks, and optional extra-token handling.
  - Generates normalized theme tokens, CSS variables, and `@theme` declarations.
  - Provides expanded diagnostics with new `circular-alias` reporting.

- **Bug Fixes**
  - Invalid theme token configurations now produce more actionable validation errors, including detection and details for alias cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->