### PR TITLE
fix(jsx): exclude children from memo() shallow comparison

### DIFF
--- a/packages/jsx/src/memo.ts
+++ b/packages/jsx/src/memo.ts
@@ -76,7 +76,12 @@ export function memo<P extends Record<string, any>>(
 
         if (fiber) {
             const entry = cache.get(fiber);
-            if (entry && compare(entry.prevProps, props as P)) {
+            // Exclude children from comparison — children are new VNode
+            // references every render, so including them means memo() never
+            // skips a re-render for components that receive children.
+            const { children: _prevChildren, ...prevRest } = (entry?.prevProps ?? {}) as any;
+            const { children: _nextChildren, ...nextRest } = (props ?? {}) as any;
+            if (entry && compare(prevRest, nextRest)) {
                 return entry.prevResult;
             }
             const result = component(props);


### PR DESCRIPTION
## Summary
Fixes #3155 — `memo()` was passing `children` into the shallow comparison, causing unnecessary re-renders whenever children changed even if the component's own props hadn't.

## Changes
- `packages/memo.ts`: Filter out `children` from the props object before passing it to the shallow-comparison cache key, so that changes to `children` no longer invalidate the memo.

## Test plan
- [ ] Verified that `memo()`-wrapped components no longer re-render when only children change.
- [ ] Verified that the components still re-render when their own props change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memoized component rendering by ignoring changes to the `children` reference when other properties remain unchanged.
  * Prevented unnecessary re-renders caused solely by changes in the `children` reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->