### PR TITLE
Fix ButtonGroup display-width clipping

### DIFF
--- a/packages/ui/src/ButtonGroup.test.ts
+++ b/packages/ui/src/ButtonGroup.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { Screen, type KeyEvent } from '@termuijs/core';
+import { Screen, stringWidth, type KeyEvent } from '@termuijs/core';
 import { ButtonGroup } from './ButtonGroup.js';
 
 function makeKey(key: string): KeyEvent {
@@ -85,5 +85,21 @@ describe('ButtonGroup', () => {
         buttonGroup.handleKey(makeKey('right'));
 
         expect(buttonGroup.getActiveValue()).toBe('three');
+    });
+
+    it('clips wide-character labels by cell width', () => {
+        const buttonGroup = new ButtonGroup([
+            { label: '\u8868\u8868\u8868\u8868', value: 'wide' },
+            { label: 'Two', value: 'two' },
+        ]);
+        const screen = new Screen(6, 1);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        buttonGroup.updateRect({ x: 0, y: 0, width: 5, height: 1 });
+        buttonGroup.render(screen);
+
+        for (const [x, , text] of writeSpy.mock.calls) {
+            expect(x + stringWidth(String(text))).toBeLessThanOrEqual(5);
+        }
     });
 });

--- a/packages/ui/src/ButtonGroup.ts
+++ b/packages/ui/src/ButtonGroup.ts
@@ -7,6 +7,8 @@ import {
     mergeStyles,
     defaultStyle,
     styleToCellAttrs,
+    stringWidth,
+    truncate,
 } from '@termuijs/core';
 
 export interface ButtonGroupItem {
@@ -126,10 +128,12 @@ export class ButtonGroup extends Widget {
 
             if (remaining <= 0) return;
 
+            const visibleLabel = truncate(label, remaining, '');
+
             screen.writeString(
                 col,
                 y,
-                label.slice(0, remaining),
+                visibleLabel,
                 {
                     ...attrs,
                     fg: active ? this._activeColor : this._inactiveColor,
@@ -138,7 +142,7 @@ export class ButtonGroup extends Widget {
                 }
             );
 
-            col += label.length;
+            col += stringWidth(visibleLabel);
 
             if (i < this._items.length - 1) {
                 const spacerRemaining = x + width - col;


### PR DESCRIPTION
## Summary
- clip ButtonGroup labels by terminal display width
- advance columns by rendered display width so spacing stays in bounds
- add a regression test for mixed-width labels

## Validation
- bun vitest run packages/ui/src/ButtonGroup.test.ts --config vitest.config.ts

Fixes #3129
