### PR TITLE
Fix typewriter grapheme progress

### DIFF
--- a/packages/motion/src/transitions.test.ts
+++ b/packages/motion/src/transitions.test.ts
@@ -131,3 +131,22 @@ describe("cubicBezier easing", () => {
     expect(midValue).toBeLessThan(1);
   });
 });
+
+describe('typewriter', () => {
+    beforeEach(() => {
+        vi.unstubAllEnvs();
+        vi.resetModules();
+    });
+
+    it('counts grapheme clusters for mixed-width text', async () => {
+        vi.stubEnv('NO_MOTION', '1');
+        vi.stubEnv('CI', '');
+        vi.resetModules();
+        const { typewriter } = await import('./transitions.js');
+
+        const frames: number[] = [];
+        typewriter('\u{1F44B}\u{1F3FD}a', 300, value => frames.push(value));
+
+        expect(frames).toEqual([2]);
+    });
+});

--- a/packages/motion/src/transitions.ts
+++ b/packages/motion/src/transitions.ts
@@ -2,7 +2,7 @@
 // Transitions — pre-built animation effects
 // ─────────────────────────────────────────────────────
 
-import { prefersReducedMotion } from '@termuijs/core';
+import { prefersReducedMotion, splitGraphemes } from '@termuijs/core';
 import { subscribe } from './timer-pool.js';
 
 export type EasingFn = (t: number) => number;
@@ -76,10 +76,12 @@ export function slideIn(from: number, durationMs: number, onFrame: (offset: numb
 
 /** Typewriter: reveal text character by character */
 export function typewriter(text: string, durationMs: number, onFrame: (visibleChars: number) => void, onComplete?: () => void): () => void {
+    const totalGraphemes = splitGraphemes(text).length;
+
     return transition({
         durationMs,
         easing: easings.linear,
-        onFrame: t => onFrame(Math.floor(t * text.length)),
+        onFrame: t => onFrame(Math.floor(t * totalGraphemes)),
         onComplete,
     });
 }


### PR DESCRIPTION
## Summary
- calculate typewriter progress from grapheme clusters instead of UTF-16 code units
- add a reduced-motion regression test for emoji plus text input

## Validation
- bun vitest run packages/motion/src/transitions.test.ts --config vitest.config.ts

Fixes #3045
