### PR TITLE
  fix(widgets): truncate callout message by display width to prevent overflow #3068    

### DIFF
--- a/packages/widgets/src/feedback/Callout.test.ts
+++ b/packages/widgets/src/feedback/Callout.test.ts
@@ -72,4 +72,10 @@ describe('Callout', () => {
         expect(callout.isDirty).toBe(false);
     });
 
+    it('truncates double-width emoji message text without overflowing available width', () => {
+        const callout = new Callout('🌟🌟🌟🌟🌟');
+        expect(() => render(callout, 5, 1)).not.toThrow();
+        const output = render(callout, 5, 1);
+        expect(output.length).toBeLessThanOrEqual(5);
+    });
 });

--- a/packages/widgets/src/feedback/Callout.ts
+++ b/packages/widgets/src/feedback/Callout.ts
@@ -84,7 +84,7 @@ export class Callout extends Widget {
         const msgStr = msgPrefix + this._message;
         const avail = width - cursor;
         if (avail > 0) {
-            screen.writeString(cursor, y, msgStr.slice(0, avail), { ...attrs, fg: color });
+            screen.writeString(cursor, y, truncate(msgStr, avail, ''), { ...attrs, fg: color });
         }
     }
 }


### PR DESCRIPTION
 ### Title
    fix(widgets): truncate callout message by display width to prevent overflow
    
    ### Summary of Changes
    - Replaced `msgStr.slice(0, avail)` with `truncate(msgStr, avail, '')` in
  `packages/widgets/src/feedback/Callout.ts`.
    - Added unit test in `packages/widgets/src/feedback/Callout.test.ts` verifying emoji truncation.
    
    Closes #3068 
## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->
