### PR TITLE
fix(core): added _translateY offset application in writeString for scrolled containers

### DIFF
--- a/packages/core/src/terminal/Screen.test.ts
+++ b/packages/core/src/terminal/Screen.test.ts
@@ -114,6 +114,27 @@ describe('Screen', () => {
         expect(screen.back[0][0].char).toBe(' ');
     });
 
+    it('writeString applies _translateY offset in scrolled containers', () => {
+        const screen = new Screen(20, 10);
+        // Simulate a scrolled container: push a translateY offset
+        // This is how ScrollView offsets content rendering
+        screen.pushTranslateY(-3);
+
+        // Row 2 + (-3) = -1, which is out of bounds, so clipped
+        screen.writeString(0, 2, 'Hello');
+        expect(screen.back[0][0].char).toBe(' ');
+        expect(screen.back[1][0].char).toBe(' ');
+
+        // For positive translateY, content should appear shifted down
+        screen.popTranslateY();
+        screen.pushTranslateY(2);
+        screen.writeString(0, 0, 'Hi');
+        // Row 0 + translateY(2) = 2
+        expect(screen.back[2][0].char).toBe('H');
+        expect(screen.back[2][1].char).toBe('i');
+        screen.popTranslateY();
+    });
+
     it('writeString handles wide CJK characters with unicode support enabled', () => {
         const screen = new Screen(10, 3);
         screen.writeString(0, 0, '你好');

--- a/packages/core/src/terminal/Screen.ts
+++ b/packages/core/src/terminal/Screen.ts
@@ -374,6 +374,8 @@ export class Screen {
     ): void {
         row = Math.floor(row);
         col = Math.floor(col);
+        // Apply Y translation before bounds/clip checks (mirrors setCell behavior)
+        row += this._translateY;
         if (!(row >= 0 && row < this._rows)) return;
 
         // Strip ANSI control sequences from user-supplied content to prevent escape injection


### PR DESCRIPTION
## Summary of What Has Been Done
Fixed the `writeString` method in `packages/core/src/terminal/Screen.ts` to correctly apply the `_translateY` offset when checking row bounds in scrolled containers.

## Changes Made
- Added `row += this._translateY` before the bounds check in `writeString`, mirroring the `setCell` behavior
- Added a corresponding test case verifying that `writeString` respects `pushTranslateY`/`popTranslateY`

## Impact it Made
- Text content in scrolled containers now renders at correct positions
- Previously, `writeString` wrote at absolute row positions while `setCell` used translated positions, causing misalignment

Closes #3082

## Note
Please assign this PR to the `tmdeveloper007` account.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text rendering in vertically translated or scrolled containers.
  * Content now appears at the correct translated row and is properly clipped when positioned outside the visible screen area.

* **Tests**
  * Added coverage for translated text rendering and off-screen clipping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->