### PR TITLE
   fix(widgets): add variant and shape getters and setters to Skeleton widget  

### DIFF
--- a/packages/widgets/src/feedback/Skeleton.test.ts
+++ b/packages/widgets/src/feedback/Skeleton.test.ts
@@ -104,4 +104,24 @@ describe('Skeleton', () => {
 
         expect(unsub).toHaveBeenCalled();
     });
+
+    it('getVariant and setVariant work correctly and trigger markDirty', () => {
+        const s = new Skeleton({}, { variant: 'pulse' });
+        expect(s.getVariant()).toBe('pulse');
+        s.clearDirty();
+
+        s.setVariant('shimmer');
+        expect(s.getVariant()).toBe('shimmer');
+        expect(s.isDirty).toBe(true);
+    });
+
+    it('getShape and setShape work correctly and trigger markDirty', () => {
+        const s = new Skeleton({}, { shape: 'text' });
+        expect(s.getShape()).toBe('text');
+        s.clearDirty();
+
+        s.setShape('card');
+        expect(s.getShape()).toBe('card');
+        expect(s.isDirty).toBe(true);
+    });
 });

--- a/packages/widgets/src/feedback/Skeleton.ts
+++ b/packages/widgets/src/feedback/Skeleton.ts
@@ -40,6 +40,26 @@ export class Skeleton extends Widget {
         }
     }
 
+    getVariant(): 'pulse' | 'shimmer' {
+        return this._variant;
+    }
+
+    setVariant(variant: 'pulse' | 'shimmer'): void {
+        if (this._variant === variant) return;
+        this._variant = variant;
+        this.markDirty();
+    }
+
+    getShape(): 'text' | 'card' | 'table' | 'list' {
+        return this._shape;
+    }
+
+    setShape(shape: 'text' | 'card' | 'table' | 'list'): void {
+        if (this._shape === shape) return;
+        this._shape = shape;
+        this.markDirty();
+    }
+
     override unmount(): void {
         this._unsubscribe?.();
         super.unmount();


### PR DESCRIPTION
  ### Title
    fix(widgets): add variant and shape getters and setters to Skeleton widget
    
    ### Summary of Changes
    - Added `getVariant()`, `setVariant()`, `getShape()`, `setShape()` methods to
  `packages/widgets/src/feedback/Skeleton.ts`.
    - Added unit tests in `packages/widgets/src/feedback/Skeleton.test.ts`.
    
    Closes #3148 
## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [ ] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to read and update Skeleton widget variants, including pulse and shimmer.
  - Added the ability to read and update Skeleton widget shapes, including text, card, table, and list.
  - Changes automatically trigger the widget to refresh when needed.

- **Tests**
  - Added coverage verifying Skeleton option updates and refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->