### PR TITLE
Validate interpolate input stops

### DIFF
--- a/packages/motion/src/interpolate.test.ts
+++ b/packages/motion/src/interpolate.test.ts
@@ -60,4 +60,17 @@ describe('interpolate and mapRange', () => {
         expect(() => interpolate(5, [0, 1], [0, 1, 2])).toThrow();
         expect(() => interpolate(5, [0], [0])).toThrow();
     });
+
+    it('throws when interpolate input stops are duplicated', () => {
+        expect(() => interpolate(0.5, [0, 0, 1], [0, 10, 20])).toThrow(/strictly increasing/);
+    });
+
+    it('throws when interpolate input stops are descending', () => {
+        expect(() => interpolate(0.5, [0, 1, 0.5], [0, 10, 20])).toThrow(/strictly increasing/);
+    });
+
+    it('throws when interpolate input stops are not finite', () => {
+        expect(() => interpolate(0.5, [0, Number.NaN, 1], [0, 10, 20])).toThrow(/finite/);
+        expect(() => interpolate(0.5, [0, Infinity, 1], [0, 10, 20])).toThrow(/finite/);
+    });
 });

--- a/packages/motion/src/interpolate.ts
+++ b/packages/motion/src/interpolate.ts
@@ -51,6 +51,14 @@ export function interpolate(
     if (inputRange.length < 2) {
         throw new Error('inputRange and outputRange must have at least 2 elements.');
     }
+    for (let i = 0; i < inputRange.length; i++) {
+        if (!Number.isFinite(inputRange[i])) {
+            throw new Error('inputRange values must be finite numbers.');
+        }
+        if (i > 0 && inputRange[i] <= inputRange[i - 1]) {
+            throw new Error('inputRange values must be strictly increasing.');
+        }
+    }
 
     let index = 0;
     while (index < inputRange.length - 2 && value > inputRange[index + 1]) {


### PR DESCRIPTION
## Summary
- validate interpolate input ranges for finite, strictly increasing stops
- add regression tests for duplicate, descending, and non-finite input stops

## Validation
- bun vitest run packages/motion/src/interpolate.test.ts --config vitest.config.ts

Fixes #3047
