### PR TITLE
Add testId queries to the test renderer

### DIFF
--- a/packages/testing/src/render.test.tsx
+++ b/packages/testing/src/render.test.tsx
@@ -49,10 +49,14 @@ class FakeWidget extends Widget {
     protected _renderSelf(): void {}
 }
 
-function FakeA11yWidget(props: { role?: string, label?: string }) {
+function FakeA11yWidget(props: { role?: string, label?: string, testId?: string, a11yTestId?: string }) {
     const box = new Box();
     if (props.role !== undefined) Reflect.set(box, "role", props.role);
     if (props.label !== undefined) Reflect.set(box, "label", props.label);
+    if (props.testId !== undefined) Reflect.set(box, "testId", props.testId);
+    if (props.a11yTestId !== undefined) {
+        box.setA11y({ testId: props.a11yTestId } as any);
+    }
     return box;
 }
 
@@ -97,6 +101,44 @@ describe("render harness", () => {
         it("returns null when no node matches", () => {
             const screen = render(<FakeA11yWidget label="Email" />);
             expect(screen.getByLabelText("Password")).toBeNull();
+        });
+    });
+
+    describe("testId queries", () => {
+        it("returns the widget whose testId metadata matches the query", () => {
+            const screen = render(<FakeA11yWidget testId="submit-button" />);
+            const widget = screen.getByTestId("submit-button");
+
+            expect(widget).toBeTruthy();
+            expect(Reflect.get(widget!, "testId")).toBe("submit-button");
+        });
+
+        it("reads testId metadata from a11y props", () => {
+            const screen = render(<FakeA11yWidget a11yTestId="status-region" />);
+            const widget = screen.queryByTestId("status-region");
+
+            expect(widget).toBeTruthy();
+            expect(widget?.a11y).toEqual({ testId: "status-region" });
+        });
+
+        it("returns null when no testId matches", () => {
+            const screen = render(<FakeA11yWidget testId="submit-button" />);
+
+            expect(screen.getByTestId("cancel-button")).toBeNull();
+            expect(screen.queryByTestId("cancel-button")).toBeNull();
+        });
+
+        it("returns all widgets whose testId matches", () => {
+            const screen = render(
+                <box>
+                    <FakeA11yWidget testId="row" />
+                    <FakeA11yWidget testId="row" />
+                    <FakeA11yWidget testId="other" />
+                </box>
+            );
+
+            expect(screen.queryAllByTestId("row")).toHaveLength(2);
+            expect(screen.queryAllByTestId("missing")).toEqual([]);
         });
     });
 

--- a/packages/testing/src/render.ts
+++ b/packages/testing/src/render.ts
@@ -59,6 +59,12 @@ export interface TestInstance {
     getByLabelText(label: string): Widget | null;
 
     /**
+     * Find a widget whose testId metadata matches the given string.
+     * Returns null if not found.
+     */
+    getByTestId(testId: string): Widget | null;
+
+    /**
      * Find all widgets of a specific type (by constructor).
      */
     getAllByType<T extends Widget>(type: new (...args: any[]) => T): T[]; // any[] is required to accept widget constructors with varying signatures
@@ -79,6 +85,18 @@ export interface TestInstance {
      * Find all widgets having the specified accessibility role.
      */
     queryAllByRole(role: string): Widget[];
+
+    /**
+     * Find the first widget whose testId metadata matches the given string.
+     * Returns null instead of throwing when nothing matches.
+     */
+    queryByTestId(testId: string): Widget | null;
+
+    /**
+     * Find all widgets whose testId metadata matches the given string.
+     * Returns empty array instead of throwing when nothing matches.
+     */
+    queryAllByTestId(testId: string): Widget[];
 
     /**
      * Find the first widget of a specific type (by constructor).
@@ -206,6 +224,23 @@ function getTextContent(widget: Widget): string {
         return (widget as any)._content ?? ""; // as any: Text._content is private; accessed for test renderer content inspection
     }
     return "";
+}
+
+function getWidgetMetadata(widget: Widget, key: string): unknown {
+    const direct = Reflect.get(widget, key);
+    if (direct !== undefined) return direct;
+
+    const props = Reflect.get(widget, "props");
+    if (props && typeof props === "object" && key in props) {
+        return (props as Record<string, unknown>)[key];
+    }
+
+    const a11y = Reflect.get(widget, "a11y") ?? Reflect.get(widget, "accessibility");
+    if (a11y && typeof a11y === "object" && key in a11y) {
+        return (a11y as Record<string, unknown>)[key];
+    }
+
+    return undefined;
 }
 
 /** Render the widget tree to the screen buffer */
@@ -373,12 +408,17 @@ export function render(
         },
 
         getByRole(role: string): Widget | null {
-            const matches = walkWidgets(container, (w) => Reflect.get(w, 'role') === role);
+            const matches = walkWidgets(container, (w) => getWidgetMetadata(w, "role") === role);
             return matches.length > 0 ? matches[0] : null;
         },
 
         getByLabelText(label: string): Widget | null {
-            const matches = walkWidgets(container, (w) => Reflect.get(w, 'label') === label);
+            const matches = walkWidgets(container, (w) => getWidgetMetadata(w, "label") === label);
+            return matches.length > 0 ? matches[0] : null;
+        },
+
+        getByTestId(testId: string): Widget | null {
+            const matches = walkWidgets(container, (w) => getWidgetMetadata(w, "testId") === testId);
             return matches.length > 0 ? matches[0] : null;
         },
 
@@ -419,13 +459,17 @@ export function render(
 
         queryAllByRole(role: string): Widget[] {
             return walkWidgets(container, (widget) => {
-                const accessibility = (widget as any).accessibility;
-        
-                return (
-                    (widget as any).role === role ||
-                    accessibility?.role === role
-                );
+                return getWidgetMetadata(widget, "role") === role;
             });
+        },
+
+        queryByTestId(testId: string): Widget | null {
+            const matches = instance.queryAllByTestId(testId);
+            return matches.length > 0 ? matches[0] : null;
+        },
+
+        queryAllByTestId(testId: string): Widget[] {
+            return walkWidgets(container, (widget) => getWidgetMetadata(widget, "testId") === testId);
         },
 
         queryByType<T extends Widget>(type: new (...args: any[]) => T): T | null {


### PR DESCRIPTION
## Summary
- add getByTestId, queryByTestId, and queryAllByTestId to the test renderer
- reuse a shared widget metadata reader for role, label, and testId lookups
- cover direct widget metadata and a11y-backed testId metadata

## Tests
- bun test packages/testing/src/render.test.tsx

Closes #2951