### PR TITLE
bug: Fix Double-Render Screen Flicker on Rapid Redraw Requests (#3226)

### DIFF
--- a/packages/core/src/renderer/Scheduler.test.ts
+++ b/packages/core/src/renderer/Scheduler.test.ts
@@ -57,7 +57,7 @@ describe('Scheduler', () => {
         scheduler.flush();
         expect(count).toBe(1);
 
-        // Verify queue is empty and timer is cancelled by ensuring 
+        // Verify queue is empty and timer is cancelled by ensuring
         // neither manual flush nor advancing time triggers the task again.
         scheduler.flush();
         vi.advanceTimersByTime(34);
@@ -66,7 +66,7 @@ describe('Scheduler', () => {
 
     it('should continue executing remaining tasks if one task throws an error', () => {
         let executed = false;
-        
+
         // Mock stderr to prevent test output pollution
         const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 
@@ -82,10 +82,10 @@ describe('Scheduler', () => {
     it('should not deduplicate identical function references', () => {
         let count = 0;
         const task = () => { count++; };
-        
+
         scheduler.enqueue(task);
         scheduler.enqueue(task);
-        
+
         scheduler.flush();
         expect(count).toBe(2);
     });
@@ -97,23 +97,53 @@ describe('Scheduler', () => {
         expect(() => scheduler.setFPS(Infinity)).toThrow();
     });
 
-    it('should prevent re-entrant flush passes while flushing', () => {
-        let nestedFlushCalls = 0;
-        let task2Run = false;
+    it('should prevent re-entrant flush and defer tasks enqueued during flush to the next frame', () => {
+        // This test would pass WITHOUT _isFlushing IF the nested flush() ran inline:
+        // the follow-up task would be run by the nested flush, not the scheduled frame.
+        // With the guard, nested flush() is a no-op, and the follow-up task is scheduled
+        // via scheduleFrame() in the finally block, then runs on the next timer tick.
+        const executionOrder: string[] = [];
 
         scheduler.enqueue(() => {
-            // Attempt to trigger a re-entrant flush while already flushing
-            scheduler.flush();
-            nestedFlushCalls++;
-        });
-        scheduler.enqueue(() => {
-            task2Run = true;
+            executionOrder.push('task1');
+            // Enqueue a follow-up task and attempt a nested flush during the outer flush
+            scheduler.enqueue(() => { executionOrder.push('followup'); });
+            scheduler.flush(); // Must be a no-op while _isFlushing === true
+            executionOrder.push('task1-after-nested-flush');
         });
 
         scheduler.flush();
 
-        expect(nestedFlushCalls).toBe(1);
-        expect(task2Run).toBe(true);
+        // After the outer flush completes: task1 and task1-after-nested-flush ran;
+        // the follow-up was scheduled (not run inline) because the nested flush was blocked.
+        expect(executionOrder).toEqual(['task1', 'task1-after-nested-flush']);
+
+        // Advance fake timers to let the scheduled follow-up frame execute (~33ms for 30fps)
+        vi.advanceTimersByTime(34);
+
+        expect(executionOrder).toEqual(['task1', 'task1-after-nested-flush', 'followup']);
+    });
+
+    it('should clear the timer handle before flushing so tasks enqueued during flush can schedule a new frame', () => {
+        // This validates the _timer = null fix in scheduleFrame's callback.
+        // Without the fix, the stale timer handle is non-null after the timeout fires,
+        // causing scheduleFrame() to return early and strand follow-up tasks enqueued
+        // during a timer-driven flush.
+        const results: string[] = [];
+
+        // Force a timer-driven flush by just enqueueing (not calling flush() directly)
+        scheduler.enqueue(() => {
+            results.push('initial-task');
+            // Enqueue another task during this timer-driven flush
+            scheduler.enqueue(() => { results.push('followup-task'); });
+        });
+
+        // Advance fake timers to trigger the first timer-driven flush (~33ms for 30fps)
+        vi.advanceTimersByTime(34);
+        expect(results).toContain('initial-task');
+
+        // followup-task should now be scheduled; advance again to run it
+        vi.advanceTimersByTime(34);
+        expect(results).toContain('followup-task');
     });
 });
-

--- a/packages/core/src/renderer/Scheduler.test.ts
+++ b/packages/core/src/renderer/Scheduler.test.ts
@@ -96,4 +96,24 @@ describe('Scheduler', () => {
         expect(() => scheduler.setFPS(NaN)).toThrow();
         expect(() => scheduler.setFPS(Infinity)).toThrow();
     });
+
+    it('should prevent re-entrant flush passes while flushing', () => {
+        let nestedFlushCalls = 0;
+        let task2Run = false;
+
+        scheduler.enqueue(() => {
+            // Attempt to trigger a re-entrant flush while already flushing
+            scheduler.flush();
+            nestedFlushCalls++;
+        });
+        scheduler.enqueue(() => {
+            task2Run = true;
+        });
+
+        scheduler.flush();
+
+        expect(nestedFlushCalls).toBe(1);
+        expect(task2Run).toBe(true);
+    });
 });
+

--- a/packages/core/src/renderer/Scheduler.ts
+++ b/packages/core/src/renderer/Scheduler.ts
@@ -38,6 +38,7 @@ export class Scheduler {
         const delay = Math.floor(1000 / this._fps);
         
         this._timer = setTimeout(() => {
+            this._timer = null; // Clear handle before flush so follow-up enqueues can schedule a new frame
             this.flush();
         }, delay);
     }

--- a/packages/core/src/renderer/Scheduler.ts
+++ b/packages/core/src/renderer/Scheduler.ts
@@ -1,4 +1,3 @@
-
 import process from 'node:process';
 /**
  * Coordinated Frame Scheduler
@@ -11,6 +10,7 @@ export class Scheduler {
     private _queue: Array<() => void> = [];
     private _timer: ReturnType<typeof setTimeout> | null = null;
     private _fps = 30;
+    private _isFlushing = false;
 
     /**
      * Enqueues a state mutation task. 
@@ -32,7 +32,7 @@ export class Scheduler {
     }
 
     private scheduleFrame(): void {
-        if (this._timer) return;
+        if (this._timer || this._isFlushing) return;
 
         // Use a window based on target FPS (e.g., ~33ms for 30fps)
         const delay = Math.floor(1000 / this._fps);
@@ -47,6 +47,8 @@ export class Scheduler {
      * This should trigger exactly one reconciliation pass in the framework.
      */
     flush(): void {
+        if (this._isFlushing) return;
+
         if (this._timer) {
             clearTimeout(this._timer);
             this._timer = null;
@@ -54,18 +56,24 @@ export class Scheduler {
 
         if (this._queue.length === 0) return;
 
-        // Take a snapshot of the current queue and clear it immediately.
-        // This ensures the scheduler is ready for the next frame and 
-        // remains resilient even if an update throws an error.
-        const tasks = this._queue;
-        this._queue = [];
+        this._isFlushing = true;
+        try {
+            // Take a snapshot of the current queue and clear it immediately.
+            const tasks = this._queue;
+            this._queue = [];
 
-        for (const update of tasks) {
-            try {
-                update();
-            } catch (error) {
-                // Write to stderr to avoid interfering with the main terminal buffer
-                process.stderr.write(`[Scheduler] Task failed: ${error}\n`);
+            for (const update of tasks) {
+                try {
+                    update();
+                } catch (error) {
+                    // Write to stderr to avoid interfering with the main terminal buffer
+                    process.stderr.write(`[Scheduler] Task failed: ${error}\n`);
+                }
+            }
+        } finally {
+            this._isFlushing = false;
+            if (this._queue.length > 0) {
+                this.scheduleFrame();
             }
         }
     }


### PR DESCRIPTION
## Description

This PR fixes double-render screen flickering caused by rapid redraw requests. It introduces a re-entrancy guard (_isFlushing) in Scheduler (@termuijs/core) that prevents nested or duplicate flush passes when tasks enqueue additional updates during render execution, ensuring state mutations are batched cleanly into target frame windows.

## Related Issue

Closes #3226

## Which package(s)?

@termuijs/core

## Type of Change

- [x] 🐛 Bug fix (	ype:bug)
- [ ] ✨ Feature (	ype:feature)
- [ ] 📝 Docs (	ype:docs)
- [x] 🧪 Tests (	ype:testing)
- [ ] ♻️ Refactor (	ype:refactor)
- [ ] 🎨 Design / UX (	ype:design)
- [ ] ♿ Accessibility (	ype:accessibility)
- [x] ⚡ Performance (	ype:performance)
- [ ] 🔧 DevOps / CI (	ype:devops)
- [ ] 🔒 Security (	ype:security)

## Checklist

- [x] ⭐ You starred the repo. The 
eeds-star check blocks your merge otherwise.
- [x] Tests pass locally: un vitest run
- [x] Build passes: un run build
- [x] Typecheck passes: un run typecheck
- [x] You read [CONTRIBUTING.md](./CONTRIBUTING.md).
- [x] Your PR title follows 	ype: short description.
- [x] Widget state mutators call markDirty() (if your change affects rendering).
- [x] No new ny types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: https://gssoc.girlscript.org/profile/knoxiboy

## Notes for the Reviewer

Added _isFlushing guard and re-entrancy prevention in Scheduler.ts. Added unit tests in Scheduler.test.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler reliability by preventing duplicate and re-entrant flush operations.
  * Ensured tasks queued while a flush is running complete in a later scheduled cycle (not inline).
  * Preserved existing task error reporting while refining follow-up scheduling behavior.

* **Tests**
  * Added coverage for nested flush attempts and for tasks added during timer-driven flushes, including proper multi-step execution with advanced timers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->