### PR TITLE
Fix CheckboxGroup display-width clipping

### DIFF
--- a/packages/ui/src/CheckboxGroup.test.ts
+++ b/packages/ui/src/CheckboxGroup.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, it, expect, vi } from 'vitest';
-import { Screen, caps } from '@termuijs/core';
+import { Screen, caps, stringWidth } from '@termuijs/core';
 import { CheckboxGroup } from './CheckboxGroup.js';
 
 const OPTIONS = [
@@ -464,6 +464,19 @@ describe('CheckboxGroup', () => {
             for (const row of rows) {
                 expect(row.length).toBeLessThanOrEqual(width);
             }
+        });
+
+        it('clips wide-character labels by cell width', () => {
+            const group = new CheckboxGroup({
+                options: [{ label: '\u8868\u8868\u8868\u8868', value: 'wide' }],
+            });
+            const screen = new Screen(6, 1);
+            const writeSpy = vi.spyOn(screen, 'writeString');
+
+            group.updateRect({ x: 0, y: 0, width: 5, height: 1 });
+            group.render(screen);
+
+            expect(stringWidth(String(writeSpy.mock.calls[0][2]))).toBeLessThanOrEqual(5);
         });
     });
 

--- a/packages/ui/src/CheckboxGroup.ts
+++ b/packages/ui/src/CheckboxGroup.ts
@@ -6,6 +6,7 @@ import {
     defaultStyle,
     styleToCellAttrs,
     caps,
+    truncate,
 } from '@termuijs/core';
 import { nextEnabledIndex, previousEnabledIndex } from './navigation.js';
 
@@ -123,7 +124,7 @@ export class CheckboxGroup extends Widget {
             screen.writeString(
                 x,
                 y + i,
-                text.slice(0, width),
+                truncate(text, width, ''),
                 {
                     ...attrs,
                     bold: focused,


### PR DESCRIPTION
## Summary
- clip CheckboxGroup option rows by terminal display width
- add a regression test for mixed-width option labels

## Validation
- bun vitest run packages/ui/src/CheckboxGroup.test.ts --config vitest.config.ts

Fixes #3128
