### PR TITLE
fix(widgets): resolve FileExplorer test failures on Windows due to PO…

### DIFF
--- a/packages/widgets/src/FileExplorer.test.ts
+++ b/packages/widgets/src/FileExplorer.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, vi, afterEach, beforeAll, afterAll } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, dirname } from 'node:path';
+import { join, dirname, basename } from 'node:path';
 import { Screen, caps, type KeyEvent } from '@termuijs/core';
 import { FileExplorer } from './FileExplorer.js';
 import type { FileItem } from './FileExplorer.js';
@@ -280,7 +280,7 @@ describe('FileExplorer widget behaviour', () => {
         fe.reload();
         const screen = new Screen(60, 10);
         fe.updateRect({ x: 0, y: 0, width: 60, height: 10 });
-        const childBase = CHILD_A.split('/').pop() as string;
+        const childBase = basename(CHILD_A);
         fe.render(screen);
         expect(rowText(screen, 1)).not.toContain(childBase);
 
@@ -306,7 +306,7 @@ describe('FileExplorer widget behaviour', () => {
         // The child row should be indented relative to the directory row.
         const dirRow = rowText(screen, 1);
         const childRow = rowText(screen, 2);
-        const childBase = CHILD_A.split('/').pop() as string;
+        const childBase = basename(CHILD_A);
         expect(childRow.indexOf(childBase)).toBeGreaterThan(dirRow.indexOf(SUB));
     });
 


### PR DESCRIPTION
## Description

Fixes cross-platform test failures in `packages/widgets/src/FileExplorer.test.ts` when running unit tests on Windows operating systems by using Node's `basename()` helper instead of a POSIX forward-slash split.

## Related Issue

Closes #2971

## Which package(s)?

@termuijs/widgets

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [x] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/karthikj5453`

## Screenshots / Recordings (UI changes)

N/A (test-only fix)

## Notes for the Reviewer

`CHILD_A` in `FileExplorer.test.ts` is constructed with `join('sub', 'a.txt')`, which produces Windows backslashes `sub\a.txt`. Replacing `CHILD_A.split('/').pop()` with `basename(CHILD_A)` allows `FileExplorer` tests to pass reliably across all platforms (Windows, Linux, macOS).
