### PR TITLE
fix(widgets): remove dead code from Collapsible constructor

### DIFF
--- a/packages/widgets/src/display/Collapsible.ts
+++ b/packages/widgets/src/display/Collapsible.ts
@@ -50,10 +50,8 @@ export class Collapsible extends Widget {
         style: Partial<Style> = {},
         opts: CollapsibleOptions = {},
     ) {
-        const open = opts.open ?? false;
         const bodyLines = opts.open ? body.split('\n').length : 0;
         super({ ...style, height: 1 + bodyLines });
-        this._open = open;
 
         this._title = title;
         this._body = body;


### PR DESCRIPTION
## Summary of What Has Been Done

Removed dead code from the `Collapsible` constructor:

1. Removed the unused `const open = opts.open ?? false;` variable declaration.
2. Removed the first `this._open = open;` assignment (assigned to the unused `open` variable).

The `const bodyLines` calculation is retained as it is used in the `super()` call.

## Changes Made

Modified `packages/widgets/src/display/Collapsible.ts`:
- Removed `const open = opts.open ?? false;`
- Removed `this._open = open;`

## Impact it Made

This change removes dead code and clarifies the constructor's logic, making the codebase easier to maintain. No runtime behavior changes.

Closes #3031

Note: Please assign this PR to the `tmdeveloper007` account.
