### PR TITLE
Fix Rating display-width clipping

### DIFF
--- a/packages/ui/src/Rating.test.ts
+++ b/packages/ui/src/Rating.test.ts
@@ -3,7 +3,7 @@
 // ─────────────────────────────────────────────────────
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { Screen, caps, createKeyEvent } from '@termuijs/core';
+import { Screen, caps, createKeyEvent, stringWidth } from '@termuijs/core';
 import { Rating } from './Rating.js';
 
 /** Shorthand to build a KeyEvent for a given key name. */
@@ -241,6 +241,25 @@ describe('Rating', () => {
 
         rating.setValue(4);
         expect(onChange).toHaveBeenCalledWith(4);
+    });
+
+    it('keeps custom wide glyphs and labels within the widget width', () => {
+        const rating = new Rating({}, {
+            value: 2,
+            max: 4,
+            filledChar: '\u8868',
+            emptyChar: '\u8868',
+            showLabel: true,
+        });
+        const screen = new Screen(5, 1);
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        rating.updateRect({ x: 0, y: 0, width: 5, height: 1 });
+        rating.render(screen);
+
+        for (const [x, , text] of writeSpy.mock.calls) {
+            expect(x + stringWidth(String(text))).toBeLessThanOrEqual(5);
+        }
     });
 });
 

--- a/packages/ui/src/Rating.ts
+++ b/packages/ui/src/Rating.ts
@@ -16,6 +16,8 @@ import {
     defaultStyle,
     styleToCellAttrs,
     caps,
+    stringWidth,
+    truncate,
 } from '@termuijs/core';
 
 export interface RatingOptions {
@@ -239,14 +241,17 @@ export class Rating extends Widget {
                 fgColor = this._filledColor;
             }
 
+            const charWidth = stringWidth(charToRender);
+            if (currentX + charWidth > maxX) break;
+
             const cellAttrs = fgColor ? { ...attrs, fg: fgColor } : attrs;
             screen.writeString(currentX, y, charToRender, cellAttrs);
-            currentX += charToRender.length;
+            currentX += charWidth;
         }
 
         if (this._showLabel && currentX < maxX) {
             const label = ` (${this._value}/${this._max})`;
-            screen.writeString(currentX, y, label.slice(0, maxX - currentX), attrs);
+            screen.writeString(currentX, y, truncate(label, maxX - currentX, ''), attrs);
         }
     }
 }


### PR DESCRIPTION
## Summary
- advance Rating star rendering by terminal display width
- clip the optional numerical label by display width
- add a regression test for custom wide glyphs and labels

## Validation
- bun vitest run packages/ui/src/Rating.test.ts --config vitest.config.ts

Fixes #3130
