### PR TITLE
add tabs keyboard switching

### DIFF
--- a/packages/ui/src/Tabs.test.ts
+++ b/packages/ui/src/Tabs.test.ts
@@ -5,7 +5,17 @@
 import { describe, it, expect, vi } from 'vitest';
 import { Tabs } from './Tabs.js';
 import { Box, Text, Widget } from '@termuijs/widgets';
-import { Screen, stringWidth } from '@termuijs/core';
+import { Screen, stringWidth, type KeyEvent } from '@termuijs/core';
+
+const key = (key: string, shift = false): KeyEvent => ({
+    key,
+    shift,
+    ctrl: false,
+    alt: false,
+    raw: Buffer.alloc(0),
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+});
 
 const makeTabs = () => new Tabs([
     { label: 'Home', content: new Box() },
@@ -60,6 +70,41 @@ describe('Tabs', () => {
         const tabs = makeTabs();
         tabs.prevTab(); // wraps to 2
         expect(tabs.activeIndex).toBe(2);
+    });
+
+    it('switches tabs with right and left keys', () => {
+        const tabs = makeTabs();
+        const right = key('right');
+        const left = key('left');
+
+        tabs.handleKey(right);
+        expect(tabs.activeIndex).toBe(1);
+        tabs.handleKey(left);
+        expect(tabs.activeIndex).toBe(0);
+        expect(right.preventDefault).toHaveBeenCalled();
+        expect(right.stopPropagation).toHaveBeenCalled();
+        expect(left.preventDefault).toHaveBeenCalled();
+        expect(left.stopPropagation).toHaveBeenCalled();
+    });
+
+    it('switches tabs with tab and shift+tab', () => {
+        const tabs = makeTabs();
+
+        tabs.handleKey(key('tab'));
+        expect(tabs.activeIndex).toBe(1);
+        tabs.handleKey(key('tab', true));
+        expect(tabs.activeIndex).toBe(0);
+    });
+
+    it('does not consume unrelated keys', () => {
+        const tabs = makeTabs();
+        const event = key('enter');
+
+        tabs.handleKey(event);
+
+        expect(tabs.activeIndex).toBe(0);
+        expect(event.preventDefault).not.toHaveBeenCalled();
+        expect(event.stopPropagation).not.toHaveBeenCalled();
     });
 
     it('safe with no tabs', () => {

--- a/packages/ui/src/Tabs.ts
+++ b/packages/ui/src/Tabs.ts
@@ -1,6 +1,6 @@
 // Tabs — tabbed container with keyboard switching
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Screen, mergeStyles, defaultStyle, styleToCellAttrs, caps, stringWidth, truncate } from '@termuijs/core';
+import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, caps, stringWidth, truncate } from '@termuijs/core';
 
 export interface Tab { label: string; content: Widget; }
 export interface TabsOptions {
@@ -15,6 +15,7 @@ export class Tabs extends Widget {
     private _activeColor: NonNullable<Style['fg']>;
     private _inactiveColor: NonNullable<Style['fg']>;
     private _contentMounted = false;
+    private readonly _keyHandler = (event: KeyEvent): void => this.handleKey(event);
     focusable = true;
 
     constructor(tabs: Tab[], options: TabsOptions = {}) {
@@ -22,6 +23,7 @@ export class Tabs extends Widget {
         this._tabs = tabs;
         this._activeColor = options.activeColor ?? { type: 'named', name: 'cyan' };
         this._inactiveColor = options.inactiveColor ?? { type: 'named', name: 'brightBlack' };
+        this.events.on('key', this._keyHandler);
     }
 
     get activeIndex(): number { return this._activeIndex; }
@@ -43,8 +45,27 @@ export class Tabs extends Widget {
     }
     get activeContent(): Widget | undefined { return this._tabs[this._activeIndex]?.content; }
 
+    handleKey(event: KeyEvent): void {
+        let handled = false;
+
+        if (event.key === 'left' || (event.key === 'tab' && event.shift)) {
+            this.prevTab();
+            handled = true;
+        } else if (event.key === 'right' || event.key === 'tab') {
+            this.nextTab();
+            handled = true;
+        }
+
+        if (handled) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+    }
+
     override mount(): void {
         super.mount();
+        this.events.off('key', this._keyHandler);
+        this.events.on('key', this._keyHandler);
         if (!this._contentMounted) {
             this.activeContent?.mount();
             this._contentMounted = true;


### PR DESCRIPTION
## Summary
- Add keyboard handling for focused Tabs widgets.
- Support left/right and tab/shift+tab switching.
- Consume handled tab navigation events and test ignored keys.

Fixes #3000

## Validation
- bun vitest run packages/ui/src/Tabs.test.ts
