### PR TITLE
fix data grid filter backspace

### DIFF
--- a/packages/widgets/src/data/DataGrid.test.ts
+++ b/packages/widgets/src/data/DataGrid.test.ts
@@ -139,6 +139,22 @@ describe('DataGrid', () => {
         expect(text).toContain('Carol');
     });
 
+    it('backspace removes one grapheme from the filter', () => {
+        const onFilter = vi.fn();
+        const grid = new DataGrid(COLUMNS, ROWS, {}, { onFilter });
+        grid.handleKey(keyOf('/'));
+        grid.handleKey(keyOf('C'));
+        grid.handleKey(keyOf('a'));
+        grid.handleKey(keyOf('f'));
+        grid.handleKey(keyOf('e'));
+        grid.handleKey(keyOf('\u0301'));
+
+        grid.handleKey(keyOf('backspace'));
+
+        expect(grid.filter).toBe('Caf');
+        expect(onFilter).toHaveBeenLastCalledWith('Caf');
+    });
+
     it('calls onSort callback with key and direction', () => {
         const onSort = vi.fn();
         const grid = new DataGrid(COLUMNS, ROWS, {}, { onSort });

--- a/packages/widgets/src/data/DataGrid.ts
+++ b/packages/widgets/src/data/DataGrid.ts
@@ -16,6 +16,7 @@ import {
     stringWidth,
     truncate,
     caps,
+    splitGraphemes,
 } from '@termuijs/core';
 import { Table, type TableColumn, type TableRow, type TableOptions } from './Table.js';
 
@@ -121,7 +122,7 @@ export class DataGrid extends Table {
                     return;
                 case 'backspace':
                     if (this._filter.length > 0) {
-                        this.setFilter(this._filter.slice(0, -1));
+                        this.setFilter(splitGraphemes(this._filter).slice(0, -1).join(''));
                     }
                     return;
                 default:


### PR DESCRIPTION
## Summary
- Make DataGrid filter backspace remove one grapheme instead of one code unit.
- Add regression coverage for combining-character input and filter callbacks.

Fixes #2998

## Validation
- bun vitest run packages/widgets/src/data/DataGrid.test.ts
