### PR TITLE
fix: empty history undo guard and inline-viewport rows validation

### DIFF
--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -26,15 +26,16 @@ export class History<T> {
     }
 
     undo(): T | undefined {
-        if (this.undoStack.length <= 1) {
+        if (this.undoStack.length === 0) {
+            return undefined;
+        }
+
+        if (this.undoStack.length === 1) {
             return this.undoStack[0];
         }
 
-        const current = this.undoStack.pop();
-
-        if (current !== undefined) {
-            this.redoStack.push(current);
-        }
+        const current = this.undoStack.pop()!;
+        this.redoStack.push(current);
 
         return this.undoStack[this.undoStack.length - 1];
     }

--- a/packages/core/src/inline-viewport.ts
+++ b/packages/core/src/inline-viewport.ts
@@ -11,6 +11,7 @@ export interface InlineViewportOptions {
  * Preserves scrollback by writing lines to stdout rather than taking over the alternate screen.
  */
 export function renderInlineToTerminal(terminal: Terminal, screen: Screen, rows: number): void {
+    if (rows <= 0) return;
     const totalRows = screen.rows;
     const start = Math.max(0, totalRows - rows);
     const lines: string[] = [];


### PR DESCRIPTION
## Changes

- **core/history**: Added explicit empty stack guard in undo() to return undefined instead of accessing index 0
- **core/inline-viewport**: Added rows parameter validation in renderInlineToTerminal to handle non-positive values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved undo behavior for empty and single-entry histories.
  * Ensured undo operations correctly preserve redo history when multiple entries exist.
  * Prevented terminal rendering when a non-positive number of rows is requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->