### PR TITLE
fix(adapters): make addDocuments atomic to prevent partial store corruption

### DIFF
--- a/packages/adapters/src/ai/vectorStore.ts
+++ b/packages/adapters/src/ai/vectorStore.ts
@@ -107,13 +107,15 @@ export class LocalVectorStore {
         if (!ai.embed) {
             throw new Error('The AI adapter does not support embeddings.');
         }
-        for (const doc of docs) {
-            const embedding = await ai.embed(doc.text);
-            this._documents.push({
+        // Embed all documents first — if any fail, nothing is added to the store
+        const embedded = await Promise.all(
+            docs.map(async (doc) => ({
                 ...doc,
-                embedding,
-            });
-        }
+                embedding: await ai.embed!(doc.text),
+            }))
+        );
+        // Only push to store after all embeddings succeed
+        this._documents.push(...embedded);
     }
 
     async query(queryText: string, ai: AIAdapter, limit = 3): Promise<DocumentChunk[]> {


### PR DESCRIPTION
## Summary
Made `addDocuments` atomic to prevent partial store corruption.

## Problem
If `ai.embed()` failed on document N, documents 0..N-1 were already pushed into the store while N+1..end were missing, leaving the store in a corrupted partial state.

## Fix
All documents are now embedded first via `Promise.all`, and only pushed to `_documents` after all embeddings succeed. If any embed fails, nothing is added to the store.

## Changed
- `packages/adapters/src/ai/vectorStore.ts`: Changed `for` loop to `Promise.all` with deferred push

Fixes #2981
