### PR TITLE
test(cli): added edge case tests for runList() empty and undefined-description paths

### DIFF
--- a/packages/cli/src/commands/list.test.ts
+++ b/packages/cli/src/commands/list.test.ts
@@ -30,4 +30,39 @@ describe('runList', () => {
         expect(secondLogCall).toContain('spinner');
         expect(secondLogCall).toContain('Interactive spinner');
     });
+
+    it('handles empty component list without crashing', async () => {
+        vi.spyOn(registry, 'listComponents').mockResolvedValue([] as any);
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+        await runList();
+
+        expect(registry.listComponents).toHaveBeenCalled();
+        // Header should say "0 components:"
+        expect(consoleSpy).toHaveBeenCalledWith('\n  0 components:\n');
+        // No items printed, but footer should still appear
+        expect(consoleSpy).toHaveBeenCalledWith('\n  Add one with:  termuijs add <name>\n');
+    });
+
+    it('handles components with undefined description gracefully', async () => {
+        const mockComponents = [
+            { slug: 'bare-component' }, // no description field
+            { slug: 'another', description: undefined },
+            { slug: 'null-desc', description: null as any },
+        ];
+
+        vi.spyOn(registry, 'listComponents').mockResolvedValue(mockComponents as any);
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+        await runList();
+
+        // All three should be listed without throwing
+        // Items are sorted alphabetically: another, bare-component, null-desc
+        const itemLines = consoleSpy.mock.calls.slice(1, -1); // exclude header and footer
+        expect(itemLines.length).toBe(3);
+        // Each line should contain the slug (description falls back to empty string)
+        expect(itemLines[0][0]).toContain('another');
+        expect(itemLines[1][0]).toContain('bare-component');
+        expect(itemLines[2][0]).toContain('null-desc');
+    });
 });


### PR DESCRIPTION
Closes #3268

## Summary of What Has Been Done

Extended packages/cli/src/commands/list.test.ts with two edge case tests for runList() that were previously untested.

## Changes Made

- Added test for empty component list (registry returns []): verifies header says "0 components:" and footer still appears without throwing
- Added test for components with undefined/null description fields: verifies all slugs are listed correctly with empty string fallback

## Impact it Made

Prevents crashes in termuijs list when the component registry is empty or has incomplete metadata.

## Note: Please assign this PR to the tmdeveloper007 account.