### PR TITLE
Fix Toast display-width animation

### DIFF
--- a/packages/ui/src/Toast.test.ts
+++ b/packages/ui/src/Toast.test.ts
@@ -4,7 +4,7 @@
 
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { Toast } from './Toast.js';
-import { Screen } from '@termuijs/core';
+import { Screen, stringWidth } from '@termuijs/core';
 
 afterEach(() => {
     vi.useRealTimers();
@@ -63,5 +63,22 @@ describe('Toast', () => {
         toast.render(screen);
 
         expect(writeSpy).not.toHaveBeenCalled();
+    });
+
+    it('keeps mixed-width labels stable during reveal animation', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+        const toast = new Toast({ durationMs: 1000, animationMs: 300, announce: false });
+        const screen = new Screen(16, 4);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        toast.updateRect({ x: 0, y: 0, width: 12, height: 4 });
+        toast.info('\u8868\u8868\u8868\u8868');
+        vi.setSystemTime(150);
+        toast.render(screen);
+
+        const rendered = String(writeSpy.mock.calls[0][2]);
+        expect(stringWidth(rendered)).toBe(10);
+        expect(rendered).not.toContain('\uFFFD');
     });
 });

--- a/packages/ui/src/Toast.ts
+++ b/packages/ui/src/Toast.ts
@@ -1,6 +1,6 @@
 // Toast - auto-dismiss notification
 import { Widget } from '@termuijs/widgets';
-import { type Screen, stripAnsiControl, mergeStyles, defaultStyle, styleToCellAttrs, caps } from '@termuijs/core';
+import { type Screen, stripAnsiControl, mergeStyles, defaultStyle, styleToCellAttrs, caps, stringWidth, truncate } from '@termuijs/core';
 
 export type ToastType = 'info' | 'success' | 'warning' | 'error';
 
@@ -22,6 +22,11 @@ export interface ToastOptions {
 const ICONS_UNICODE: Record<ToastType, string> = { info: 'ℹ', success: '✓', warning: '⚠', error: '✗' };
 const ICONS_ASCII: Record<ToastType, string> = { info: 'i', success: '+', warning: '!', error: 'x' };
 const COLORS: Record<ToastType, string> = { info: 'cyan', success: 'green', warning: 'yellow', error: 'red' };
+
+function padToDisplayWidth(text: string, width: number): string {
+  const clipped = truncate(text, width, '');
+  return clipped + ' '.repeat(Math.max(0, width - stringWidth(clipped)));
+}
 
 export class Toast extends Widget {
   private _messages: ToastMessage[] = [];
@@ -91,9 +96,9 @@ export class Toast extends Widget {
     for (let i = 0; i < visible.length; i++) {
       const m = visible[i];
       const progress = this._getAnimationProgress(m.createdAt, m.expireAt);
-      const fullLabel = (' ' + icons[m.type] + ' ' + m.text + ' ').slice(0, tw).padEnd(tw);
-      const visibleChars = Math.floor(progress * tw);
-      const label = fullLabel.slice(0, visibleChars).padEnd(tw);
+      const fullLabel = padToDisplayWidth(' ' + icons[m.type] + ' ' + m.text + ' ', tw);
+      const visibleWidth = Math.floor(progress * tw);
+      const label = padToDisplayWidth(truncate(fullLabel, visibleWidth, ''), tw);
       screen.writeString(sx, sy + i, label, { ...attrs, fg: { type: 'named', name: COLORS[m.type] as any }, bold: true });
     }
     const anyAnimating = visible.some(m => {


### PR DESCRIPTION
## Summary
- clip and pad Toast labels by terminal display width during animation
- add a regression test for mixed-width labels during reveal

## Validation
- bun vitest run packages/ui/src/Toast.test.ts --config vitest.config.ts

Fixes #3044
