### PR TITLE
fix(widgets): use correct box-drawing characters for focus ring corners

### DIFF
--- a/packages/widgets/src/base/Widget.ts
+++ b/packages/widgets/src/base/Widget.ts
@@ -566,24 +566,27 @@ export abstract class Widget {
             const cellStyle = { fg, bold: true };
 
             const useAscii = (this._style.asciiOnly ?? false) || !caps.unicode;
-            const corner = useAscii ? '+' : '┌';
+            const topLeft = useAscii ? '+' : '┌';
+            const topRight = useAscii ? '+' : '┐';
+            const bottomLeft = useAscii ? '+' : '└';
+            const bottomRight = useAscii ? '+' : '┘';
             const horizontal = useAscii ? '-' : '─';
             const vertical = useAscii ? '|' : '│';
 
             // Top-left corner
-            screen.setCell(x, y, { char: corner, ...cellStyle });
+            screen.setCell(x, y, { char: topLeft, ...cellStyle });
             if (width > 2) screen.setCell(x + 1, y, { char: horizontal, ...cellStyle });
 
             // Top-right corner
-            screen.setCell(x + width - 1, y, { char: corner, ...cellStyle });
+            screen.setCell(x + width - 1, y, { char: topRight, ...cellStyle });
             if (width > 2) screen.setCell(x + width - 2, y, { char: horizontal, ...cellStyle });
 
             // Bottom-left corner
-            screen.setCell(x, y + height - 1, { char: corner, ...cellStyle });
+            screen.setCell(x, y + height - 1, { char: bottomLeft, ...cellStyle });
             if (width > 2) screen.setCell(x + 1, y + height - 1, { char: horizontal, ...cellStyle });
 
             // Bottom-right corner
-            screen.setCell(x + width - 1, y + height - 1, { char: corner, ...cellStyle });
+            screen.setCell(x + width - 1, y + height - 1, { char: bottomRight, ...cellStyle });
             if (width > 2) screen.setCell(x + width - 2, y + height - 1, { char: horizontal, ...cellStyle });
 
             // Short vertical marks if tall enough


### PR DESCRIPTION
## Bug Fix

**`packages/widgets/src/base/Widget.ts`**: The focus ring rendering in `_renderBorder()` used a single `corner` variable (set to `┌`) for all four corners of the focus ring indicator. This caused the top-right corner to display as `┌` instead of `┐`, the bottom-left as `┌` instead of `└`, and the bottom-right as `┌` instead of `┘`.

Fixed by defining four separate corner variables (`topLeft`, `topRight`, `bottomLeft`, `bottomRight`) with the correct box-drawing Unicode characters.

## Verification
- Focus ring now renders with correct corner glyphs: `┌`, `┐`, `└`, `┘` in Unicode mode
- ASCII mode (`+`) remains unchanged and correct for all corners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected focus-ring corner rendering when widget borders are disabled.
  * Corners now display with the appropriate characters in Unicode mode and consistent symbols in ASCII mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->