### PR TITLE
test(ui): add ARIA attribute tests for Select component

### DIFF
--- a/packages/ui/src/Select.aria.test.tsx
+++ b/packages/ui/src/Select.aria.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { render, fireEvent, screen } from "@testing-library/react";
+import React from "react";
+import { Select } from "./Select";
+
+const options = [
+  { value: "a", label: "Option A" },
+  { value: "b", label: "Option B" },
+];
+
+describe("Select -- ARIA attributes", () => {
+  it("should set aria-expanded=false when closed", () => {
+    render(<Select options={options} value="a" onChange={() => {}} />);
+    expect(screen.getByRole("combobox")).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("should set aria-expanded=true when open", () => {
+    render(<Select options={options} value="a" onChange={() => {}} />);
+    fireEvent.click(screen.getByRole("combobox"));
+    expect(screen.getByRole("combobox")).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("should set aria-haspopup=listbox on the combobox", () => {
+    render(<Select options={options} value="a" onChange={() => {}} />);
+    expect(screen.getByRole("combobox")).toHaveAttribute("aria-haspopup", "listbox");
+  });
+
+  it("should set aria-selected=true on the active option", () => {
+    render(<Select options={options} value="b" onChange={() => {}} />);
+    fireEvent.click(screen.getByRole("combobox"));
+    const opts = screen.getAllByRole("option");
+    expect(opts[1]).toHaveAttribute("aria-selected", "true");
+    expect(opts[0]).toHaveAttribute("aria-selected", "false");
+  });
+});


### PR DESCRIPTION
## What
Adds Vitest tests asserting correct ARIA attributes (aria-expanded, aria-haspopup, aria-selected) on the `Select` component in all interaction states.

## Why
Accessibility tests for Select were missing. Incorrect ARIA attributes can cause screen reader failures.

## Testing
`bun vitest run packages/ui/src/Select.aria.test.tsx`


---
*Automated by Mavis TermUI Bot*