### PR TITLE
fix(quick): remove inner catch in _refreshReactiveWidgets to propagate errors

### DIFF
--- a/packages/quick/src/app.ts
+++ b/packages/quick/src/app.ts
@@ -434,74 +434,69 @@ export class AppBuilder {
      * Walk the widget tree and update any reactive values.
      */
     private _refreshReactiveWidgets(widget: Widget): void {
-        try {
-            const w = widget as any; // as any: reactive metadata is monkey-patched onto Widget instances in widgets.ts
+        const w = widget as any; // as any: reactive metadata is monkey-patched onto Widget instances in widgets.ts
 
-            // Text — reactive content
-            if (widget instanceof Text && w.__reactiveContent) {
-                widget.setContent(resolve(w.__reactiveContent));
-            }
+        // Text — reactive content
+        if (widget instanceof Text && w.__reactiveContent) {
+            widget.setContent(resolve(w.__reactiveContent));
+        }
 
-            // Gauge — reactive value
-            if (widget instanceof Gauge && w.__reactiveValue) {
-                widget.setValue(resolve(w.__reactiveValue));
-            }
+        // Gauge — reactive value
+        if (widget instanceof Gauge && w.__reactiveValue) {
+            widget.setValue(resolve(w.__reactiveValue));
+        }
 
-            // Table — reactive data
-            if (widget instanceof Table && w.__reactiveData) {
-                const data: Record<string, string | number>[] = resolve(w.__reactiveData);
-                widget.setRows(data);
-            }
+        // Table — reactive data
+        if (widget instanceof Table && w.__reactiveData) {
+            const data: Record<string, string | number>[] = resolve(w.__reactiveData);
+            widget.setRows(data);
+        }
 
-            // Sparkline — reactive data
-            if (widget instanceof Sparkline && w.__reactiveData) {
-                widget.setData(resolve(w.__reactiveData));
-            }
+        // Sparkline — reactive data
+        if (widget instanceof Sparkline && w.__reactiveData) {
+            widget.setData(resolve(w.__reactiveData));
+        }
 
-            // StatusIndicator — reactive status
-            if (widget instanceof StatusIndicator && w.__reactiveStatus) {
-                widget.setStatus(resolve(w.__reactiveStatus));
-            }
+        // StatusIndicator — reactive status
+        if (widget instanceof StatusIndicator && w.__reactiveStatus) {
+            widget.setStatus(resolve(w.__reactiveStatus));
+        }
 
-            // LogView — reactive lines
-            if (widget instanceof LogView && w.__reactiveLines) {
-                widget.setLines(resolve(w.__reactiveLines));
-            }
+        // LogView — reactive lines
+        if (widget instanceof LogView && w.__reactiveLines) {
+            widget.setLines(resolve(w.__reactiveLines));
+        }
 
-            // List — reactive items
-            if (widget instanceof List && w.__reactiveItems) {
-                const items: string[] = resolve(w.__reactiveItems);
-                widget.setItems(items.map(label => ({ label, value: label })));
-            }
+        // List — reactive items
+        if (widget instanceof List && w.__reactiveItems) {
+            const items: string[] = resolve(w.__reactiveItems);
+            widget.setItems(items.map(label => ({ label, value: label })));
+        }
 
-            // BarChart — reactive data
-            if (widget instanceof BarChart && w.__reactiveBarData) {
-                widget.setData(resolve(w.__reactiveBarData));
-            }
+        // BarChart — reactive data
+        if (widget instanceof BarChart && w.__reactiveBarData) {
+            widget.setData(resolve(w.__reactiveBarData));
+        }
 
-            // ProgressBar — reactive value
-            if (widget instanceof ProgressBar && w.__reactiveValue) {
-                widget.setValue(resolve(w.__reactiveValue));
-            }
+        // ProgressBar — reactive value
+        if (widget instanceof ProgressBar && w.__reactiveValue) {
+            widget.setValue(resolve(w.__reactiveValue));
+        }
 
-            // Tree — reactive nodes (if data changes)
-            if (widget instanceof Tree && w.__reactiveTreeNodes) {
-                widget.setNodes(resolve(w.__reactiveTreeNodes));
-            }
+        // Tree — reactive nodes (if data changes)
+        if (widget instanceof Tree && w.__reactiveTreeNodes) {
+            widget.setNodes(resolve(w.__reactiveTreeNodes));
+        }
 
-            // MultiProgress — reactive items
-            if (widget instanceof MultiProgress && w.__reactiveMultiItems) {
-                const items: ProgressItem[] = resolve(w.__reactiveMultiItems);
-                widget.setItems(items);
-            }
+        // MultiProgress — reactive items
+        if (widget instanceof MultiProgress && w.__reactiveMultiItems) {
+            const items: ProgressItem[] = resolve(w.__reactiveMultiItems);
+            widget.setItems(items);
+        }
 
-            // Recurse into children
-            for (const child of widget.children) {
-                this._refreshReactiveWidgets(child);
-            }
-        } catch (err) {
-            // Reactive widget error — don't crash the process
-            console.error('[quick] reactive widget error:', err);
+        // Recurse into children
+        for (const child of widget.children) {
+            this._refreshReactiveWidgets(child);
         }
     }
 }

--- a/packages/quick/src/app.ts
+++ b/packages/quick/src/app.ts
@@ -320,7 +320,11 @@ export class AppBuilder {
                     appInstance.exit();
                     return;
                 } else if (action === 'refresh') {
-                    this._refreshReactiveWidgets(root);
+                    try {
+                        this._refreshReactiveWidgets(root);
+                    } catch (err) {
+                        this._onError?.(err);
+                    }
                     appInstance.requestRender();
                     return;
                 } else if (typeof action === 'function') {


### PR DESCRIPTION
## Description

Removed inner catch block in `_refreshReactiveWidgets` so errors propagate to the caller's `onError` callback.

## Related Issue

Closes #2978

## Which package(s)?

@termuijs/quick

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)

## Checklist

- [ ] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.


## Notes for the Reviewer

The inner `try/catch` in `_refreshReactiveWidgets` was swallowing all errors, preventing them from reaching the outer `try/catch` in the setInterval callback which forwards them to `onError`. Removing it allows users who set `onError` to receive reactive widget errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when refreshing reactive widgets through the refresh hotkey.
  * Errors are now routed to the configured error handler instead of being silently logged or suppressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->