### PR TITLE
docs: append quick-reference directory map to ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -130,3 +130,13 @@ Use these rules when deciding where a change belongs:
 * Third-party integrations belong in `adapters`.
 
 When in doubt, prefer the lowest-level package that owns the responsibility and avoid moving functionality across package boundaries without a documented reason.
+
+
+---
+
+## ⚡ Quick Directory Map
+* `packages/core/` — Primary engine runtime, buffer loops, cell grids, and terminal inputs.
+* `packages/widgets/` — Visible interface layout modules (Boxes, Tables, Gauges).
+* `packages/ui/` — Highly interactive overlay controls, compound prompt boxes, and Modals.
+* `packages/jsx/` — Custom TypeScript compilation runtimes and core hooks handlers.
+* `packages/testing/` — Custom headless mock-rendering blocks for continuous validation.


### PR DESCRIPTION
## Description
Appends a concise, high-level directory reference summary map section to the architecture document to assist incoming contributors with rapid workspace navigation.

## Related Issue
Closes #3242

## Which package(s)?
docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a quick directory map to the architecture documentation, clarifying the responsibilities of key workspace packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->