### PR TITLE
Consume SurveyPrompt handled keys

### DIFF
--- a/packages/ui/src/SurveyPrompt.test.ts
+++ b/packages/ui/src/SurveyPrompt.test.ts
@@ -129,4 +129,53 @@ describe("SurveyPrompt", () => {
             name: "Caf",
         });
     });
+
+    it("consumes handled text input events", () => {
+        const prompt = new SurveyPrompt(QUESTIONS);
+        const event = {
+            key: "A",
+            ctrl: false,
+            alt: false,
+            preventDefault: vi.fn(),
+            stopPropagation: vi.fn(),
+        } as any;
+
+        prompt.handleKey(event);
+
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+        expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+    });
+
+    it("consumes handled choice navigation events", () => {
+        const prompt = new SurveyPrompt(QUESTIONS);
+        prompt.handleKey({ key: "enter", ctrl: false, alt: false } as any);
+        const event = {
+            key: "down",
+            ctrl: false,
+            alt: false,
+            preventDefault: vi.fn(),
+            stopPropagation: vi.fn(),
+        } as any;
+
+        prompt.handleKey(event);
+
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+        expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not consume unhandled text events", () => {
+        const prompt = new SurveyPrompt(QUESTIONS);
+        const event = {
+            key: "tab",
+            ctrl: false,
+            alt: false,
+            preventDefault: vi.fn(),
+            stopPropagation: vi.fn(),
+        } as any;
+
+        prompt.handleKey(event);
+
+        expect(event.preventDefault).not.toHaveBeenCalled();
+        expect(event.stopPropagation).not.toHaveBeenCalled();
+    });
 });

--- a/packages/ui/src/SurveyPrompt.ts
+++ b/packages/ui/src/SurveyPrompt.ts
@@ -74,11 +74,13 @@ export class SurveyPrompt extends Widget {
                 case "backspace":
                     this._textBuffer = splitGraphemes(this._textBuffer).slice(0, -1).join("");
                     this.markDirty();
+                    consumeKey(event);
                     break;
 
                 case "enter":
                     this._answers[question.id] = this._textBuffer;
                     this._advance();
+                    consumeKey(event);
                     break;
 
                 default:
@@ -90,6 +92,7 @@ export class SurveyPrompt extends Widget {
                     ) {
                         this._textBuffer += event.key;
                         this.markDirty();
+                        consumeKey(event);
                     }
             }
 
@@ -102,6 +105,7 @@ export class SurveyPrompt extends Widget {
                     this._choiceIndex--;
                     this.markDirty();
                 }
+                consumeKey(event);
                 break;
 
             case "down":
@@ -112,6 +116,7 @@ export class SurveyPrompt extends Widget {
                     this._choiceIndex++;
                     this.markDirty();
                 }
+                consumeKey(event);
                 break;
 
             case "enter":
@@ -120,6 +125,7 @@ export class SurveyPrompt extends Widget {
                         question.options[this._choiceIndex];
                     this._advance();
                 }
+                consumeKey(event);
                 break;
         }
     }
@@ -187,4 +193,9 @@ export class SurveyPrompt extends Widget {
             row++;
         }
     }
+}
+
+function consumeKey(event: KeyEvent): void {
+    event.preventDefault?.();
+    event.stopPropagation?.();
 }


### PR DESCRIPTION
## Summary
- consume SurveyPrompt text, backspace, submit, and choice navigation keys after handling
- keep unrelated keys available to parent handlers
- add regression tests for handled text, handled choice navigation, and unhandled keys

## Validation
- bun vitest run packages/ui/src/SurveyPrompt.test.ts --config vitest.config.ts

Fixes #3049
