### PR TITLE
fix(cli): added Windows backslash normalization in registry path matching

### DIFF
--- a/packages/cli/src/commands/add.test.ts
+++ b/packages/cli/src/commands/add.test.ts
@@ -52,4 +52,20 @@ describe('writeComponentFiles', () => {
             [{ path: '../../evil.ts', content: 'x' }], { dryRun: false }))
             .toThrow(/outside/);
     });
+
+    it('normalizes Windows backslashes in registry file paths', () => {
+        const root = mkdtempSync(join(tmpdir(), 'tcli-'));
+        // Simulate Windows-style paths from registry
+        const written = writeComponentFiles(root, 'spinner', [
+            { path: 'registry\\components\\spinner\\index.ts', content: 'x' },
+            { path: 'registry\\components\\spinner\\utils\\helper.ts', content: 'y' },
+        ], { dryRun: false });
+
+        const target1 = join(root, 'spinner', 'index.ts');
+        const target2 = join(root, 'spinner', 'utils', 'helper.ts');
+        expect(existsSync(target1)).toBe(true);
+        expect(existsSync(target2)).toBe(true);
+        expect(written).toContain(target1);
+        expect(written).toContain(target2);
+    });
 });

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -48,6 +48,8 @@ export function writeComponentFiles(
 }
 
 function normalizeComponentPath(slug: string, filePath: string): string {
+    // Normalize Windows backslashes to forward slashes for cross-platform compatibility
+    filePath = filePath.replace(/\\/g, '/');
     const prefix = `registry/components/${slug}/`;
     if (filePath.startsWith(prefix)) {
         return filePath.slice(prefix.length);


### PR DESCRIPTION
## Summary of What Has Been Done
Fixed `normalizeComponentPath` in `packages/cli/src/commands/add.ts` to normalize Windows backslashes to forward slashes before stripping the registry path prefix.

## Changes Made
- Added `filePath = filePath.replace(/\\/g, '/')` at the start of `normalizeComponentPath`
- Added a test case verifying Windows-style paths are handled correctly

## Impact it Made
- CLI `add` command works correctly on Windows where registry file paths may use backslash separators
- Prevents path resolution failures when registry data contains Windows-style paths

Closes #3086

## Note
Please assign this PR to the `tmdeveloper007` account.
