### PR TITLE
Consume SortPrompt handled keys

### DIFF
--- a/packages/ui/src/SortPrompt.test.ts
+++ b/packages/ui/src/SortPrompt.test.ts
@@ -154,4 +154,32 @@ describe('SortPrompt', () => {
 
         expect(onSubmit).toHaveBeenCalled();
     });
+
+    it('consumes handled keyboard events', () => {
+        const prompt = new SortPrompt(['A', 'B']);
+        const event = {
+            key: 'enter',
+            preventDefault: vi.fn(),
+            stopPropagation: vi.fn(),
+        } as any;
+
+        prompt.handleKey(event);
+
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+        expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not consume unhandled keyboard events', () => {
+        const prompt = new SortPrompt(['A', 'B']);
+        const event = {
+            key: 'tab',
+            preventDefault: vi.fn(),
+            stopPropagation: vi.fn(),
+        } as any;
+
+        prompt.handleKey(event);
+
+        expect(event.preventDefault).not.toHaveBeenCalled();
+        expect(event.stopPropagation).not.toHaveBeenCalled();
+    });
 });

--- a/packages/ui/src/SortPrompt.ts
+++ b/packages/ui/src/SortPrompt.ts
@@ -63,14 +63,20 @@ export class SortPrompt extends Widget {
         switch (event.key) {
             case 'shift+up':
                 this.moveItemUp();
+                event.preventDefault?.();
+                event.stopPropagation?.();
                 break;
 
             case 'shift+down':
                 this.moveItemDown();
+                event.preventDefault?.();
+                event.stopPropagation?.();
                 break;
 
             case 'enter':
                 this.submit();
+                event.preventDefault?.();
+                event.stopPropagation?.();
                 break;
         }
     }


### PR DESCRIPTION
## Summary
- consume SortPrompt keys after handled reorder and submit actions
- keep unhandled keys available to parent handlers
- add regression tests for handled and unhandled event propagation

## Validation
- bun vitest run packages/ui/src/SortPrompt.test.ts --config vitest.config.ts

Fixes #3048
