### PR TITLE
Add TSS token JSON export

### DIFF
--- a/packages/tss/src/index.ts
+++ b/packages/tss/src/index.ts
@@ -23,8 +23,8 @@ export type { PseudoClass } from './pseudo.js';
 export { BUILTIN_THEMES, getBuiltinThemeNames, getBuiltinTheme, getAllBuiltinThemes } from './themes.js';
 
 // Design Tokens
-export { systemTheme, defaultDark, defaultLight, detectDark, tokensToTSS } from './tokens.js';
-export type { ThemeTokens } from './tokens.js';
+export { systemTheme, defaultDark, defaultLight, detectDark, tokensToTSS, compileTokensToJSON } from './tokens.js';
+export type { CompiledTokenJSON, ThemeTokens } from './tokens.js';
 
 // Named ThemeTokens
 export {

--- a/packages/tss/src/token-json.test.ts
+++ b/packages/tss/src/token-json.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { compileTokensToJSON } from './tokens.js';
+
+const SOURCE = `
+@theme default {
+  --bg: #000000;
+  --fg: #ffffff;
+  --accent: var(--fg);
+}
+
+@theme light {
+  --bg: #ffffff;
+  --fg: #111111;
+}
+`;
+
+describe('compiled token JSON export', () => {
+  it('exports the active default theme tokens with resolved aliases', () => {
+    expect(compileTokensToJSON(SOURCE)).toEqual({
+      theme: 'default',
+      tokens: {
+        accent: '#ffffff',
+        bg: '#000000',
+        fg: '#ffffff',
+      },
+    });
+  });
+
+  it('exports selected theme tokens merged over default tokens', () => {
+    expect(compileTokensToJSON(SOURCE, 'light')).toEqual({
+      theme: 'light',
+      tokens: {
+        accent: '#111111',
+        bg: '#ffffff',
+        fg: '#111111',
+      },
+    });
+  });
+
+  it('falls back to the first theme when no default theme exists', () => {
+    expect(compileTokensToJSON('@theme custom { --fg: #f0f0f0; }', 'missing')).toEqual({
+      theme: 'missing',
+      tokens: {
+        fg: '#f0f0f0',
+      },
+    });
+  });
+});

--- a/packages/tss/src/tokens.ts
+++ b/packages/tss/src/tokens.ts
@@ -1,3 +1,6 @@
+import { parse } from './parser.js';
+import { tokenize } from './tokenizer.js';
+
 export interface ThemeTokens {
   bg: string;
   fg: string;
@@ -9,6 +12,11 @@ export interface ThemeTokens {
   muted: string;
   border: string;
   highlight: string;
+}
+
+export interface CompiledTokenJSON {
+  theme: string;
+  tokens: Record<string, string>;
 }
 
 /**
@@ -76,5 +84,47 @@ export function tokensToTSS(name: string, tokens: ThemeTokens): string {
     return `@theme ${name} {\n` +
         Object.entries(tokens).map(([k, v]) => `  --${k}: ${v};`).join('\n') +
         '\n}';
+}
+
+/** Compile TSS @theme variables into JSON-ready token data. */
+export function compileTokensToJSON(source: string, theme = 'default'): CompiledTokenJSON {
+  const ast = parse(tokenize(source));
+  const merged: Record<string, string> = {};
+  const defaultTheme = ast.themes.find(t => t.name === 'default');
+  const selectedTheme = theme === 'default'
+    ? undefined
+    : ast.themes.find(t => t.name === theme);
+
+  if (defaultTheme) Object.assign(merged, normalizeThemeVariables(defaultTheme.variables));
+  if (selectedTheme) Object.assign(merged, normalizeThemeVariables(selectedTheme.variables));
+  if (!defaultTheme && !selectedTheme && ast.themes.length > 0) {
+    Object.assign(merged, normalizeThemeVariables(ast.themes[0].variables));
+  }
+
+  const tokens: Record<string, string> = {};
+  for (const key of Object.keys(merged).sort()) {
+    tokens[key] = resolveTokenValue(key, merged, new Set<string>());
+  }
+
+  return { theme, tokens };
+}
+
+function resolveTokenValue(name: string, tokens: Record<string, string>, seen: Set<string>): string {
+  if (seen.has(name)) return '';
+  seen.add(name);
+
+  const value = tokens[name] ?? '';
+  const match = value.match(/^(?:var\()?--([^)]+)\)?$/);
+  if (!match) return value;
+
+  return resolveTokenValue(match[1], tokens, seen);
+}
+
+function normalizeThemeVariables(variables: Record<string, string>): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  for (const [key, value] of Object.entries(variables)) {
+    normalized[key.replace(/^--/, '')] = value;
+  }
+  return normalized;
 }
 


### PR DESCRIPTION
## Summary
- add compileTokensToJSON for TSS @theme variables
- normalize token names and resolve token aliases in exported data
- export the JSON-ready token type and compiler from the TSS package

## Tests
- bun test packages/tss/src/token-json.test.ts

Closes #2955