### PR TITLE
bug: Resolve Memory Leak in Event Emitter Subscriptions on Dynamic Screen Transitions (#3225)

### DIFF
--- a/packages/core/src/events/EventEmitter.test.ts
+++ b/packages/core/src/events/EventEmitter.test.ts
@@ -276,4 +276,35 @@ describe('EventEmitter', () => {
         expect(handlerB).toHaveBeenCalledTimes(1); // Not called again
         expect(handlerC).toHaveBeenCalledTimes(2);
     });
+
+    it('once returned unsubscribe removes empty Map entry', () => {
+        const emitter = new EventEmitter<TestEvents>();
+        const handler = vi.fn();
+
+        const unsub = emitter.once('message', handler);
+        expect(emitter.hasListeners('message')).toBe(true);
+
+        unsub();
+
+        expect(emitter.hasListeners('message')).toBe(false);
+        expect(emitter['_onceHandlers'].has('message' as any)).toBe(false);
+    });
+
+    it('listenerCount reports exact listener count per event and total', () => {
+        const emitter = new EventEmitter<TestEvents>();
+        const h1 = vi.fn();
+        const h2 = vi.fn();
+        const h3 = vi.fn();
+
+        expect(emitter.listenerCount()).toBe(0);
+
+        emitter.on('message', h1);
+        emitter.once('message', h2);
+        emitter.on('count', h3);
+
+        expect(emitter.listenerCount('message')).toBe(2);
+        expect(emitter.listenerCount('count')).toBe(1);
+        expect(emitter.listenerCount()).toBe(3);
+    });
 });
+

--- a/packages/core/src/events/EventEmitter.ts
+++ b/packages/core/src/events/EventEmitter.ts
@@ -37,7 +37,13 @@ export class EventEmitter<TEventMap extends Record<string, any>> {
         this._onceHandlers.get(event)!.add(handler);
 
         return () => {
-            this._onceHandlers.get(event)?.delete(handler);
+            const reg = this._onceHandlers.get(event);
+            if (reg) {
+                reg.delete(handler);
+                if (reg.size === 0) {
+                    this._onceHandlers.delete(event);
+                }
+            }
         };
     }
 
@@ -123,4 +129,22 @@ export class EventEmitter<TEventMap extends Record<string, any>> {
             (this._onceHandlers.get(event)?.size ?? 0) > 0
         );
     }
+
+    /**
+     * Get the count of listeners for a specific event or all events.
+     */
+    listenerCount(event?: keyof TEventMap): number {
+        if (event) {
+            return (this._handlers.get(event)?.size ?? 0) + (this._onceHandlers.get(event)?.size ?? 0);
+        }
+        let total = 0;
+        for (const set of this._handlers.values()) {
+            total += set.size;
+        }
+        for (const set of this._onceHandlers.values()) {
+            total += set.size;
+        }
+        return total;
+    }
 }
+


### PR DESCRIPTION
## Description

This PR fixes a memory leak in EventEmitter (@termuijs/core) where unsubscribing from once() event handlers left empty Set instances in internal handler maps, preventing garbage collection on dynamic screen transitions. It also introduces a listenerCount(event?: keyof TEventMap) method for querying listener metrics.

## Related Issue

Closes #3225

## Which package(s)?

@termuijs/core

## Type of Change

- [x] 🐛 Bug fix (	ype:bug)
- [ ] ✨ Feature (	ype:feature)
- [ ] 📝 Docs (	ype:docs)
- [x] 🧪 Tests (	ype:testing)
- [ ] ♻️ Refactor (	ype:refactor)
- [ ] 🎨 Design / UX (	ype:design)
- [ ] ♿ Accessibility (	ype:accessibility)
- [ ] ⚡ Performance (	ype:performance)
- [ ] 🔧 DevOps / CI (	ype:devops)
- [ ] 🔒 Security (	ype:security)

## Checklist

- [x] ⭐ You starred the repo. The 
eeds-star check blocks your merge otherwise.
- [x] Tests pass locally: un vitest run
- [x] Build passes: un run build
- [x] Typecheck passes: un run typecheck
- [x] You read [CONTRIBUTING.md](./CONTRIBUTING.md).
- [x] Your PR title follows 	ype: short description.
- [x] Widget state mutators call markDirty() (if your change affects rendering).
- [x] No new ny types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: https://gssoc.girlscript.org/profile/knoxiboy

## Notes for the Reviewer

Ensured 	his._onceHandlers.delete(event) is invoked when once() unsubscription reduces listener count to zero. Added unit tests for map cleanup and listenerCount().