### PR TITLE
fix(motion): remove ghost subscribers from savedSubs on unsubscribe

### DIFF
--- a/packages/motion/src/timer-pool.ts
+++ b/packages/motion/src/timer-pool.ts
@@ -116,6 +116,10 @@ export function subscribe(...args: unknown[]): () => void {
             unsub();
             const idx = clockSubs.indexOf(entry);
             if (idx !== -1) clockSubs.splice(idx, 1);
+            // Also remove from savedSubs so ghost subscribers are not
+            // restored when the clock detaches.
+            const saved = savedSubs.get(delayMs);
+            if (saved) saved.delete(cb);
         };
     }
 


### PR DESCRIPTION
## Summary
Fixes #3156 — When a timer was unsubscribed during an active clock period, it was removed from the active subscription but remained in `savedSubs`, creating a ghost entry that persisted until the next clock period.

## Changes
- `packages/timer-pool.ts`: Remove the entry from `savedSubs` when `unsubscribe()` is called during an active period.

## Test plan
- [ ] Verified that unsubscribing mid-period no longer leaves entries in `savedSubs`.
- [ ] Verified that the timer pool correctly cleans up all resources after unsubscription.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed timer callbacks being restored after they were unsubscribed when switching from a virtual clock back to the regular timer system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->