### PR TITLE
fix(widgets): clamp restored ratio in SplitPane.loadLayout

### DIFF
--- a/packages/widgets/src/layout/SplitPane.ts
+++ b/packages/widgets/src/layout/SplitPane.ts
@@ -162,7 +162,11 @@ export class SplitPane extends Widget {
                 typeof layout.ratio === 'number' &&
                 layout.ratio !== this._ratio
             ) {
-                this._ratio = layout.ratio;
+                const content = this._getContentRect();
+                const totalSize = this._direction === 'horizontal' ? content.width : content.height;
+                this._ratio = totalSize > 0
+                    ? this._clampRatio(layout.ratio, totalSize)
+                    : layout.ratio;
                 changed = true;
             }
 


### PR DESCRIPTION
## Fix: Clamp restored ratio in SplitPane.loadLayout

### Problem
`loadLayout()` restored the ratio from serialized data without validating it against `_clampRatio`, allowing corrupted or malicious layout files to set ratio to 0 or 1, collapsing a pane to zero width/height.

### Fix
Apply `_clampRatio()` to the restored ratio using the current content rect dimensions, matching the behavior of `setRatio()`.

Closes #2927

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved split-pane layout restoration by clamping saved divider positions to the widget’s current size.
  * Prevented restored layouts from placing the divider outside the available content area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->