### PR TITLE
Fix SortPrompt display-width clipping

### DIFF
--- a/packages/ui/src/SortPrompt.test.ts
+++ b/packages/ui/src/SortPrompt.test.ts
@@ -3,6 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi } from 'vitest';
+import { Screen, stringWidth } from '@termuijs/core';
 import { SortPrompt } from './SortPrompt.js';
 
 const ITEMS = ['Apple', 'Banana', 'Cherry', 'Date'];
@@ -153,5 +154,17 @@ describe('SortPrompt', () => {
         prompt.handleKey({ key: 'enter' } as any);
 
         expect(onSubmit).toHaveBeenCalled();
+    });
+
+    it('renders wide-character rows within the prompt width', () => {
+        const prompt = new SortPrompt(['\u8868\u8868\u8868\u8868']);
+        const screen = new Screen(6, 2);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        prompt.updateRect({ x: 0, y: 0, width: 5, height: 2 });
+        prompt.render(screen);
+
+        const rendered = String(writeSpy.mock.calls[0][2]);
+        expect(stringWidth(rendered)).toBeLessThanOrEqual(5);
     });
 });

--- a/packages/ui/src/SortPrompt.ts
+++ b/packages/ui/src/SortPrompt.ts
@@ -1,6 +1,6 @@
 // SortPrompt — sortable item list
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, caps } from '@termuijs/core';
+import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, caps, truncate } from '@termuijs/core';
 
 export interface SortPromptOptions {
     activeColor?: Style['fg'];
@@ -89,7 +89,7 @@ export class SortPrompt extends Widget {
             screen.writeString(
                 x,
                 y + i,
-                line.slice(0, width),
+                truncate(line, width, ''),
                 {
                     ...attrs,
                     fg: active ? this._activeColor : attrs.fg,


### PR DESCRIPTION
## Summary
- clip SortPrompt rows by terminal display width instead of string length
- add a regression test for wide-character item labels

## Validation
- bun vitest run packages/ui/src/SortPrompt.test.ts --config vitest.config.ts

Fixes #3040


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sorting prompt rendering for wide and Unicode characters.
  * Ensured list entries remain within the available display width without visual overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->