### PR TITLE
fix(widgets): truncate title, description, and hint in EmptyState to prevent text overflow

### DIFF
--- a/packages/widgets/src/feedback/EmptyState.test.ts
+++ b/packages/widgets/src/feedback/EmptyState.test.ts
@@ -45,11 +45,12 @@ describe('EmptyState', () => {
         expect(row(screen, titleRow).trim()).not.toContain('Old title');
     });
 
-    it('handles very narrow width gracefully', () => {
-        const es = new EmptyState('Wide title', {}, { description: 'desc' });
-        es.updateRect({ x: 0, y: 0, width: 3, height: 5 });
-        const screen = new Screen(3, 5);
+    it('handles very narrow width gracefully and truncates text', () => {
+        const es = new EmptyState('Very Long Empty State Title', {}, { description: 'Very long description text' });
+        es.updateRect({ x: 0, y: 0, width: 5, height: 5 });
+        const screen = new Screen(5, 5);
         expect(() => es.render(screen)).not.toThrow();
+        expect(row(screen, 2).length).toBeLessThanOrEqual(5);
     });
 
     it('renders hint when provided', () => {

--- a/packages/widgets/src/feedback/EmptyState.ts
+++ b/packages/widgets/src/feedback/EmptyState.ts
@@ -1,4 +1,4 @@
-import { type Screen, type Style, styleToCellAttrs, stringWidth, caps } from '@termuijs/core';
+import { type Screen, type Style, styleToCellAttrs, stringWidth, caps, truncate } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
 export interface EmptyStateOptions {
@@ -64,21 +64,22 @@ export class EmptyState extends Widget {
         const contentLines = 1 + 1 + (hasDesc ? 1 : 0);
         const startRow = y + Math.max(0, Math.floor((mainHeight - contentLines) / 2));
 
-        const iconX = x + Math.max(0, Math.floor((width - stringWidth(this._icon)) / 2));
-        screen.writeString(iconX, startRow, this._icon, attrs);
+        const iconStr = truncate(this._icon, width);
+        const iconX = x + Math.max(0, Math.floor((width - stringWidth(iconStr)) / 2));
+        screen.writeString(iconX, startRow, iconStr, attrs);
 
-        const titleStr = this._title;
+        const titleStr = truncate(this._title, width);
         const titleX = x + Math.max(0, Math.floor((width - stringWidth(titleStr)) / 2));
         screen.writeString(titleX, startRow + 1, titleStr, { ...attrs, bold: true });
 
         if (hasDesc) {
-            const descStr = this._description;
+            const descStr = truncate(this._description, width);
             const descX = x + Math.max(0, Math.floor((width - stringWidth(descStr)) / 2));
             screen.writeString(descX, startRow + 2, descStr, { ...attrs, dim: true });
         }
 
         if (hasHint) {
-            const hintStr = this._hint;
+            const hintStr = truncate(this._hint, width);
             const hintX = x + Math.max(0, Math.floor((width - stringWidth(hintStr)) / 2));
             screen.writeString(hintX, hintRow, hintStr, { ...attrs, dim: true });
         }


### PR DESCRIPTION
 ### Title
    fix(widgets): truncate title, description, and hint in EmptyState to prevent text overflow
    
    ### Summary of Changes
    - Truncated `iconStr`, `titleStr`, `descStr`, and `hintStr` to `width` in
  `packages/widgets/src/feedback/EmptyState.ts`.
    - Added unit test in `packages/widgets/src/feedback/EmptyState.test.ts`.
    
    Closes #3147 
## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [ ] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [ ] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved narrow-width rendering for empty states.
  * Long icons, titles, descriptions, and hints are now truncated to fit the available space and remain correctly centered.
  * Prevented rendering errors and content overflow in extremely small layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->