### PR TITLE
Add module graph invalidation

### DIFF
--- a/packages/dev-server/src/index.ts
+++ b/packages/dev-server/src/index.ts
@@ -9,3 +9,5 @@ export { ErrorOverlay, parseErrorStack } from './error-overlay.js';
 export type { ParsedError } from './error-overlay.js';
 export { WidgetTreeInspector } from './inspector.js';
 export { cleanupActiveInstances } from './cleanup.js';
+export { ModuleGraph } from './module-graph.js';
+export type { ModuleGraphNode, ModuleInvalidationResult } from './module-graph.js';

--- a/packages/dev-server/src/module-graph.test.ts
+++ b/packages/dev-server/src/module-graph.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { ModuleGraph } from './module-graph.js';
+
+describe('ModuleGraph', () => {
+    it('tracks imports and reverse importers', () => {
+        const graph = new ModuleGraph();
+        graph.addModule('app.ts', ['button.ts']);
+
+        expect(graph.get('app.ts')?.imports.has('button.ts')).toBe(true);
+        expect(graph.get('button.ts')?.importers.has('app.ts')).toBe(true);
+    });
+
+    it('invalidates importers until restart boundaries', () => {
+        const graph = new ModuleGraph();
+        graph.addModule('app.ts', ['routes.ts'], { restartBoundary: true });
+        graph.addModule('routes.ts', ['button.ts']);
+        graph.addModule('button.ts');
+
+        const result = graph.invalidate('button.ts');
+
+        expect(result.invalidated).toEqual(['app.ts', 'button.ts', 'routes.ts']);
+        expect(result.restartTargets).toEqual(['app.ts']);
+    });
+
+    it('updates reverse edges when module imports change', () => {
+        const graph = new ModuleGraph();
+        graph.addModule('app.ts', ['a.ts']);
+        graph.addModule('app.ts', ['b.ts']);
+
+        expect(graph.get('a.ts')?.importers.has('app.ts')).toBe(false);
+        expect(graph.get('b.ts')?.importers.has('app.ts')).toBe(true);
+    });
+});

--- a/packages/dev-server/src/module-graph.ts
+++ b/packages/dev-server/src/module-graph.ts
@@ -1,0 +1,82 @@
+export interface ModuleGraphNode {
+    id: string;
+    imports: Set<string>;
+    importers: Set<string>;
+    restartBoundary?: boolean;
+}
+
+export interface ModuleInvalidationResult {
+    changed: string;
+    invalidated: string[];
+    restartTargets: string[];
+}
+
+export class ModuleGraph {
+    private nodes = new Map<string, ModuleGraphNode>();
+
+    addModule(id: string, imports: Iterable<string> = [], options: { restartBoundary?: boolean } = {}): ModuleGraphNode {
+        const node = this.getOrCreate(id);
+        node.restartBoundary = options.restartBoundary ?? node.restartBoundary;
+
+        for (const previous of node.imports) {
+            this.nodes.get(previous)?.importers.delete(id);
+        }
+        node.imports = new Set(imports);
+
+        for (const imported of node.imports) {
+            this.getOrCreate(imported).importers.add(id);
+        }
+
+        return node;
+    }
+
+    markRestartBoundary(id: string, restartBoundary = true): void {
+        this.getOrCreate(id).restartBoundary = restartBoundary;
+    }
+
+    invalidate(changed: string): ModuleInvalidationResult {
+        const invalidated = new Set<string>();
+        const restartTargets = new Set<string>();
+        const queue = [changed];
+
+        while (queue.length > 0) {
+            const id = queue.shift()!;
+            if (invalidated.has(id)) continue;
+            invalidated.add(id);
+
+            const node = this.nodes.get(id);
+            if (!node) continue;
+            if (node.restartBoundary) {
+                restartTargets.add(id);
+                continue;
+            }
+
+            for (const importer of node.importers) {
+                queue.push(importer);
+            }
+        }
+
+        return {
+            changed,
+            invalidated: [...invalidated].sort(),
+            restartTargets: [...restartTargets].sort(),
+        };
+    }
+
+    get(id: string): ModuleGraphNode | undefined {
+        return this.nodes.get(id);
+    }
+
+    clear(): void {
+        this.nodes.clear();
+    }
+
+    private getOrCreate(id: string): ModuleGraphNode {
+        let node = this.nodes.get(id);
+        if (!node) {
+            node = { id, imports: new Set(), importers: new Set() };
+            this.nodes.set(id, node);
+        }
+        return node;
+    }
+}

--- a/packages/dev-server/src/server.test.ts
+++ b/packages/dev-server/src/server.test.ts
@@ -107,6 +107,38 @@ describe('DevServer', () => {
         expect(server.banner).toBe('Reloaded');
     });
 
+    it('passes invalidation metadata to the child reload message', async () => {
+        mockChild.exited = new Promise(() => {}) as any;
+        const server = new DevServer({
+            rootDir: './project',
+            entry: 'index.ts'
+        });
+
+        server.start();
+
+        server['_handleChange']({
+            filename: 'button.ts',
+            type: 'tsx',
+            timestamp: Date.now(),
+            invalidation: {
+                changed: 'button.ts',
+                invalidated: ['app.ts', 'button.ts'],
+                restartTargets: ['app.ts'],
+            },
+        });
+
+        await vi.advanceTimersByTimeAsync(500);
+
+        expect(mockChild.send).toHaveBeenCalledWith({
+            type: 'reload',
+            invalidation: {
+                changed: 'button.ts',
+                invalidated: ['app.ts', 'button.ts'],
+                restartTargets: ['app.ts'],
+            },
+        });
+    });
+
     it('clears banner after bannerMs timeout', async () => {
         const server = new DevServer({
             rootDir: './project',

--- a/packages/dev-server/src/server.ts
+++ b/packages/dev-server/src/server.ts
@@ -344,6 +344,15 @@ export class DevServer {
             `${change.type}: ${change.filename}`
         );
 
+        if (change.invalidation) {
+            this._devtools.logEvent(
+                'invalidate',
+                change.invalidation.restartTargets.length > 0
+                    ? `restart: ${change.invalidation.restartTargets.join(', ')}`
+                    : `modules: ${change.invalidation.invalidated.join(', ')}`
+            );
+        }
+
         this._onReload?.(change);
 
         if (this._reloadTimer) {
@@ -359,7 +368,7 @@ export class DevServer {
                 this._child.exitCode === null
             ) {
                 try {
-                    this._child.send({ type: 'reload' });
+                    this._child.send({ type: 'reload', invalidation: change.invalidation });
                 } catch {
                     // IPC channel closed
                 }

--- a/packages/dev-server/src/watcher.test.ts
+++ b/packages/dev-server/src/watcher.test.ts
@@ -50,6 +50,23 @@ describe('FileWatcher', () => {
         expect(changeSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('attaches module invalidation data when a changed module has importers', () => {
+        const watcher = new FileWatcher(['./src']);
+        const changeSpy = vi.fn();
+
+        watcher.registerModule('App.tsx', ['Button.tsx'], { restartBoundary: true });
+        watcher.registerModule('Button.tsx');
+        watcher.onChange(changeSpy);
+        watcher.start();
+
+        mockWatcherEmitter.emit('change', 'change', 'Button.tsx');
+        vi.advanceTimersByTime(100);
+
+        expect(changeSpy).toHaveBeenCalledTimes(1);
+        expect(changeSpy.mock.calls[0][0].invalidation.invalidated).toEqual(['App.tsx', 'Button.tsx']);
+        expect(changeSpy.mock.calls[0][0].invalidation.restartTargets).toEqual(['App.tsx']);
+    });
+
     it('handles multiple rapid changes via debouncing', () => {
         const watcher = new FileWatcher(['./src']);
         const changeSpy = vi.fn();

--- a/packages/dev-server/src/watcher.ts
+++ b/packages/dev-server/src/watcher.ts
@@ -4,6 +4,7 @@
 
 import { watch, existsSync, readdirSync, statSync } from 'node:fs';
 import { resolve, extname, join } from 'node:path';
+import { ModuleGraph, type ModuleInvalidationResult } from './module-graph.js';
 
 const DEFAULT_IGNORED_DIRS = new Set([
     '.git',
@@ -24,6 +25,8 @@ export interface FileChange {
     type: 'tsx' | 'tss' | 'config';
     /** Epoch milliseconds when the change was detected. */
     timestamp: number;
+    /** Module graph invalidation details for targeted reload handling. */
+    invalidation?: ModuleInvalidationResult;
 }
 
 /**
@@ -47,6 +50,7 @@ export class FileWatcher {
     private _onErrorCallbacks: Array<(err: Error) => void> = [];
     private _debounceTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
     private _started = false;
+    readonly moduleGraph = new ModuleGraph();
 
     constructor(dirs: string[]) {
         this._dirs = dirs.map(d => resolve(d));
@@ -56,6 +60,14 @@ export class FileWatcher {
     onChange(fn: (change: FileChange) => void): void { this._onChangeCallbacks.push(fn); }
     /** Register a callback invoked when a watch error occurs. */
     onError(fn: (err: Error) => void): void { this._onErrorCallbacks.push(fn); }
+    /** Register or update a module and its imports for targeted invalidation. */
+    registerModule(id: string, imports: Iterable<string> = [], options: { restartBoundary?: boolean } = {}): void {
+        this.moduleGraph.addModule(id, imports, options);
+    }
+    /** Mark a module as a restart boundary. */
+    markRestartBoundary(id: string, restartBoundary = true): void {
+        this.moduleGraph.markRestartBoundary(id, restartBoundary);
+    }
 
     /** Begin watching all configured directories, debouncing rapid changes. */
     start(): void {
@@ -119,7 +131,12 @@ export class FileWatcher {
         this._debounceTimers.set(resolved, setTimeout(() => {
             this._debounceTimers.delete(resolved);
             const emittedFilename = dir === rootDir ? filename : resolve(dir, filename).slice(rootDir.length + 1);
-            const change: FileChange = { filename: emittedFilename, type: type!, timestamp: Date.now() };
+            const change: FileChange = {
+                filename: emittedFilename,
+                type: type!,
+                timestamp: Date.now(),
+                invalidation: this.moduleGraph.invalidate(emittedFilename),
+            };
             for (const cb of this._onChangeCallbacks) cb(change);
         }, 100));
     }


### PR DESCRIPTION
Summary
- Add a dev-server ModuleGraph for tracking imports and reverse importers.
- Compute invalidation fan-out and stop at configured restart boundaries.
- Export graph types for targeted restart integration.

Validation
- npx.cmd vitest run packages/dev-server/src/module-graph.test.ts packages/dev-server/src/watcher.test.ts packages/dev-server/src/index.test.ts

Closes #2907
