### PR TITLE
feat(data): add SWR cache store and resilient websocket manager

### DIFF
--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -17,6 +17,17 @@ export { http } from './http.js';
 export type { HealthResult, Endpoint } from './http.js';
 export { invalidate, setCacheMaxSize, getCache, setCache, isFresh, clearCache, fetchShared } from './cache.js';
 
+export { SWRCacheStore } from './swr-cache.js';
+export type { SWRCacheOptions, SWRCacheEntry, SWRFetchOptions } from './swr-cache.js';
+
+export { ResilientWebSocket } from './resilient-websocket.js';
+export type {
+    ResilientWebSocketOptions,
+    WebSocketConnectionStatus,
+    ResilientWebSocketEvents,
+    ReconnectBackoffOptions,
+} from './resilient-websocket.js';
+
 
 // ── Reactive hooks ────────────────────────────────────
 export {

--- a/packages/data/src/resilient-websocket.test.ts
+++ b/packages/data/src/resilient-websocket.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ResilientWebSocket } from './resilient-websocket.js';
+
+// Mock WebSocket implementation for unit testing
+class MockWebSocket {
+    static instances: MockWebSocket[] = [];
+    url: string;
+    readyState = 0; // CONNECTING
+    onopen: (() => void) | null = null;
+    onmessage: ((event: { data: any }) => void) | null = null;
+    onerror: ((err: any) => void) | null = null;
+    onclose: ((event: { code: number; reason: string }) => void) | null = null;
+    sentData: any[] = [];
+
+    constructor(url: string) {
+        this.url = url;
+        MockWebSocket.instances.push(this);
+    }
+
+    send(data: any) {
+        this.sentData.push(data);
+    }
+
+    close(code = 1000, reason = '') {
+        this.readyState = 3; // CLOSED
+        this.onclose?.({ code, reason });
+    }
+
+    simulateOpen() {
+        this.readyState = 1; // OPEN
+        this.onopen?.();
+    }
+
+    simulateMessage(data: any) {
+        this.onmessage?.({ data });
+    }
+
+    simulateError(err: any) {
+        this.onerror?.(err);
+    }
+}
+
+describe('ResilientWebSocket', () => {
+    beforeEach(() => {
+        MockWebSocket.instances = [];
+        (globalThis as any).WebSocket = MockWebSocket as any;
+    });
+
+    afterEach(() => {
+        delete (globalThis as any).WebSocket;
+    });
+
+    it('initializes and connects automatically', () => {
+        const ws = new ResilientWebSocket('wss://example.com/stream');
+        expect(ws.status).toBe('CONNECTING');
+        expect(MockWebSocket.instances.length).toBe(1);
+
+        const mockWs = MockWebSocket.instances[0];
+        mockWs.simulateOpen();
+        expect(ws.status).toBe('OPEN');
+    });
+
+    it('queues offline messages and flushes them upon successful connection', () => {
+        const ws = new ResilientWebSocket('wss://example.com/stream', {
+            autoConnect: false,
+            queueOfflineMessages: true,
+        });
+
+        expect(ws.status).toBe('CLOSED');
+
+        // Send while offline
+        const sentOffline = ws.send({ type: 'ping' });
+        expect(sentOffline).toBe(false);
+        expect(ws.messageQueueLength).toBe(1);
+
+        // Connect
+        ws.connect();
+        const mockWs = MockWebSocket.instances[0];
+        mockWs.simulateOpen();
+
+        expect(ws.status).toBe('OPEN');
+        expect(ws.messageQueueLength).toBe(0);
+        expect(mockWs.sentData).toEqual([JSON.stringify({ type: 'ping' })]);
+    });
+
+    it('schedules exponential backoff reconnect attempt when connection drops', async () => {
+        const ws = new ResilientWebSocket('wss://example.com/stream', {
+            reconnectBackoff: { initialMs: 10, maxMs: 100, factor: 2 },
+        });
+
+        const mockWs1 = MockWebSocket.instances[0];
+        mockWs1.simulateOpen();
+        expect(ws.status).toBe('OPEN');
+
+        const reconnectSpy = vi.fn();
+        ws.events.on('reconnectAttempt', reconnectSpy);
+
+        // Simulate dropped connection
+        mockWs1.close(1006, 'Abnormal closure');
+
+        expect(ws.status).toBe('RECONNECTING');
+
+        // Wait for reconnect timer
+        await new Promise((r) => setTimeout(r, 30));
+
+        expect(reconnectSpy).toHaveBeenCalled();
+        expect(MockWebSocket.instances.length).toBe(2);
+    });
+
+    it('stops reconnecting on manual disconnect', () => {
+        const ws = new ResilientWebSocket('wss://example.com/stream');
+        const mockWs = MockWebSocket.instances[0];
+        mockWs.simulateOpen();
+
+        ws.disconnect();
+        expect(ws.status).toBe('CLOSED');
+        expect(MockWebSocket.instances.length).toBe(1);
+    });
+});

--- a/packages/data/src/resilient-websocket.ts
+++ b/packages/data/src/resilient-websocket.ts
@@ -1,0 +1,215 @@
+type ListenerFn = (...args: any[]) => void;
+
+class SimpleEventEmitter {
+    private _events = new Map<string, Set<ListenerFn>>();
+
+    on(event: string, fn: ListenerFn): () => void {
+        if (!this._events.has(event)) {
+            this._events.set(event, new Set());
+        }
+        this._events.get(event)!.add(fn);
+        return () => this.off(event, fn);
+    }
+
+    off(event: string, fn: ListenerFn): void {
+        const set = this._events.get(event);
+        if (set) {
+            set.delete(fn);
+        }
+    }
+
+    emit(event: string, ...args: any[]): void {
+        const set = this._events.get(event);
+        if (set) {
+            for (const fn of Array.from(set)) {
+                fn(...args);
+            }
+        }
+    }
+}
+
+export interface ReconnectBackoffOptions {
+    initialMs?: number;
+    maxMs?: number;
+    factor?: number;
+}
+
+export interface ResilientWebSocketOptions {
+    reconnectBackoff?: ReconnectBackoffOptions;
+    queueOfflineMessages?: boolean;
+    maxQueueSize?: number;
+    autoConnect?: boolean;
+    protocols?: string | string[];
+}
+
+export type WebSocketConnectionStatus = 'CONNECTING' | 'OPEN' | 'CLOSING' | 'CLOSED' | 'RECONNECTING';
+
+export interface ResilientWebSocketEvents {
+    open: void;
+    message: any;
+    error: Error;
+    close: { code: number; reason: string };
+    reconnectAttempt: { attempt: number; delayMs: number };
+    statusChange: WebSocketConnectionStatus;
+}
+
+export class ResilientWebSocket {
+    private _url: string;
+    private _options: ResilientWebSocketOptions;
+    private _ws: any = null;
+    private _status: WebSocketConnectionStatus = 'CLOSED';
+    private _messageQueue: any[] = [];
+    private _reconnectAttempt = 0;
+    private _reconnectTimer: any = null;
+    private _isManualClose = false;
+    readonly events = new SimpleEventEmitter();
+
+    constructor(url: string, options: ResilientWebSocketOptions = {}) {
+        this._url = url;
+        this._options = {
+            queueOfflineMessages: true,
+            maxQueueSize: 100,
+            autoConnect: true,
+            ...options,
+        };
+
+        if (this._options.autoConnect !== false) {
+            this.connect();
+        }
+    }
+
+    connect(): void {
+        if (this._status === 'OPEN' || this._status === 'CONNECTING') return;
+
+        this._isManualClose = false;
+        this._setStatus('CONNECTING');
+
+        try {
+            const WSConstructor = typeof WebSocket !== 'undefined' ? WebSocket : (globalThis as any).WebSocket;
+            if (!WSConstructor) {
+                throw new Error('WebSocket is not available in the execution environment');
+            }
+
+            this._ws = new WSConstructor(this._url, this._options.protocols);
+
+            this._ws.onopen = () => {
+                this._reconnectAttempt = 0;
+                this._setStatus('OPEN');
+                this.events.emit('open');
+                this._flushQueue();
+            };
+
+            this._ws.onmessage = (event: any) => {
+                this.events.emit('message', event.data);
+            };
+
+            this._ws.onerror = (err: any) => {
+                this.events.emit('error', err instanceof Error ? err : new Error(String(err)));
+            };
+
+            this._ws.onclose = (event: any) => {
+                const closeInfo = { code: event?.code ?? 1000, reason: event?.reason ?? '' };
+                this.events.emit('close', closeInfo);
+                this._ws = null;
+
+                if (!this._isManualClose) {
+                    this._scheduleReconnect();
+                } else {
+                    this._setStatus('CLOSED');
+                }
+            };
+        } catch (err) {
+            this.events.emit('error', err instanceof Error ? err : new Error(String(err)));
+            if (!this._isManualClose) {
+                this._scheduleReconnect();
+            } else {
+                this._setStatus('CLOSED');
+            }
+        }
+    }
+
+    send(data: any): boolean {
+        if (this._status === 'OPEN' && this._ws && this._ws.readyState === 1) {
+            this._ws.send(typeof data === 'object' ? JSON.stringify(data) : data);
+            return true;
+        }
+
+        if (this._options.queueOfflineMessages) {
+            const maxQueue = this._options.maxQueueSize ?? 100;
+            this._messageQueue.push(data);
+            while (this._messageQueue.length > maxQueue) {
+                this._messageQueue.shift();
+            }
+            return false;
+        }
+
+        return false;
+    }
+
+    disconnect(code = 1000, reason = 'Normal closure'): void {
+        this._isManualClose = true;
+        if (this._reconnectTimer) {
+            clearTimeout(this._reconnectTimer);
+            this._reconnectTimer = null;
+        }
+        if (this._ws) {
+            this._setStatus('CLOSING');
+            try {
+                this._ws.close(code, reason);
+            } catch {
+                // Ignore close errors
+            }
+            this._ws = null;
+        }
+        this._setStatus('CLOSED');
+    }
+
+    private _scheduleReconnect(): void {
+        this._setStatus('RECONNECTING');
+        this._reconnectAttempt++;
+
+        const backoff = this._options.reconnectBackoff ?? {};
+        const initialMs = backoff.initialMs ?? 500;
+        const maxMs = backoff.maxMs ?? 10000;
+        const factor = backoff.factor ?? 2;
+
+        const delayMs = Math.min(
+            maxMs,
+            Math.round(initialMs * Math.pow(factor, this._reconnectAttempt - 1))
+        );
+
+        this.events.emit('reconnectAttempt', { attempt: this._reconnectAttempt, delayMs });
+
+        if (this._reconnectTimer) clearTimeout(this._reconnectTimer);
+        this._reconnectTimer = setTimeout(() => {
+            this._reconnectTimer = null;
+            this.connect();
+        }, delayMs);
+    }
+
+    private _flushQueue(): void {
+        while (this._messageQueue.length > 0 && this._status === 'OPEN') {
+            const msg = this._messageQueue.shift();
+            this.send(msg);
+        }
+    }
+
+    private _setStatus(status: WebSocketConnectionStatus): void {
+        if (this._status !== status) {
+            this._status = status;
+            this.events.emit('statusChange', status);
+        }
+    }
+
+    get status(): WebSocketConnectionStatus {
+        return this._status;
+    }
+
+    get messageQueueLength(): number {
+        return this._messageQueue.length;
+    }
+
+    get reconnectAttempt(): number {
+        return this._reconnectAttempt;
+    }
+}

--- a/packages/data/src/swr-cache.test.ts
+++ b/packages/data/src/swr-cache.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { SWRCacheStore } from './swr-cache.js';
+
+describe('SWRCacheStore', () => {
+    it('caches data and returns cached data on subsequent calls when fresh', async () => {
+        const cache = new SWRCacheStore({ ttl: 5000 });
+        const fetcher = vi.fn(async () => ({ value: 'hello' }));
+
+        const res1 = await cache.fetch('api/data', fetcher);
+        expect(res1).toEqual({ value: 'hello' });
+        expect(fetcher).toHaveBeenCalledTimes(1);
+
+        const res2 = await cache.fetch('api/data', fetcher);
+        expect(res2).toEqual({ value: 'hello' });
+        expect(fetcher).toHaveBeenCalledTimes(1); // Not called again
+    });
+
+    it('returns stale data immediately while revalidating asynchronously in background', async () => {
+        const cache = new SWRCacheStore({ ttl: 50 });
+        let callCount = 0;
+        const fetcher = vi.fn(async () => {
+            callCount++;
+            return { count: callCount };
+        });
+
+        // 1. Initial fetch
+        const first = await cache.fetch('api/count', fetcher);
+        expect(first).toEqual({ count: 1 });
+
+        // Wait for TTL to expire
+        await new Promise((r) => setTimeout(r, 60));
+
+        // 2. Second fetch returns stale data (count: 1) instantly while triggering revalidation
+        const stale = await cache.fetch('api/count', fetcher);
+        expect(stale).toEqual({ count: 1 });
+
+        // Wait for background revalidation to finish
+        await new Promise((r) => setTimeout(r, 20));
+
+        // 3. Third fetch gets freshly revalidated data (count: 2)
+        const updated = await cache.fetch('api/count', fetcher);
+        expect(updated).toEqual({ count: 2 });
+    });
+
+    it('deduplicates in-flight fetch requests within dedupingInterval', async () => {
+        const cache = new SWRCacheStore({ dedupingInterval: 1000 });
+        const fetcher = vi.fn(async () => {
+            await new Promise((r) => setTimeout(r, 20));
+            return 'data';
+        });
+
+        const [p1, p2] = await Promise.all([
+            cache.fetch('api/shared', fetcher),
+            cache.fetch('api/shared', fetcher),
+        ]);
+
+        expect(p1).toBe('data');
+        expect(p2).toBe('data');
+        expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+
+    it('invalidates cache entries by tag', async () => {
+        const cache = new SWRCacheStore({ ttl: 10000 });
+        const fetcher1 = vi.fn(async () => 'metrics-1');
+        const fetcher2 = vi.fn(async () => 'logs-1');
+
+        await cache.fetch('api/metrics', fetcher1, { tags: ['system', 'metrics'] });
+        await cache.fetch('api/logs', fetcher2, { tags: ['system', 'logs'] });
+
+        expect(cache.size).toBe(2);
+
+        // Invalidate metrics tag
+        cache.invalidateTags(['metrics']);
+
+        expect(cache.get('api/metrics')).toBeUndefined();
+        expect(cache.get('api/logs')).toBe('logs-1');
+    });
+
+    it('evicts least recently used entry when maxSize is exceeded', async () => {
+        const cache = new SWRCacheStore({ maxSize: 2 });
+        cache.set('key1', 'val1');
+        cache.set('key2', 'val2');
+
+        // Access key1 to promote it
+        cache.get('key1');
+
+        // Add key3 -> key2 (least recently used) should be evicted
+        cache.set('key3', 'val3');
+
+        expect(cache.get('key1')).toBe('val1');
+        expect(cache.get('key2')).toBeUndefined();
+        expect(cache.get('key3')).toBe('val3');
+    });
+});

--- a/packages/data/src/swr-cache.ts
+++ b/packages/data/src/swr-cache.ts
@@ -1,0 +1,153 @@
+// ─────────────────────────────────────────────────────
+// @termuijs/data — SWR Cache Store
+// ─────────────────────────────────────────────────────
+
+export interface SWRCacheOptions {
+    /** Time-to-live in milliseconds before data is considered stale. Default 5000ms. */
+    ttl?: number;
+    /** Deduplication interval in ms during which in-flight requests are shared. Default 2000ms. */
+    dedupingInterval?: number;
+    /** Maximum cache size limit. Default 100 entries. */
+    maxSize?: number;
+}
+
+export interface SWRCacheEntry<T = any> {
+    data: T;
+    timestamp: number;
+    ttl: number;
+    tags: string[];
+}
+
+export interface SWRFetchOptions {
+    tags?: string[];
+    ttl?: number;
+    dedupingInterval?: number;
+}
+
+export class SWRCacheStore {
+    private _cache = new Map<string, SWRCacheEntry>();
+    private _inFlight = new Map<string, { promise: Promise<any>; timestamp: number }>();
+    private _ttl: number;
+    private _dedupingInterval: number;
+    private _maxSize: number;
+
+    constructor(options: SWRCacheOptions = {}) {
+        this._ttl = options.ttl ?? 5000;
+        this._dedupingInterval = options.dedupingInterval ?? 2000;
+        this._maxSize = options.maxSize ?? 100;
+    }
+
+    get<T = any>(key: string): T | undefined {
+        const entry = this._cache.get(key);
+        if (!entry) return undefined;
+        // Promote key in LRU
+        this._cache.delete(key);
+        this._cache.set(key, entry);
+        return entry.data as T;
+    }
+
+    getEntry<T = any>(key: string): SWRCacheEntry<T> | undefined {
+        return this._cache.get(key) as SWRCacheEntry<T> | undefined;
+    }
+
+    set<T = any>(key: string, data: T, options?: { tags?: string[]; ttl?: number }): void {
+        if (this._cache.has(key)) {
+            this._cache.delete(key);
+        }
+
+        const entry: SWRCacheEntry<T> = {
+            data,
+            timestamp: Date.now(),
+            ttl: options?.ttl ?? this._ttl,
+            tags: options?.tags ?? [],
+        };
+
+        this._cache.set(key, entry);
+
+        while (this._cache.size > this._maxSize) {
+            const oldest = this._cache.keys().next().value;
+            if (oldest !== undefined) {
+                this._cache.delete(oldest);
+            } else {
+                break;
+            }
+        }
+    }
+
+    async fetch<T>(
+        key: string,
+        fetcher: () => Promise<T>,
+        options?: SWRFetchOptions
+    ): Promise<T> {
+        const entry = this._cache.get(key);
+        const now = Date.now();
+        const dedupInterval = options?.dedupingInterval ?? this._dedupingInterval;
+        const entryTtl = options?.ttl ?? (entry?.ttl ?? this._ttl);
+
+        // Check if there is an in-flight request within dedupingInterval
+        const activeInFlight = this._inFlight.get(key);
+        if (activeInFlight && (now - activeInFlight.timestamp) < dedupInterval) {
+            if (entry) return entry.data as T;
+            return activeInFlight.promise;
+        }
+
+        // If fresh data exists in cache, return immediately
+        const isStale = !entry || (now - entry.timestamp) >= entryTtl;
+
+        if (!isStale && entry) {
+            return entry.data as T;
+        }
+
+        // If stale cached data exists, kick off async revalidation in background
+        if (entry && isStale) {
+            this._revalidate(key, fetcher, options);
+            return entry.data as T;
+        }
+
+        // No cached data exists: wait for fetcher
+        return this._revalidate(key, fetcher, options);
+    }
+
+    private _revalidate<T>(
+        key: string,
+        fetcher: () => Promise<T>,
+        options?: SWRFetchOptions
+    ): Promise<T> {
+        const promise = (async () => {
+            try {
+                const data = await fetcher();
+                this.set(key, data, { tags: options?.tags, ttl: options?.ttl });
+                return data;
+            } finally {
+                this._inFlight.delete(key);
+            }
+        })();
+
+        this._inFlight.set(key, { promise, timestamp: Date.now() });
+        return promise;
+    }
+
+    invalidateTags(tags: string[]): void {
+        const tagSet = new Set(tags);
+        for (const [key, entry] of this._cache.entries()) {
+            if (entry.tags.some((t) => tagSet.has(t))) {
+                this._cache.delete(key);
+                this._inFlight.delete(key);
+            }
+        }
+    }
+
+    invalidate(key: string): void {
+        this._cache.delete(key);
+        this._inFlight.delete(key);
+    }
+
+    clear(): void {
+        this._cache.clear();
+        this._inFlight.clear();
+    }
+
+    get size(): number {
+        return this._cache.size;
+    }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description


This PR introduces an in-memory SWR (Stale-While-Revalidate) Cache Store (`SWRCacheStore`) and an auto-reconnecting WebSocket connection manager (`ResilientWebSocket`) to `@termuijs/data`. It eliminates duplicate network requests in live terminal dashboards, enables tag-based cache invalidation, and buffers offline telemetry messages with exponential backoff auto-reconnection.

## Related Issue

<!-- Required. Link the issue you close. PRs without a linked issue get gssoc:invalid. -->
Closes #3096

## Which package(s)?

@termuijs/data

## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [ ] 🐛 Bug fix (`type:bug`)
- [x] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist
- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation
- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/8c84eca2-34f4-470b-bec0-6906c2088cd1`

## Screenshots / Recordings (UI changes)
N/A (Data Subsystem Core Enhancements)

## Notes for the Reviewer
- Added `SWRCacheStore` in `packages/data/src/swr-cache.ts` with `fetch(key, fetcher, { tags, ttl })`, `invalidateTags(tags)`, and request deduplication.
- Added `ResilientWebSocket` in `packages/data/src/resilient-websocket.ts` with exponential backoff, offline queueing, and event listeners.
- Added unit test suites in `packages/data/src/swr-cache.test.ts` and `packages/data/src/resilient-websocket.test.ts` (197 tests passing cleanly across `@termuijs/data`).