### PR TITLE
fix(store): merge batch changes in mutate commit instead of replacing state

### DIFF
--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -533,7 +533,7 @@ export function createStore<T extends object>(
             } else {
                 Object.assign(existing.changes, changes);
                 existing.nextState = nextState;
-                existing.commit = () => { state = nextState; persistState(); };
+                existing.commit = () => { state = { ...state, ...existing.changes } as T; persistState(); return state; };
                 existing.rollback = () => { state = existing.prevState; };
             }
         } else {


### PR DESCRIPTION
## Fix: Merge batch changes in mutate commit instead of replacing state

### Problem
The mutate batch commit closure captured `nextState` and assigned it directly (`state = nextState`), overwriting any interleaved `setState` changes within the same batch. The `setState` batch path correctly uses `state = { ...state, ...changes }`.

### Fix
Change `existing.commit` to use the merge pattern `{ ...state, ...existing.changes }` to match `setState`'s batch behavior.

Closes #2928

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when applying batched state updates.
  * Prevented unrelated state values from being overwritten during batched mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->