### PR TITLE
fix scroll view key consumption

### DIFF
--- a/packages/widgets/src/layout/ScrollView.test.ts
+++ b/packages/widgets/src/layout/ScrollView.test.ts
@@ -16,6 +16,12 @@ const key = (k: string): KeyEvent => ({
     preventDefault: () => {},
 });
 
+const spyKey = (k: string): KeyEvent => ({
+    ...key(k),
+    stopPropagation: vi.fn(),
+    preventDefault: vi.fn(),
+});
+
 afterEach(() => {
     vi.restoreAllMocks();
 });
@@ -142,6 +148,28 @@ describe("ScrollView", () => {
         sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
         sv.handleKey(key("down"));
         expect(sv.scrollOffset).toBe(1);
+    });
+
+    it("consumes handled navigation keys", () => {
+        const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
+        const event = spyKey("down");
+        sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
+
+        sv.handleKey(event);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(event.stopPropagation).toHaveBeenCalled();
+    });
+
+    it("does not consume unhandled keys", () => {
+        const sv = new ScrollView({ height: 5 }, { contentHeight: 20 });
+        const event = spyKey("x");
+        sv.updateRect({ x: 0, y: 0, width: 40, height: 5 });
+
+        sv.handleKey(event);
+
+        expect(event.preventDefault).not.toHaveBeenCalled();
+        expect(event.stopPropagation).not.toHaveBeenCalled();
     });
 
     it("up scrolls up by 1", () => {

--- a/packages/widgets/src/layout/ScrollView.ts
+++ b/packages/widgets/src/layout/ScrollView.ts
@@ -90,11 +90,18 @@ export class ScrollView extends Widget {
     /** Handle keyboard navigation */
     handleKey(event: KeyEvent): void {
         const token = `${event.ctrl ? 'ctrl+' : ''}${event.alt ? 'alt+' : ''}${event.shift ? 'shift+' : ''}${String(event.key).toLowerCase()}`;
+        let handled = true;
         switch (normalizeNavigationKey(token)) {
             case 'up':       this.scrollBy(-this.getScrollDelta(1)); break;
             case 'down':     this.scrollBy(this.getScrollDelta(1)); break;
             case 'pageup':   this.scrollBy(-this.getScrollDelta(Math.max(1, this._rect.height - 1))); break;
             case 'pagedown': this.scrollBy(this.getScrollDelta(Math.max(1, this._rect.height - 1))); break;
+            default:         handled = false; break;
+        }
+
+        if (handled) {
+            event.preventDefault();
+            event.stopPropagation();
         }
     }
 


### PR DESCRIPTION
## Summary
- Consume ScrollView key events after handled navigation.
- Keep unhandled keys available to parent widgets and keymaps.
- Add focused tests for both event paths.

Fixes #2994

## Validation
- bun vitest run packages/widgets/src/layout/ScrollView.test.ts
