### PR TITLE
Fix QuizPrompt display-width clipping

### DIFF
--- a/packages/ui/src/QuizPrompt.test.ts
+++ b/packages/ui/src/QuizPrompt.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { Screen } from '@termuijs/core';
+import { Screen, stringWidth } from '@termuijs/core';
 import { QuizPrompt } from './QuizPrompt.js';
 
 const SAMPLE_QUESTIONS = [
@@ -129,5 +129,24 @@ describe('QuizPrompt', () => {
         expect(quiz['_currentIndex']).toBe(0);
         expect(onComplete).not.toHaveBeenCalled();
         vi.useRealTimers();
+    });
+
+    it('renders mixed-width rows within the prompt width', () => {
+        const quiz = new QuizPrompt([
+            {
+                question: '\u8868\u8868\u8868\u8868?',
+                options: ['\u8868\u8868\u8868\u8868', 'ok'],
+                correctIndex: 0,
+            },
+        ]);
+        const screen = new Screen(6, 5);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        quiz.updateRect({ x: 0, y: 0, width: 5, height: 5 });
+        quiz.render(screen);
+
+        for (const call of writeSpy.mock.calls) {
+            expect(stringWidth(String(call[2]))).toBeLessThanOrEqual(5);
+        }
     });
 });

--- a/packages/ui/src/QuizPrompt.ts
+++ b/packages/ui/src/QuizPrompt.ts
@@ -1,5 +1,5 @@
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, caps } from '@termuijs/core';
+import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, caps, truncate } from '@termuijs/core';
 
 export interface QuizQuestion {
     question: string;
@@ -131,7 +131,7 @@ export class QuizPrompt extends Widget {
             // Show completion screen
             const result = this.getResult();
             const scoreText = `Quiz Complete! Score: ${result.correct}/${result.total}`;
-            screen.writeString(x, y, scoreText.slice(0, width), attrs);
+            screen.writeString(x, y, truncate(scoreText, width, ''), attrs);
             return;
         }
         
@@ -140,7 +140,7 @@ export class QuizPrompt extends Widget {
         
         // Render question
         const questionText = `${this._currentIndex + 1}. ${currentQuestion.question}`;
-        screen.writeString(x, y + row, questionText.slice(0, width), { ...attrs, bold: true });
+        screen.writeString(x, y + row, truncate(questionText, width, ''), { ...attrs, bold: true });
         row += 2;
         
         // Render options
@@ -153,7 +153,7 @@ export class QuizPrompt extends Widget {
                                  this._feedback === 'wrong' && i === this._selectedIndex ? this._wrongColor : attrs.fg;
             
             const line = `${cursor}${i + 1}. ${option}${indicator}`;
-            screen.writeString(x, y + row, line.slice(0, width), {
+            screen.writeString(x, y + row, truncate(line, width, ''), {
                 ...attrs,
                 fg: feedbackColor,
                 bold: isSelected,
@@ -165,11 +165,11 @@ export class QuizPrompt extends Widget {
         if (row >= height) return;
 
         if (this._feedback === 'correct') {
-            screen.writeString(x, y + row, '✓ Correct!'.slice(0, width), { ...attrs, fg: this._correctColor });
+            screen.writeString(x, y + row, truncate('✓ Correct!', width, ''), { ...attrs, fg: this._correctColor });
         } else if (this._feedback === 'wrong') {
             const correctIndex = currentQuestion.correctIndex;
             const correctText = `✗ Wrong. Correct answer: ${correctIndex + 1}. ${currentQuestion.options[correctIndex]}`;
-            screen.writeString(x, y + row, correctText.slice(0, width), { ...attrs, fg: this._wrongColor });
+            screen.writeString(x, y + row, truncate(correctText, width, ''), { ...attrs, fg: this._wrongColor });
         }
     }
 }


### PR DESCRIPTION
## Summary
- clip QuizPrompt rows by terminal display width
- add a regression test for mixed-width quiz content

## Validation
- bun vitest run packages/ui/src/QuizPrompt.test.ts --config vitest.config.ts

Fixes #3123


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quiz prompt rendering for wide characters.
  * Prevented question, answer, score, and feedback text from exceeding the configured display width.
  * Ensured terminal rows are truncated based on visual width rather than character count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->