### PR TITLE
fix: use import type for type-only import and fix always-bold key bug in KeyValue

### DIFF
--- a/packages/widgets/src/data/KeyValue.ts
+++ b/packages/widgets/src/data/KeyValue.ts
@@ -187,7 +187,7 @@ export class KeyValue extends Widget {
             screen.writeString(keyX, y + i, row.displayKey, {
                 ...attrs,
                 fg: displayFg ?? this._keyColor ?? attrs.fg,
-                bold: isSelected || true,
+                bold: !!isSelected,
             });
 
             // Separator

--- a/packages/widgets/src/data/TableState.ts
+++ b/packages/widgets/src/data/TableState.ts
@@ -1,5 +1,5 @@
 // packages/widgets/src/data/TableState.ts
-import { TableRow } from './Table.js';
+import type { TableRow } from './Table.js';
 
 /** External state object for Table widget. */
 export interface TableState {


### PR DESCRIPTION
Fixes two bugs:
- TableState.ts: use import type for TableRow type-only import to align with TypeScript best practices
- KeyValue.ts: bold: isSelected || true always evaluates to true; changed to !!isSelected so only selected rows are bold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Key-value rows now display key text in bold only when the row is selected, improving visual clarity for unselected rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->