### PR TITLE
Improve router redirect loop diagnostics

### DIFF
--- a/packages/router/src/redirect.test.ts
+++ b/packages/router/src/redirect.test.ts
@@ -56,6 +56,22 @@ describe('Router Redirects', () => {
         router.push('/a');
 
         expect(errorHandler).toHaveBeenCalled();
+        expect(errorHandler.mock.calls[0][0].message).toBe('Redirect loop detected: /a -> /b -> /a');
+    });
+
+    it('includes the redirect trail when max depth is exceeded', () => {
+        const router = new Router();
+        const errorHandler = vi.fn();
+        router.events.on('error', errorHandler);
+
+        for (let i = 0; i < 11; i++) {
+            router.addRoute(`/step-${i}`, DummyComponent, undefined, undefined, undefined, `/step-${i + 1}`);
+        }
+
+        router.push('/step-0');
+
+        expect(errorHandler).toHaveBeenCalled();
+        expect(errorHandler.mock.calls[0][0].message).toContain('/step-0 -> /step-1 -> /step-2');
         expect(errorHandler.mock.calls[0][0].message).toMatch(/Max redirect depth exceeded/);
     });
 });

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -212,9 +212,18 @@ export class Router {
         };
     }
 
-    private _resolveRedirect(path: string, depth = 0): string | null {
-        if (depth > 10) {
-            this.events.emit('error', new Error(`Max redirect depth exceeded for path: ${path}`));
+    private _resolveRedirect(path: string, trail: string[] = []): string | null {
+        const cycleStart = trail.indexOf(path);
+        if (cycleStart !== -1) {
+            const cycle = [...trail.slice(cycleStart), path].join(' -> ');
+            this.events.emit('error', new Error(`Redirect loop detected: ${cycle}`));
+            return null;
+        }
+
+        const nextTrail = [...trail, path];
+
+        if (nextTrail.length > 10) {
+            this.events.emit('error', new Error(`Max redirect depth exceeded: ${nextTrail.join(' -> ')}`));
             return null;
         }
 
@@ -224,7 +233,7 @@ export class Router {
         if (match.route.redirect) {
             const redirectTarget = match.route.redirect;
             const nextPath = typeof redirectTarget === 'function' ? redirectTarget(match.params) : redirectTarget;
-            return this._resolveRedirect(nextPath, depth + 1);
+            return this._resolveRedirect(nextPath, nextTrail);
         }
 
         return path;


### PR DESCRIPTION
## Summary
- detect redirect cycles by tracking the visited path trail
- include the redirect path trail in cycle and max-depth errors
- cover direct loops and excessive redirect chains

## Tests
- bun test packages/router/src/redirect.test.ts

Closes #2952