### PR TITLE
fix(tss): use safeResolve in auto-theme OSC 11 timeout catch block

### DIFF
--- a/packages/tss/src/auto-theme.ts
+++ b/packages/tss/src/auto-theme.ts
@@ -134,7 +134,7 @@ async function queryOSC11BackgroundColor(): Promise<TerminalBackground | null> {
     } catch {
       // setRawMode can throw in some environments — bail out
       clearTimeout(timer)
-      resolve(null)
+      safeResolve(null)
       return
     }
 


### PR DESCRIPTION
## Summary
Used `safeResolve` in the auto-theme OSC 11 timeout catch block.

## Problem
When `setRawMode` threw in the catch block, the code called `resolve(null)` directly instead of `safeResolve(null)`. This bypassed cleanup logic that removes the stdin data listener and sets the resolved flag, causing a memory leak and potential double-resolution.

## Fix
Changed `resolve(null)` to `safeResolve(null)` in the catch block.

## Changed
- `packages/tss/src/auto-theme.ts`: Changed `resolve(null)` to `safeResolve(null)` in catch block

Fixes #2979
