### PR TITLE
fix(jsx): guard runEffects/runLayoutEffects against effect exceptions

### DIFF
--- a/packages/jsx/src/hooks.ts
+++ b/packages/jsx/src/hooks.ts
@@ -589,11 +589,16 @@ export function useReducer<S, A>(
 export function runEffects(fiber: Fiber): void {
     for (const record of fiber.effects) {
         if (!record.ran) {
-            // Run cleanup from previous effect
-            record.cleanup?.();
-            const cleanup = record.effect();
-            if (typeof cleanup === 'function') {
-                record.cleanup = cleanup;
+            try {
+                // Run cleanup from previous effect
+                record.cleanup?.();
+                const cleanup = record.effect();
+                if (typeof cleanup === 'function') {
+                    record.cleanup = cleanup;
+                }
+            } catch (err) {
+                // Mark as ran to prevent infinite re-execution
+                console.error('[useEffect] Effect threw:', err);
             }
             record.ran = true;
         }
@@ -603,11 +608,15 @@ export function runEffects(fiber: Fiber): void {
 export function runLayoutEffects(fiber: Fiber): void {
     for (const record of fiber.layoutEffects) {
         if (!record.ran) {
-            // Run cleanup from previous effect
-            record.cleanup?.();
-            const cleanup = record.effect();
-            if (typeof cleanup === 'function') {
-                record.cleanup = cleanup;
+            try {
+                // Run cleanup from previous effect
+                record.cleanup?.();
+                const cleanup = record.effect();
+                if (typeof cleanup === 'function') {
+                    record.cleanup = cleanup;
+                }
+            } catch (err) {
+                console.error('[useLayoutEffect] Effect threw:', err);
             }
             record.ran = true;
         }


### PR DESCRIPTION
## Fix: Guard runEffects/runLayoutEffects against effect exceptions

### Problem
If an effect threw an exception, `record.ran` was never set to `true`, causing the effect to re-execute on every render cycle in an infinite loop that freezes the terminal.

### Fix
Wrap effect execution in try/catch blocks in both `runEffects` and `runLayoutEffects`. Always set `record.ran = true` after the try/catch to prevent infinite re-execution. Log the error for debugging.

Closes #2929