### PR TITLE
Fix ConfirmDialog message clipping

### DIFF
--- a/packages/ui/src/ConfirmDialog.test.ts
+++ b/packages/ui/src/ConfirmDialog.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { Buffer } from 'node:buffer';
-import { Screen, createKeyEvent, type KeyEvent } from '@termuijs/core';
+import { Screen, createKeyEvent, stringWidth, type KeyEvent } from '@termuijs/core';
 import { ConfirmDialog } from './ConfirmDialog.js';
 
 // ── Helpers ───────────────────────────────────────────
@@ -104,6 +104,20 @@ describe('ConfirmDialog', () => {
         dialog.hide();
         const screen = renderDialog(dialog);
         expect(screenHasContent(screen)).toBe(false);
+    });
+
+    it('clips mixed-width messages inside the dialog body', () => {
+        const dialog = new ConfirmDialog({ message: '\u8868\u8868\u8868\u8868?' });
+        dialog.show();
+        const screen = makeScreen(16, 8);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        dialog.updateRect({ x: 0, y: 0, width: 16, height: 8 });
+        dialog.render(screen);
+
+        const messageCall = writeSpy.mock.calls.find(([, , text]) => String(text).includes('\u8868'));
+        expect(messageCall).toBeDefined();
+        expect(stringWidth(String(messageCall![2]))).toBeLessThanOrEqual(8);
     });
 
     // ── 4. show() resets previous selection ──────────

--- a/packages/ui/src/ConfirmDialog.ts
+++ b/packages/ui/src/ConfirmDialog.ts
@@ -1,6 +1,6 @@
 // ConfirmDialog — yes/no prompt overlay
 import { Widget } from '@termuijs/widgets';
-import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, getBorderChars } from '@termuijs/core';
+import { type Style, type Screen, type KeyEvent, mergeStyles, defaultStyle, styleToCellAttrs, getBorderChars, truncate } from '@termuijs/core';
 
 export interface ConfirmDialogOptions {
     message: string;
@@ -100,7 +100,7 @@ export class ConfirmDialog extends Widget {
             screen.writeString(bx + bw - 1, by + r, border.right, ba);
         }
         screen.writeString(bx, by + bh - 1, border.bottomLeft + border.bottom.repeat(bw - 2) + border.bottomRight, ba);
-        screen.writeString(bx + 2, by + 1, this._message.slice(0, bw - 4), { ...attrs, bold: true });
+        screen.writeString(bx + 2, by + 1, truncate(this._message, bw - 4, ''), { ...attrs, bold: true });
         const yesStr = this._selected === 'confirm' ? ` [${this._confirmLabel}] ` : `  ${this._confirmLabel}  `;
         const noStr = this._selected === 'cancel' ? ` [${this._cancelLabel}] ` : `  ${this._cancelLabel}  `;
         screen.writeString(bx + 2, by + 3, yesStr, { ...attrs, fg: this._selected === 'confirm' ? { type: 'named', name: 'green' } : attrs.fg, bold: this._selected === 'confirm' });


### PR DESCRIPTION
## Summary
- clip ConfirmDialog messages by terminal display width
- add a regression test for mixed-width message text inside a narrow dialog

## Validation
- bun vitest run packages/ui/src/ConfirmDialog.test.ts --config vitest.config.ts

Fixes #3126
