### PR TITLE
fix status bar narrow width layout

### DIFF
--- a/packages/widgets/src/display/StatusBar.test.ts
+++ b/packages/widgets/src/display/StatusBar.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { StatusBar } from './StatusBar.js';
+import { Screen } from '@termuijs/core';
 
 describe('StatusBar', () => {
     it('creates a StatusBar instance', () => {
@@ -34,5 +35,30 @@ describe('StatusBar', () => {
         statusBar.setRight('F1 Help');
 
         expect(statusBar).toBeDefined();
+    });
+
+    it('clips sections before they can overlap on narrow widths', () => {
+        const statusBar = new StatusBar({}, {
+            left: 'LEFT-LONG',
+            center: 'CENTER',
+            right: 'RIGHT',
+        });
+        const screen = new Screen(12, 1);
+        const writes: Array<{ x: number; text: string }> = [];
+        const originalWriteString = screen.writeString.bind(screen);
+        screen.writeString = ((x, y, text, attrs) => {
+            writes.push({ x, text });
+            return originalWriteString(x, y, text, attrs);
+        }) as typeof screen.writeString;
+
+        statusBar.updateRect({ x: 0, y: 0, width: 12, height: 1 });
+        statusBar.render(screen);
+
+        for (let i = 1; i < writes.length; i++) {
+            const previous = writes[i - 1];
+            const current = writes[i];
+            expect(previous.x + previous.text.length).toBeLessThanOrEqual(current.x);
+        }
+        expect(writes.at(-1)).toEqual({ x: 7, text: 'RIGHT' });
     });
 });

--- a/packages/widgets/src/display/StatusBar.ts
+++ b/packages/widgets/src/display/StatusBar.ts
@@ -56,36 +56,34 @@ export class StatusBar extends Widget {
 
         const attrs = styleToCellAttrs(this._style);
 
-        // Left
-        screen.writeString(
+        const rightText = truncate(this._right, width);
+        const rightWidth = stringWidth(rightText);
+        const rightX = x + width - rightWidth;
+
+        const centerAvailable = Math.max(0, rightX - x);
+        const centerText = truncate(this._center, centerAvailable);
+        const centerWidth = stringWidth(centerText);
+        const desiredCenterX = x + Math.floor((width - centerWidth) / 2);
+        const centerX = Math.max(
             x,
-            y,
-            truncate(this._left, width),
-            attrs,
+            Math.min(desiredCenterX, rightX - centerWidth),
         );
 
-        // Center
-        const centerX = x + Math.max(
-            0,
-            Math.floor((width - stringWidth(this._center)) / 2),
-        );
+        const leftAvailable = centerWidth > 0
+            ? Math.max(0, centerX - x)
+            : Math.max(0, rightX - x);
+        const leftText = truncate(this._left, leftAvailable);
 
-        screen.writeString(
-            centerX,
-            y,
-            truncate(this._center, width),
-            attrs,
-        );
+        if (leftText) {
+            screen.writeString(x, y, leftText, attrs);
+        }
 
-        // Right
-        const rightWidth = stringWidth(this._right);
-        const rightX = Math.max(x, x + width - rightWidth);
+        if (centerText) {
+            screen.writeString(centerX, y, centerText, attrs);
+        }
 
-        screen.writeString(
-            rightX,
-            y,
-            truncate(this._right, width),
-            attrs,
-        );
+        if (rightText) {
+            screen.writeString(rightX, y, rightText, attrs);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Reserve separate StatusBar regions before rendering left, center, and right text.
- Add a narrow-width regression test to ensure writes do not overlap.

Fixes #2992

## Validation
- bun run build
- bun vitest run packages/widgets/src/display/StatusBar.test.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `StatusBar` rendering on narrow terminal widths by reserving space for the right, center, and left sections in sequence.
  * Prevented the left/center/right sections from overlapping.
  * Truncates each section to the available space and skips rendering empty segments.
* **Tests**
  * Added coverage to verify correct clipping and positioning when the terminal width is small.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->