### PR TITLE
    fix(widgets): use stringWidth and truncate for StatusMessage offset and message rendering  #3151

### DIFF
--- a/packages/widgets/src/feedback/StatusMessage.test.ts
+++ b/packages/widgets/src/feedback/StatusMessage.test.ts
@@ -181,4 +181,12 @@ describe('StatusMessage', () => {
         expect(widget.isDirty).toBe(false);
     });
 
+    it('truncates double-width message text without overflowing width', () => {
+        const screen = renderStatus(
+            new StatusMessage('🌟🌟🌟🌟🌟', {}, { icon: '🚀' }),
+            8,
+            1,
+        );
+        expect(rowText(screen, 0).length).toBeLessThanOrEqual(8);
+    });
 });

--- a/packages/widgets/src/feedback/StatusMessage.ts
+++ b/packages/widgets/src/feedback/StatusMessage.ts
@@ -2,7 +2,7 @@
 // @termuijs/widgets — StatusMessage widget
 // ─────────────────────────────────────────────────────
 
-import { type Screen, type Style, type Color, styleToCellAttrs, caps } from '@termuijs/core';
+import { type Screen, type Style, type Color, styleToCellAttrs, caps, stringWidth, truncate } from '@termuijs/core';
 import { Widget } from '../base/Widget.js';
 
 export type StatusVariant = 'success' | 'error' | 'warning' | 'info';
@@ -81,10 +81,11 @@ export class StatusMessage extends Widget {
         screen.writeString(x, y, icon, { ...attrs, fg: color, bold: true });
 
         // Space + message
-        const msgX = x + icon.length + 1;
-        const remaining = width - icon.length - 1;
+        const iconWidth = stringWidth(icon);
+        const msgX = x + iconWidth + 1;
+        const remaining = width - iconWidth - 1;
         if (remaining > 0) {
-            screen.writeString(msgX, y, this._message.slice(0, remaining), { ...attrs, fg: color });
+            screen.writeString(msgX, y, truncate(this._message, remaining, ''), { ...attrs, fg: color });
         }
     }
 }


### PR DESCRIPTION
### Title
    fix(widgets): use stringWidth and truncate for StatusMessage offset and message rendering
    
    ### Summary of Changes
    - Updated `StatusMessage._renderSelf` in `packages/widgets/src/feedback/StatusMessage.ts` to use
  `stringWidth(icon)` and `truncate(this._message, remaining, '')`.
    - Added unit test in `packages/widgets/src/feedback/StatusMessage.test.ts`.
    
    Closes #3151 
## Type of Change

<!-- Check one or more. Your reviewer sets difficulty (level:*) and quality (quality:*) after review. -->

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [ ] Tests pass locally: `bun vitest run`
- [ ] Build passes: `bun run build`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [ ] Your PR title follows `type: short description`.
- [ ] Widget state mutators call `markDirty()` (if your change affects rendering).
- [ ] No new `any` types without an inline comment explaining why.
- [ ] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/____`

## Screenshots / Recordings (UI changes)

<!-- Drag and drop terminal recordings or screenshots here. -->

## Notes for the Reviewer

<!-- Anything your reviewer should know. Trade-offs, follow-ups, open questions. -->
