### PR TITLE
Fix TreeSelect display-width clipping

### DIFF
--- a/packages/ui/src/TreeSelect.test.ts
+++ b/packages/ui/src/TreeSelect.test.ts
@@ -3,7 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { Screen, caps } from '@termuijs/core';
+import { Screen, caps, stringWidth } from '@termuijs/core';
 import { TreeSelect } from './TreeSelect.js';
 
 // KeyEvent stub — tests only need the `key` field; cast avoids importing the full KeyEvent type
@@ -100,5 +100,26 @@ describe('TreeSelect', () => {
         ts.handleKey(key('down'));
         ts.handleKey(key('space'));
         expect(ts.selectedValues).toContain('a');
+    });
+
+    it('renders wide-character option rows within the component width', () => {
+        const roots = [
+            {
+                label: '\u8868\u8868\u8868\u8868',
+                value: 'root',
+                expanded: true,
+                children: [{ label: '\u8868\u8868\u8868\u8868', value: 'child' }],
+            },
+        ];
+        const screen = new Screen(6, 3);
+        const ts = new TreeSelect(roots, { multiple: true });
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        ts.updateRect({ x: 0, y: 0, width: 5, height: 3 });
+        ts.render(screen);
+
+        for (const call of writeSpy.mock.calls) {
+            expect(stringWidth(String(call[2]))).toBeLessThanOrEqual(5);
+        }
     });
 });

--- a/packages/ui/src/TreeSelect.ts
+++ b/packages/ui/src/TreeSelect.ts
@@ -1,6 +1,6 @@
 // TreeSelect — expandable tree with single or multi selection
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, caps } from '@termuijs/core';
+import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, caps, truncate } from '@termuijs/core';
 
 export interface TreeSelectNode {
     label: string;
@@ -163,7 +163,7 @@ export class TreeSelect extends Widget {
                 : '  ';
             const selectIcon = this._selected.has(it.node.value) ? selectedMarker : unselectedMarker;
             const line = `${indent}${expandIcon}${selectIcon}${it.node.label}`;
-            screen.writeString(x, y + i, line.slice(0, width), {
+            screen.writeString(x, y + i, truncate(line, width, ''), {
                 ...attrs,
                 fg: active ? this._activeColor : attrs.fg,
                 bold: active,


### PR DESCRIPTION
## Summary
- clip TreeSelect rows by terminal display width instead of string length
- add a regression test for nested wide-character option labels

## Validation
- bun vitest run packages/ui/src/TreeSelect.test.ts --config vitest.config.ts

Fixes #3043
