### PR TITLE
Add structured event replay sessions

### DIFF
--- a/packages/testing/src/event-replay.test.ts
+++ b/packages/testing/src/event-replay.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ReplaySession } from './event-replay.js';
+
+describe('ReplaySession', () => {
+    it('records structured events in timestamp order', () => {
+        const session = new ReplaySession();
+
+        session.input('enter', 20);
+        session.frame('ready', 5);
+
+        expect(session.snapshot().events.map(event => event.type)).toEqual(['frame', 'input']);
+    });
+
+    it('replays waits and typed events through a driver', async () => {
+        const session = new ReplaySession();
+        const calls: string[] = [];
+
+        session.input('a', 10);
+        session.resize(80, 24, 25);
+        session.frame('done', 30);
+
+        await session.replay({
+            wait: async ms => { calls.push(`wait:${ms}`); },
+            input: async key => { calls.push(`input:${key}`); },
+            resize: async (width, height) => { calls.push(`resize:${width}x${height}`); },
+            frame: async buffer => { calls.push(`frame:${buffer}`); },
+        });
+
+        expect(calls).toEqual([
+            'wait:10',
+            'input:a',
+            'wait:15',
+            'resize:80x24',
+            'wait:5',
+            'frame:done',
+        ]);
+    });
+
+    it('restores sessions from snapshots without sharing event objects', () => {
+        const session = new ReplaySession();
+        session.input('tab', 1);
+
+        const restored = ReplaySession.from(session.snapshot());
+        const snapshot = restored.snapshot();
+        snapshot.events[0].at = 99;
+
+        expect(restored.snapshot().events[0].at).toBe(1);
+    });
+
+    it('supports explicit wait events', async () => {
+        const session = new ReplaySession();
+        const wait = vi.fn();
+        session.wait(50, 0);
+
+        await session.replay({ wait });
+
+        expect(wait).toHaveBeenCalledWith(50);
+    });
+});

--- a/packages/testing/src/event-replay.ts
+++ b/packages/testing/src/event-replay.ts
@@ -1,0 +1,80 @@
+export type ReplayEvent =
+    | { type: 'input'; at: number; key: string }
+    | { type: 'frame'; at: number; buffer: string }
+    | { type: 'resize'; at: number; width: number; height: number }
+    | { type: 'wait'; at: number; ms: number };
+
+export interface ReplayDriver {
+    input?: (key: string) => void | Promise<void>;
+    frame?: (buffer: string) => void | Promise<void>;
+    resize?: (width: number, height: number) => void | Promise<void>;
+    wait?: (ms: number) => void | Promise<void>;
+}
+
+export interface ReplaySessionSnapshot {
+    version: 1;
+    events: ReplayEvent[];
+}
+
+export class ReplaySession {
+    private events: ReplayEvent[] = [];
+    private start = Date.now();
+
+    record(event: Omit<ReplayEvent, 'at'> & { at?: number }): ReplayEvent {
+        const replayEvent = {
+            ...event,
+            at: event.at ?? Date.now() - this.start,
+        } as ReplayEvent;
+        this.events.push(replayEvent);
+        this.events.sort((a, b) => a.at - b.at);
+        return replayEvent;
+    }
+
+    input(key: string, at?: number): ReplayEvent {
+        return this.record({ type: 'input', key, at });
+    }
+
+    frame(buffer: string, at?: number): ReplayEvent {
+        return this.record({ type: 'frame', buffer, at });
+    }
+
+    resize(width: number, height: number, at?: number): ReplayEvent {
+        return this.record({ type: 'resize', width, height, at });
+    }
+
+    wait(ms: number, at?: number): ReplayEvent {
+        return this.record({ type: 'wait', ms, at });
+    }
+
+    snapshot(): ReplaySessionSnapshot {
+        return { version: 1, events: this.events.map(event => ({ ...event })) };
+    }
+
+    clear(): void {
+        this.events = [];
+        this.start = Date.now();
+    }
+
+    async replay(driver: ReplayDriver): Promise<void> {
+        let cursor = 0;
+        for (const event of this.events) {
+            const gap = Math.max(0, event.at - cursor);
+            if (gap > 0) await driver.wait?.(gap);
+            cursor = event.at;
+
+            if (event.type === 'input') await driver.input?.(event.key);
+            if (event.type === 'frame') await driver.frame?.(event.buffer);
+            if (event.type === 'resize') await driver.resize?.(event.width, event.height);
+            if (event.type === 'wait') {
+                await driver.wait?.(event.ms);
+                cursor += event.ms;
+            }
+        }
+    }
+
+    static from(snapshot: ReplaySessionSnapshot): ReplaySession {
+        const session = new ReplaySession();
+        session.events = snapshot.events.map(event => ({ ...event }));
+        return session;
+    }
+}

--- a/packages/testing/src/event-replay.ts
+++ b/packages/testing/src/event-replay.ts
@@ -4,6 +4,12 @@ export type ReplayEvent =
     | { type: 'resize'; at: number; width: number; height: number }
     | { type: 'wait'; at: number; ms: number };
 
+export type ReplayEventInput = ReplayEvent extends infer Event
+    ? Event extends ReplayEvent
+        ? Omit<Event, 'at'> & { at?: number }
+        : never
+    : never;
+
 export interface ReplayDriver {
     input?: (key: string) => void | Promise<void>;
     frame?: (buffer: string) => void | Promise<void>;
@@ -20,7 +26,7 @@ export class ReplaySession {
     private events: ReplayEvent[] = [];
     private start = Date.now();
 
-    record(event: Omit<ReplayEvent, 'at'> & { at?: number }): ReplayEvent {
+    record(event: ReplayEventInput): ReplayEvent {
         const replayEvent = {
             ...event,
             at: event.at ?? Date.now() - this.start,

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -15,3 +15,5 @@ export { getByRole, getByLabel, queryByText } from "./queries.js";
 // ── Screen Recorder ──
 export { ScreenRecorder } from './recorder.js';
 export type { FrameData } from './recorder.js';
+export { ReplaySession } from './event-replay.js';
+export type { ReplayDriver, ReplayEvent, ReplaySessionSnapshot } from './event-replay.js';


### PR DESCRIPTION
Summary
- Add ReplaySession for structured input, frame, resize, and wait events.
- Support deterministic replay through a small driver interface.
- Add snapshot and restore helpers for renderer-session fixtures.

Validation
- npx.cmd vitest run packages/testing/src/event-replay.test.ts packages/testing/src/recorder.test.ts packages/testing/src/index.test.ts

Closes #2906


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event recording and replay capabilities for keyboard input, frames, resizing, and timed waits.
  * Added support for saving, restoring, clearing, and replaying recorded sessions.
  * Exposed the replay session tools through the testing package’s public API.

* **Tests**
  * Added coverage for event ordering, replay timing, callbacks, and session restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->