### PR TITLE
Fix SurveyPrompt display-width clipping

### DIFF
--- a/packages/ui/src/SurveyPrompt.test.ts
+++ b/packages/ui/src/SurveyPrompt.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { Screen } from "@termuijs/core";
+import { Screen, stringWidth } from "@termuijs/core";
 import { SurveyPrompt } from "./SurveyPrompt.js";
 
 describe("SurveyPrompt", () => {
@@ -128,5 +128,25 @@ describe("SurveyPrompt", () => {
         expect(prompt.getAnswers()).toEqual({
             name: "Caf",
         });
+    });
+
+    it("renders mixed-width survey text within the content width", () => {
+        const prompt = new SurveyPrompt([
+            {
+                id: "food",
+                question: "\u8868\u8868\u8868\u8868?",
+                type: "choice",
+                options: ["\u8868\u8868\u8868\u8868"],
+            },
+        ]);
+        const screen = new Screen(8, 6);
+        const writeSpy = vi.spyOn(screen, "writeString");
+
+        prompt.updateRect({ x: 0, y: 0, width: 5, height: 6 });
+        prompt.render(screen);
+
+        for (const call of writeSpy.mock.calls) {
+            expect(stringWidth(String(call[2]))).toBeLessThanOrEqual(5);
+        }
     });
 });

--- a/packages/ui/src/SurveyPrompt.ts
+++ b/packages/ui/src/SurveyPrompt.ts
@@ -8,6 +8,7 @@ import {
     styleToCellAttrs,
     caps,
     splitGraphemes,
+    truncate,
 } from "@termuijs/core";
 
 export interface SurveyQuestion {
@@ -132,7 +133,7 @@ export class SurveyPrompt extends Widget {
         const attrs = styleToCellAttrs(this.style);
 
         if (this._currentIndex >= this._questions.length) {
-            screen.writeString(x, y, "Survey Complete".slice(0, width), attrs);
+            screen.writeString(x, y, truncate("Survey Complete", width, ""), attrs);
             return;
         }
 
@@ -143,15 +144,12 @@ export class SurveyPrompt extends Widget {
         screen.writeString(
             x,
             y + row,
-            `${this._currentIndex + 1} / ${this._questions.length}`.slice(
-                0,
-                width,
-            ),
+            truncate(`${this._currentIndex + 1} / ${this._questions.length}`, width, ""),
             attrs,
         );
         row += 2;
 
-        screen.writeString(x, y + row, question.question.slice(0, width), {
+        screen.writeString(x, y + row, truncate(question.question, width, ""), {
             ...attrs,
             bold: true,
         });
@@ -161,7 +159,7 @@ export class SurveyPrompt extends Widget {
             screen.writeString(
                 x,
                 y + row,
-                this._textBuffer.slice(0, width),
+                truncate(this._textBuffer, width, ""),
                 attrs,
             );
             return;
@@ -177,7 +175,7 @@ export class SurveyPrompt extends Widget {
             screen.writeString(
                 x,
                 y + row,
-                `${prefix}${options[i]}`.slice(0, width),
+                truncate(`${prefix}${options[i]}`, width, ""),
                 {
                     ...attrs,
                     bold: active,


### PR DESCRIPTION
## Summary
- clip SurveyPrompt progress, question, input, completion, and option rows by terminal display width
- add a regression test for mixed-width survey content

## Validation
- bun vitest run packages/ui/src/SurveyPrompt.test.ts --config vitest.config.ts

Fixes #3041
