### PR TITLE
Add adaptive polling backpressure

### DIFF
--- a/packages/data/src/hooks/adaptive-polling.test.ts
+++ b/packages/data/src/hooks/adaptive-polling.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { AdaptivePollingController } from './adaptive-polling.js';
+
+describe('AdaptivePollingController', () => {
+    it('skips overlapping polls and applies backpressure', () => {
+        const controller = new AdaptivePollingController({ baseInterval: 100, maxInterval: 1000 });
+
+        expect(controller.begin()).toBe(true);
+        expect(controller.begin()).toBe(false);
+
+        expect(controller.snapshot().skipped).toBe(1);
+        expect(controller.nextDelay()).toBe(200);
+    });
+
+    it('backs off after failures and recovers after success', () => {
+        const controller = new AdaptivePollingController({ baseInterval: 100, maxInterval: 1000 });
+
+        controller.begin();
+        controller.failure();
+        expect(controller.nextDelay()).toBe(400);
+
+        controller.begin();
+        controller.success(25);
+        expect(controller.nextDelay()).toBe(200);
+    });
+
+    it('caps delay at the configured maximum', () => {
+        const controller = new AdaptivePollingController({ baseInterval: 100, maxInterval: 250 });
+
+        controller.begin();
+        controller.failure();
+        controller.begin();
+        controller.failure();
+
+        expect(controller.nextDelay()).toBe(250);
+    });
+});

--- a/packages/data/src/hooks/adaptive-polling.ts
+++ b/packages/data/src/hooks/adaptive-polling.ts
@@ -1,0 +1,80 @@
+export interface AdaptivePollingOptions {
+    baseInterval: number;
+    minInterval?: number;
+    maxInterval?: number;
+    backoffFactor?: number;
+}
+
+export interface AdaptivePollingState {
+    inFlight: boolean;
+    skipped: number;
+    failures: number;
+    pressure: number;
+    delay: number;
+}
+
+export class AdaptivePollingController {
+    private state: AdaptivePollingState;
+    private readonly minInterval: number;
+    private readonly maxInterval: number;
+    private readonly backoffFactor: number;
+
+    constructor(private readonly options: AdaptivePollingOptions) {
+        this.minInterval = options.minInterval ?? options.baseInterval;
+        this.maxInterval = options.maxInterval ?? options.baseInterval * 16;
+        this.backoffFactor = options.backoffFactor ?? 2;
+        this.state = {
+            inFlight: false,
+            skipped: 0,
+            failures: 0,
+            pressure: 0,
+            delay: this.clamp(options.baseInterval),
+        };
+    }
+
+    begin(): boolean {
+        if (this.state.inFlight) {
+            this.state.skipped++;
+            this.recalculate();
+            return false;
+        }
+        this.state.inFlight = true;
+        return true;
+    }
+
+    success(durationMs: number): void {
+        this.state.inFlight = false;
+        this.state.failures = 0;
+        this.state.skipped = 0;
+        this.state.pressure = Math.max(0, this.state.pressure - 1);
+        if (durationMs > this.state.delay) {
+            this.state.pressure++;
+        }
+        this.recalculate();
+    }
+
+    failure(): void {
+        this.state.inFlight = false;
+        this.state.failures++;
+        this.state.pressure += 2;
+        this.recalculate();
+    }
+
+    nextDelay(): number {
+        return this.state.delay;
+    }
+
+    snapshot(): AdaptivePollingState {
+        return { ...this.state };
+    }
+
+    private recalculate(): void {
+        const pressureDelay = this.options.baseInterval * Math.pow(this.backoffFactor, this.state.pressure);
+        const skippedDelay = this.state.skipped * this.options.baseInterval;
+        this.state.delay = this.clamp(Math.max(pressureDelay, this.options.baseInterval + skippedDelay));
+    }
+
+    private clamp(value: number): number {
+        return Math.max(this.minInterval, Math.min(this.maxInterval, Math.round(value)));
+    }
+}

--- a/packages/data/src/hooks/usePolling.ts
+++ b/packages/data/src/hooks/usePolling.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect ,useRef } from '@termuijs/jsx';
+import { AdaptivePollingController, type AdaptivePollingOptions } from './adaptive-polling.js';
 
 export interface UsePollingResult<T> {
     data: T | null;
@@ -10,6 +11,10 @@ export interface UsePollingResult<T> {
     refresh: () => void;
 }
 
+export interface UsePollingOptions {
+    adaptive?: AdaptivePollingOptions;
+}
+
 /**
  * usePolling — repeatedly execute an async function on a configurable interval.
  * Supports pause, resume, and manual refresh without restarting the timer or resetting state.
@@ -17,7 +22,8 @@ export interface UsePollingResult<T> {
 export function usePolling<T>(
     fn: () => Promise<T>,
     interval: number,
-    deps: unknown[] = []
+    deps: unknown[] = [],
+    options: UsePollingOptions = {},
 ): UsePollingResult<T> {
     const [data, setData] = useState<T | null>(null);
     const [error, setError] = useState<Error | null>(null);
@@ -31,15 +37,23 @@ export function usePolling<T>(
 
     const inFlightRef = useRef(false);
     const requestIdRef = useRef(0);
+    const adaptiveRef = useRef<AdaptivePollingController | null>(null);
 
     const execute = async () => {
+        const startedAt = Date.now();
         if (inFlightRef.current) {
+            adaptiveRef.current?.begin();
+            return;
+        }
+        if (adaptiveRef.current && !adaptiveRef.current.begin()) {
             return;
         }
         inFlightRef.current = true;
         const requestId = ++requestIdRef.current;
+        let succeeded = false;
         try {
             const result = await fnRef.current();
+            succeeded = true;
             if (mountedRef.current && requestId === requestIdRef.current) {
                 setData(result);
                 setError(null);
@@ -51,6 +65,13 @@ export function usePolling<T>(
                 setLoading(false);
             }
         } finally {
+            if (adaptiveRef.current) {
+                if (succeeded) {
+                    adaptiveRef.current.success(Date.now() - startedAt);
+                } else {
+                    adaptiveRef.current.failure();
+                }
+            }
             if (requestId === requestIdRef.current) {
                 inFlightRef.current = false;
             }
@@ -75,7 +96,27 @@ export function usePolling<T>(
     useEffect(() => {
         mountedRef.current = true;
         setLoading(true);
+        adaptiveRef.current = options.adaptive ? new AdaptivePollingController(options.adaptive) : null;
         execute();
+
+        if (adaptiveRef.current) {
+            let timeout: ReturnType<typeof setTimeout> | undefined;
+            const tick = async () => {
+                if (!pausedRef.current) {
+                    await execute();
+                }
+                if (mountedRef.current && adaptiveRef.current) {
+                    timeout = setTimeout(tick, adaptiveRef.current.nextDelay());
+                }
+            };
+            timeout = setTimeout(tick, adaptiveRef.current.nextDelay());
+            return () => {
+                mountedRef.current = false;
+                inFlightRef.current = false;
+                requestIdRef.current++;
+                if (timeout) clearTimeout(timeout);
+            };
+        }
 
         const timer = setInterval(() => {
             if (!pausedRef.current) {
@@ -90,7 +131,7 @@ export function usePolling<T>(
             clearInterval(timer);
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [interval, ...deps]);
+    }, [interval, options.adaptive, ...deps]);
 
     return { data, error, loading, paused, pause, resume, refresh };
 }

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -48,7 +48,9 @@ export { useBattery } from './hooks/useBattery.js';
 export type { BatteryData, UseBatteryResult } from './hooks/useBattery.js';
 
 export { usePolling } from './hooks/usePolling.js';
-export type { UsePollingResult } from './hooks/usePolling.js';
+export type { UsePollingOptions, UsePollingResult } from './hooks/usePolling.js';
+export { AdaptivePollingController } from './hooks/adaptive-polling.js';
+export type { AdaptivePollingOptions, AdaptivePollingState } from './hooks/adaptive-polling.js';
 
 export { useMutation } from './hooks/useMutation.js'
 export type { HttpMethod, UseMutationReturn } from './hooks/useMutation.js'


### PR DESCRIPTION
Summary
- Add an AdaptivePollingController that increases delay under failures and overlapping work.
- Wire usePolling to support optional adaptive scheduling while preserving fixed-interval behavior by default.
- Export adaptive polling types for data hook consumers.

Validation
- npx.cmd vitest run packages/data/src/hooks/adaptive-polling.test.ts packages/data/src/hooks/usePolling.test.ts packages/data/src/index.test.ts

Closes #2909
