### PR TITLE
Fix ScalePrompt display-width clipping

### DIFF
--- a/packages/ui/src/ScalePrompt.test.ts
+++ b/packages/ui/src/ScalePrompt.test.ts
@@ -139,4 +139,20 @@ describe('ScalePrompt', () => {
             expect(x + stringWidth(text)).toBeLessThanOrEqual(5);
         }
     });
+
+    it('clips question and scale rows by cell width', () => {
+        const prompt = new ScalePrompt(undefined, {
+            question: '\u8868\u8868\u8868\u8868?',
+            max: 20,
+        });
+        const screen = new Screen(6, 3);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        prompt.updateRect({ x: 0, y: 0, width: 5, height: 3 });
+        prompt.render(screen);
+
+        for (const [, , text] of writeSpy.mock.calls) {
+            expect(stringWidth(text)).toBeLessThanOrEqual(5);
+        }
+    });
 });

--- a/packages/ui/src/ScalePrompt.ts
+++ b/packages/ui/src/ScalePrompt.ts
@@ -69,7 +69,7 @@ export class ScalePrompt extends Widget {
         let row = 0;
 
         if (this._question) {
-            screen.writeString(x, y + row, this._question.slice(0, width), attrs);
+            screen.writeString(x, y + row, truncate(this._question, width, ''), attrs);
             row++;
         }
 
@@ -83,7 +83,7 @@ export class ScalePrompt extends Widget {
             screen.writeString(
                 x,
                 y + row,
-                numbers.join(' ').slice(0, width),
+                truncate(numbers.join(' '), width, ''),
                 { ...attrs, fg: this._activeColor }
             );
             row++;


### PR DESCRIPTION
## Summary
- clip ScalePrompt question and scale rows by terminal display width
- add a regression test for mixed-width question content and long scale rows

## Validation
- bun vitest run packages/ui/src/ScalePrompt.test.ts --config vitest.config.ts

Fixes #3124


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scale prompt rendering so question text and numeric labels are correctly clipped to fit their available cell widths.
  * Added coverage to ensure rendered content does not exceed the configured display area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->