### PR TITLE
Add sticky variable-height virtualization

### DIFF
--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -39,8 +39,8 @@ export { Image } from './display/Image.js';
 export type { ImageOptions } from './display/Image.js';
 
 // ── Virtual Scroll Helpers ────────────────────────────
-export { computeRange, computeVariableRange } from './input/virtual-scroll.js';
-export type { ScrollRange } from './input/virtual-scroll.js';
+export { computeRange, computeVariableRange, createVariableHeightVirtualizer } from './input/virtual-scroll.js';
+export type { ScrollRange, VariableRangeOptions } from './input/virtual-scroll.js';
 
 // ── Spring Scroll Helper ─────────────────────────────
 export { calculateSpringScroll } from './scroll.js';

--- a/packages/widgets/src/input/virtual-scroll.test.ts
+++ b/packages/widgets/src/input/virtual-scroll.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeRange, computeVariableRange } from './virtual-scroll.js';
+import { computeRange, computeVariableRange, createVariableHeightVirtualizer } from './virtual-scroll.js';
 
 describe('computeRange', () => {
     it('start=0, end=12 with default overscan=2 at offset 0', () => {
@@ -78,5 +78,30 @@ describe('computeVariableRange', () => {
         // no item visible; startIdx = sizes.length = 3, then max(0,3-2)=1
         // endIdx = sizes.length = 3, +2 = min(3,5)=3
         expect(r.start).toBeLessThanOrEqual(r.end);
+    });
+
+    it('returns total height metadata for variable-height lists', () => {
+        const r = computeVariableRange(0, 10, [3, 4, 5], 0);
+        expect(r.totalPx).toBe(12);
+    });
+
+    it('returns sticky rows outside the visible window', () => {
+        const r = computeVariableRange(20, 5, [5, 5, 5, 5, 5, 5], {
+            overscan: 0,
+            stickyIndices: [0, 4, 99],
+        });
+
+        expect(r.start).toBe(4);
+        expect(r.end).toBe(5);
+        expect(r.sticky).toEqual([0]);
+    });
+
+    it('creates a reusable virtualizer with normalized item sizes', () => {
+        const virtualize = createVariableHeightVirtualizer([5, -2, 10], { overscan: 0, stickyIndices: [0] });
+        const r = virtualize(5, 5);
+
+        expect(r.totalPx).toBe(15);
+        expect(r.start).toBe(2);
+        expect(r.sticky).toEqual([0]);
     });
 });

--- a/packages/widgets/src/input/virtual-scroll.ts
+++ b/packages/widgets/src/input/virtual-scroll.ts
@@ -2,6 +2,13 @@ export interface ScrollRange {
     start: number;    // first item index to render
     end: number;      // one past last item index to render (exclusive)
     offsetPx: number; // scroll offset in pixels (for variable height)
+    totalPx?: number;
+    sticky?: number[];
+}
+
+export interface VariableRangeOptions {
+    overscan?: number;
+    stickyIndices?: number[];
 }
 
 /**
@@ -33,13 +40,17 @@ export function computeVariableRange(
     scrollPx: number,
     viewportPx: number,
     sizes: number[],
-    overscan = 2,
+    overscanOrOptions: number | VariableRangeOptions = 2,
 ): ScrollRange {
+    const options = typeof overscanOrOptions === 'number'
+        ? { overscan: overscanOrOptions }
+        : overscanOrOptions;
+    const overscan = options.overscan ?? 2;
     const cumulative: number[] = [];
     let sum = 0;
     for (const s of sizes) {
         cumulative.push(sum);
-        sum += s;
+        sum += Math.max(0, s);
     }
     cumulative.push(sum); // sentinel
 
@@ -54,5 +65,18 @@ export function computeVariableRange(
     if (endIdx < 0) endIdx = sizes.length;
     endIdx = Math.min(sizes.length, endIdx + overscan);
 
-    return { start: startIdx, end: endIdx, offsetPx: cumulative[startIdx] };
+    const sticky = (options.stickyIndices ?? [])
+        .filter(index => index >= 0 && index < sizes.length)
+        .filter(index => index < startIdx || index >= endIdx)
+        .sort((a, b) => a - b);
+
+    return { start: startIdx, end: endIdx, offsetPx: cumulative[startIdx], totalPx: sum, sticky };
+}
+
+export function createVariableHeightVirtualizer(
+    sizes: number[],
+    options: VariableRangeOptions = {},
+): (scrollPx: number, viewportPx: number) => ScrollRange {
+    const normalizedSizes = sizes.map(size => Math.max(0, size));
+    return (scrollPx, viewportPx) => computeVariableRange(scrollPx, viewportPx, normalizedSizes, options);
 }


### PR DESCRIPTION
Summary
- Extend variable-height range calculation with options for overscan and sticky rows.
- Return total height metadata for scroll container sizing.
- Add a reusable virtualizer factory that normalizes item sizes.

Validation
- npx.cmd vitest run packages/widgets/src/input/virtual-scroll.test.ts packages/widgets/src/input/VirtualList.test.ts

Closes #2905
