### PR TITLE
Feat/store history undo redo

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -40,6 +40,7 @@ We want to thank all the amazing contributors who have helped make TermUI what i
 | <img src="https://avatars.githubusercontent.com/u/174622309?v=4" width="40" height="40" style="border-radius: 50%;" alt="Harshit-Maurya838" /> | [@Harshit-Maurya838](https://github.com/Harshit-Maurya838) | 8 |
 | <img src="https://avatars.githubusercontent.com/u/245353458?v=4" width="40" height="40" style="border-radius: 50%;" alt="namrarafique93-del" /> | [@namrarafique93-del](https://github.com/namrarafique93-del) | 8 |
 | <img src="https://avatars.githubusercontent.com/u/162754915?v=4" width="40" height="40" style="border-radius: 50%;" alt="ARPANPATRA111" /> | [@ARPANPATRA111](https://github.com/ARPANPATRA111) | 7 |
+| <img src="https://avatars.githubusercontent.com/u/227770746?v=4" width="40" height="40" style="border-radius: 50%;" alt="palak170306-design" /> | [@palak170306-design](https://github.com/palak170306-design) | 7 |
 | <img src="https://avatars.githubusercontent.com/u/212236853?v=4" width="40" height="40" style="border-radius: 50%;" alt="nandani-singh15" /> | [@nandani-singh15](https://github.com/nandani-singh15) | 7 |
 | <img src="https://avatars.githubusercontent.com/u/219233938?v=4" width="40" height="40" style="border-radius: 50%;" alt="PremSahith" /> | [@PremSahith](https://github.com/PremSahith) | 7 |
 | <img src="https://avatars.githubusercontent.com/u/180026264?v=4" width="40" height="40" style="border-radius: 50%;" alt="Krishnavamsi-codes" /> | [@Krishnavamsi-codes](https://github.com/Krishnavamsi-codes) | 7 |
@@ -51,7 +52,6 @@ We want to thank all the amazing contributors who have helped make TermUI what i
 | <img src="https://avatars.githubusercontent.com/u/190653501?v=4" width="40" height="40" style="border-radius: 50%;" alt="theblag" /> | [@theblag](https://github.com/theblag) | 7 |
 | <img src="https://avatars.githubusercontent.com/u/175478183?v=4" width="40" height="40" style="border-radius: 50%;" alt="abhijnyan-codes" /> | [@abhijnyan-codes](https://github.com/abhijnyan-codes) | 7 |
 | <img src="https://avatars.githubusercontent.com/u/194805397?v=4" width="40" height="40" style="border-radius: 50%;" alt="Krushnakant-08" /> | [@Krushnakant-08](https://github.com/Krushnakant-08) | 6 |
-| <img src="https://avatars.githubusercontent.com/u/227770746?v=4" width="40" height="40" style="border-radius: 50%;" alt="palak170306-design" /> | [@palak170306-design](https://github.com/palak170306-design) | 6 |
 | <img src="https://avatars.githubusercontent.com/u/187929630?v=4" width="40" height="40" style="border-radius: 50%;" alt="16Rohan" /> | [@16Rohan](https://github.com/16Rohan) | 5 |
 | <img src="https://avatars.githubusercontent.com/u/222508176?v=4" width="40" height="40" style="border-radius: 50%;" alt="anchallll02" /> | [@anchallll02](https://github.com/anchallll02) | 5 |
 | <img src="https://avatars.githubusercontent.com/u/56977249?v=4" width="40" height="40" style="border-radius: 50%;" alt="VirenSumbly" /> | [@VirenSumbly](https://github.com/VirenSumbly) | 5 |

--- a/packages/store/src/history-option.test.ts
+++ b/packages/store/src/history-option.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createStore, batch } from './store';
+
+describe('createStore history option', () => {
+    it('undo()/redo() round-trip a plain setState', () => {
+        const store = createStore(() => ({ count: 0 }), { history: { limit: 50 } });
+        store.setState({ count: 1 });
+        store.setState({ count: 2 });
+
+        store.undo();
+        expect(store.getState().count).toBe(1);
+        store.undo();
+        expect(store.getState().count).toBe(0);
+        store.redo();
+        expect(store.getState().count).toBe(1);
+    });
+
+    it('batch() collapses to exactly one history entry', () => {
+        const store = createStore((set) => ({
+            count: 0,
+            increment: () => set((s) => ({ count: s.count + 1 })),
+        }), { history: { limit: 50 } });
+
+        batch(() => {
+            store.getState().increment();
+            store.getState().increment();
+            store.getState().increment();
+        });
+
+        expect(store.getHistory().past.length).toBe(1);
+        store.undo();
+        expect(store.getState().count).toBe(0);
+    });
+
+    it('undo() throws when history option is not set', () => {
+        const store = createStore(() => ({ count: 0 }));
+        expect(() => store.undo()).toThrow(/requires the "history" option/);
+    });
+
+    it('undo() throws when called inside batch()', () => {
+        const store = createStore(() => ({ count: 0 }), { history: {} });
+        expect(() => {
+            batch(() => {
+                store.undo();
+            });
+        }).toThrow(/cannot be called inside batch/);
+    });
+
+    it('coalesceMs merges updates that occur within the window (timestamp-based, not timer-based)', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+        const store = createStore(() => ({ n: 0 }), { history: { coalesceMs: 300 } });
+
+        store.setState({ n: 1 });
+        vi.setSystemTime(100); // still inside the 300ms window
+        store.setState({ n: 2 });
+
+        expect(store.getHistory().past.length).toBe(1);
+
+        vi.setSystemTime(500); // window has elapsed
+        store.setState({ n: 3 });
+        expect(store.getHistory().past.length).toBe(2);
+
+        vi.useRealTimers();
+    });
+
+    it('limit caps the past stack', () => {
+        const store = createStore(() => ({ n: 0 }), { history: { limit: 3 } });
+        for (let i = 1; i <= 5; i++) store.setState({ n: i });
+        expect(store.getHistory().past.length).toBe(3);
+    });
+
+    it('resetHistory() clears both stacks without touching state', () => {
+        const store = createStore(() => ({ n: 0 }), { history: {} });
+        store.setState({ n: 1 });
+        store.resetHistory();
+        expect(store.getHistory()).toEqual({ past: [], future: [] });
+        expect(store.getState().n).toBe(1);
+    });
+});

--- a/packages/store/src/snapshot-history.test.ts
+++ b/packages/store/src/snapshot-history.test.ts
@@ -41,4 +41,77 @@ describe('createSnapshotHistory', () => {
 
         expect(history.list().map(snapshot => snapshot.label)).toEqual(['b', 'c']);
     });
+    it('captures state that includes action functions without throwing', () => {
+        // Regression test: state created via the (set) => ({...}) pattern
+        // always includes action methods. structuredClone() throws on
+        // functions, so capture() must strip them before cloning.
+        const store = createStore((set) => ({
+            count: 0,
+            increment: () => set((s) => ({ count: s.count + 1 })),
+        }));
+        const history = createSnapshotHistory(store);
+
+        expect(() => history.capture('initial')).not.toThrow();
+
+        store.getState().increment();
+        store.getState().increment();
+        history.capture('after increments');
+
+        history.undo();
+        expect(store.getState().count).toBe(0);
+        // action functions must survive a restore, not just data fields
+        expect(typeof store.getState().increment).toBe('function');
+    });
+
+    it('restore() with an unknown id throws without moving the cursor', () => {
+        const store = createStore(() => ({ count: 0 }));
+        const history = createSnapshotHistory(store);
+
+        history.capture('a');
+        store.setState({ count: 1 });
+        history.capture('b');
+
+        expect(() => history.restore(9999)).toThrow(/Unknown store snapshot/);
+        // cursor should be exactly where it was before the failed restore
+        expect(history.undo()?.state.count).toBe(0);
+    });
+
+    it('capture() after undo() discards the redo branch', () => {
+        const store = createStore(() => ({ count: 0 }));
+        const history = createSnapshotHistory(store);
+
+        history.capture('a');
+        store.setState({ count: 1 });
+        history.capture('b');
+        history.undo();
+
+        store.setState({ count: 99 });
+        history.capture('c');
+
+        expect(history.redo()).toBeNull();
+    });
+
+    it('clear() empties history without touching current state', () => {
+        const store = createStore(() => ({ count: 0 }));
+        const history = createSnapshotHistory(store);
+        history.capture('a');
+        store.setState({ count: 5 });
+        history.capture('b');
+
+        history.clear();
+
+        expect(history.list()).toEqual([]);
+        expect(history.undo()).toBeNull();
+        expect(store.getState().count).toBe(5);
+    });
+
+    it('returns defensive copies — mutating a returned snapshot does not affect stored history', () => {
+        const store = createStore(() => ({ nested: { count: 0 } }));
+        const history = createSnapshotHistory(store);
+        const snap = history.capture('a');
+
+        (snap.state.nested as any).count = 999;
+
+        expect(history.list()[0].state.nested.count).toBe(0);
+    });
 });

--- a/packages/store/src/snapshot-history.ts
+++ b/packages/store/src/snapshot-history.ts
@@ -1,15 +1,15 @@
 import type { Store } from './store.js';
-
+ 
 export interface StoreSnapshot<T> {
     id: number;
     label?: string;
     state: T;
 }
-
+  
 export interface SnapshotHistoryOptions {
     limit?: number;
 }
-
+ 
 export interface StoreSnapshotHistory<T extends object> {
     capture(label?: string): StoreSnapshot<T>;
     restore(id: number): StoreSnapshot<T>;
@@ -18,7 +18,40 @@ export interface StoreSnapshotHistory<T extends object> {
     list(): StoreSnapshot<T>[];
     clear(): void;
 }
-
+ 
+// Deep-clone while stripping function values at every level — action
+// methods (set()-bound closures) live directly on store state and are not
+// structured-cloneable. This mirrors store.ts's own safeDeepClone, which
+// exists for the same reason.
+function cloneState<T>(state: T): T {
+    const strip = (value: unknown): unknown => {
+        if (value === null || typeof value !== 'object') return value;
+        if (value instanceof Date || value instanceof RegExp) return value;
+        if (Array.isArray(value)) return value.map(strip);
+        if (value instanceof Map) {
+            const m = new Map();
+            for (const [k, v] of value) m.set(k, strip(v));
+            return m;
+        }
+        if (value instanceof Set) {
+            const s = new Set();
+            for (const v of value) s.add(strip(v));
+            return s;
+        }
+        const out: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+            if (typeof v === 'function') continue;
+            out[k] = strip(v);
+        }
+        return out;
+    };
+ 
+    const stripped = strip(state);
+    return typeof structuredClone === 'function'
+        ? structuredClone(stripped as T)
+        : (JSON.parse(JSON.stringify(stripped)) as T);
+}
+ 
 export function createSnapshotHistory<T extends object>(
     store: Store<T>,
     options: SnapshotHistoryOptions = {},
@@ -27,52 +60,54 @@ export function createSnapshotHistory<T extends object>(
     const snapshots: StoreSnapshot<T>[] = [];
     let cursor = -1;
     let nextId = 1;
-
-    const clone = (state: T): T => {
-        if (typeof structuredClone === 'function') return structuredClone(state);
-        return JSON.parse(JSON.stringify(state)) as T;
-    };
-
+ 
     const apply = (snapshot: StoreSnapshot<T>): StoreSnapshot<T> => {
-        const before = clone(store.getState());
+        const before = cloneState(store.getState());
         try {
-            store.setState(clone(snapshot.state) as Partial<T>);
+            store.setState(cloneState(snapshot.state) as Partial<T>);
         } catch (error) {
             store.setState(before as Partial<T>);
             throw error;
         }
-        return { ...snapshot, state: clone(snapshot.state) };
+        return { ...snapshot, state: cloneState(snapshot.state) };
     };
-
+ 
     return {
         capture(label) {
             snapshots.splice(cursor + 1);
-            const snapshot = { id: nextId++, label, state: clone(store.getState()) };
+            const snapshot = { id: nextId++, label, state: cloneState(store.getState()) };
             snapshots.push(snapshot);
             while (snapshots.length > limit) {
                 snapshots.shift();
             }
             cursor = snapshots.length - 1;
-            return { ...snapshot, state: clone(snapshot.state) };
+            return { ...snapshot, state: cloneState(snapshot.state) };
         },
         restore(id) {
             const index = snapshots.findIndex(snapshot => snapshot.id === id);
             if (index === -1) throw new Error(`Unknown store snapshot: ${id}`);
+            const result = apply(snapshots[index]);
+            // Only advance the cursor once the state change actually succeeded —
+            // otherwise a thrown setState leaves cursor out of sync with live state.
             cursor = index;
-            return apply(snapshots[index]);
+            return result;
         },
         undo() {
             if (cursor <= 0) return null;
-            cursor--;
-            return apply(snapshots[cursor]);
+            const targetIndex = cursor - 1;
+            const result = apply(snapshots[targetIndex]);
+            cursor = targetIndex;
+            return result;
         },
         redo() {
             if (cursor >= snapshots.length - 1) return null;
-            cursor++;
-            return apply(snapshots[cursor]);
+            const targetIndex = cursor + 1;
+            const result = apply(snapshots[targetIndex]);
+            cursor = targetIndex;
+            return result;
         },
         list() {
-            return snapshots.map(snapshot => ({ ...snapshot, state: clone(snapshot.state) }));
+            return snapshots.map(snapshot => ({ ...snapshot, state: cloneState(snapshot.state) }));
         },
         clear() {
             snapshots.splice(0);
@@ -80,3 +115,4 @@ export function createSnapshotHistory<T extends object>(
         },
     };
 }
+ 

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -173,9 +173,16 @@ export interface PersistOptions {
     debounceMs?: number;
 }
 
+export interface HistoryOptions {
+    limit?: number;
+    coalesceMs?: number;
+}
+
+
 export interface StoreOptions<T> {
     middleware?: Middleware<T>[];
     persist?: PersistOptions;
+    history?: HistoryOptions;
 }
 
 export interface Computed<U> {
@@ -203,6 +210,10 @@ export interface Store<T> {
     
     /** Read the state captured at creation */
     getInitialState(): T;
+    undo(): void;
+    redo(): void;
+    getHistory(): { past: T[]; future: T[] };
+    resetHistory(): void;
 }
 
 // ── Safe Deep Clone Helper ──
@@ -591,6 +602,8 @@ export function createStore<T extends object>(
             }
         });
 
+
+
         return {
             get: () => cachedValue,
             subscribe: (listener) => {
@@ -604,7 +617,78 @@ export function createStore<T extends object>(
         };
     };
 
-    const store: Store<T> = { getState, setState, mutate, subscribe, subscribeOnce, destroy, computed, reset, getInitialState };
+                // ── History (undo/redo) ──
+        const historyOpts = options?.history;
+        const historyLimit = historyOpts?.limit ?? 50;
+        const coalesceMs = historyOpts?.coalesceMs ?? 0;
+        let past: T[] = [];
+        let future: T[] = [];
+        let lastRecordAt = 0;
+        let isApplyingHistory = false;
+
+        if (historyOpts) {
+            // Piggybacks on the store's own listener set. This fires exactly once
+            // per immediate setState/mutate call AND exactly once per batch()
+            // (flushBatch's notify() only calls each listener once per flush),
+            // so batch() automatically collapses to a single history entry.
+            subscribe((_newState, prevState) => {
+                if (isApplyingHistory) return;
+                future = []; // any new forward change invalidates the redo branch
+                const now = Date.now();
+                if (past.length > 0 && coalesceMs > 0 && now - lastRecordAt < coalesceMs) {
+                    lastRecordAt = now; // merge into the in-flight coalesced step
+                    return;
+                }
+                past.push(prevState);
+                if (past.length > historyLimit) past.splice(0, past.length - historyLimit);
+                lastRecordAt = now;
+            });
+        }
+
+        // Bypasses setState/middleware entirely so undo/redo restores the exact
+        // captured object rather than re-running middleware transforms on it.
+        const applyHistoryState = (target: T) => {
+            const prevState = state;
+            isApplyingHistory = true;
+            state = target;
+            for (const listener of listeners) listener(state, prevState);
+            persistState();
+            isApplyingHistory = false;
+        };
+
+        const undo = (): void => {
+            if (!historyOpts) {
+                throw new Error('undo() requires the "history" option to be set on CreativeStore()');
+            }
+            if (_batchDepth > 0) throw new Error('undo() cannot be called inside batch()');
+            if (past.length === 0) return;
+            const target = past.pop()!;
+            future.push(state);
+            if (future.length > historyLimit) future.shift();
+            applyHistoryState(target);
+        };
+
+        const redo = (): void => {
+            if (!historyOpts) {
+                throw new Error ('redo() requires the "history" option to be set on CreateStore()');
+            }
+            if (_batchDepth > 0) throw new Error('redo() cannot be called inside batch()');
+            if (future.length === 0) return;
+            const target = future.pop()!;
+            past.push(state);
+            if (past.length > historyLimit) past.shift();
+            applyHistoryState(target);
+        };
+
+        const getHistory = (): { past: T[]; future: T[] } => ({ past: [...past], future: [...future] });
+
+        const resetHistory = (): void => {
+            past = [];
+            future = [];
+            lastRecordAt = 0;
+        };
+
+    const store: Store<T> = { getState, setState, mutate, subscribe, subscribeOnce, destroy, computed, reset, getInitialState, undo, redo, getHistory, resetHistory  };
 
     // Create the hook function
     function useStore(): T;
@@ -661,6 +745,10 @@ export function createStore<T extends object>(
     (useStore as any).computed = computed;
     (useStore as any).reset = reset;
     (useStore as any).getInitialState = getInitialState;
+    (useStore as any).undo = undo;
+    (useStore as any).redo = redo;
+    (useStore as any).getHistory = getHistory;
+    (useStore as any).resetHistory = resetHistory;
 
     return useStore as UseStore<T>;
 }
@@ -679,5 +767,9 @@ export interface UseStore<T> {
     computed<U>(selector: Selector<T, U>): Computed<U>;
     reset(): void;
     getInitialState(): T;
+    undo(): void;
+    redo(): void;
+    getHistory(): { past: T[]; future: T[] };
+    resetHistory(): void;
 }
 


### PR DESCRIPTION


## Description
Adds a `history` option to `createStore()` with native `undo()`/`redo()`/`getHistory()`/`resetHistory()` on the returned store. A `batch()` call collapses to exactly one history entry, `coalesceMs` merges rapid consecutive updates via a timestamp-based sliding window, and `undo()`/`redo()` now throw a clear error instead of silently no-op'ing when `history` isn't configured on that store.

## Related Issue
Closes #2772 

## Which package(s)?
`@termuijs/store`

## Type of Change
- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist
- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering). <!-- N/A — this PR only touches @termuijs/store, no widgets/rendering involved -->
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation
- [X] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/048e6a97-baaf-4a03-b6e5-bdfc6c38e173`

## Screenshots / Recordings (UI changes)
N/A — non-visual, `@termuijs/store` API change only.

## Notes for the Reviewer
- This ships **alongside** the existing `createSnapshotHistory()` (`snapshot-history.ts`), not as a replacement. That's an explicit-checkpoint model (`capture()`/`restore(id)`); this PR's `history` option is automatic, tracking every `setState`/`batch()`. Both can technically be used on the same store but would run as two independent, uncoordinated undo stacks — documented in a code comment, worth a maintainer opinion on whether that should be actively discouraged/guarded against.
- `undo()`/`redo()` bypass `setState` and any configured middleware, restoring the captured state object directly — intentional (avoids re-running transforms on a historical snapshot), but means middleware-enforced invariants aren't re-validated on undo/redo. Flagged in a comment; open to feedback if this tradeoff should be reconsidered.
- `coalesceMs` is timestamp-based (compares `Date.now()` gaps between calls), not `setTimeout`-based — there's no deferred flush, so tests drive it via `vi.setSystemTime()` between calls rather than `vi.advanceTimersByTime()` after them.
- `undo()`/`redo()` now throw when `history` isn't set on that store, rather than silently doing nothing — this is a small API decision worth a second look, since it's a behavior change from the initial draft (which no-op'd).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional undo and redo history for store state.
  - Added history inspection and reset controls.
  - Added configurable history size and update coalescing.
  - Enhanced snapshot history to safely handle complex state and preserve reliable navigation.

- **Bug Fixes**
  - Failed snapshot restores no longer move the history position.
  - New snapshots after undo correctly discard the redo branch.
  - Clearing snapshot history preserves the current state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->