### PR TITLE
Add store snapshot history

### DIFF
--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -23,4 +23,10 @@ export type { EqualityFn } from './shallow.js';
 export { shallow } from './shallow.js';
 
 export { setIn, updateIn, deleteIn } from './immutable.js';
+export { createSnapshotHistory } from './snapshot-history.js';
+export type {
+    SnapshotHistoryOptions,
+    StoreSnapshot,
+    StoreSnapshotHistory,
+} from './snapshot-history.js';
 

--- a/packages/store/src/snapshot-history.test.ts
+++ b/packages/store/src/snapshot-history.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { createSnapshotHistory } from './snapshot-history.js';
+import { createStore } from './store.js';
+
+describe('createSnapshotHistory', () => {
+    it('captures and restores store state', () => {
+        const store = createStore(() => ({ count: 0, label: 'zero' }));
+        const history = createSnapshotHistory(store);
+
+        const initial = history.capture('initial');
+        store.setState({ count: 2, label: 'two' });
+
+        history.restore(initial.id);
+
+        expect(store.getState()).toEqual({ count: 0, label: 'zero' });
+    });
+
+    it('supports undo and redo', () => {
+        const store = createStore(() => ({ count: 0 }));
+        const history = createSnapshotHistory(store);
+
+        history.capture('zero');
+        store.setState({ count: 1 });
+        history.capture('one');
+
+        expect(history.undo()?.state.count).toBe(0);
+        expect(store.getState().count).toBe(0);
+        expect(history.redo()?.state.count).toBe(1);
+        expect(store.getState().count).toBe(1);
+    });
+
+    it('bounds snapshot history by limit', () => {
+        const store = createStore(() => ({ count: 0 }));
+        const history = createSnapshotHistory(store, { limit: 2 });
+
+        history.capture('a');
+        store.setState({ count: 1 });
+        history.capture('b');
+        store.setState({ count: 2 });
+        history.capture('c');
+
+        expect(history.list().map(snapshot => snapshot.label)).toEqual(['b', 'c']);
+    });
+});

--- a/packages/store/src/snapshot-history.ts
+++ b/packages/store/src/snapshot-history.ts
@@ -1,0 +1,82 @@
+import type { Store } from './store.js';
+
+export interface StoreSnapshot<T> {
+    id: number;
+    label?: string;
+    state: T;
+}
+
+export interface SnapshotHistoryOptions {
+    limit?: number;
+}
+
+export interface StoreSnapshotHistory<T extends object> {
+    capture(label?: string): StoreSnapshot<T>;
+    restore(id: number): StoreSnapshot<T>;
+    undo(): StoreSnapshot<T> | null;
+    redo(): StoreSnapshot<T> | null;
+    list(): StoreSnapshot<T>[];
+    clear(): void;
+}
+
+export function createSnapshotHistory<T extends object>(
+    store: Store<T>,
+    options: SnapshotHistoryOptions = {},
+): StoreSnapshotHistory<T> {
+    const limit = options.limit ?? 50;
+    const snapshots: StoreSnapshot<T>[] = [];
+    let cursor = -1;
+    let nextId = 1;
+
+    const clone = (state: T): T => {
+        if (typeof structuredClone === 'function') return structuredClone(state);
+        return JSON.parse(JSON.stringify(state)) as T;
+    };
+
+    const apply = (snapshot: StoreSnapshot<T>): StoreSnapshot<T> => {
+        const before = clone(store.getState());
+        try {
+            store.setState(clone(snapshot.state) as Partial<T>);
+        } catch (error) {
+            store.setState(before as Partial<T>);
+            throw error;
+        }
+        return { ...snapshot, state: clone(snapshot.state) };
+    };
+
+    return {
+        capture(label) {
+            snapshots.splice(cursor + 1);
+            const snapshot = { id: nextId++, label, state: clone(store.getState()) };
+            snapshots.push(snapshot);
+            while (snapshots.length > limit) {
+                snapshots.shift();
+            }
+            cursor = snapshots.length - 1;
+            return { ...snapshot, state: clone(snapshot.state) };
+        },
+        restore(id) {
+            const index = snapshots.findIndex(snapshot => snapshot.id === id);
+            if (index === -1) throw new Error(`Unknown store snapshot: ${id}`);
+            cursor = index;
+            return apply(snapshots[index]);
+        },
+        undo() {
+            if (cursor <= 0) return null;
+            cursor--;
+            return apply(snapshots[cursor]);
+        },
+        redo() {
+            if (cursor >= snapshots.length - 1) return null;
+            cursor++;
+            return apply(snapshots[cursor]);
+        },
+        list() {
+            return snapshots.map(snapshot => ({ ...snapshot, state: clone(snapshot.state) }));
+        },
+        clear() {
+            snapshots.splice(0);
+            cursor = -1;
+        },
+    };
+}


### PR DESCRIPTION
Summary
- Add bounded store snapshot history with capture, restore, undo, redo, list, and clear operations.
- Clone snapshot state to keep history entries isolated from later mutations.
- Roll back restore attempts if store listeners throw during the transaction.

Validation
- npx.cmd vitest run packages/store/src/snapshot-history.test.ts packages/store/src/store.test.ts packages/store/src/batch.test.ts

Closes #2908
