### PR TITLE
fix searchable select key consumption

### DIFF
--- a/packages/ui/src/SearchableSelect.test.ts
+++ b/packages/ui/src/SearchableSelect.test.ts
@@ -106,6 +106,33 @@ describe('SearchableSelect', () => {
         expect(widget.searchQuery).toBe('hi');
     });
 
+    it('consumes handled search input keys', () => {
+        const widget = new SearchableSelect(sampleOptions);
+        const event = makeKey('a', {
+            preventDefault: vi.fn(),
+            stopPropagation: vi.fn(),
+        });
+
+        widget.handleKey(event);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(event.stopPropagation).toHaveBeenCalled();
+    });
+
+    it('does not consume ignored modifier keys', () => {
+        const widget = new SearchableSelect(sampleOptions);
+        const event = makeKey('a', {
+            ctrl: true,
+            preventDefault: vi.fn(),
+            stopPropagation: vi.fn(),
+        });
+
+        widget.handleKey(event);
+
+        expect(event.preventDefault).not.toHaveBeenCalled();
+        expect(event.stopPropagation).not.toHaveBeenCalled();
+    });
+
     it('typing characters filters options case-insensitively', () => {
         const widget = new SearchableSelect([
             { label: 'Dashboard', value: 'dashboard' },
@@ -141,6 +168,28 @@ describe('SearchableSelect', () => {
         const widget = new SearchableSelect(sampleOptions);
         widget.handleKey(makeKey('down'));
         expect(widget.selectedIndex).toBe(1);
+    });
+
+    it('consumes handled navigation and confirm keys', () => {
+        const onSelect = vi.fn();
+        const widget = new SearchableSelect(sampleOptions, { onSelect });
+        const down = makeKey('down', {
+            preventDefault: vi.fn(),
+            stopPropagation: vi.fn(),
+        });
+        const enter = makeKey('enter', {
+            preventDefault: vi.fn(),
+            stopPropagation: vi.fn(),
+        });
+
+        widget.handleKey(down);
+        widget.handleKey(enter);
+
+        expect(down.preventDefault).toHaveBeenCalled();
+        expect(down.stopPropagation).toHaveBeenCalled();
+        expect(enter.preventDefault).toHaveBeenCalled();
+        expect(enter.stopPropagation).toHaveBeenCalled();
+        expect(onSelect).toHaveBeenCalledWith(sampleOptions[1], 1);
     });
 
     it('down and up change the selected option', () => {

--- a/packages/ui/src/SearchableSelect.ts
+++ b/packages/ui/src/SearchableSelect.ts
@@ -51,12 +51,17 @@ export class SearchableSelect extends Widget {
     handleKey(event: KeyEvent): void {
         if (event._propagationStopped || event._defaultPrevented) return;
         const char = event.key;
+        const consume = () => {
+            event.preventDefault();
+            event.stopPropagation();
+        };
 
         if (char.length === 1 && !event.ctrl && !event.alt) {
             this._searchQuery += char;
             this._filterOptions();
             this._selectedIndex = 0;
             this.markDirty();
+            consume();
             return;
         }
 
@@ -65,21 +70,25 @@ export class SearchableSelect extends Widget {
             this._filterOptions();
             this._selectedIndex = 0;
             this.markDirty();
+            consume();
             return;
         }
 
         if (event.key === 'down') {
             this.selectNext();
+            consume();
             return;
         }
 
         if (event.key === 'up') {
             this.selectPrev();
+            consume();
             return;
         }
 
         if (event.key === 'enter' || event.key === 'return') {
             this.confirm();
+            consume();
             return;
         }
     }


### PR DESCRIPTION
## Summary
- Consume SearchableSelect key events when typing, deleting, navigating, or confirming.
- Leave ignored modifier keys untouched so parent handlers can still see them.
- Add focused event-consumption coverage.

Fixes #2999

## Validation
- bun vitest run packages/ui/src/SearchableSelect.test.ts
