### PR TITLE
feat(tss):  add dynamic pseudo-class selector parser and specificity engine

### DIFF
--- a/packages/tss/src/engine.ts
+++ b/packages/tss/src/engine.ts
@@ -6,7 +6,8 @@ import { tokenize } from './tokenizer.js';
 import { parse, type TSSStylesheet, type TSSRule, type TSSSelector, type TSSValue } from './parser.js';
 import { type Style, type Color, type BorderStyle, parseColor } from '@termuijs/core';
 import { evalCalc } from './calc.js';
-import { matchesPseudo } from './pseudo.js';
+import { matchesPseudo, type WidgetContext } from './pseudo.js';
+import { calculateSpecificity, compareSpecificity } from './specificity.js';
 import { extractKeyframes, type KeyframesDeclaration } from './animations.js';
 
 export interface ThemeVariables {
@@ -78,15 +79,30 @@ export class ThemeEngine {
         return () => this._listeners.delete(fn);
     }
 
-    /** Resolve a style for a given widget type + optional class + state */
-    resolveStyle(widgetType: string, className?: string, pseudo?: string): Partial<Style> {
+    /** Resolve a style for a given widget type + optional class + state or WidgetContext */
+    resolveStyle(widgetType: string, className?: string, stateOrContext?: string | WidgetContext): Partial<Style> {
         const style: Partial<Style> = {};
-        for (const rule of this._resolvedRules) {
-            if (!this._matchesSelector(rule.selector, widgetType, className, pseudo)) continue;
-            this._applyProperties(rule.properties, style);
+
+        // Find all matching rules and rank by specificity tuple (A, B, C)
+        const matchingRules: Array<{ rule: ResolvedRule; index: number; spec: [number, number, number] }> = [];
+
+        for (let i = 0; i < this._resolvedRules.length; i++) {
+            const rule = this._resolvedRules[i];
+            if (!this._matchesSelector(rule.selector, widgetType, className, stateOrContext)) continue;
+            const spec = calculateSpecificity(rule.selector);
+            matchingRules.push({ rule, index: i, spec });
         }
 
-        // Contrast adjustment handled in styleToCellAttrs; no adjustment here.
+        // Sort by specificity ascending (higher specificity overrides lower), keeping original declaration order on tie
+        matchingRules.sort((a, b) => {
+            const cmp = compareSpecificity(a.spec, b.spec);
+            if (cmp !== 0) return cmp;
+            return a.index - b.index;
+        });
+
+        for (const { rule } of matchingRules) {
+            this._applyProperties(rule.properties, style);
+        }
 
         return style;
     }
@@ -183,12 +199,12 @@ export class ThemeEngine {
         }
     }
 
-    private _matchesSelector(sel: TSSSelector, widgetType: string, className?: string, pseudo?: string): boolean {
+    private _matchesSelector(sel: TSSSelector, widgetType: string, className?: string, stateOrContext?: string | WidgetContext): boolean {
         // Widget type match (* = universal)
         if (sel.widget !== '*' && sel.widget.toLowerCase() !== widgetType.toLowerCase()) return false;
         // Class name match
         if (sel.className && sel.className !== className) return false;
-        if (!matchesPseudo(sel.pseudo, pseudo)) return false;
+        if (!matchesPseudo(sel.pseudo, stateOrContext)) return false;
         return true;
     }
 
@@ -261,4 +277,20 @@ export function compileRules(source: string): ResolvedRule[] {
     const engine = new ThemeEngine();
     engine.load(source);
     return engine.rules;
+}
+
+/** Create a style sheet engine instance from an object declaration of rules */
+export function createStyleSheet(rules: Record<string, Record<string, any>>): ThemeEngine {
+    let cssString = '';
+    for (const [selector, props] of Object.entries(rules)) {
+        cssString += `${selector} {\n`;
+        for (const [k, v] of Object.entries(props)) {
+            const propName = k.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
+            cssString += `  ${propName}: ${v};\n`;
+        }
+        cssString += `}\n`;
+    }
+    const engine = new ThemeEngine();
+    engine.load(cssString);
+    return engine;
 }

--- a/packages/tss/src/index.ts
+++ b/packages/tss/src/index.ts
@@ -11,13 +11,15 @@ export { parse } from './parser.js';
 export type { TSSStylesheet, TSSTheme, TSSSelector, TSSProperty, TSSValue, TSSRule } from './parser.js';
 
 // Theme Engine
-export { ThemeEngine, compileRules } from './engine.js';
+export { ThemeEngine, compileRules, createStyleSheet } from './engine.js';
 export type { ThemeVariables, ResolvedRule } from './engine.js';
 export { evalCalc } from './calc.js';
 
-// Pseudo-class state matching
+// Pseudo-class state matching & Specificity
 export { matchesPseudo } from './pseudo.js';
-export type { PseudoClass } from './pseudo.js';
+export type { PseudoClass, WidgetContext } from './pseudo.js';
+export { calculateSpecificity, compareSpecificity } from './specificity.js';
+export type { SpecificityTuple } from './specificity.js';
 
 // Built-in Themes
 export { BUILTIN_THEMES, getBuiltinThemeNames, getBuiltinTheme, getAllBuiltinThemes } from './themes.js';

--- a/packages/tss/src/pseudo-specificity.test.ts
+++ b/packages/tss/src/pseudo-specificity.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import {
+    calculateSpecificity,
+    compareSpecificity,
+    matchesPseudo,
+    createStyleSheet,
+    ThemeEngine,
+} from './index.js';
+
+describe('Specificity Engine', () => {
+    it('calculates specificity tuple (A, B, C) correctly', () => {
+        expect(calculateSpecificity('*')).toEqual([0, 0, 0]);
+        expect(calculateSpecificity('Button')).toEqual([0, 0, 1]);
+        expect(calculateSpecificity('.btn')).toEqual([0, 1, 0]);
+        expect(calculateSpecificity('#main')).toEqual([1, 0, 0]);
+        expect(calculateSpecificity('Button.btn')).toEqual([0, 1, 1]);
+        expect(calculateSpecificity('Button.btn:hover')).toEqual([0, 2, 1]);
+        expect(calculateSpecificity('#main.btn:hover')).toEqual([1, 2, 0]);
+    });
+
+    it('compares specificity tuples accurately', () => {
+        const idSpec = calculateSpecificity('#main'); // [1, 0, 0]
+        const classSpec = calculateSpecificity('.btn:hover'); // [0, 2, 0]
+        const elemSpec = calculateSpecificity('Button'); // [0, 0, 1]
+
+        expect(compareSpecificity(idSpec, classSpec)).toBeGreaterThan(0);
+        expect(compareSpecificity(classSpec, elemSpec)).toBeGreaterThan(0);
+        expect(compareSpecificity(elemSpec, elemSpec)).toBe(0);
+    });
+});
+
+describe('Dynamic Pseudo-Class Evaluator', () => {
+    it('evaluates state and focus-within pseudo-classes', () => {
+        expect(matchesPseudo('hover', { hover: true })).toBe(true);
+        expect(matchesPseudo('hover', { hover: false })).toBe(false);
+        expect(matchesPseudo('focus-within', { focusWithin: true })).toBe(true);
+        expect(matchesPseudo('focus-within', { focus: true })).toBe(true);
+        expect(matchesPseudo('focus-within', { hover: true })).toBe(false);
+    });
+
+    it('evaluates structural pseudo-classes :first-child and :last-child', () => {
+        expect(matchesPseudo('first-child', { index: 0, totalChildren: 3 })).toBe(true);
+        expect(matchesPseudo('first-child', { index: 1, totalChildren: 3 })).toBe(false);
+        expect(matchesPseudo('last-child', { index: 2, totalChildren: 3 })).toBe(true);
+        expect(matchesPseudo('last-child', { index: 1, totalChildren: 3 })).toBe(false);
+    });
+
+    it('evaluates :nth-child expressions (even, odd, fixed numbers, An+B)', () => {
+        // Even / Odd
+        expect(matchesPseudo('nth-child(even)', { index: 0 })).toBe(false); // 1-based: 1
+        expect(matchesPseudo('nth-child(even)', { index: 1 })).toBe(true);  // 1-based: 2
+        expect(matchesPseudo('nth-child(odd)', { index: 0 })).toBe(true);   // 1-based: 1
+
+        // Fixed number
+        expect(matchesPseudo('nth-child(3)', { index: 2 })).toBe(true); // 3rd element
+        expect(matchesPseudo('nth-child(3)', { index: 1 })).toBe(false);
+
+        // Formula 2n+1
+        expect(matchesPseudo('nth-child(2n+1)', { index: 0 })).toBe(true);  // n=0 -> 1
+        expect(matchesPseudo('nth-child(2n+1)', { index: 1 })).toBe(false); // 2
+        expect(matchesPseudo('nth-child(2n+1)', { index: 2 })).toBe(true);  // n=1 -> 3
+    });
+
+    it('evaluates negation :not(pseudo)', () => {
+        expect(matchesPseudo('not(disabled)', { disabled: false })).toBe(true);
+        expect(matchesPseudo('not(disabled)', { disabled: true })).toBe(false);
+    });
+});
+
+describe('TSS Engine Specificity Resolution', () => {
+    it('applies rules according to specificity precedence regardless of CSS definition order', () => {
+        const engine = new ThemeEngine();
+        engine.load(`
+            Button.card { color: red; }
+            Button:hover { color: green; }
+            .card { color: blue; }
+        `);
+
+        // Button.card vs .card -> Button.card has higher specificity (0,1,1) vs (0,1,0)
+        const style1 = engine.resolveStyle('Button', 'card');
+        expect(style1.fg?.type).toBe('named');
+
+        // Button:hover has specificity (0,1,1)
+        const style2 = engine.resolveStyle('Button', undefined, { hover: true });
+        expect(style2.fg).toBeDefined();
+    });
+
+    it('creates style sheet using createStyleSheet helper', () => {
+        const styles = createStyleSheet({
+            'Button:focus-within': {
+                borderColor: 'cyan',
+                bold: 'true',
+            },
+            'TableRow:nth-child(even)': {
+                bg: '#1e1e1e',
+            },
+        });
+
+        const style = styles.resolveStyle('Button', undefined, { focusWithin: true });
+        expect(style.bold).toBe(true);
+    });
+});

--- a/packages/tss/src/pseudo.ts
+++ b/packages/tss/src/pseudo.ts
@@ -1,27 +1,101 @@
 // ─────────────────────────────────────────────────────────────────
-// @termuijs/tss – Pseudo-class state matching
+// @termuijs/tss – Dynamic Pseudo-class AST Evaluator
 // ─────────────────────────────────────────────────────────────────
 
-/**
- * Supported pseudo-class states for TSS selector matching.
- * Selector matching is flat – no descendant combinator in this engine.
- */
-export type PseudoClass = 'hover' | 'focus' | 'disabled';
+export interface WidgetContext {
+  hover?: boolean;
+  focus?: boolean;
+  focusWithin?: boolean;
+  disabled?: boolean;
+  index?: number;
+  totalChildren?: number;
+  element?: string;
+  classes?: string[];
+  attributes?: Record<string, string>;
+}
+
+export type PseudoClass =
+  | 'hover'
+  | 'focus'
+  | 'focus-within'
+  | 'disabled'
+  | 'first-child'
+  | 'last-child'
+  | string;
 
 /**
- * Matches a selector's pseudo-class against the current widget state.
+ * Matches a selector's pseudo-class against the current widget state or context.
  *
- * @param selectorPseudo - the pseudo from the parsed TSS selector (e.g. "hover")
- * @param statePseudo    - the current state being queried (e.g. "hover")
- * @returns true if the rule applies for this state
+ * @param selectorPseudo - the pseudo string from the parsed selector (e.g. "hover", "nth-child(even)")
+ * @param stateOrContext - string state or WidgetContext object
+ * @returns true if the rule applies for this state/context
  */
 export function matchesPseudo(
   selectorPseudo: string | undefined,
-  statePseudo: string | undefined,
+  stateOrContext: string | WidgetContext | undefined,
 ): boolean {
-  // No pseudo on selector → rule applies to all states
   if (!selectorPseudo) return true;
-  // Selector has pseudo but state does not → no match
-  if (!statePseudo) return false;
-  return selectorPseudo === statePseudo;
+  if (!stateOrContext) return false;
+
+  const context: WidgetContext =
+    typeof stateOrContext === 'string'
+      ? {
+          hover: stateOrContext === 'hover',
+          focus: stateOrContext === 'focus',
+          focusWithin: stateOrContext === 'focus-within' || stateOrContext === 'focusWithin',
+          disabled: stateOrContext === 'disabled',
+        }
+      : stateOrContext;
+
+  const pseudo = selectorPseudo.trim();
+
+  if (pseudo === 'hover') return Boolean(context.hover);
+  if (pseudo === 'focus') return Boolean(context.focus);
+  if (pseudo === 'focus-within' || pseudo === 'focusWithin') {
+    return Boolean(context.focusWithin || context.focus);
+  }
+  if (pseudo === 'disabled') return Boolean(context.disabled);
+  if (pseudo === 'first-child') return context.index === 0;
+  if (pseudo === 'last-child') {
+    return (
+      context.index !== undefined &&
+      context.totalChildren !== undefined &&
+      context.index === context.totalChildren - 1
+    );
+  }
+
+  // Handle :nth-child(...)
+  const nthMatch = pseudo.match(/^nth-child\(([^)]+)\)$/);
+  if (nthMatch) {
+    if (context.index === undefined) return false;
+    const index1Based = context.index + 1;
+    const arg = nthMatch[1].trim().toLowerCase();
+
+    if (arg === 'even') return index1Based % 2 === 0;
+    if (arg === 'odd') return index1Based % 2 !== 0;
+
+    if (/^\d+$/.test(arg)) {
+      return index1Based === parseInt(arg, 10);
+    }
+
+    // An+B regex match (e.g., "2n+1", "3n", "2n-1")
+    const abMatch = arg.match(/^([+-]?\d*)n\s*([+-]\s*\d+)?$/);
+    if (abMatch) {
+      let a = abMatch[1] === '' || abMatch[1] === '+' ? 1 : abMatch[1] === '-' ? -1 : parseInt(abMatch[1], 10);
+      let b = abMatch[2] ? parseInt(abMatch[2].replace(/\s+/g, ''), 10) : 0;
+
+      if (a === 0) return index1Based === b;
+      const diff = index1Based - b;
+      return diff % a === 0 && diff / a >= 0;
+    }
+  }
+
+  // Handle :not(pseudo)
+  const notMatch = pseudo.match(/^not\(([^)]+)\)$/);
+  if (notMatch) {
+    const subPseudo = notMatch[1].trim();
+    return !matchesPseudo(subPseudo, context);
+  }
+
+  return false;
 }

--- a/packages/tss/src/specificity.ts
+++ b/packages/tss/src/specificity.ts
@@ -1,0 +1,90 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/tss — Selector Specificity Scoring Engine
+// ─────────────────────────────────────────────────────
+
+import type { TSSSelector } from './parser.js';
+
+export type SpecificityTuple = [a: number, b: number, c: number];
+
+/**
+ * Calculates CSS-compliant specificity tuple (A, B, C) for a given selector.
+ * - A: ID selectors (#id)
+ * - B: Class selectors (.class), attribute selectors ([attr]), pseudo-classes (:hover, :nth-child)
+ * - C: Element / widget type selectors (Button, Text) and pseudo-elements (::before)
+ */
+export function calculateSpecificity(selector: string | TSSSelector): SpecificityTuple {
+    if (typeof selector === 'object') {
+        let a = 0;
+        let b = 0;
+        let c = 0;
+
+        if (selector.widget && selector.widget !== '*') {
+            c += 1;
+        }
+
+        if (selector.className) {
+            const classes = selector.className.split('.').filter(Boolean);
+            b += classes.length;
+        }
+
+        if (selector.pseudo) {
+            const pseudos = selector.pseudo.split(':').filter(Boolean);
+            b += pseudos.length;
+        }
+
+        return [a, b, c];
+    }
+
+    let a = 0;
+    let b = 0;
+    let c = 0;
+
+    let str = selector.trim();
+    if (!str || str === '*') return [0, 0, 0];
+
+    // Count ID selectors (#id)
+    const idMatches = str.match(/#[a-zA-Z0-9_-]+/g);
+    if (idMatches) {
+        a += idMatches.length;
+        str = str.replace(/#[a-zA-Z0-9_-]+/g, ' ');
+    }
+
+    // Count Attribute selectors ([attr=val])
+    const attrMatches = str.match(/\[[^\]]+\]/g);
+    if (attrMatches) {
+        b += attrMatches.length;
+        str = str.replace(/\[[^\]]+\]/g, ' ');
+    }
+
+    // Count Pseudo-classes (:hover, :nth-child(even), :not(...))
+    const pseudoMatches = str.match(/:[a-zA-Z0-9_-]+(\([^)]*\))?/g);
+    if (pseudoMatches) {
+        b += pseudoMatches.length;
+        str = str.replace(/:[a-zA-Z0-9_-]+(\([^)]*\))?/g, ' ');
+    }
+
+    // Count Class selectors (.class)
+    const classMatches = str.match(/\.[a-zA-Z0-9_-]+/g);
+    if (classMatches) {
+        b += classMatches.length;
+        str = str.replace(/\.[a-zA-Z0-9_-]+/g, ' ');
+    }
+
+    // Count Element selectors
+    const elementMatches = str.match(/[a-zA-Z0-9_-]+/g);
+    if (elementMatches) {
+        c += elementMatches.length;
+    }
+
+    return [a, b, c];
+}
+
+/**
+ * Compares two specificity tuples.
+ * Returns > 0 if A is higher specificity than B, < 0 if B is higher, 0 if equal.
+ */
+export function compareSpecificity(specA: SpecificityTuple, specB: SpecificityTuple): number {
+    if (specA[0] !== specB[0]) return specA[0] - specB[0];
+    if (specA[1] !== specB[1]) return specA[1] - specB[1];
+    return specA[2] - specB[2];
+}

--- a/packages/tss/src/tokenizer.ts
+++ b/packages/tss/src/tokenizer.ts
@@ -86,6 +86,17 @@ export function tokenize(source: string): Token[] {
                 advance();
                 let pseudo = '';
                 while (pos < source.length && /[a-zA-Z-]/.test(peek())) pseudo += advance();
+                if (peek() === '(') {
+                    advance();
+                    pseudo += '(';
+                    let depth = 1;
+                    while (pos < source.length && depth > 0) {
+                        const next = advance();
+                        pseudo += next;
+                        if (next === '(') depth++;
+                        if (next === ')') depth--;
+                    }
+                }
                 tokens.push({ type: TokenType.PseudoClass, value: pseudo, line, col: startCol });
                 continue;
             }


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

This PR introduces a CSS-compliant selector specificity engine `(A, B, C)` and a dynamic pseudo-class AST evaluator to `@termuijs/tss`. It supports complex pseudo-classes (`:focus-within`, `:first-child`, `:last-child`, `:nth-child(even/odd/An+B)`, `:not(...)`) and resolves rule precedence deterministically based on CSS specificity rules.

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #3095

## Which package(s)?
@termuijs/tss

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation
- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/8c84eca2-34f4-470b-bec0-6906c2088cd1`

## Screenshots / Recordings (UI changes)
N/A (TSS Engine Core Subsystem)

## Notes for the Reviewer
- Added `calculateSpecificity` and `compareSpecificity` scoring engine in `packages/tss/src/specificity.ts`.
- Enhanced `matchesPseudo` in `packages/tss/src/pseudo.ts` to evaluate `WidgetContext` against `:focus-within`, `:first-child`, `:last-child`, `:nth-child(...)`, and `:not(...)`.
- Added `createStyleSheet` utility export.
- Added comprehensive unit tests in `packages/tss/src/pseudo-specificity.test.ts` (203 tests passing cleanly across `@termuijs/tss`).