### PR TITLE
fix(tss): remove incorrect Apple_Terminal profile detection in detectTerminalBackground

### DIFF
--- a/packages/tss/src/auto-theme.ts
+++ b/packages/tss/src/auto-theme.ts
@@ -72,13 +72,8 @@ export async function detectTerminalBackground(): Promise<TerminalBackground> {
   }
 
   if (termProgram === 'Apple_Terminal') {
-    // macOS Terminal.app: "Basic", "Grass", "Homebrew", "Man Page",
-    // "Novel", "Ocean", "Pro", "Red Sands", "Silver Aerogel", "Solid Colors"
-    // Most defaults are dark. "Novel", "Silver Aerogel" are light.
-    const profile = (process.env['TERM_PROGRAM_VERSION'] ?? '').toLowerCase()
-    if (profile.includes('novel') || profile.includes('silver')) {
-      return 'light'
-    }
+    // macOS Terminal.app does not expose the active profile name via environment.
+    // Default profiles are dark; users who want light detection can set TERM_BACKGROUND.
     return 'dark'
   }
 


### PR DESCRIPTION
## Summary of What Has Been Done

Removed the incorrect light profile detection for Apple_Terminal in `detectTerminalBackground`.

The code was checking `TERM_PROGRAM_VERSION` (which contains version strings like "3.4.6") for profile names like "Novel" or "Silver". Since `TERM_PROGRAM_VERSION` never contains profile names, this detection was completely non-functional.

## Changes Made

Modified `packages/tss/src/auto-theme.ts`:
- Removed the `TERM_PROGRAM_VERSION` profile lookup
- Added a comment explaining that macOS Terminal.app does not expose the active profile via environment variables
- The function now returns `'dark'` as the default for Apple_Terminal

## Impact it Made

Before this fix, the Apple_Terminal light profile detection was completely non-functional. The fix clarifies the behavior and removes dead logic.

Closes #3029

Note: Please assign this PR to the `tmdeveloper007` account.
