### PR TITLE
Pass reasons through motion cancellation

### DIFF
--- a/packages/motion/src/index.ts
+++ b/packages/motion/src/index.ts
@@ -18,7 +18,7 @@ export { transition, fadeIn, fadeOut, slideIn, typewriter, pulse, easings, cubic
 export type { TransitionOptions, EasingFn } from './transitions.js';
 // Sequencing
 export { sequence, parallel, repeat } from './sequence.js';
-export type { AnimationRunner, SequenceStep, AnimatableValue, RepeatOptions } from './sequence.js';
+export type { AnimationCancel, AnimationRunner, SequenceStep, AnimatableValue, RepeatOptions } from './sequence.js';
 export { stagger } from './stagger.js';
 // Shared interval timer pool
 export { subscribe as timerPoolSubscribe, unsubscribeAll as timerPoolUnsubscribeAll } from './timer-pool.js';

--- a/packages/motion/src/repeat.test.ts
+++ b/packages/motion/src/repeat.test.ts
@@ -63,6 +63,18 @@ describe('repeat()', () => {
     expect(calls).toBe(1);
   });
 
+  it('passes a cancellation reason to the active pass', () => {
+    const cancelSpy = vi.fn();
+    const runner: AnimationRunner = () => cancelSpy;
+
+    const repeated = repeat(runner, { count: 3 });
+    const cancel = repeated(vi.fn());
+
+    cancel('component-unmounted');
+
+    expect(cancelSpy).toHaveBeenCalledWith('component-unmounted');
+  });
+
   it('infinite loop does not call done', () => {
     let calls = 0;
     let cancel: (() => void) | null = null;

--- a/packages/motion/src/sequence.test.ts
+++ b/packages/motion/src/sequence.test.ts
@@ -103,6 +103,16 @@ describe('sequence()', () => {
         expect(order).toEqual(['start1']); // Anim2 never started
         expect(onComplete).not.toHaveBeenCalled();
     });
+
+    it('passes a cancellation reason to the active animation', () => {
+        const cancelSpy = vi.fn();
+        const anim: AnimationRunner = () => cancelSpy;
+
+        const cancelMaster = sequence([anim]);
+        cancelMaster('interrupted');
+
+        expect(cancelSpy).toHaveBeenCalledWith('interrupted');
+    });
 });
 
 describe('parallel()', () => {
@@ -159,6 +169,20 @@ describe('parallel()', () => {
 
         expect(cancelSpy1).toHaveBeenCalledTimes(1);
         expect(cancelSpy2).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes a cancellation reason to each active animation', () => {
+        const cancelSpy1 = vi.fn();
+        const cancelSpy2 = vi.fn();
+
+        const anim1: AnimationRunner = () => cancelSpy1;
+        const anim2: AnimationRunner = () => cancelSpy2;
+
+        const cancelMaster = parallel([anim1, anim2]);
+        cancelMaster('route-change');
+
+        expect(cancelSpy1).toHaveBeenCalledWith('route-change');
+        expect(cancelSpy2).toHaveBeenCalledWith('route-change');
     });
 
     it('ignores late completion callbacks after cancellation', () => {

--- a/packages/motion/src/sequence.ts
+++ b/packages/motion/src/sequence.ts
@@ -9,12 +9,13 @@ export interface SequenceStep {
   duration?: number
 }
 
-export type AnimationRunner = (done: () => void) => () => void
+export type AnimationCancel = (reason?: string) => void
+export type AnimationRunner = (done: () => void) => AnimationCancel
 
 export function sequence(
   runners: AnimationRunner[],
   onComplete?: () => void
-): () => void
+): AnimationCancel
 export function sequence(
   runners: SequenceStep[],
   onComplete?: () => void
@@ -22,7 +23,7 @@ export function sequence(
 export function sequence(
   runners: AnimationRunner[] | SequenceStep[],
   onComplete?: () => void
-): (() => void) | SequenceStep[] {
+): AnimationCancel | SequenceStep[] {
   // 1. Handle empty runners (always returns dummy cancel function)
   if (runners.length === 0) {
     onComplete?.()
@@ -39,7 +40,7 @@ export function sequence(
   const fns = runners as AnimationRunner[]
 
   let cancelled = false
-  let cancelCurrent: () => void = () => {}
+  let cancelCurrent: AnimationCancel = () => {}
 
   function runNext(index: number) {
     if (cancelled || index >= fns.length) {
@@ -51,16 +52,16 @@ export function sequence(
 
   runNext(0)
 
-  return () => {
+  return (reason?: string) => {
     cancelled = true
-    cancelCurrent()
+    cancelCurrent(reason)
   }
 }
 
 export function parallel(
   runners: AnimationRunner[],
   onComplete?: () => void
-): () => void {
+): AnimationCancel {
   if (runners.length === 0) {
     onComplete?.()
     return () => {}
@@ -68,7 +69,7 @@ export function parallel(
 
   let remaining = runners.length
   let cancelled = false
-  const cancellers: Array<() => void> = []
+  const cancellers: AnimationCancel[] = []
 
   for (const runner of runners) {
     const cancel = runner(() => {
@@ -79,9 +80,9 @@ export function parallel(
     cancellers.push(cancel)
   }
 
-  return () => {
+  return (reason?: string) => {
     cancelled = true
-    cancellers.forEach(c => c())
+    cancellers.forEach(c => c(reason))
   }
 }
 
@@ -111,7 +112,7 @@ export function repeat(
     }
 
     let cancelled = false
-    let cancelCurrent: () => void = () => {}
+    let cancelCurrent: AnimationCancel = () => {}
 
     function runNext(index: number) {
       if (cancelled || index >= count) {
@@ -131,9 +132,9 @@ export function repeat(
 
     runNext(0)
 
-    return () => {
+    return (reason?: string) => {
       cancelled = true
-      cancelCurrent()
+      cancelCurrent(reason)
     }
   }
 }

--- a/packages/motion/src/stagger.test.ts
+++ b/packages/motion/src/stagger.test.ts
@@ -111,4 +111,16 @@ describe('stagger()', () => {
 
         expect(parallelSpy).toHaveBeenCalledTimes(1);
     });
+
+    it('passes cancellation reasons to already-started delayed animations', () => {
+        vi.useFakeTimers();
+        const cancelStarted = vi.fn();
+        const animation: AnimationRunner = () => cancelStarted;
+
+        const cancel = stagger([animation, animation], 100);
+        vi.advanceTimersByTime(100);
+        cancel('route-change');
+
+        expect(cancelStarted).toHaveBeenCalledWith('route-change');
+    });
 });

--- a/packages/motion/src/stagger.ts
+++ b/packages/motion/src/stagger.ts
@@ -2,7 +2,7 @@
 // Animation Staggering — delayed parallel starts
 // ─────────────────────────────────────────────────────
 
-import type { AnimationRunner } from './sequence.js';
+import type { AnimationCancel, AnimationRunner } from './sequence.js';
 import * as sequencing from './sequence.js';
 
 /**
@@ -10,7 +10,7 @@ import * as sequencing from './sequence.js';
  * item 0 starts immediately, item 1 after delayMs, item 2 after 2*delayMs, etc.
  * Returns a master cancel function to stop pending and active animations.
  */
-export function stagger(animations: AnimationRunner[], delayMs: number, onComplete?: () => void): () => void {
+export function stagger(animations: AnimationRunner[], delayMs: number, onComplete?: () => void): AnimationCancel {
     const normalizedDelayMs = Math.max(0, delayMs);
     const delayedAnimations = animations.map((runner, index) => withDelay(runner, index * normalizedDelayMs));
     return sequencing.parallel(delayedAnimations, onComplete);
@@ -28,7 +28,7 @@ function withDelay(runner: AnimationRunner, delayMs: number): AnimationRunner {
             return runner(done);
         }
 
-        let cancelStarted: (() => void) | null = null;
+        let cancelStarted: AnimationCancel | null = null;
         let isStarted = false;
 
         const timeoutId = setTimeout(() => {
@@ -36,10 +36,10 @@ function withDelay(runner: AnimationRunner, delayMs: number): AnimationRunner {
             cancelStarted = runner(done);
         }, delayMs);
 
-        return () => {
+        return (reason?: string) => {
             clearTimeout(timeoutId);
             if (isStarted) {
-                cancelStarted?.();
+                cancelStarted?.(reason);
             }
             cancelStarted = null;
         };

--- a/packages/motion/src/transitions.test.ts
+++ b/packages/motion/src/transitions.test.ts
@@ -2,8 +2,14 @@
 // @termuijs/motion — Tests for Transitions (easing functions)
 // ─────────────────────────────────────────────────────
 
-import { describe, it, expect, vi, beforeEach, test } from 'vitest';
-import { easings, cubicBezier } from './transitions.js';
+import { describe, it, expect, vi, beforeEach, afterEach, test } from 'vitest';
+import { easings, cubicBezier, fadeIn, pulse, transition } from './transitions.js';
+import { unsubscribeAll as timerPoolUnsubscribeAll } from './timer-pool.js';
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    timerPoolUnsubscribeAll();
+});
 
 describe('Easing Functions', () => {
     it('linear(0) = 0 and linear(1) = 1', () => {
@@ -130,4 +136,37 @@ describe("cubicBezier easing", () => {
     expect(midValue).toBeGreaterThan(0);
     expect(midValue).toBeLessThan(1);
   });
+});
+
+describe('transition cancellation reasons', () => {
+    it('passes the cancellation reason to transition onCancel', () => {
+        const onCancel = vi.fn();
+        const cancel = transition({
+            durationMs: 300,
+            onFrame: () => {},
+            onCancel,
+        });
+
+        cancel('route-change');
+
+        expect(onCancel).toHaveBeenCalledWith('route-change');
+    });
+
+    it('passes the cancellation reason through pre-built transitions', () => {
+        const onCancel = vi.fn();
+        const cancel = fadeIn(300, () => {}, undefined, onCancel);
+
+        cancel('component-unmounted');
+
+        expect(onCancel).toHaveBeenCalledWith('component-unmounted');
+    });
+
+    it('passes the cancellation reason through pulse', () => {
+        const onCancel = vi.fn();
+        const cancel = pulse(1000, () => {}, onCancel);
+
+        cancel('screen-hidden');
+
+        expect(onCancel).toHaveBeenCalledWith('screen-hidden');
+    });
 });

--- a/packages/motion/src/transitions.ts
+++ b/packages/motion/src/transitions.ts
@@ -4,6 +4,7 @@
 
 import { prefersReducedMotion } from '@termuijs/core';
 import { subscribe } from './timer-pool.js';
+import type { AnimationCancel } from './sequence.js';
 
 export type EasingFn = (t: number) => number;
 
@@ -26,19 +27,22 @@ export interface TransitionOptions {
     easing?: EasingFn;
     onFrame: (progress: number) => void;
     onComplete?: () => void;
+    onCancel?: (reason?: string) => void;
 }
 
 /**
  * Run a tween animation from 0→1 over durationMs.
  * Returns a cleanup function to cancel.
  */
-export function transition(options: TransitionOptions): () => void {
-    const { durationMs, easing = easings.easeInOut, onFrame, onComplete } = options;
+export function transition(options: TransitionOptions): AnimationCancel {
+    const { durationMs, easing = easings.easeInOut, onFrame, onComplete, onCancel } = options;
 
     if (prefersReducedMotion()) {
         onFrame(easing(1));
         onComplete?.();
-        return () => {};
+        return (reason?: string) => {
+            onCancel?.(reason);
+        };
     }
 
     const startTime = Date.now();
@@ -54,41 +58,47 @@ export function transition(options: TransitionOptions): () => void {
         }
     });
 
-    return () => unsub();
+    return (reason?: string) => {
+        unsub();
+        onCancel?.(reason);
+    };
 }
 
 // ── Pre-built transitions ──
 
 /** Fade: progress = opacity (0→1) */
-export function fadeIn(durationMs: number, onFrame: (opacity: number) => void, onComplete?: () => void): () => void {
-    return transition({ durationMs, easing: easings.easeOut, onFrame, onComplete });
+export function fadeIn(durationMs: number, onFrame: (opacity: number) => void, onComplete?: () => void, onCancel?: (reason?: string) => void): AnimationCancel {
+    return transition({ durationMs, easing: easings.easeOut, onFrame, onComplete, onCancel });
 }
 
 /** Fade out: progress = opacity (1→0) */
-export function fadeOut(durationMs: number, onFrame: (opacity: number) => void, onComplete?: () => void): () => void {
-    return transition({ durationMs, easing: easings.easeIn, onFrame: t => onFrame(1 - t), onComplete });
+export function fadeOut(durationMs: number, onFrame: (opacity: number) => void, onComplete?: () => void, onCancel?: (reason?: string) => void): AnimationCancel {
+    return transition({ durationMs, easing: easings.easeIn, onFrame: t => onFrame(1 - t), onComplete, onCancel });
 }
 
 /** Slide: progress = position offset (from→0) */
-export function slideIn(from: number, durationMs: number, onFrame: (offset: number) => void, onComplete?: () => void): () => void {
-    return transition({ durationMs, easing: easings.easeOutCubic, onFrame: t => onFrame(from * (1 - t)), onComplete });
+export function slideIn(from: number, durationMs: number, onFrame: (offset: number) => void, onComplete?: () => void, onCancel?: (reason?: string) => void): AnimationCancel {
+    return transition({ durationMs, easing: easings.easeOutCubic, onFrame: t => onFrame(from * (1 - t)), onComplete, onCancel });
 }
 
 /** Typewriter: reveal text character by character */
-export function typewriter(text: string, durationMs: number, onFrame: (visibleChars: number) => void, onComplete?: () => void): () => void {
+export function typewriter(text: string, durationMs: number, onFrame: (visibleChars: number) => void, onComplete?: () => void, onCancel?: (reason?: string) => void): AnimationCancel {
     return transition({
         durationMs,
         easing: easings.linear,
         onFrame: t => onFrame(Math.floor(t * text.length)),
         onComplete,
+        onCancel,
     });
 }
 
 /** Pulse: oscillates between 0 and 1 */
-export function pulse(periodMs: number, onFrame: (intensity: number) => void): () => void {
+export function pulse(periodMs: number, onFrame: (intensity: number) => void, onCancel?: (reason?: string) => void): AnimationCancel {
     if (prefersReducedMotion()) {
         onFrame(1);
-        return () => {};
+        return (reason?: string) => {
+            onCancel?.(reason);
+        };
     }
 
     const start = Date.now();
@@ -100,7 +110,10 @@ export function pulse(periodMs: number, onFrame: (intensity: number) => void): (
         onFrame(intensity);
     });
 
-    return unsub;
+    return (reason?: string) => {
+        unsub();
+        onCancel?.(reason);
+    };
 }
 /**
  * Creates a custom cubic bezier easing function for animations.


### PR DESCRIPTION
## Summary
- add an AnimationCancel type that accepts an optional reason
- pass cancellation reasons through sequence, parallel, and repeat
- export the cancellation type from the motion package

## Tests
- bun test packages/motion/src/sequence.test.ts packages/motion/src/repeat.test.ts

Closes #2954

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Animation cancellation now supports optional reason messages.
  - Cancellation reasons are consistently forwarded through sequences, parallel animations, repeats, staggered animations, and transitions.
  - Transition callbacks can respond to cancellation reasons across built-in effects such as fade, slide, typewriter, and pulse.

- **Tests**
  - Added coverage confirming cancellation reasons propagate correctly across animation utilities and transition helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->