### PR TITLE
test(cli): added edge case tests for runInit() package.json scenarios

### DIFF
--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import { mkdtempSync, readFileSync, existsSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -65,6 +65,62 @@ describe('runInit', () => {
             expect(pkg.dependencies['@termuijs/widgets']).toBe('latest');
             expect(pkg.dependencies['@termuijs/jsx']).toBe('latest');
         } finally {
+            process.chdir(originalCwdInner);
+        }
+    });
+
+    it('skips updating when all termui dependencies are already present', async () => {
+        const testDir = mkdtempSync(join(tmpdir(), 'termui-init-test-uptodate-'));
+        const originalCwdInner = process.cwd();
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+        try {
+            process.chdir(testDir);
+
+            // Pre-existing package.json with all termui deps at latest
+            const userPkg = {
+                name: 'my-app',
+                version: '0.1.0',
+                dependencies: {
+                    '@termuijs/core': 'latest',
+                    '@termuijs/widgets': 'latest',
+                    '@termuijs/jsx': 'latest',
+                },
+            };
+            writeFileSync(join(testDir, 'package.json'), JSON.stringify(userPkg, null, 2), 'utf-8');
+
+            await runInit();
+
+            // package.json should NOT have been modified (no '+' log for dependencies)
+            const logCalls = consoleSpy.mock.calls.map(c => c[0] as string);
+            const depUpdateCall = logCalls.find(l => l.includes('dependencies updated'));
+            expect(depUpdateCall).toBeUndefined();
+        } finally {
+            consoleSpy.mockRestore();
+            process.chdir(originalCwdInner);
+        }
+    });
+
+    it('handles malformed package.json without crashing', async () => {
+        const testDir = mkdtempSync(join(tmpdir(), 'termui-init-test-bad-json-'));
+        const originalCwdInner = process.cwd();
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+        try {
+            process.chdir(testDir);
+
+            // Write a malformed package.json (not valid JSON)
+            writeFileSync(join(testDir, 'package.json'), '{ not valid json }', 'utf-8');
+
+            // runInit should not throw — it catches the parse error
+            await expect(runInit()).resolves.not.toThrow();
+
+            // Should log a parse error
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                expect.stringContaining('invalid JSON')
+            );
+        } finally {
+            consoleErrorSpy.mockRestore();
+            consoleLogSpy.mockRestore();
             process.chdir(originalCwdInner);
         }
     });


### PR DESCRIPTION
Closes #3275

## Summary of What Has Been Done

Extended packages/cli/src/commands/init.test.ts with two additional edge case tests:

## Changes Made

- Added test for the no-op case: when all three termui dependencies are already present,
  runInit() should not log a dependency update message
- Added test for malformed JSON: when package.json exists but contains invalid JSON,
  runInit() should catch the parse error, log it, and not throw

## Impact it Made

Ensures runInit is safe to run in existing projects without corrupting configs or crashing.

## Note: Please assign this PR to the tmdeveloper007 account.