### PR TITLE
validate virtual list item counts

### DIFF
--- a/packages/widgets/src/input/VirtualList.test.ts
+++ b/packages/widgets/src/input/VirtualList.test.ts
@@ -23,6 +23,14 @@ describe('VirtualList', () => {
             expect(list.scrollOffset).toBe(0);
         });
 
+        it('rejects invalid totalItems values', () => {
+            for (const totalItems of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+                expect(() => createList(totalItems)).toThrow(
+                    'VirtualList totalItems must be a non-negative integer',
+                );
+            }
+        });
+
         it('is focusable', () => {
             const list = createList();
             expect(list.focusable).toBe(true);
@@ -183,6 +191,18 @@ describe('VirtualList', () => {
             list.selectNext();
             list.setTotalItems(0);
             expect(list.selectedIndex).toBe(0);
+        });
+
+        it('setTotalItems rejects invalid values', () => {
+            const list = createList(10);
+
+            for (const totalItems of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+                expect(() => list.setTotalItems(totalItems)).toThrow(
+                    'VirtualList totalItems must be a non-negative integer',
+                );
+            }
+
+            expect(list.totalItems).toBe(10);
         });
     });
 

--- a/packages/widgets/src/input/VirtualList.ts
+++ b/packages/widgets/src/input/VirtualList.ts
@@ -18,6 +18,14 @@ import { Widget } from '../base/Widget.js';
 import { computeRange } from './virtual-scroll.js';
 import { calculateSpringScroll, type ScrollSpringState } from '../scroll.js';
 
+function validateTotalItems(count: number): number {
+    if (!Number.isFinite(count) || !Number.isInteger(count) || count < 0) {
+        throw new Error('VirtualList totalItems must be a non-negative integer');
+    }
+
+    return count;
+}
+
 export interface VirtualListOptions {
     /** Total number of items (the full dataset size) */
     totalItems: number;
@@ -82,7 +90,7 @@ export class VirtualList extends Widget {
 
     constructor(options: VirtualListOptions) {
         super({ border: 'single', ...options.style });
-        this._totalItems = options.totalItems;
+        this._totalItems = validateTotalItems(options.totalItems);
         const resolvedItemHeight = options.fixedItemHeight ?? options.itemHeight ?? 1;
         if (!Number.isFinite(resolvedItemHeight) || resolvedItemHeight <= 0) {
             throw new Error('VirtualList itemHeight must be a positive number');
@@ -107,9 +115,10 @@ export class VirtualList extends Widget {
 
     /** Update the total item count (e.g., after data refresh) */
     setTotalItems(count: number): void {
+        const nextCount = validateTotalItems(count);
         this._clearCache();
-        this._totalItems = count;
-        this._selectedIndex = Math.min(this._selectedIndex, Math.max(0, count - 1));
+        this._totalItems = nextCount;
+        this._selectedIndex = Math.min(this._selectedIndex, Math.max(0, nextCount - 1));
         this._clampScroll();
         this.markDirty();
     }


### PR DESCRIPTION
## Summary
- Add shared validation for VirtualList total item counts.
- Reject negative, fractional, and non-finite values in the constructor and setter.
- Keep zero-item lists supported.

Fixes #2995

## Validation
- bun vitest run packages/widgets/src/input/VirtualList.test.ts
