### PR TITLE
test(adapters): add stress test for chalk adapter at 10k writes

### DIFF
--- a/packages/adapters/src/chalk/stress.test.ts
+++ b/packages/adapters/src/chalk/stress.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { ChalkAdapter } from "./index";
+
+const adapter = new ChalkAdapter();
+
+describe("ChalkAdapter -- stress test", () => {
+  it("should not corrupt output at 10k rapid writes", () => {
+    const outputs: string[] = [];
+
+    for (let i = 0; i < 10_000; i++) {
+      const result = adapter.write(`line-${i}`, i % 2 === 0 ? "red" : "blue");
+      outputs.push(result);
+    }
+
+    // All writes should return a non-empty string
+    expect(outputs.every((o) => o.length > 0)).toBe(true);
+
+    // No writes should contain style bleed sequences from adjacent outputs
+    for (let i = 1; i < outputs.length; i++) {
+      expect(outputs[i]).not.toMatch(/\x1b\[0m\x1b\[3[0-4]m/);
+    }
+  });
+
+  it("should maintain color state isolation across writes", () => {
+    const a = adapter.write("normal", undefined);
+    const b = adapter.write("red", "red");
+    const c = adapter.write("back to normal", undefined);
+    // b should contain red ANSI codes, c should not
+    expect(b).not.toBe(c);
+    expect(c).not.toContain("\x1b[31m");
+  });
+});


### PR DESCRIPTION
## What
Adds a stress test that performs 10,000 rapid successive chalk writes in a tight loop, verifying no buffer overflow, style bleed, or crashes occur.

## Why
The chalk adapter had no stress testing. High-volume output scenarios (e.g., progress bars, live logs) could corrupt styled output.

## Testing
`bun vitest run packages/adapters/src/chalk/stress.test.ts`


---
*Automated by Mavis TermUI Bot*