### PR TITLE
fix(core): writeString drops translated text in scrolled containers 

### DIFF
--- a/packages/core/src/terminal/Screen.test.ts
+++ b/packages/core/src/terminal/Screen.test.ts
@@ -32,6 +32,15 @@ describe('Screen', () => {
         // No errors thrown
     });
 
+    it('writeString allows negative local row if pushTranslateY brings it on-screen', () => {
+        const screen = new Screen(10, 5);
+        screen.pushTranslateY(3);
+        // Local row -1, absolute row 2
+        screen.writeString(0, -1, 'Hello');
+        screen.popTranslateY();
+        expect(screen.getLine(2)).toBe('Hello     ');
+    });
+
     it('writes a string to the back buffer', () => {
         const screen = new Screen(10, 5);
         screen.writeString(0, 0, 'Hello');

--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -374,7 +374,8 @@ export class Screen {
     ): void {
         row = Math.floor(row);
         col = Math.floor(col);
-        if (!(row >= 0 && row < this._rows)) return;
+        const absoluteRow = row + this._translateY;
+        if (!(absoluteRow >= 0 && absoluteRow < this._rows)) return;
 
         // Strip ANSI control sequences from user-supplied content to prevent escape injection
         const safeStr = stripAnsiEscapes(str);


### PR DESCRIPTION
fix(core): writeString drops translated text in scrolled containers due to early bounds check

Closes #3026

GSSoC'26

<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

This PR fixes a critical rendering bug in `Screen.ts` where `writeString()` would incorrectly drop text if its local `row` coordinate was negative, completely ignoring the `pushTranslateY` offset. The bounds check now tests the absolute (translated) row coordinate against the screen bounds, allowing text inside scrolled containers (like `ScrollView`) to render correctly when pushed back into the visible region.

## Related Issue

Closes #3026

## Which package(s)?

@termuijs/core

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/Unnati1007`

## Screenshots / Recordings (UI changes)

N/A - Core rendering fix.

## Notes for the Reviewer

Added a unit test for `writeString` to specifically test rendering with negative local coordinates pushed into view by `pushTranslateY`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed translated terminal output so text written with negative local row positions appears correctly when its translated screen row is visible.
* **Tests**
  * Added coverage verifying translated writes render on the expected screen line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->