### PR TITLE
test(core): add error-path unit tests for session module

### DIFF
--- a/packages/core/src/session/session.test.ts
+++ b/packages/core/src/session/session.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { Session, SessionClosedError } from "./session";
+
+describe("Session -- error paths", () => {
+  it("should throw SessionClosedError when emitting after close", () => {
+    const session = new Session();
+    session.close();
+    expect(() => session.emit("data", "hello")).toThrow(SessionClosedError);
+  });
+
+  it("should throw SessionClosedError on subscribe after close", () => {
+    const session = new Session();
+    session.close();
+    expect(() => session.subscribe(() => {})).toThrow(SessionClosedError);
+  });
+
+  it("should allow reconnection after graceful close", () => {
+    const session = new Session();
+    session.close();
+    expect(() => session.reconnect()).not.toThrow();
+    expect(session.isConnected).toBe(true);
+  });
+
+  it("should deduplicate subscribers added twice", () => {
+    const session = new Session();
+    const handler = () => {};
+    session.subscribe(handler);
+    session.subscribe(handler);
+    expect(session.subscribers.length).toBe(1);
+  });
+
+  it("should clear all subscribers on destroy", () => {
+    const session = new Session();
+    session.subscribe(() => {});
+    session.subscribe(() => {});
+    session.destroy();
+    expect(session.subscribers.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## What
Adds error-path unit tests for the `packages/core/src/session/` module, covering SessionClosedError, reconnection logic, and edge-case state transitions.

## Why
The session module was missing test coverage for error paths. Unhandled SessionClosedError in production would silently break event subscriptions.

## Testing
`bun vitest run packages/core/src/session/session.test.ts`


---
*Automated by Mavis TermUI Bot*