### PR TITLE
Add API status bar helper

### DIFF
--- a/packages/widgets/src/display/StatusBar.test.ts
+++ b/packages/widgets/src/display/StatusBar.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { StatusBar } from './StatusBar.js';
+import { Screen } from '@termuijs/core';
+import { StatusBar, createApiStatusBar, formatApiStatusBar } from './StatusBar.js';
+
+function renderStatusBar(statusBar: StatusBar, width = 60): string {
+    const screen = new Screen(width, 1);
+    statusBar.updateRect({ x: 0, y: 0, width, height: 1 });
+    statusBar.render(screen);
+    return screen.back[0].map((cell) => cell.char).join('');
+}
 
 describe('StatusBar', () => {
     it('creates a StatusBar instance', () => {
@@ -34,5 +42,35 @@ describe('StatusBar', () => {
         statusBar.setRight('F1 Help');
 
         expect(statusBar).toBeDefined();
+    });
+
+    it('formats API status bar sections', () => {
+        expect(formatApiStatusBar({
+            method: 'post',
+            endpoint: '/v1/chat',
+            status: 201,
+            latencyMs: 42.4,
+            environment: 'prod',
+            requestId: 'req_123',
+        })).toEqual({
+            left: 'POST /v1/chat',
+            center: '201 OK',
+            right: '42ms prod #req_123',
+        });
+    });
+
+    it('creates a rendered API status bar helper', () => {
+        const statusBar = createApiStatusBar({
+            method: 'get',
+            endpoint: '/health',
+            status: 503,
+            latencyMs: 1200,
+        });
+
+        const row = renderStatusBar(statusBar);
+
+        expect(row).toContain('GET /health');
+        expect(row).toContain('503 Server Error');
+        expect(row).toContain('1200ms');
     });
 });

--- a/packages/widgets/src/display/StatusBar.ts
+++ b/packages/widgets/src/display/StatusBar.ts
@@ -18,6 +18,15 @@ export interface StatusBarOptions {
     right?: string;
 }
 
+export interface ApiStatusBarOptions {
+    method?: string;
+    endpoint?: string;
+    status?: number | string;
+    latencyMs?: number;
+    environment?: string;
+    requestId?: string;
+}
+
 export class StatusBar extends Widget {
     private _left: string;
     private _center: string;
@@ -88,4 +97,40 @@ export class StatusBar extends Widget {
             attrs,
         );
     }
+}
+
+export function createApiStatusBar(
+    options: ApiStatusBarOptions,
+    style: Partial<Style> = {},
+): StatusBar {
+    return new StatusBar(style, formatApiStatusBar(options));
+}
+
+export function formatApiStatusBar(options: ApiStatusBarOptions): StatusBarOptions {
+    const method = options.method?.trim().toUpperCase();
+    const endpoint = options.endpoint?.trim();
+    const status = options.status;
+    const latencyMs = options.latencyMs;
+
+    const left = [method, endpoint].filter(Boolean).join(' ') || 'API';
+    const center = status === undefined ? 'Pending' : formatStatus(status);
+    const right = [
+        latencyMs === undefined ? undefined : `${Math.max(0, Math.round(latencyMs))}ms`,
+        options.environment?.trim(),
+        options.requestId ? `#${options.requestId.trim()}` : undefined,
+    ].filter(Boolean).join(' ');
+
+    return { left, center, right };
+}
+
+function formatStatus(status: number | string): string {
+    if (typeof status === 'number') {
+        if (status >= 200 && status < 300) return `${status} OK`;
+        if (status >= 300 && status < 400) return `${status} Redirect`;
+        if (status >= 400 && status < 500) return `${status} Client Error`;
+        if (status >= 500) return `${status} Server Error`;
+        return String(status);
+    }
+
+    return status.trim() || 'Pending';
 }

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -199,8 +199,8 @@ export type { BulletChartOptions, BulletRange } from './data/BulletChart.js';
 // ── New Display Widgets ───────────────────────────────
 export { Breadcrumbs } from './display/Breadcrumbs.js';
 export type { BreadcrumbsOptions } from './display/Breadcrumbs.js';
-export { StatusBar } from './display/StatusBar.js';
-export type { StatusBarOptions } from './display/StatusBar.js';
+export { StatusBar, createApiStatusBar, formatApiStatusBar } from './display/StatusBar.js';
+export type { ApiStatusBarOptions, StatusBarOptions } from './display/StatusBar.js';
 export { LoggerPanel } from './display/LoggerPanel.js';
 export type { LoggerPanelOptions, LogEntry, LogLevel } from './display/LoggerPanel.js';
 export { Avatar } from './display/Avatar.js';


### PR DESCRIPTION
## Summary
- add API status bar formatting helpers on top of StatusBar
- include method, endpoint, status, latency, environment, and request id sections
- export the helper functions and option type from the widgets package

## Tests
- bun test packages/widgets/src/display/StatusBar.test.ts

Closes #2953