### PR TITLE
Add named Grid area placement

### DIFF
--- a/packages/widgets/src/layout/Grid.test.ts
+++ b/packages/widgets/src/layout/Grid.test.ts
@@ -151,6 +151,65 @@ describe('Grid layout', () => {
         expect(c.rect.width).toBe(20);
     });
 
+    it('places GridItems by named template areas', () => {
+        const grid = new Grid(
+            { width: 40, height: 20 },
+            {
+                columns: '1fr 3fr',
+                rows: '5 15',
+                areas: [
+                    'header header',
+                    'nav main',
+                ],
+                gap: 0,
+            }
+        );
+
+        const header = new GridItem({}, { area: 'header' });
+        const nav = new GridItem({}, { area: 'nav' });
+        const main = new GridItem({}, { area: 'main' });
+
+        grid.addChild(header);
+        grid.addChild(nav);
+        grid.addChild(main);
+
+        const node = grid.getLayoutNode();
+        computeLayout(node, 40, 20);
+        grid.syncLayout();
+
+        expect(grid.getAreaPlacement('header')).toEqual({
+            columnStart: 1,
+            columnEnd: 3,
+            rowStart: 1,
+            rowEnd: 2,
+        });
+        expect(header.rect).toEqual({ x: 0, y: 0, width: 40, height: 5 });
+        expect(nav.rect).toEqual({ x: 0, y: 5, width: 10, height: 15 });
+        expect(main.rect).toEqual({ x: 10, y: 5, width: 30, height: 15 });
+    });
+
+    it('rejects non-rectangular named template areas', () => {
+        expect(() => new Grid(
+            { width: 40, height: 20 },
+            {
+                columns: 2,
+                areas: [
+                    'a a',
+                    'a b',
+                ],
+            }
+        )).toThrow(/rectangular/);
+    });
+
+    it('throws when a GridItem references an unknown named area', () => {
+        const grid = new Grid(
+            { width: 40, height: 20 },
+            { columns: 2, areas: ['main aside'] }
+        );
+
+        expect(() => grid.addChild(new GridItem({}, { area: 'footer' }))).toThrow(/Unknown grid area/);
+    });
+
     it('respects child margins in layout cells', () => {
         const grid = new Grid(
             { width: 40, height: 20 },

--- a/packages/widgets/src/layout/Grid.ts
+++ b/packages/widgets/src/layout/Grid.ts
@@ -5,6 +5,8 @@
 import type { Screen, Style } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
+export type GridAreas = string | string[];
+
 export interface GridOptions {
     /** CSS grid-template-columns track definitions, e.g. "1fr 2fr", "10 20" or number of columns */
     columns?: number | string;
@@ -12,9 +14,85 @@ export interface GridOptions {
     rows?: number | string;
     /** Grid gap in characters/cells */
     gap?: number;
+    /** Named grid area rows, e.g. ["header header", "nav main"] */
+    areas?: GridAreas;
+}
+
+export interface GridAreaPlacement {
+    columnStart: number;
+    columnEnd: number;
+    rowStart: number;
+    rowEnd: number;
+}
+
+function getWidgetArea(widget: Widget): string | undefined {
+    return (widget as { gridArea?: string }).gridArea;
+}
+
+function parseGridAreas(areas: GridAreas | undefined): Map<string, GridAreaPlacement> {
+    const rows = normalizeAreaRows(areas);
+    const placements = new Map<string, GridAreaPlacement>();
+
+    for (let row = 0; row < rows.length; row++) {
+        for (let col = 0; col < rows[row].length; col++) {
+            const name = rows[row][col];
+            if (name === '.') continue;
+
+            const current = placements.get(name);
+            if (!current) {
+                placements.set(name, {
+                    columnStart: col + 1,
+                    columnEnd: col + 2,
+                    rowStart: row + 1,
+                    rowEnd: row + 2,
+                });
+                continue;
+            }
+
+            current.columnStart = Math.min(current.columnStart, col + 1);
+            current.columnEnd = Math.max(current.columnEnd, col + 2);
+            current.rowStart = Math.min(current.rowStart, row + 1);
+            current.rowEnd = Math.max(current.rowEnd, row + 2);
+        }
+    }
+
+    for (const [name, placement] of placements) {
+        for (let row = placement.rowStart - 1; row < placement.rowEnd - 1; row++) {
+            for (let col = placement.columnStart - 1; col < placement.columnEnd - 1; col++) {
+                if (rows[row]?.[col] !== name) {
+                    throw new Error(`Grid area "${name}" must be rectangular`);
+                }
+            }
+        }
+    }
+
+    return placements;
+}
+
+function normalizeAreaRows(areas: GridAreas | undefined): string[][] {
+    if (!areas) return [];
+
+    const rawRows = Array.isArray(areas)
+        ? areas
+        : areas.split(/\r?\n/);
+    const rows = rawRows
+        .map(row => row.trim())
+        .filter(Boolean)
+        .map(row => row.replace(/^['"]|['"]$/g, '').trim().split(/\s+/));
+
+    if (rows.length === 0) return [];
+
+    const width = rows[0].length;
+    if (width === 0 || rows.some(row => row.length !== width)) {
+        throw new Error('Grid area rows must all have the same number of columns');
+    }
+
+    return rows;
 }
 
 export interface GridItemOptions {
+    /** Named area from the parent Grid area's template */
+    area?: string;
     /** grid-column-start index (1-indexed) or "span N" */
     columnStart?: number | string;
     /** grid-column-end index (1-indexed) or "span N" */
@@ -29,6 +107,8 @@ export interface GridItemOptions {
  * Grid — a true CSS-Grid-like layout container.
  */
 export class Grid extends Widget {
+    private readonly _areas: Map<string, GridAreaPlacement>;
+
     constructor(style: Partial<Style> = {}, options: GridOptions = {}) {
         const columns = typeof options.columns === 'number'
             ? Array(Math.max(1, options.columns)).fill('1fr').join(' ')
@@ -44,11 +124,24 @@ export class Grid extends Widget {
             gridGap: options.gap,
             ...style
         });
+
+        this._areas = parseGridAreas(options.areas);
     }
 
     /** Add an item explicitly (alias for addChild) */
     addItem(widget: Widget): void {
         this.addChild(widget);
+    }
+
+    override addChild(child: Widget): void {
+        this._applyNamedArea(child);
+        super.addChild(child);
+    }
+
+    /** Return the resolved placement for a named grid area. */
+    getAreaPlacement(area: string): GridAreaPlacement | undefined {
+        const placement = this._areas.get(area);
+        return placement ? { ...placement } : undefined;
     }
 
     /** Remove all items and reset the grid */
@@ -64,20 +157,44 @@ export class Grid extends Widget {
     protected _renderSelf(_screen: Screen): void {
         // Grid is a pure layout container — no self-rendering needed.
     }
+
+    private _applyNamedArea(child: Widget): void {
+        const area = getWidgetArea(child);
+        if (!area) return;
+
+        const placement = this._areas.get(area);
+        if (!placement) {
+            throw new Error(`Unknown grid area "${area}"`);
+        }
+
+        child.setStyle({
+            gridColumnStart: placement.columnStart,
+            gridColumnEnd: placement.columnEnd,
+            gridRowStart: placement.rowStart,
+            gridRowEnd: placement.rowEnd,
+        });
+    }
 }
 
 /**
  * GridItem — a child container that can define grid column/row spans or starts.
  */
 export class GridItem extends Widget {
+    readonly gridArea?: string;
+
     constructor(style: Partial<Style> = {}, options: GridItemOptions = {}) {
-        super({
+        const placement = options.area ? {} : {
             gridColumnStart: options.columnStart,
             gridColumnEnd: options.columnEnd,
             gridRowStart: options.rowStart,
             gridRowEnd: options.rowEnd,
+        };
+
+        super({
+            ...placement,
             ...style
         });
+        this.gridArea = options.area;
     }
 
     protected _renderSelf(_screen: Screen): void {


### PR DESCRIPTION
## Summary
- add named grid area templates to Grid
- place GridItem children by area names through existing grid line styles
- validate jagged and non-rectangular area templates

## Tests
- bun test packages/widgets/src/layout/Grid.test.ts

Closes #2949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for named areas in grid layouts.
  * Grid items can now be positioned using a named area instead of explicit row and column values.
  * Added validation for grid area definitions, including rectangular layouts and recognized area names.
  * Added access to calculated placement details for named areas. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->