### PR TITLE
fix(jsx): detect deps length changes in useEffect and useLayoutEffect

### DIFF
--- a/packages/jsx/src/hooks.ts
+++ b/packages/jsx/src/hooks.ts
@@ -263,7 +263,7 @@ export function useEffect(effect: () => void | (() => void), deps?: any[]): void
         fiber.effects.push(record);
     } else {
         const prev = fiber.hooks[idx];
-        const shouldRun = !deps || !prev.deps || deps.some((d, i) => !Object.is(d, prev.deps![i]));
+        const shouldRun = !deps || !prev.deps || deps.length !== prev.deps.length || deps.some((d, i) => !Object.is(d, prev.deps![i]));
 
         if (shouldRun) {
             prev.deps = deps;
@@ -287,7 +287,7 @@ export function useLayoutEffect(effect: () => void | (() => void), deps?: any[])
         fiber.layoutEffects.push(record);
     } else {
         const prev = fiber.hooks[idx];
-        const shouldRun = !deps || !prev.deps || deps.some((d, i) => !Object.is(d, prev.deps![i]));
+        const shouldRun = !deps || !prev.deps || deps.length !== prev.deps.length || deps.some((d, i) => !Object.is(d, prev.deps![i]));
 
         if (shouldRun) {
             prev.deps = deps;


### PR DESCRIPTION
## Summary
Added length check to deps comparison in `useEffect` and `useLayoutEffect`.

## Problem
When deps shrinks (e.g., `[a,b,c]` → `[a,b]`), the `deps.some()` comparison only checked indices 0 and 1, missing the removed third element. This caused effects to not re-run when dependencies were removed, leading to stale closures.

## Fix
Added `deps.length !== prev.deps.length` check before element-wise comparison in both `useEffect` and `useLayoutEffect`.

## Changed
- `packages/jsx/src/hooks.ts`: Added length comparison to both `depsChanged()` checks

Fixes #2977


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed effect hooks so they re-run when the number of dependencies changes.
  * Improved dependency tracking for both standard and layout effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->