### PR TITLE
fix(store): call persistState in batch rollback to sync disk state

### DIFF
--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -417,13 +417,13 @@ export function createStore<T extends object>(
                             nextState,
                             changes,
                             commit: () => { state = { ...state, ...changes } as T; persistState(); return state; },
-                            rollback: () => { state = prevState; },
+                            rollback: () => { state = prevState; persistState(); },
                         });
                     } else {
                         Object.assign(existing.changes, finalPartial);
                         existing.nextState = nextState;
                         existing.commit = () => { state = { ...state, ...existing.changes } as T; persistState(); return state; };
-                        existing.rollback = () => { state = existing.prevState; };
+                        existing.rollback = () => { state = existing.prevState; persistState(); };
                     }
                 } else {
                     state = nextState; 
@@ -528,13 +528,13 @@ export function createStore<T extends object>(
                     nextState,
                     changes,
                     commit: () => { state = { ...state, ...changes } as T; persistState(); return state; },
-                    rollback: () => { state = prevState; },
+                    rollback: () => { state = prevState; persistState(); },
                 });
             } else {
                 Object.assign(existing.changes, changes);
                 existing.nextState = nextState;
                 existing.commit = () => { state = nextState; persistState(); };
-                existing.rollback = () => { state = existing.prevState; };
+                existing.rollback = () => { state = existing.prevState; persistState(); };
             }
         } else {
             state = nextState;


### PR DESCRIPTION
## Fix: Call persistState in batch rollback to sync disk state

### Problem
Batch rollback restored in-memory state but never called `persistState()`, leaving the persist file out of sync after a nested batch throw. On next app startup, stale data would be loaded.

### Fix
Add `persistState()` to all four rollback closures (two in setState batch path, two in mutate batch path).

Closes #2930

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed batched state rollbacks so persisted storage now correctly reflects the restored state.
  * Ensured rollback behavior is consistent across state updates and mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->