### PR TITLE
fix(widgets) : added getIcon() getter to Alert widget

### DIFF
--- a/packages/widgets/src/feedback/Alert.ts
+++ b/packages/widgets/src/feedback/Alert.ts
@@ -84,6 +84,12 @@ export class Alert extends Widget {
         return this._variant;
     }
 
+    /** Get the current icon string for the active variant. */
+    getIcon(): string {
+        const iconMap = caps.unicode ? ICONS_UNICODE : ICONS_ASCII;
+        return iconMap[this._variant];
+    }
+
     protected _renderSelf(screen: Screen): void {
         const { x, y, width, height } = this._rect;
         if (width < 2 || height < 2) return;


### PR DESCRIPTION
## Summary of What Has Been Done

Added a `getIcon()` getter method to the `Alert` widget in `packages/widgets/src/feedback/Alert.ts`.

The method returns the current icon string based on the active variant, respecting the `caps.unicode` flag to choose between Unicode and ASCII icon sets.

## Changes Made

- Added `getIcon(): string` getter method to the `Alert` class
- Mirrors the existing icon resolution logic used during rendering
- No breaking changes to existing API

## Impact it Made

- Completes the getter/setter symmetry for all `Alert` properties
- Enables unit tests to assert on the rendered icon without inspecting private fields
- Matches the API pattern used by `StatusMessage` and other widgets

Closes #3166

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving the appropriate alert icon based on the active alert status.
  * Icons automatically adapt to the selected Unicode or ASCII display style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->