### PR TITLE
docs: add @termuijs/adapters to README package table and project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ render(
 | [`@termuijs/data`](./packages/data) | Real-time system data: CPU, memory, disk, network, processes; raw API and reactive hooks |
 | [`@termuijs/dev-server`](./packages/dev-server) | Hot-reload dev server with graceful restart in under 200ms |
 | [`@termuijs/quick`](./packages/quick) | Fluent builder API for dashboards in ~20 lines |
+| [`@termuijs/adapters`](./packages/adapters) | Storage, AI/RAG, CLI tool, and integration adapters for terminal apps |
 | [`create-termui-app`](./packages/create-termui-app) | Project scaffolding CLI |
 
 ## Features
@@ -460,6 +461,7 @@ packages/
   data/              System data providers and hooks
   dev-server/        Hot-reload dev server
   quick/             Fluent builder API
+  adapters/          Storage, AI/RAG, CLI tool, and integration adapters
   create-termui-app/ Project scaffolding CLI
 examples/
   ai-streaming/          Mock AI chat with StreamingText, ChatMessage, ToolCall

--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ examples/
 
 ```bash
 bun install
-bun run build      # Build all 14 packages
+bun run build      # Build all 15 packages
 bun run test        # Run all 5018 tests
 bun run coverage    # Generate test coverage report
 bun run typecheck  # Type-check all packages


### PR DESCRIPTION
## Description

Added the missing \@termuijs/adapters\ package to the README in both the package table and the project structure section. The package was already referenced in the docs site and appeared in open issues, but was completely absent from the GitHub README — the first touchpoint for most contributors and npm users.

## Related Issue

Closes #2600

## Which package(s)?

Documentation only — root \README.md\

## Type of Change

- [ ] 🐛 Bug fix (\	ype:bug\)
- [ ] ✨ Feature (\	ype:feature\)
- [x] 📝 Docs (\	ype:docs\)
- [ ] 🧪 Tests (\	ype:testing\)
- [ ] ♻️ Refactor (\	ype:refactor\)
- [ ] 🎨 Design / UX (\	ype:design\)
- [ ] ♿ Accessibility (\	ype:accessibility\)
- [ ] ⚡ Performance (\	ype:performance\)
- [ ] 🔧 DevOps / CI (\	ype:devops\)
- [ ] 🔒 Security (\	ype:security\)

## Checklist

- [x] ⭐ You starred the repo. The \
eeds-star\ check blocks your merge otherwise.
- [x] Tests pass locally: \un vitest run\
- [x] Build passes: \un run build\
- [x] Typecheck passes: \un run typecheck\
- [x] You read [\CONTRIBUTING.md\](./CONTRIBUTING.md).
- [x] Your PR title follows \	ype: short description\.
- [x] Widget state mutators call \markDirty()\ (if your change affects rendering).
- [x] No new \ny\ types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: \https://gssoc.girlscript.org/profile/ac85deec-3598-47ef-a9e8-f39ae0af5147\

## Notes for the Reviewer

Two-line change. The adapters package exports 12 adapters (git, conf, github, keychain, zod, chalk, clipboardy, ai, dotenv, localStorage, execa, open) and was already listed on the docs site at termui.io/adapters but missing from the repo README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the package overview to include the new `@termuijs/adapters` package.
  * Added an `adapters/` entry to the project structure listing.
  * Refreshed the development build command comment to reflect building 15 packages (up from 14).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->