### PR TITLE
fix(core): NO_UNICODE env var check inconsistent with NO_COLOR convention

### DIFF
--- a/packages/core/src/terminal/env-caps.ts
+++ b/packages/core/src/terminal/env-caps.ts
@@ -19,7 +19,7 @@ export const caps = {
     return this.colorDepth !== ColorDepth.None;
   },
   /** Whether Unicode characters are supported. Disabled by NO_UNICODE or TERM=dumb. */
-  unicode: !process.env.NO_UNICODE && process.env.TERM !== 'dumb',
+  unicode: process.env.NO_UNICODE === undefined && process.env.TERM !== 'dumb',
   /** Whether animations are enabled. Disabled by NO_MOTION or CI environments. */
   motion:  !process.env.NO_MOTION && !process.env.CI,
   /** Whether running inside a CI system (CI=1). */


### PR DESCRIPTION
## Bug Fix

**env-caps.ts** — The `unicode` capability check used `!process.env.NO_UNICODE` which treats an empty-string assignment (`NO_UNICODE=`) as "not set", enabling unicode when the user explicitly intended to disable it.

Changed to `process.env.NO_UNICODE === undefined` to match the `NO_COLOR` convention (per [no-color.org](https://no-color.org)): setting the variable to ANY value disables the feature.

### Before
```ts
unicode: !process.env.NO_UNICODE && process.env.TERM !== 'dumb',
```

### After
```ts
unicode: process.env.NO_UNICODE === undefined && process.env.TERM !== 'dumb',
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal compatibility detection so Unicode is disabled whenever the `NO_UNICODE` environment setting is present, including when set to an empty value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->