### PR TITLE
fix(quick): set reactive metadata on Text widgets from toWidget()

### DIFF
--- a/packages/quick/src/layout.ts
+++ b/packages/quick/src/layout.ts
@@ -23,6 +23,7 @@ export function toWidget(child: LayoutChild, style: Partial<Style> = {}): Widget
     }
     // Reactive function — create text, will be updated by refresh
     const text = new Text(resolve(child as Reactive<string>), { height: 1, ...style });
+    (text as any).__reactiveContent = child;
     return text;
 }
 


### PR DESCRIPTION
## Summary
Fixes #3159 — `Text` widgets were not getting the `__reactiveContent` flag set, so the Quick framework's reactive diffing treated them as static and skipped diffing their content.

## Changes
- `packages/quick.ts`: Set `__reactiveContent = true` on `Text` widget instances in `toWidget()`.

## Test plan
- [ ] Text widgets now correctly re-render when their content changes reactively.