### PR TITLE
    fix(motion): prevent onComplete invocation when parallel animation is cancelled #2936

### DIFF
--- a/packages/motion/src/sequence.test.ts
+++ b/packages/motion/src/sequence.test.ts
@@ -160,4 +160,21 @@ describe('parallel()', () => {
         expect(cancelSpy1).toHaveBeenCalledTimes(1);
         expect(cancelSpy2).toHaveBeenCalledTimes(1);
     });
+
+    it('does not invoke onComplete if cancelled before animations finish', () => {
+        const onComplete = vi.fn();
+        let trigger1: () => void = () => {};
+
+        const anim1: AnimationRunner = (done) => {
+            trigger1 = done;
+            return () => {};
+        };
+
+        const cancelMaster = parallel([anim1], onComplete);
+        cancelMaster();
+
+        // Late completion after cancellation
+        trigger1();
+        expect(onComplete).not.toHaveBeenCalled();
+    });
 });

--- a/packages/motion/src/sequence.ts
+++ b/packages/motion/src/sequence.ts
@@ -58,11 +58,13 @@ export function parallel(
     return () => {}
   }
 
+  let cancelled = false
   let remaining = runners.length
   const cancellers: Array<() => void> = []
 
   for (const runner of runners) {
     const cancel = runner(() => {
+      if (cancelled) return
       remaining--
       if (remaining === 0) onComplete?.()
     })
@@ -70,6 +72,7 @@ export function parallel(
   }
 
   return () => {
+    cancelled = true
     cancellers.forEach(c => c())
   }
 }


### PR DESCRIPTION
   
  ### Pull Request Description

    ### Title
    fix(motion): prevent onComplete invocation when parallel animation is cancelled
    
    ### Summary of Changes
    - Introduced `cancelled` boolean tracking within `parallel()` in
  `packages/motion/src/sequence.ts`.
    - Guarded the completion callback with `if (cancelled) return`.
    - Added unit test in `packages/motion/src/sequence.test.ts` confirming `onComplete` is
  suppressed upon late runner completion after cancellation.
    
    Closes #2936 