### PR TITLE
Fix Pagination display-width clipping

### DIFF
--- a/packages/ui/src/Pagination.test.ts
+++ b/packages/ui/src/Pagination.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { Screen } from '@termuijs/core';
+import { Screen, stringWidth } from '@termuijs/core';
 import { Pagination } from './Pagination.js';
 
 describe('Pagination', () => {
@@ -59,5 +59,19 @@ describe('Pagination', () => {
 
         expect(p.totalPages).toBe(1);
         expect(p.page).toBe(1);
+    });
+
+    it('renders custom mixed-width labels within the widget width', () => {
+        const p = new Pagination(3, 10, {
+            previousLabel: '\u8868\u8868',
+            nextLabel: '\u8868\u8868',
+        });
+        const screen = new Screen(6, 1);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        p.updateRect({ x: 0, y: 0, width: 5, height: 1 });
+        p.render(screen);
+
+        expect(stringWidth(String(writeSpy.mock.calls[0][2]))).toBeLessThanOrEqual(5);
     });
 });

--- a/packages/ui/src/Pagination.ts
+++ b/packages/ui/src/Pagination.ts
@@ -1,15 +1,19 @@
 // Pagination — simple page navigator
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs } from '@termuijs/core';
+import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, truncate } from '@termuijs/core';
 
 export interface PaginationOptions {
     onChange?: (page: number) => void;
+    previousLabel?: string;
+    nextLabel?: string;
 }
 
 export class Pagination extends Widget {
     private _page: number;
     private _totalPages: number;
     private _onChange?: (page: number) => void;
+    private _previousLabel: string;
+    private _nextLabel: string;
     focusable = true;
 
     constructor(page: number, totalPages: number, options: PaginationOptions = {}) {
@@ -17,6 +21,8 @@ export class Pagination extends Widget {
         this._totalPages = this._normalizeTotalPages(totalPages);
         this._page = this._clamp(Math.floor(page));
         this._onChange = options.onChange;
+        this._previousLabel = options.previousLabel ?? '<';
+        this._nextLabel = options.nextLabel ?? '>';
     }
 
     get page(): number { return this._page; }
@@ -60,7 +66,7 @@ export class Pagination extends Widget {
         const { x, y, width } = this._rect;
         if (width <= 0) return;
         const attrs = styleToCellAttrs(this.style);
-        const text = `< ${this._page} / ${this._totalPages} >`;
-        screen.writeString(x, y, text.slice(0, width), attrs);
+        const text = `${this._previousLabel} ${this._page} / ${this._totalPages} ${this._nextLabel}`;
+        screen.writeString(x, y, truncate(text, width, ''), attrs);
     }
 }


### PR DESCRIPTION
## Summary
- clip Pagination summary text by terminal display width
- add optional previous and next labels while preserving the default output
- add a regression test for mixed-width labels

## Validation
- bun vitest run packages/ui/src/Pagination.test.ts --config vitest.config.ts

Fixes #3125
