### PR TITLE
test(store): added edge case tests for shallow equality with complex types

### DIFF
--- a/packages/store/src/shallow.test.ts
+++ b/packages/store/src/shallow.test.ts
@@ -20,6 +20,62 @@ describe('shallow', () => {
   })
 })
 
+describe('shallow edge cases', () => {
+  it('returns true for null compared to null', () => {
+    expect(shallow(null, null)).toBe(true)
+  })
+
+  it('returns false for null compared to an object', () => {
+    expect(shallow(null, {})).toBe(false)
+    expect(shallow({}, null)).toBe(false)
+  })
+
+  it('returns true for undefined compared to undefined', () => {
+    expect(shallow(undefined, undefined)).toBe(true)
+  })
+
+  it('returns false for undefined compared to an object', () => {
+    expect(shallow(undefined, {})).toBe(false)
+    expect(shallow({}, undefined)).toBe(false)
+  })
+
+  it('returns true for Date objects with the same ms value', () => {
+    expect(shallow(new Date(0), new Date(0))).toBe(true)
+  })
+
+  it('returns true for Date objects with the same ms value', () => {
+    expect(shallow(new Date(0), new Date(0))).toBe(true)
+  })
+
+  it('returns true for Date objects with different ms values (shallow: no own enumerable keys)', () => {
+    // shallow() compares own enumerable keys. Date instances have no own enumerable keys,
+    // so two Dates are always shallow-equal regardless of their internal timestamp.
+    expect(shallow(new Date(0), new Date(1))).toBe(true)
+  })
+
+  it('returns true for two Map instances with identical entries (shallow: no own enumerable keys)', () => {
+    // shallow() does not inspect Map/Symbol-keyed internals.
+    // new Map() has zero own enumerable keys, so two Maps are always shallow-equal.
+    const a = new Map([['x', 1]])
+    const b = new Map([['x', 1]])
+    expect(shallow(a, b)).toBe(true)
+  })
+
+  it('returns true for two Set instances with identical entries (shallow: no own enumerable keys)', () => {
+    const a = new Set([1, 2, 3])
+    const b = new Set([1, 2, 3])
+    expect(shallow(a, b)).toBe(true)
+  })
+
+  it('returns true for NaN compared to NaN (Object.is behavior)', () => {
+    expect(shallow(NaN, NaN)).toBe(true)
+  })
+
+  it('returns false for 0 compared to -0 (Object.is distinguishes these)', () => {
+    expect(shallow(0, -0)).toBe(false)
+  })
+})
+
 describe('useStore selector with shallow', () => {
   it('selector with shallow skips notify on equal slice', () => {
     const useStore = createStore({ obj: { a: 1, b: 2 }, other: 0 })


### PR DESCRIPTION
Closes #3270

## Summary of What Has Been Done

Extended packages/store/src/shallow.test.ts with a dedicated shallow edge cases describe block covering null, undefined, Date, Map, Set, NaN, and 0/-0 comparisons.

## Changes Made

Added 9 new test cases:
- null vs null returns true
- null vs object returns false
- undefined vs undefined returns true
- undefined vs object returns false
- Date(0) vs Date(0) returns true (same timestamp)
- Date(0) vs Date(1) returns true (shallow: both have no own enumerable keys)
- Map([[x,1]]) vs Map([[x,1]]) returns true (shallow: no own enumerable keys)
- Set([1,2,3]) vs Set([1,2,3]) returns true (shallow: no own enumerable keys)
- NaN vs NaN returns true (Object.is behavior)
- 0 vs -0 returns false (Object.is distinguishes these)

## Impact it Made

Documents the actual shallow equality behavior for complex types, preventing silent misclassifications in store selectors that use the shallow helper.

## Note: please assign this PR to the tmdeveloper007 account.