### PR TITLE
fix : correct RGB components in grayscale distance calculation in Color.ts

### DIFF
--- a/packages/core/src/style/Color.ts
+++ b/packages/core/src/style/Color.ts
@@ -204,8 +204,10 @@ function rgbToAnsi256(r: number, g: number, b: number): number {
     if (grayIdx < 0) grayIdx = 0;
     if (grayIdx > 23) grayIdx = 23;
     const grayColor = 232 + grayIdx;
-    r_c = ANSI256_RGB[grayColor * 3];
-    const distGray = (r - r_c)**2 + (g - r_c)**2 + (b - r_c)**2;
+    const r_gray = ANSI256_RGB[grayColor * 3];
+    const g_gray = ANSI256_RGB[grayColor * 3 + 1];
+    const b_gray = ANSI256_RGB[grayColor * 3 + 2];
+    const distGray = (r - r_gray)**2 + (g - g_gray)**2 + (b - b_gray)**2;
     if (distGray < bestDist) {
         bestDist = distGray;
         bestColor = grayColor;


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed a variable reuse bug in `packages/core/src/style/Color.ts` where the ANSI-256 grayscale distance calculation incorrectly used `r_c` for all three color channels (`r`, `g`, and `b`). Introduced `r_gray`, `g_gray`, and `b_gray` variables with the correct array offsets.

## Changes Made

**packages/core/src/style/Color.ts**
- Replaced the single `r_c = ANSI256_RGB[grayColor * 3]` reuse with three separate variables: `r_gray`, `g_gray`, and `b_gray` with correct array offsets
- Fixed `distGray` calculation to use all three correct gray components

## Impact it Made

Corrected ANSI-256 color conversion accuracy for grayscale colors. The closest grayscale is now selected based on proper Euclidean distance across all three RGB channels.

Closes #3230

Note: Please assign this PR to the `tmdeveloper007` account.