### PR TITLE
fix(motion): added empty/null guard in stagger function

### DIFF
--- a/packages/motion/src/stagger.test.ts
+++ b/packages/motion/src/stagger.test.ts
@@ -44,6 +44,15 @@ describe('stagger()', () => {
         expect(onComplete).toHaveBeenCalledTimes(1);
     });
 
+    it('handles undefined and null animations without throwing', () => {
+        const onComplete = vi.fn();
+        expect(() => stagger(undefined as any, 100, onComplete)).not.toThrow();
+        expect(onComplete).toHaveBeenCalledTimes(1);
+        const onComplete2 = vi.fn();
+        expect(() => stagger(null as any, 50, onComplete2)).not.toThrow();
+        expect(onComplete2).toHaveBeenCalledTimes(1);
+    });
+
     it('starts all animations immediately for zero delay', () => {
         const starts: number[] = [];
         const onComplete = vi.fn();

--- a/packages/motion/src/stagger.ts
+++ b/packages/motion/src/stagger.ts
@@ -11,6 +11,10 @@ import * as sequencing from './sequence.js';
  * Returns a master cancel function to stop pending and active animations.
  */
 export function stagger(animations: AnimationRunner[], delayMs: number, onComplete?: () => void): () => void {
+    if (!animations || animations.length === 0) {
+        onComplete?.();
+        return () => {};
+    }
     const normalizedDelayMs = Math.max(0, delayMs);
     const delayedAnimations = animations.map((runner, index) => withDelay(runner, index * normalizedDelayMs));
     return sequencing.parallel(delayedAnimations, onComplete);


### PR DESCRIPTION
## Summary of What Has Been Done
Fixed the `stagger` function in `packages/motion/src/stagger.ts` to handle empty and null/undefined `animations` arrays gracefully.

## Changes Made
- Added a guard clause: `if (!animations || animations.length === 0) { onComplete?.(); return () => {}; }`
- Added a test verifying undefined/null inputs do not throw and call onComplete

## Impact it Made
- Prevents TypeErrors when `stagger` is called with undefined/null animations
- Makes the animation API more robust for dynamic item lists

Closes #3085

## Note
Please assign this PR to the `tmdeveloper007` account.
