### PR TITLE
add virtual list empty state

### DIFF
--- a/packages/widgets/src/input/VirtualList.test.ts
+++ b/packages/widgets/src/input/VirtualList.test.ts
@@ -212,6 +212,43 @@ describe('VirtualList', () => {
         });
     });
 
+    describe('empty state', () => {
+        it('renders configured empty text when there are no items', () => {
+            const list = new VirtualList({
+                totalItems: 0,
+                renderItem: (i) => `Item ${i}`,
+                emptyText: 'No results',
+                style: { width: 20, height: 3 },
+            });
+            const node = list.getLayoutNode();
+            computeLayout(node, 20, 3);
+            list.syncLayout();
+            const screen = new Screen(20, 3);
+
+            list.render(screen);
+
+            const content = screen.back.map(row => row.map(c => c.char).join('')).join('\n');
+            expect(content).toContain('No results');
+        });
+
+        it('keeps empty lists blank when no empty text is configured', () => {
+            const list = new VirtualList({
+                totalItems: 0,
+                renderItem: (i) => `Item ${i}`,
+                style: { width: 20, height: 3 },
+            });
+            const node = list.getLayoutNode();
+            computeLayout(node, 20, 3);
+            list.syncLayout();
+            const screen = new Screen(20, 3);
+
+            list.render(screen);
+
+            const contentRow = screen.back[1].slice(1, -1).map(c => c.char).join('');
+            expect(contentRow.trim()).toBe('');
+        });
+    });
+
     describe('spring scrolling', () => {
         // Helper: set up a VirtualList with a real computed layout so _getContentRect()
         // returns correct values without touching private internals.

--- a/packages/widgets/src/input/VirtualList.ts
+++ b/packages/widgets/src/input/VirtualList.ts
@@ -39,6 +39,8 @@ export interface VirtualListOptions {
     showScrollbar?: boolean;
     /** Enable spring scroll animations (default: true, respects prefersReducedMotion) */
     springScroll?: boolean;
+    /** Optional text to render when the list has no items */
+    emptyText?: string;
 }
 
 /**
@@ -61,6 +63,7 @@ export class VirtualList extends Widget {
     private _scrollOffset = 0;
     private _overscan: number;
     private _showScrollbar: boolean;
+    private _emptyText: string;
     
     private _memoizeLayout: boolean;
     private _isScrolling = false;
@@ -93,6 +96,7 @@ export class VirtualList extends Widget {
         this._onSelect = options.onSelect;
         this._overscan = options.overscan ?? 2;
         this._showScrollbar = options.showScrollbar ?? true;
+        this._emptyText = options.emptyText ?? '';
         this._springScroll = options.springScroll ?? !prefersReducedMotion();
         this.focusable = true;
     }
@@ -277,7 +281,15 @@ export class VirtualList extends Widget {
     protected _renderSelf(screen: Screen): void {
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;
-        if (width <= 0 || height <= 0 || this._totalItems === 0) return;
+        if (width <= 0 || height <= 0) return;
+
+        const attrs = styleToCellAttrs(this._style);
+        if (this._totalItems === 0) {
+            if (this._emptyText) {
+                screen.writeString(x, y, truncate(this._emptyText, width), { ...attrs, dim: true });
+            }
+            return;
+        }
 
         // Update spring animation if active
         if (this._springScroll && this._isAnimating) {
@@ -316,7 +328,6 @@ export class VirtualList extends Widget {
             }
         }
 
-        const attrs = styleToCellAttrs(this._style);
         const visibleItemCount = Math.floor(height / this._itemHeight);
 
         // Calculate the visible window with overscan


### PR DESCRIPTION
## Summary
- Add an optional `emptyText` setting for VirtualList.
- Render the message only when the list has no items.
- Preserve the previous blank empty-list behavior when the option is omitted.

Fixes #2996

## Validation
- bun vitest run packages/widgets/src/input/VirtualList.test.ts
