### PR TITLE
Fix TypingIndicator display-width rendering

### DIFF
--- a/packages/widgets/src/display/TypingIndicator.test.ts
+++ b/packages/widgets/src/display/TypingIndicator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { Screen, caps } from '@termuijs/core';
+import { Screen, caps, stringWidth } from '@termuijs/core';
 import { TypingIndicator } from './TypingIndicator.js';
 
 describe('TypingIndicator', () => {
@@ -81,6 +81,18 @@ describe('TypingIndicator', () => {
         indicator.render(screen);
         row = screen.back[0].map(c => c.char).join('').trim();
         expect(row).toBe('Typing...');
+    });
+
+    it('clips reduced-motion fallback text by cell width', () => {
+        vi.spyOn(caps, 'motion', 'get').mockReturnValue(false);
+        const indicator = new TypingIndicator({}, { fallbackText: '\u8868\u8868\u8868\u8868' });
+        const writeSpy = vi.spyOn(screen, 'writeString');
+
+        indicator.updateRect({ x: 0, y: 0, width: 5, height: 1 });
+        indicator.start();
+        indicator.render(screen);
+
+        expect(stringWidth(String(writeSpy.mock.calls[0][2]))).toBe(5);
     });
 
     it('clears interval on unmount', () => {

--- a/packages/widgets/src/display/TypingIndicator.ts
+++ b/packages/widgets/src/display/TypingIndicator.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets — TypingIndicator widget
 // ─────────────────────────────────────────────────────
 
-import { type Screen, type Style, type Color, styleToCellAttrs, stringWidth, caps } from '@termuijs/core';
+import { type Screen, type Style, type Color, styleToCellAttrs, stringWidth, caps, truncate } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
 export interface TypingIndicatorOptions {
@@ -96,15 +96,16 @@ export class TypingIndicator extends Widget {
         if (!caps.motion) {
             // Render fallback if reduced motion is preferred
             const display = this._running ? this._fallbackText : '';
-            const padded = display.padEnd(width, ' ');
-            const len = Math.min(stringWidth(padded), width);
-            screen.writeString(x, y, padded.slice(0, len), attrs);
+            screen.writeString(x, y, padToDisplayWidth(display, width), attrs);
             return;
         }
 
         const frame = this._running ? FRAMES[this._frameIndex] : '';
-        const padded = frame.padEnd(3, ' ');
-        const len = Math.min(stringWidth(padded), width);
-        screen.writeString(x, y, padded.slice(0, len), attrs);
+        screen.writeString(x, y, padToDisplayWidth(frame, Math.min(3, width)), attrs);
     }
+}
+
+function padToDisplayWidth(text: string, width: number): string {
+    const clipped = truncate(text, width, '');
+    return clipped + ' '.repeat(Math.max(0, width - stringWidth(clipped)));
 }


### PR DESCRIPTION
## Summary
- clip and pad TypingIndicator fallback and frame text by terminal display width
- add a regression test for mixed-width reduced-motion fallback text

## Validation
- bun vitest run packages/widgets/src/display/TypingIndicator.test.ts --config vitest.config.ts

Fixes #3132
