### PR TITLE
fix : applied clamping when inMin equals inMax in mapRange

### DIFF
--- a/packages/motion/src/interpolate.ts
+++ b/packages/motion/src/interpolate.ts
@@ -21,6 +21,9 @@ export function mapRange(
     const clamp = options?.clamp ?? true;
 
     if (inMin === inMax) {
+        if (clamp && outMin !== outMax) {
+            return Math.min(outMin, outMax);
+        }
         return outMin;
     }
 


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed the `mapRange()` function in `packages/motion/src/interpolate.ts` to respect the `clamp` option in the degenerate case where `inMin === inMax`.

Previously, the early return for `inMin === inMax` bypassed the clamping logic entirely. The fix applies clamping before returning when `clamp: true` and `outMin !== outMax` — the result is bounded to `Math.min(outMin, outMax)`, consistent with how the normal mapping path handles clamping.

## Changes Made

**packages/motion/src/interpolate.ts**
- Changed the `inMin === inMax` branch to check the `clamp` option
- When `clamp: true` and `outMin !== outMax`: return `Math.min(outMin, outMax)` (clamped to output range)
- When `clamp: false` or `outMin === outMax`: return `outMin` (original behavior)

## Impact it Made

Ensures the clamping option is respected consistently even for degenerate input ranges. Users who explicitly set `clamp: true` can now rely on consistent behavior regardless of input range configuration.

Closes #3191

**Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved range mapping for zero-length input ranges when clamping is enabled.
  - Ensures results use the lower output bound consistently, including reversed output ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->