### PR TITLE
fix: resolve 5 type/safety bugs across adapters, jsx, data, and widgets

### DIFF
--- a/packages/adapters/src/conf/index.ts
+++ b/packages/adapters/src/conf/index.ts
@@ -9,12 +9,22 @@ export type SetConfValue<T extends Record<string, unknown>> =
 
 export type UseConfResult<T extends Record<string, unknown>> = readonly [T, SetConfValue<T>]
 
+interface ConfInstance<T extends Record<string, unknown>> {
+  store: T;
+  get<K extends keyof T>(key: K): T[K];
+  set<K extends keyof T>(key: K, value: T[K]): void;
+  set(object: Partial<T>): void;
+  has<K extends keyof T>(key: K): boolean;
+  delete<K extends keyof T>(key: K): void;
+  clear(): void;
+}
+
 type ConfConstructor = new <T extends Record<string, unknown> = Record<string, unknown>>(
   options?: Readonly<Partial<ConfOptions<T>>>
-) => { store: T }
+) => ConfInstance<T>
 
 interface ConfStore<T extends Record<string, unknown>> {
-  config: { store: T }
+  config: ConfInstance<T>
   value: T
   setValue: SetConfValue<T>
 }

--- a/packages/data/src/hooks.ts
+++ b/packages/data/src/hooks.ts
@@ -683,7 +683,7 @@ export function useInfiniteQuery<T, P = number>(
                 setError(err instanceof Error ? err : new Error(String(err)));
                 setLoading(false);
             });
-    }, [nextParam, queryFn]);
+    }, [nextParam, queryFn, loadingRef]);
 
     return { pages, error, loading, hasNextPage, fetchNextPage };
 }

--- a/packages/jsx/src/hooks/usePrevious.test.ts
+++ b/packages/jsx/src/hooks/usePrevious.test.ts
@@ -4,13 +4,14 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
     createFiber, setCurrentFiber, clearCurrentFiber,
-    setRequestRender, runEffects, destroyFiber,
+    setRequestRender, runEffects, runLayoutEffects, destroyFiber,
 } from '../hooks.js';
 import { usePrevious } from './usePrevious.js';
 
 function renderWithFiber<T>(fiber: ReturnType<typeof createFiber>, fn: () => T): T {
     setCurrentFiber(fiber);
     const result = fn();
+    runLayoutEffects(fiber);
     clearCurrentFiber();
     runEffects(fiber);
     return result;

--- a/packages/jsx/src/hooks/usePrevious.ts
+++ b/packages/jsx/src/hooks/usePrevious.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from '../hooks.js';
+import { useLayoutEffect, useRef } from '../hooks.js';
 
 /**
  * usePrevious — returns the value held during the previous render.
@@ -17,7 +17,7 @@ import { useEffect, useRef } from '../hooks.js';
 export function usePrevious<T>(value: T): T | undefined {
     const ref = useRef<T | undefined>(undefined);
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         ref.current = value;
     });
 

--- a/packages/jsx/src/hooks/useThrottle.ts
+++ b/packages/jsx/src/hooks/useThrottle.ts
@@ -25,7 +25,7 @@ export function useThrottle<T>(value: T, intervalMs: number): T {
             } else {
                 timeoutRef.current = null;
             }
-        }, intervalMs);
+        }, intervalRef.current);
     };
     // Effect to handle value updates and start throttle timer
     useEffect(() => {

--- a/packages/widgets/src/feedback/ProgressCircle.ts
+++ b/packages/widgets/src/feedback/ProgressCircle.ts
@@ -46,10 +46,10 @@ export class ProgressCircle extends Widget {
     /** Update the current progress. Out-of-range values are clamped to [0, 1]. */
     setValue(value: number): void {
         const nextValue = clamp01(value);
-            if (this._value === nextValue) {
+        if (this._value === nextValue) {
             return;
         }
-        this._value = clamp01(value);
+        this._value = nextValue;
         this.markDirty();
     }
 


### PR DESCRIPTION
## Summary

Resolves 5 bugs across 4 packages:

| # | Package | Fix |
|---|---------|-----|
| #3074 | `adapters/conf` | `ConfStore.config` typed as `ConfInstance<T>` instead of `{ store: T }` |
| #3073 | `jsx` | `usePrevious` uses `useLayoutEffect` so ref updates synchronously |
| #3072 | `data` | `loadingRef` added to `useInfiniteQuery` `fetchNextPage` deps |
| #3070 | `widgets` | Remove redundant `clamp01(value)` call in `ProgressCircle.setValue` |
| #3071 | `jsx` | `useThrottle` `runTimeout` uses `intervalRef.current` instead of stale closure |

## CI

All checks pass:
- `bun run build` ✅
- `bun vitest run` ✅ (427 files, 5976 tests)
- `bun run typecheck` ✅

Closes #3074
Closes #3073
Closes #3072
Closes #3070
Closes #3071


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved throttled updates so changing the interval takes effect reliably.
  - Fixed progress indicators to consistently retain their correctly bounded values.
  - Improved previous-value tracking timing for more predictable rendering behavior.
  - Ensured loading state changes are reflected when fetching additional results.

- **Internal Improvements**
  - Strengthened configuration type definitions for better compile-time reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->