### PR TITLE
Preserve FilePicker selection on refresh

### DIFF
--- a/packages/ui/src/FilePicker.test.ts
+++ b/packages/ui/src/FilePicker.test.ts
@@ -239,6 +239,57 @@ describe('FilePicker', () => {
             expect(names).not.toContain('..');
         });
 
+        it('refresh preserves the selected entry when it still exists', async () => {
+            readdirSync
+                .mockReturnValueOnce([
+                    makeDirent('a.ts', false),
+                    makeDirent('b.ts', false),
+                    makeDirent('c.ts', false),
+                ] as any)
+                .mockReturnValueOnce([
+                    makeDirent('c.ts', false),
+                    makeDirent('a.ts', false),
+                    makeDirent('b.ts', false),
+                    makeDirent('d.ts', false),
+                ] as any);
+            statSync.mockReturnValue({ isDirectory: () => false } as any);
+
+            const { FilePicker } = await import('./FilePicker.js');
+            const picker = new FilePicker({ startPath: '/project' });
+            picker.selectNext();
+            picker.selectNext();
+
+            expect(picker.selectedEntry?.name).toBe('b.ts');
+
+            picker.refresh();
+
+            expect(picker.selectedEntry?.name).toBe('b.ts');
+        });
+
+        it('refresh clamps selection when the previous entry disappears', async () => {
+            readdirSync
+                .mockReturnValueOnce([
+                    makeDirent('a.ts', false),
+                    makeDirent('b.ts', false),
+                    makeDirent('c.ts', false),
+                ] as any)
+                .mockReturnValueOnce([
+                    makeDirent('a.ts', false),
+                ] as any);
+            statSync.mockReturnValue({ isDirectory: () => false } as any);
+
+            const { FilePicker } = await import('./FilePicker.js');
+            const picker = new FilePicker({ startPath: '/project' });
+            picker.selectNext();
+            picker.selectNext();
+            picker.selectNext();
+
+            picker.refresh();
+
+            expect(picker.cursorIndex).toBe(1);
+            expect(picker.selectedEntry?.name).toBe('a.ts');
+        });
+
         it('treats symlink directories as directories', async () => {
             // Dirent says it is a symlink; statSync says the target is a directory
             readdirSync.mockReturnValue([makeDirent('linked-dir', false, true)] as any);

--- a/packages/ui/src/FilePicker.ts
+++ b/packages/ui/src/FilePicker.ts
@@ -111,6 +111,11 @@ export class FilePicker extends Widget {
     /** Current cursor index within `entries`. */
     get cursorIndex(): number { return this._cursor; }
 
+    /** Reload the current directory while preserving the selected entry when possible. */
+    refresh(): void {
+        this._loadEntries({ preserveSelection: true });
+    }
+
     // ── Navigation ───────────────────────────────────
 
     /** Move the cursor one row down. Clamps at the last entry. */
@@ -205,7 +210,9 @@ export class FilePicker extends Widget {
      *  2. Directories — alpha-sorted
      *  3. Files       — alpha-sorted, filtered by `this._filter`
      */
-    private _loadEntries(): void {
+    private _loadEntries(options: { preserveSelection?: boolean } = {}): void {
+        const previousSelection = options.preserveSelection ? this.selectedEntry?.fullPath : undefined;
+        const previousCursor = this._cursor;
         const entries: FileEntry[] = [];
 
         // Parent entry (unless at root)
@@ -252,7 +259,14 @@ export class FilePicker extends Widget {
         }
 
         this._entries = entries;
-        this._cursor = 0;
+        const preservedIndex = previousSelection
+            ? entries.findIndex(entry => entry.fullPath === previousSelection)
+            : -1;
+        this._cursor = !options.preserveSelection
+            ? 0
+            : preservedIndex >= 0
+            ? preservedIndex
+            : Math.min(previousCursor, Math.max(0, entries.length - 1));
         this._scrollTop = 0;
         this.markDirty();
     }


### PR DESCRIPTION
## Summary
- add a public FilePicker refresh method
- preserve the selected file entry by full path across refreshes
- clamp selection to a valid entry when the previous selection disappears

## Tests
- bun test packages/ui/src/FilePicker.test.ts

Closes #2957