### PR TITLE
fix(ui): validate current step in Wizard.complete before invoking callback

### DIFF
--- a/packages/ui/src/Wizard.ts
+++ b/packages/ui/src/Wizard.ts
@@ -114,6 +114,20 @@ export class Wizard extends Widget {
     }
 
     complete(): void {
+        const step = this._steps[this._currentStepIndex];
+        if (step && step.validate) {
+            const validationResult = step.validate();
+            if (typeof validationResult === 'string') {
+                this._error = validationResult;
+                this.markDirty();
+                return;
+            } else if (validationResult === false) {
+                this.markDirty();
+                return;
+            }
+        }
+
+        this._error = '';
         this._onComplete?.(this._getStepData());
     }
 


### PR DESCRIPTION
## Fix: Validate current step in Wizard.complete before invoking callback

### Problem
`complete()` invoked the completion callback without running the current step's `validate()` function. When the user pressed Enter on the last step, validation was silently bypassed, allowing invalid data to be submitted.

### Fix
Add the same validation logic used by `nextStep()` to `complete()`. If validation returns a string error message or `false`, block completion and mark dirty.

Closes #2942