### PR TITLE
fix(core): remove unused stripAnsi import from Fallback.ts

### DIFF
--- a/packages/core/src/app/Fallback.ts
+++ b/packages/core/src/app/Fallback.ts
@@ -3,7 +3,6 @@
 // ─────────────────────────────────────────────────────
 
 import type { Screen } from '../terminal/Screen.js';
-import { stripAnsi } from '../utils/unicode.js';
 
 /**
  * Detect if the terminal should use fallback (non-interactive) rendering.


### PR DESCRIPTION
stripAnsi was imported from ../utils/unicode.js in Fallback.ts but never referenced in the file body. Removes the unused import to eliminate TypeScript/lint warnings under strict mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused internal code without changing visible behavior or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->