### PR TITLE
feat(widgets): add getMessage, getVariant, getTitle, and setTitle methods to Callout widget

### DIFF
--- a/packages/widgets/src/feedback/Callout.test.ts
+++ b/packages/widgets/src/feedback/Callout.test.ts
@@ -78,4 +78,32 @@ describe('Callout', () => {
         expect(output.length).toBeLessThanOrEqual(6);
     });
 
+    it('returns message via getMessage', () => {
+        const callout = new Callout('initial message');
+        expect(callout.getMessage()).toBe('initial message');
+        callout.setMessage('updated message');
+        expect(callout.getMessage()).toBe('updated message');
+    });
+
+    it('returns variant via getVariant', () => {
+        const callout = new Callout('alert', {}, { variant: 'warn' });
+        expect(callout.getVariant()).toBe('warn');
+        callout.setVariant('success');
+        expect(callout.getVariant()).toBe('success');
+    });
+
+    it('gets and sets title via getTitle and setTitle', () => {
+        const callout = new Callout('msg', {}, { title: 'Initial Title' });
+        expect(callout.getTitle()).toBe('Initial Title');
+        callout.setTitle('Updated Title');
+        expect(callout.getTitle()).toBe('Updated Title');
+        expect(callout.isDirty).toBe(true);
+    });
+
+    it('does not mark dirty when title is unchanged', () => {
+        const callout = new Callout('msg', {}, { title: 'Same' });
+        callout.clearDirty();
+        callout.setTitle('Same');
+        expect(callout.isDirty).toBe(false);
+    });
 });

--- a/packages/widgets/src/feedback/Callout.ts
+++ b/packages/widgets/src/feedback/Callout.ts
@@ -48,11 +48,30 @@ export class Callout extends Widget {
         this.markDirty();
     }
 
+    getMessage(): string {
+        return this._message;
+    }
+
     setVariant(variant: CalloutVariant): void {
         if (variant === this._variant) return;
         
         this._variant = variant;
         this.markDirty();
+    }
+
+    getVariant(): CalloutVariant {
+        return this._variant;
+    }
+
+    setTitle(title: string): void {
+        if (title === this._title) return;
+
+        this._title = title;
+        this.markDirty();
+    }
+
+    getTitle(): string {
+        return this._title;
     }
 
     protected _renderSelf(screen: Screen): void {


### PR DESCRIPTION
## Description

Adds missing getter methods (`getMessage`, `getVariant`, `getTitle`) and setter method (`setTitle`) to the `Callout` widget in `@termuijs/widgets`.

Closes #3077

## Package Scope

`packages/widgets`

## Checklist before PR
- [x] Run `bun run build && bun vitest run && bun run typecheck`
- [x] Change confined to package scope
- [x] No unrelated lockfile churn