### PR TITLE
Fix Tree display-width clipping

### DIFF
--- a/packages/ui/src/Tree.test.ts
+++ b/packages/ui/src/Tree.test.ts
@@ -3,6 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi } from 'vitest';
+import { Screen, stringWidth } from '@termuijs/core';
 import { Tree } from './Tree.js';
 
 const TREE_DATA = [
@@ -66,5 +67,24 @@ describe('Tree', () => {
         const flat = [{ label: 'Alone', value: 'alone' }];
         const tree = new Tree(flat);
         expect(tree).toBeDefined();
+    });
+
+    it('renders wide-character labels within the tree width', () => {
+        const tree = new Tree([
+            {
+                label: '\u8868\u8868\u8868\u8868',
+                expanded: true,
+                children: [{ label: '\u8868\u8868\u8868\u8868' }],
+            },
+        ]);
+        const screen = new Screen(6, 3);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        tree.updateRect({ x: 0, y: 0, width: 5, height: 3 });
+        tree.render(screen);
+
+        for (const call of writeSpy.mock.calls) {
+            expect(stringWidth(String(call[2]))).toBeLessThanOrEqual(5);
+        }
     });
 });

--- a/packages/ui/src/Tree.ts
+++ b/packages/ui/src/Tree.ts
@@ -1,6 +1,6 @@
 // Tree — expandable/collapsible tree view
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Screen, mergeStyles, defaultStyle, styleToCellAttrs, caps } from '@termuijs/core';
+import { type Style, type Screen, mergeStyles, defaultStyle, styleToCellAttrs, caps, truncate } from '@termuijs/core';
 
 export interface TreeNode { label: string; children?: TreeNode[]; expanded?: boolean; icon?: string; }
 export interface TreeOptions { activeColor?: Style['fg']; onSelect?: (node: TreeNode, path: number[]) => void; }
@@ -53,7 +53,7 @@ export class Tree extends Widget {
             const icon = it.hasChildren ? (it.node.expanded ? (caps.unicode ? '▼ ' : 'v ') : (caps.unicode ? '▶ ' : '> ')) : '  ';
             const nodeIcon = it.node.icon ? `${it.node.icon} ` : '';
             const line = `${indent}${icon}${nodeIcon}${it.node.label}`;
-            screen.writeString(x, y + i, line.slice(0, width), { ...attrs, fg: active ? this._activeColor : attrs.fg, bold: active });
+            screen.writeString(x, y + i, truncate(line, width, ''), { ...attrs, fg: active ? this._activeColor : attrs.fg, bold: active });
         }
     }
 }


### PR DESCRIPTION
## Summary
- clip Tree rows by terminal display width instead of UTF-16 length
- add a regression test for nested wide-character labels

## Validation
- bun vitest run packages/ui/src/Tree.test.ts --config vitest.config.ts

Fixes #3042
