### PR TITLE
feat(router): add async navigation middleware cascade and data resolv…

### DIFF
--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -17,6 +17,10 @@ export type {
     AfterEnterGuard,
     RouteMeta,
     RedirectTarget,
+    DataResolver,
+    DataResolverMap,
+    RouterMiddleware,
+    RouterMiddlewareContext,
 } from './route.js';
 
 // Upstream Hooks

--- a/packages/router/src/middleware.test.ts
+++ b/packages/router/src/middleware.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Router } from './router.js';
+
+describe('Router Async Middleware & Data Resolvers', () => {
+    it('executes global async middlewares sequentially in order', async () => {
+        const order: string[] = [];
+        const router = new Router();
+
+        router.use(async () => {
+            order.push('mw1-start');
+            await new Promise((r) => setTimeout(r, 10));
+            order.push('mw1-end');
+        });
+
+        router.use(async () => {
+            order.push('mw2-start');
+            await new Promise((r) => setTimeout(r, 10));
+            order.push('mw2-end');
+        });
+
+        router.addRoute('/', () => null);
+        router.addRoute('/dashboard', () => null);
+
+        router.push('/dashboard');
+        await new Promise((r) => setTimeout(r, 50));
+
+        expect(order).toEqual(['mw1-start', 'mw1-end', 'mw2-start', 'mw2-end']);
+    });
+
+    it('allows middleware to block navigation by returning false', async () => {
+        const router = new Router();
+
+        router.use(async (to) => {
+            if (to === '/admin') return false;
+            return true;
+        });
+
+        router.addRoute('/', () => null);
+        router.addRoute('/admin', () => null);
+
+        router.push('/');
+        await new Promise((r) => setTimeout(r, 10));
+        expect(router.currentPath).toBe('/');
+
+        router.push('/admin');
+        await new Promise((r) => setTimeout(r, 10));
+        expect(router.currentPath).toBe('/');
+    });
+
+    it('allows middleware to redirect navigation by returning a target path string', async () => {
+        const router = new Router();
+
+        router.use(async (to) => {
+            if (to === '/protected') return '/login';
+            return true;
+        });
+
+        router.addRoute('/login', () => null);
+        router.addRoute('/protected', () => null);
+
+        router.push('/protected');
+        await new Promise((r) => setTimeout(r, 20));
+
+        expect(router.currentPath).toBe('/login');
+    });
+
+    it('pre-fetches route data using resolve map and populates component props', async () => {
+        const router = new Router();
+
+        const userResolver = vi.fn(async () => {
+            await new Promise((r) => setTimeout(r, 15));
+            return { id: 42, name: 'Alice' };
+        });
+
+        router.addRoute('/profile/[id]', (props: any) => props, {
+            resolve: {
+                user: userResolver,
+            },
+        });
+
+        router.push('/profile/42');
+        await new Promise((r) => setTimeout(r, 40));
+
+        expect(userResolver).toHaveBeenCalled();
+        expect(router.current).not.toBeNull();
+        expect(router.current?.resolvedData).toEqual({
+            user: { id: 42, name: 'Alice' },
+        });
+    });
+
+    it('cancels stale navigation requests when rapid navigation events occur', async () => {
+        const router = new Router();
+
+        router.use(async (to) => {
+            if (to === '/slow') {
+                await new Promise((r) => setTimeout(r, 100));
+            }
+        });
+
+        router.addRoute('/fast', () => null);
+        router.addRoute('/slow', () => null);
+
+        router.push('/slow');
+        // Instantly push fast navigation while slow is still in-flight
+        router.push('/fast');
+
+        await new Promise((r) => setTimeout(r, 120));
+
+        expect(router.currentPath).toBe('/fast');
+    });
+});

--- a/packages/router/src/route.ts
+++ b/packages/router/src/route.ts
@@ -58,6 +58,23 @@ export type RedirectTarget =
     | string
     | ((params: RouteParams) => string);
 
+export type DataResolver<T = any> = (match: RouteMatch, context: NavigationGuardContext) => Promise<T> | T;
+export type DataResolverMap = Record<string, DataResolver>;
+
+export interface RouterMiddlewareContext {
+    to: string;
+    from: string;
+    match: RouteMatch;
+    fromMatch: RouteMatch | null;
+    navigation: NavigationGuardContext;
+}
+
+export type RouterMiddleware = (
+    to: string,
+    from: string,
+    context: RouterMiddlewareContext
+) => Promise<boolean | string | void> | boolean | string | void;
+
 export interface Route {
     /** URL-like path, e.g. "/settings/theme" */
     path: string;
@@ -77,6 +94,8 @@ export interface Route {
     beforeEnter?: BeforeEnterGuard;
     /** Hook called after successful navigation */
     afterEnter?: AfterEnterGuard;
+    /** Async data resolvers map pre-fetched before component instantiation */
+    resolve?: DataResolverMap;
     /** Optional metadata object */
     meta?: RouteMeta;
     /** Declarative redirect target */
@@ -89,6 +108,8 @@ export interface RouteMatch {
     params: RouteParams;
     meta: RouteMeta;
     query: QueryParams;
+    /** Pre-fetched data from route resolvers */
+    resolvedData?: Record<string, any>;
 }
 
 /**

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -4,7 +4,7 @@
 
 import { EventEmitter } from '@termuijs/core';
 import { createElement, ErrorBoundary, unmountAll, type VNode, getCurrentApp } from '@termuijs/jsx';
-import { type NavigationGuardContext, type Route, type RouteMatch, type RouteParams, type RouteMeta, type QueryParams, type RedirectTarget, matchRoute, compilePattern, serializeQuery } from './route.js';
+import { type NavigationGuardContext, type Route, type RouteMatch, type RouteParams, type RouteMeta, type QueryParams, type RedirectTarget, type DataResolverMap, type RouterMiddleware, type RouterMiddlewareContext, matchRoute, compilePattern, serializeQuery } from './route.js';
 import { RouterContext } from './hooks.js';
 
 function defaultErrorScreen(err: Error): VNode {
@@ -51,6 +51,7 @@ export class Router {
     private _navigationId = 0;
     private _activeNavigationId = 0;
     private _activeNavigationController: AbortController | null = null;
+    private _middlewares: RouterMiddleware[] = [];
     public autoUnmount = true;
     readonly events = new EventEmitter<RouterEvents>();
 
@@ -63,6 +64,12 @@ export class Router {
         }
     }
 
+    /** Register global navigation middleware */
+    use(middleware: RouterMiddleware): this {
+        this._middlewares.push(middleware);
+        return this;
+    }
+
     /** Register a route */
     addRoute(
         path: string,
@@ -72,6 +79,7 @@ export class Router {
             lazy?: () => Promise<any>;
             beforeEnter?: (to: string) => boolean | string;
             afterEnter?: (to: string) => void;
+            resolve?: DataResolverMap;
             redirect?: RedirectTarget;
         },
     ): void;
@@ -86,6 +94,7 @@ export class Router {
             lazy?: () => Promise<any>;
             beforeEnter?: (to: string) => boolean | string;
             afterEnter?: (to: string) => void;
+            resolve?: DataResolverMap;
             redirect?: RedirectTarget;
         },
     ): void;
@@ -98,6 +107,7 @@ export class Router {
             lazy?: () => Promise<any>;
             beforeEnter?: (to: string) => boolean | string;
             afterEnter?: (to: string) => void;
+            resolve?: DataResolverMap;
             redirect?: RedirectTarget;
         },
         meta?: RouteMeta,
@@ -105,6 +115,7 @@ export class Router {
             lazy?: () => Promise<any>;
             beforeEnter?: (to: string) => boolean | string;
             afterEnter?: (to: string) => void;
+            resolve?: DataResolverMap;
             redirect?: RedirectTarget;
         } | RedirectTarget,
     ): void {
@@ -113,29 +124,36 @@ export class Router {
             lazy?: () => Promise<any>;
             beforeEnter?: (to: string) => boolean | string;
             afterEnter?: (to: string) => void;
+            resolve?: DataResolverMap;
             redirect?: RedirectTarget;
         } | undefined = undefined;
+
+        let actualLayout = typeof layout === 'function' ? layout : undefined;
+        if (typeof layout === 'object' && layout !== null) {
+            finalOptions = layout as any;
+        }
 
         if (Array.isArray(childrenOrOptions)) {
             children = childrenOrOptions;
         } else if (childrenOrOptions && typeof childrenOrOptions === 'object') {
-            finalOptions = childrenOrOptions as any;
+            finalOptions = { ...finalOptions, ...(childrenOrOptions as any) };
         }
 
         if (typeof options === 'string' || typeof options === 'function') {
             finalOptions = { ...finalOptions, redirect: options };
         } else if (options && typeof options === 'object') {
-            finalOptions = options;
+            finalOptions = { ...finalOptions, ...(options as any) };
         }
 
         let finalMeta = meta ?? {};
-        if (options === undefined && meta && typeof meta === 'object' && ('lazy' in meta || 'beforeEnter' in meta || 'afterEnter' in meta || 'redirect' in meta)) {
+        if (options === undefined && meta && typeof meta === 'object' && ('lazy' in meta || 'beforeEnter' in meta || 'afterEnter' in meta || 'redirect' in meta || 'resolve' in meta)) {
             finalOptions = meta as any;
             const strippedMeta = { ...meta };
             delete (strippedMeta as any).lazy;
             delete (strippedMeta as any).beforeEnter;
             delete (strippedMeta as any).afterEnter;
             delete (strippedMeta as any).redirect;
+            delete (strippedMeta as any).resolve;
             finalMeta = strippedMeta;
         }
 
@@ -146,12 +164,13 @@ export class Router {
             pattern,
             paramNames,
             component,
-            layout,
+            layout: actualLayout,
             children,
             meta: finalMeta,
             lazy: finalOptions?.lazy,
             beforeEnter: finalOptions?.beforeEnter,
             afterEnter: finalOptions?.afterEnter,
+            resolve: finalOptions?.resolve,
             redirect: finalOptions?.redirect,
         });
         this._applyInitialPathIfPending();
@@ -168,6 +187,7 @@ export class Router {
             lazy?: () => Promise<any>;
             beforeEnter?: (to: string) => boolean | string;
             afterEnter?: (to: string) => void;
+            resolve?: DataResolverMap;
             redirect?: RedirectTarget;
         }>,
     ): void {
@@ -176,6 +196,7 @@ export class Router {
                 lazy: r.lazy,
                 beforeEnter: r.beforeEnter,
                 afterEnter: r.afterEnter,
+                resolve: r.resolve,
                 redirect: r.redirect,
             });
         }
@@ -183,12 +204,13 @@ export class Router {
 
     /** Wrap a route match into a VNode with layout chain and providers */
     wrapScreen(match: RouteMatch): VNode {
-        let screen = createElement(match.route.component, match.params);
+        const props = { ...match.params, ...(match.resolvedData ?? {}) };
+        let screen = createElement(match.route.component, props);
 
         for (let i = match.chain.length - 2; i >= 0; i--) {
             const parent = match.chain[i];
             const Wrapper = parent.layout ?? parent.component;
-            screen = createElement(Wrapper, { ...match.params, outlet: screen });
+            screen = createElement(Wrapper, { ...props, outlet: screen });
         }
 
         const withProvider = createElement(RouterContext.Provider, { value: this }, screen);
@@ -253,6 +275,45 @@ export class Router {
         };
     }
 
+    private async _runMiddlewares(to: string, match: RouteMatch, navigation: NavigationGuardContext): Promise<boolean | string> {
+        const from = this.currentPath;
+        const fromMatch = this._currentMatch;
+
+        for (const mw of this._middlewares) {
+            if (navigation.isStale()) return false;
+            const res = await mw(to, from, { to, from, match, fromMatch, navigation });
+            if (navigation.isStale()) return false;
+            if (res === false || typeof res === 'string') {
+                return res;
+            }
+        }
+        return true;
+    }
+
+    private async _runResolvers(match: RouteMatch, navigation: NavigationGuardContext): Promise<Record<string, any> | false> {
+        const resolved: Record<string, any> = {};
+
+        for (const route of match.chain) {
+            if (route.resolve) {
+                const entries = Object.entries(route.resolve);
+                const results = await Promise.all(
+                    entries.map(async ([key, resolver]) => {
+                        const val = await resolver(match, navigation);
+                        return [key, val] as const;
+                    })
+                );
+
+                if (navigation.isStale()) return false;
+
+                for (const [k, v] of results) {
+                    resolved[k] = v;
+                }
+            }
+        }
+
+        return resolved;
+    }
+
     private _runBeforeEnterGuards(match: RouteMatch, path: string, navigation: NavigationGuardContext): boolean | string {
         for (const route of match.chain) {
             const result = route.beforeEnter?.(path, navigation);
@@ -262,6 +323,44 @@ export class Router {
             }
         }
         return true;
+    }
+
+    private _commitNavigation(
+        resolvedPath: string,
+        match: RouteMatch,
+        options: {
+            modifyHistory?: 'push' | 'replace' | 'none';
+            direction?: 'push' | 'replace' | 'back' | 'forward';
+        },
+        navigation: NavigationGuardContext,
+    ): void {
+        const { modifyHistory = 'push', direction = 'push' } = options;
+
+        if (modifyHistory === 'push') {
+            this._history.push(resolvedPath);
+
+            if (this._history.length > this._maxHistory) {
+                this._history = this._history.slice(-this._maxHistory);
+            }
+        } else if (modifyHistory === 'replace') {
+            if (this._history.length > 0) {
+                this._history[this._history.length - 1] = resolvedPath;
+            } else {
+                this._history.push(resolvedPath);
+            }
+        }
+
+        this._currentMatch = match;
+        const app = getCurrentApp();
+        if (app) app.focus.clearFocus();
+        if (this.autoUnmount) unmountAll();
+        const screen = this.wrapScreen(match);
+
+        const emitEvent = direction === 'back' ? 'back' : 'navigate';
+        if (navigation.isStale()) return;
+        this.events.emit(emitEvent, { match, screen, direction, navigation });
+
+        match.route.afterEnter?.(resolvedPath, navigation);
     }
 
     /**
@@ -276,7 +375,7 @@ export class Router {
             direction?: 'push' | 'replace' | 'back' | 'forward';
             navigation?: NavigationGuardContext;
         } = {},
-    ): void {
+    ): Promise<void> | void {
         const navigation = options.navigation ?? this._beginNavigation();
         const resolvedPath = this._resolveRedirect(path);
         if (navigation.isStale()) return;
@@ -335,37 +434,33 @@ export class Router {
         }
 
         if (typeof guardResult === 'string') {
-            this._executeNavigation(guardResult, { ...options, clearForwardStack: false, navigation });
+            return this._executeNavigation(guardResult, { ...options, clearForwardStack: false, navigation });
+        }
+
+        const hasMiddlewares = this._middlewares.length > 0;
+        const hasResolvers = match.chain.some((r) => r.resolve && Object.keys(r.resolve).length > 0);
+
+        if (!hasMiddlewares && !hasResolvers) {
+            this._commitNavigation(resolvedPath, match, options, navigation);
             return;
         }
 
-        const { modifyHistory = 'push', direction = 'push' } = options;
+        return (async () => {
+            const mwResult = await this._runMiddlewares(resolvedPath, match, navigation);
+            if (navigation.isStale()) return;
 
-        if (modifyHistory === 'push') {
-            this._history.push(resolvedPath);
-
-            if (this._history.length > this._maxHistory) {
-                this._history = this._history.slice(-this._maxHistory);
+            if (mwResult === false) return;
+            if (typeof mwResult === 'string') {
+                await this._executeNavigation(mwResult, { ...options, clearForwardStack: false, navigation });
+                return;
             }
-        } else if (modifyHistory === 'replace') {
-            if (this._history.length > 0) {
-                this._history[this._history.length - 1] = resolvedPath;
-            } else {
-                this._history.push(resolvedPath);
-            }
-        }
 
-        this._currentMatch = match;
-        const app = getCurrentApp();
-        if (app) app.focus.clearFocus();
-        if (this.autoUnmount) unmountAll();
-        const screen = this.wrapScreen(match);
+            const resolvedData = await this._runResolvers(match, navigation);
+            if (navigation.isStale() || resolvedData === false) return;
+            match.resolvedData = resolvedData;
 
-        const emitEvent = direction === 'back' ? 'back' : 'navigate';
-        if (navigation.isStale()) return;
-        this.events.emit(emitEvent, { match, screen, direction, navigation });
-
-        match.route.afterEnter?.(resolvedPath, navigation);
+            this._commitNavigation(resolvedPath, match, options, navigation);
+        })();
     }
 
     private _applyInitialPathIfPending(): void {


### PR DESCRIPTION


<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

This PR introduces an asynchronous navigation middleware execution cascade (`router.use()`) and route data resolvers (`resolve`) to `@termuijs/router`. It allows pre-fetching data before route components instantiate and supports async navigation blocking and redirection with automatic `AbortController` cancellation for stale navigation requests.

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #3093 

## Which package(s)?

@termuijs/router

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/8c84eca2-34f4-470b-bec0-6906c2088cd1`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

- Added `router.use()` method for global async navigation middleware pipeline registration.
- Added `resolve` options map to `Route` definition, populating component props with resolved async data via `wrapScreen()`.
- Added unit tests in `packages/router/src/middleware.test.ts` (104 tests passing cleanly across `@termuijs/router`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added navigation middleware support, including sequential async processing.
  * Middleware can block navigation or redirect to another route.
  * Added asynchronous route data resolvers that provide resolved data to route components.
  * Added support for cancelling stale navigations during rapid route changes.
  * Expanded router type exports for middleware and data resolution APIs.
* **Tests**
  * Added coverage for middleware execution, redirects, data resolution, and navigation cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->