### PR TITLE
Fix Tooltip display-width padding

### DIFF
--- a/packages/widgets/src/display/Tooltip.test.ts
+++ b/packages/widgets/src/display/Tooltip.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { Tooltip } from "./Tooltip.js";
-import { Screen, caps, prefersReducedMotion } from "@termuijs/core";
+import { Screen, caps, stringWidth } from "@termuijs/core";
 import * as motion from "@termuijs/motion";
 
 afterEach(() => {
@@ -165,6 +165,13 @@ describe("Tooltip", () => {
         tooltip.render(screen);
 
         expect(screen.back[0][0].dim).toBe(false);
+    });
+
+    it("clips and pads mixed-width content inside the border", () => {
+        const { screen } = renderTooltip("\u8868\u8868\u8868\u8868", true, 7, 3);
+        const content = screen.back[1].slice(1, 6).map((cell) => cell.char).join("");
+
+        expect(stringWidth(content)).toBe(5);
     });
 });
 

--- a/packages/widgets/src/display/Tooltip.ts
+++ b/packages/widgets/src/display/Tooltip.ts
@@ -6,6 +6,8 @@ import {
     caps,
     prefersReducedMotion,
     styleToCellAttrs,
+    stringWidth,
+    truncate,
 } from '@termuijs/core';
 import { fadeIn, fadeOut } from '@termuijs/motion';
 import { Widget } from '../base/Widget.js';
@@ -87,9 +89,7 @@ export class Tooltip extends Widget {
         if (height >= 2) {
             screen.setCell(x, y + 1, { char: vt, ...attrs });
 
-            const content = this._text
-                .slice(0, Math.max(0, width - 2))
-                .padEnd(Math.max(0, width - 2), ' ');
+            const content = padToDisplayWidth(this._text, Math.max(0, width - 2));
 
             screen.writeString(x + 1, y + 1, content, attrs);
 
@@ -169,4 +169,9 @@ export class Tooltip extends Widget {
     getVisible(): boolean {
         return this._visible;
     }
+}
+
+function padToDisplayWidth(text: string, width: number): string {
+    const clipped = truncate(text, width, '');
+    return clipped + ' '.repeat(Math.max(0, width - stringWidth(clipped)));
 }


### PR DESCRIPTION
## Summary
- clip and pad Tooltip content by terminal display width
- add a regression test for mixed-width content inside the tooltip border

## Validation
- bun vitest run packages/widgets/src/display/Tooltip.test.ts --config vitest.config.ts

Fixes #3131
