### PR TITLE
fix : nested batch error does not roll back pending state updates

### DIFF
--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -73,9 +73,7 @@ export function batch<T>(fn: () => T): T {
     } catch (err) {
         threw = true;
         _batchDepth--;
-        if (_batchDepth === 0) {
-            flushBatch(threw);
-        }
+        flushBatch(threw);
         throw err;
     }
 


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed a bug in `packages/store/src/store.ts` where an error thrown inside a nested `batch()` call did not properly roll back pending state updates. When an error was caught and `_batchDepth > 0`, `flushBatch(threw)` was not called, leaving failed state updates in `_batchStores`. When the outermost batch eventually flushed normally, it called `commit()` instead of `rollback()`, silently applying the failed state changes.

## Changes Made

**packages/store/src/store.ts**
- Removed the `if (_batchDepth === 0)` guard around `flushBatch(threw)` in the `catch` block
- Now `flushBatch(threw)` is always called on error, ensuring pending batch entries are rolled back regardless of nesting depth

## Impact it Made

Ensures data consistency by rolling back all pending state updates from failed batches, including nested ones.

Closes #3233

Note: Please assign this PR to the `tmdeveloper007` account.