### PR TITLE
Fix MultilineTextInput display-width clipping

### DIFF
--- a/packages/ui/src/MultilineTextInput.test.ts
+++ b/packages/ui/src/MultilineTextInput.test.ts
@@ -3,7 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { Screen, caps } from '@termuijs/core';
+import { Screen, caps, stringWidth } from '@termuijs/core';
 import { MultilineTextInput } from './MultilineTextInput.js';
 
 // ── Helper ─────────────────────────────────────────────
@@ -696,5 +696,32 @@ describe('MultilineTextInput — unicode and cursor rendering', () => {
         input.isFocused = true;
 
         expect(() => renderInput(input, 12, 4)).not.toThrow();
+    });
+});
+
+describe('MultilineTextInput display width clipping', () => {
+    it('clips mixed-width placeholders by cell width', () => {
+        const input = makeInput({ placeholder: '\u8868\u8868\u8868\u8868' });
+        const screen = new Screen(6, 3);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        input.updateRect({ x: 0, y: 0, width: 5, height: 3 });
+        input.render(screen);
+
+        expect(stringWidth(String(writeSpy.mock.calls[0][2]))).toBeLessThanOrEqual(3);
+    });
+
+    it('pads visible mixed-width rows to the content width', () => {
+        const input = makeInput();
+        const screen = new Screen(6, 3);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        input.value = '\u8868\u8868\u8868\u8868';
+        input.updateRect({ x: 0, y: 0, width: 5, height: 3 });
+        input.render(screen);
+
+        const rowCall = writeSpy.mock.calls.find(([, row]) => row === 1);
+        expect(rowCall).toBeDefined();
+        expect(stringWidth(String(rowCall![2]))).toBe(3);
     });
 });

--- a/packages/ui/src/MultilineTextInput.ts
+++ b/packages/ui/src/MultilineTextInput.ts
@@ -18,6 +18,7 @@ import {
     styleToCellAttrs,
     caps,
     stringWidth,
+    truncate,
 } from '@termuijs/core';
 
 export interface MultilineTextInputOptions {
@@ -226,7 +227,7 @@ export class MultilineTextInput extends Widget {
         // Show placeholder when empty and not focused
         const isEmpty = this._lines.length === 1 && this._lines[0] === '';
         if (isEmpty && !this.isFocused && this._placeholder) {
-            screen.writeString(x, y, this._placeholder.slice(0, width), { ...attrs, dim: true });
+            screen.writeString(x, y, padToDisplayWidth(this._placeholder, width), { ...attrs, dim: true });
             return;
         }
 
@@ -245,7 +246,7 @@ export class MultilineTextInput extends Widget {
             const dRow = row + scrollY;
             if (dRow >= displayRows.length) break;
             const { text } = displayRows[dRow];
-            screen.writeString(x, y + row, text.padEnd(width, ' ').slice(0, width), attrs);
+            screen.writeString(x, y + row, padToDisplayWidth(text, width), attrs);
         }
 
         // Render cursor
@@ -380,4 +381,9 @@ export class MultilineTextInput extends Widget {
         }
         return scrollY;
     }
+}
+
+function padToDisplayWidth(text: string, width: number): string {
+    const clipped = truncate(text, width, '');
+    return clipped + ' '.repeat(Math.max(0, width - stringWidth(clipped)));
 }


### PR DESCRIPTION
## Summary
- clip and pad MultilineTextInput placeholder and visible rows by terminal display width
- add regression tests for mixed-width placeholder and row content

## Validation
- bun vitest run packages/ui/src/MultilineTextInput.test.ts --config vitest.config.ts

Fixes #3127
