### PR TITLE
fix empty table selection bounds

### DIFF
--- a/packages/widgets/src/data/Table.test.ts
+++ b/packages/widgets/src/data/Table.test.ts
@@ -4,6 +4,17 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { Table } from './Table.js';
+import type { KeyEvent } from '@termuijs/core';
+
+const key = (key: string): KeyEvent => ({
+    key,
+    raw: Buffer.alloc(0),
+    ctrl: false,
+    alt: false,
+    shift: false,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+});
 
 const COLUMNS = [
     { header: 'Name', key: 'name' },
@@ -30,6 +41,32 @@ describe('Table', () => {
     it('handles empty rows array', () => {
         const table = new Table(COLUMNS, []);
         expect(() => table).not.toThrow();
+    });
+
+    it('keeps empty no-header tables on a non-header selection', () => {
+        const table = new Table(COLUMNS, [], {}, { showHeader: false });
+
+        table.handleKey(key('down'));
+
+        expect(table.selectedRow).toBe(0);
+    });
+
+    it('allows header selection for empty header-enabled tables', () => {
+        const table = new Table(COLUMNS, [], {}, { showHeader: true });
+
+        table.handleKey(key('up'));
+
+        expect(table.selectedRow).toBe(-1);
+    });
+
+    it('clamps selection when rows are replaced with an empty array', () => {
+        const table = new Table(COLUMNS, ROWS, {}, { showHeader: false });
+        table.handleKey(key('down'));
+        expect(table.selectedRow).toBe(1);
+
+        table.setRows([]);
+
+        expect(table.selectedRow).toBe(0);
     });
 
     it('computes column widths correctly', () => {

--- a/packages/widgets/src/data/Table.ts
+++ b/packages/widgets/src/data/Table.ts
@@ -149,6 +149,7 @@ export class Table extends Widget {
 
     setRows(rows: TableRow[]): void {
         this._rows = rows;
+        this._clampSelectedRow();
         this._clampScroll();
         this.markDirty();
         this._pushState();
@@ -276,6 +277,8 @@ export class Table extends Widget {
             this._selectedRow = Math.max(minRow, this._rows.length - 1);
         }
 
+        this._clampSelectedRow();
+
         // Header Navigation Mode
         if (this._selectedRow === -1) {
             if (event.key === 'left') {
@@ -291,6 +294,12 @@ export class Table extends Widget {
 
         this._clampScroll();
         this.markDirty();
+    }
+
+    private _clampSelectedRow(): void {
+        const minRow = this._showHeader ? -1 : 0;
+        const maxRow = this._rows.length > 0 ? this._rows.length - 1 : minRow;
+        this._selectedRow = Math.max(minRow, Math.min(this._selectedRow, maxRow));
     }
     
     protected _computeRowHeights(colWidths: number[]): number[] {


### PR DESCRIPTION
## Summary
- Centralize selected-row clamping in Table.
- Keep empty no-header tables from moving into the header sentinel state.
- Add regression coverage for empty tables and row replacement.

Fixes #2997

## Validation
- bun vitest run packages/widgets/src/data/Table.test.ts
