### PR TITLE
Fix widget error label clipping

### DIFF
--- a/packages/widgets/src/base/Widget.test.ts
+++ b/packages/widgets/src/base/Widget.test.ts
@@ -12,7 +12,7 @@ vi.mock('@termuijs/core', async (importOriginal) => {
     };
 });
 import { Widget } from './Widget.js';
-import { Screen, computeLayout } from '@termuijs/core';
+import { Screen, computeLayout, stringWidth } from '@termuijs/core';
 
 // Concrete test subclass – Widget is abstract
 class TestWidget extends Widget {
@@ -134,6 +134,20 @@ describe('Widget', () => {
         w.render(screen);
         expect(w.isDirty).toBe(true);
         expect(w.renderError).toBeInstanceOf(Error);
+    });
+
+    it('keeps development render error labels inside the widget width', () => {
+        const w = new ErrorWidget();
+        const screen = new Screen(8, 3);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        Object.defineProperty(w.constructor, 'name', { value: '\u8868\u8868\u8868\u8868' });
+        w.updateRect({ x: 0, y: 0, width: 6, height: 3 });
+        w.render(screen);
+
+        const fallbackCall = writeSpy.mock.calls.find(call => call[0] === 1 && call[1] === 0);
+        expect(fallbackCall).toBeDefined();
+        expect(stringWidth(String(fallbackCall![2]))).toBeLessThanOrEqual(4);
     });
 
     it('clearDirty does not clear errored widgets', () => {

--- a/packages/widgets/src/base/Widget.ts
+++ b/packages/widgets/src/base/Widget.ts
@@ -20,6 +20,7 @@ import {
     caps,
     stripAnsiEscapes,
     sanitizeForDisplay,
+    truncate,
     type A11yProps,
     emitA11y,
 } from '@termuijs/core';
@@ -324,7 +325,7 @@ export abstract class Widget {
                 const { x, y, width } = this._rect;
                 if (width > 2) {
                     const label = `Error: ${this.constructor.name}`;
-                    const truncated = label.slice(0, Math.max(3, width - 2));
+                    const truncated = truncate(label, Math.max(3, width - 2), '');
                     screen.writeString(x + 1, y, truncated, {
                         fg: { type: 'named', name: 'red' },
                     });


### PR DESCRIPTION
## Summary
- clip development render-error labels by terminal display width
- add a regression test for mixed-width fallback labels inside narrow widgets

## Validation
- bun vitest run packages/widgets/src/base/Widget.test.ts --config vitest.config.ts

Fixes #3046
