### PR TITLE
fix multiselect width truncation

### DIFF
--- a/packages/ui/src/MultiSelect.test.ts
+++ b/packages/ui/src/MultiSelect.test.ts
@@ -3,7 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { Screen, caps } from '@termuijs/core';
+import { Screen, caps, stringWidth } from '@termuijs/core';
 import { MultiSelect } from './MultiSelect.js';
 
 const OPTIONS = [
@@ -778,6 +778,22 @@ describe('MultiSelect — Rendering Bounds', () => {
         ms.updateRect({ x: 0, y: 0, width: 3, height: 3 });
         const screen = new Screen(3, 3);
         expect(() => ms.render(screen)).not.toThrow();
+    });
+
+    it('truncates double-width labels to the terminal width', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+        const ms = new MultiSelect([
+            { label: '界界界界界', value: 'wide' },
+        ]);
+        const screen = new Screen(8, 1);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        ms.updateRect({ x: 0, y: 0, width: 8, height: 1 });
+        ms.render(screen);
+
+        const rendered = String(writeSpy.mock.calls[0]?.[2] ?? '');
+        expect(stringWidth(rendered)).toBeLessThanOrEqual(8);
+        expect(rendered).not.toContain('\uFFFD');
     });
 
     it('rendering with negative width handled gracefully', () => {

--- a/packages/ui/src/MultiSelect.ts
+++ b/packages/ui/src/MultiSelect.ts
@@ -1,6 +1,6 @@
 // MultiSelect — checkbox-style multi-item selector
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Screen, mergeStyles, defaultStyle, styleToCellAttrs, caps } from '@termuijs/core';
+import { type Style, type Screen, mergeStyles, defaultStyle, styleToCellAttrs, caps, truncate } from '@termuijs/core';
 
 export interface MultiSelectOption { label: string; value: string; disabled?: boolean; }
 export interface MultiSelectOptions {
@@ -49,7 +49,7 @@ export class MultiSelect extends Widget {
             const active = i === this._cursorIndex;
             const checked = this._checked.has(i);
             const label = `${active ? (caps.unicode ? '❯ ' : '> ') : '  '}${checked ? this._checkChar : this._uncheckChar} ${o.label}`;
-            screen.writeString(x, y + i, label.slice(0, width), {
+            screen.writeString(x, y + i, truncate(label, width), {
                 ...attrs,
                 fg: o.disabled ? { type: 'named' as const, name: 'brightBlack' as const } : active ? this._activeColor : attrs.fg,
                 bold: active, dim: o.disabled,


### PR DESCRIPTION
## Summary
- Use terminal-width truncation when rendering MultiSelect rows.
- Prevent double-width labels from overflowing the widget width.
- Add regression coverage for wide-character labels.

Fixes #3001

## Validation
- bun vitest run packages/ui/src/MultiSelect.test.ts
