### PR TITLE
fix : CheckboxGroup missing event subscription for keyboard navigation

### DIFF
--- a/packages/ui/src/CheckboxGroup.ts
+++ b/packages/ui/src/CheckboxGroup.ts
@@ -42,6 +42,13 @@ export class CheckboxGroup extends Widget {
             (options.defaultValues ?? []).filter(v => knownValues.has(v)),
         );
         this.onChange = options.onChange;
+        this.events.on('key', this.handleKey);
+    }
+
+    override mount(): void {
+        super.mount();
+        this.events.off('key', this.handleKey);
+        this.events.on('key', this.handleKey);
     }
 
     get selectedValues(): string[] {


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed a bug in `packages/ui/src/CheckboxGroup.ts` where the `handleKey(event: KeyEvent)` method was defined but never connected to the component's event emitter, so keyboard interaction never worked.

## Changes Made

**packages/ui/src/CheckboxGroup.ts**
- Added `this.events.on('key', this.handleKey)` in the constructor
- Added `mount()` override that re-registers the key handler (matching the pattern used by other widgets like ConfirmDialog)

## Impact it Made

Enables keyboard navigation in CheckboxGroup, allowing users to navigate checkboxes using arrow keys and toggle selections with space.

Closes #3232

Note: Please assign this PR to the `tmdeveloper007` account.