### PR TITLE
Clamp ScrollView offset on viewport changes

### DIFF
--- a/packages/widgets/src/layout/ScrollView.test.ts
+++ b/packages/widgets/src/layout/ScrollView.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { ScrollView } from './ScrollView.js';
-import { Screen, caps, type KeyEvent } from '@termuijs/core';
+import { Screen, type KeyEvent } from '@termuijs/core';
 
 const key = (k: string): KeyEvent => ({
     key: k,
@@ -95,6 +95,32 @@ describe("ScrollView", () => {
         expect(sv.scrollOffset).toBe(15);
         sv.setContentHeight(10);
         expect(sv.scrollOffset).toBe(5);
+    });
+
+    it("clamps offset when viewport height grows", () => {
+        const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
+        sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
+        sv.scrollTo(15);
+        sv.clearDirty();
+
+        sv.updateRect({ x: 0, y: 0, width: 40, height: 10 });
+
+        expect(sv.scrollOffset).toBe(10);
+        expect(sv.isDirty).toBe(true);
+    });
+
+    it("clamps stale offsets before rendering", () => {
+        const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
+        const screen = new Screen(40, 10);
+
+        sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
+        sv.scrollTo(15);
+        sv.setContentHeight(12);
+        sv.updateRect({ x: 0, y: 0, width: 40, height: 10 });
+        (sv as any)._scrollOffset = 15;
+        sv.render(screen);
+
+        expect(sv.scrollOffset).toBe(2);
     });
 
     it("initial scrollOffset is 0", () => {
@@ -273,12 +299,19 @@ describe("ScrollView", () => {
 
 
     describe('keybindingMode integration', () => {
+        const originalKeybindings = process.env.TERMUI_KEYBINDINGS;
+
         afterEach(() => {
             vi.restoreAllMocks();
+            if (originalKeybindings === undefined) {
+                delete process.env.TERMUI_KEYBINDINGS;
+            } else {
+                process.env.TERMUI_KEYBINDINGS = originalKeybindings;
+            }
         });
 
         it('down scrolls down by 1 in vim mode using j', () => {
-            vi.spyOn(caps, 'keybindingMode', 'get').mockReturnValue('vim');
+            process.env.TERMUI_KEYBINDINGS = 'vim';
             const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
             sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
             sv.handleKey(key('j'));
@@ -286,7 +319,7 @@ describe("ScrollView", () => {
         });
 
         it('up scrolls up by 1 in emacs mode using ctrl+p', () => {
-            vi.spyOn(caps, 'keybindingMode', 'get').mockReturnValue('emacs');
+            process.env.TERMUI_KEYBINDINGS = 'emacs';
             const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
             sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
             sv.scrollBy(5);
@@ -295,7 +328,7 @@ describe("ScrollView", () => {
         });
 
         it('j does not scroll down in default mode', () => {
-            vi.spyOn(caps, 'keybindingMode', 'get').mockReturnValue('default');
+            delete process.env.TERMUI_KEYBINDINGS;
             const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
             sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
             sv.handleKey(key('j'));

--- a/packages/widgets/src/layout/ScrollView.ts
+++ b/packages/widgets/src/layout/ScrollView.ts
@@ -50,6 +50,13 @@ export class ScrollView extends Widget {
     /** Get current scroll offset */
     get scrollOffset(): number { return this._scrollOffset; }
 
+    override updateRect(rect: { x: number; y: number; width: number; height: number }): void {
+        super.updateRect(rect);
+        if (this._clampOffset()) {
+            this.markDirty();
+        }
+    }
+
     /** Scroll by delta rows */
     scrollBy(delta: number): void {
         this._scrollOffset = Math.round(this._scrollOffset + delta);
@@ -69,10 +76,12 @@ export class ScrollView extends Widget {
         }
     }
 
-    private _clampOffset(): void {
+    private _clampOffset(): boolean {
+        const previousOffset = this._scrollOffset;
         const viewHeight = this._rect.height;
         const maxOffset = Math.max(0, this._contentHeight - viewHeight);
         this._scrollOffset = Math.max(0, Math.min(this._scrollOffset, maxOffset));
+        return previousOffset !== this._scrollOffset;
     }
     
     private getScrollDelta(baseDelta: number): number {
@@ -100,6 +109,7 @@ export class ScrollView extends Widget {
 
     override render(screen: Screen): void {
         if (this._style.visible === false) return;
+        this._clampOffset();
 
         const shouldClip = true;
         if (shouldClip) screen.pushClip(this._rect);


### PR DESCRIPTION
## Summary
- clamp ScrollView offsets after viewport rect changes
- clamp any stale offset before rendering
- update keybinding tests to use the environment mode read by the runtime

## Tests
- bun test packages/widgets/src/layout/ScrollView.test.ts

Closes #2950