### PR TITLE
fix : trailing call fires unconditionally in throttle utility

### DIFF
--- a/packages/core/src/utils/throttle.ts
+++ b/packages/core/src/utils/throttle.ts
@@ -27,6 +27,7 @@ export function throttle<T extends (...args: unknown[]) => void>(
     const leading = options?.leading ?? true;
     let timer: ReturnType<typeof setTimeout> | undefined;
     let lastArgs: Parameters<T> | undefined;
+    let hasNewCalls = false;
 
     const throttled = function (...args: Parameters<T>) {
         lastArgs = args;
@@ -34,9 +35,12 @@ export function throttle<T extends (...args: unknown[]) => void>(
             if (leading) func(...args);
             timer = setTimeout(() => {
                 timer = undefined;
-                if (lastArgs !== args || !leading) func(...lastArgs!);
+                if (hasNewCalls || !leading) func(...lastArgs!);
                 lastArgs = undefined;
+                hasNewCalls = false;
             }, wait);
+        } else {
+            hasNewCalls = true;
         }
     } as T & { cancel: () => void };
 
@@ -44,6 +48,7 @@ export function throttle<T extends (...args: unknown[]) => void>(
         clearTimeout(timer);
         timer = undefined;
         lastArgs = undefined;
+        hasNewCalls = false;
     };
 
     return throttled;


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed a logic error in the `throttle` utility where the trailing edge call fired unconditionally because JavaScript array comparison uses reference equality. Added a `hasNewCalls` boolean flag to properly track whether additional calls arrived during the wait interval.

## Changes Made

**packages/core/src/utils/throttle.ts**
- Added `hasNewCalls` boolean flag
- Set `hasNewCalls = true` when a new call arrives while timer is active
- In the timer callback, use `hasNewCalls || !leading` instead of `lastArgs !== args || !leading`
- Reset `hasNewCalls = false` after timer fires

## Impact it Made

Trailing edge calls now fire only when additional calls were made during the wait interval, matching the documented throttle behavior.

Closes #3229

Note: Please assign this PR to the `tmdeveloper007` account.