### PR TITLE
fix(data): add error handling to tail file watcher truncation path

### DIFF
--- a/packages/data/src/tail.ts
+++ b/packages/data/src/tail.ts
@@ -128,11 +128,15 @@ export function tail(filePath: string, opts: TailOptions = {}): TailStream {
         } else if (curr.size < fileSize) {
             // File was truncated — re-read, again holding back an
             // unterminated trailing line as partialLine (see readInitial).
-            const content = fs.readFileSync(filePath, 'utf-8');
-            const allLines = content.split('\n');
-            partialLine = allLines.pop() ?? '';
-            stream.lines = allLines.filter(l => l.length > 0).slice(-maxLines);
-            fileSize = curr.size;
+            try {
+                const content = fs.readFileSync(filePath, 'utf-8');
+                const allLines = content.split('\n');
+                partialLine = allLines.pop() ?? '';
+                stream.lines = allLines.filter(l => l.length > 0).slice(-maxLines);
+                fileSize = curr.size;
+            } catch {
+                // File may have been deleted between stat and read
+            }
         }
     };
 


### PR DESCRIPTION
## Summary
Added error handling to the tail file watcher's truncation branch.

## Problem
The growth branch of the file watcher had proper `try/catch/finally` with fd cleanup, but the truncation branch called `readFileSync` without any error handling. If the file was deleted between the `existsSync` check and the `readFileSync` call, an unhandled ENOENT exception would crash the watcher.

## Fix
Wrapped the truncation branch's `readFileSync` and line parsing in a try/catch that silently handles file-not-found errors.

## Changed
- `packages/data/src/tail.ts`: Added try/catch around truncation branch
Fixes #2980
