### PR TITLE
fix : added null guard for empty content array in AI adapter generate method

### DIFF
--- a/packages/adapters/src/ai/index.ts
+++ b/packages/adapters/src/ai/index.ts
@@ -81,7 +81,8 @@ export function useAI(provider: AIProvider, options: AIOptions): AIAdapter {
         messages: [{ role: 'user', content: prompt }],
       })
       const block = response.content[0]
-      return block.type === 'text' ? block.text : ''
+      if (!block || block.type !== 'text') return ''
+      return block.text
     },
 
     async *chat(messages: AIMessage[]): AsyncIterable<string> {
@@ -136,4 +137,4 @@ export function useAI(provider: AIProvider, options: AIOptions): AIAdapter {
 
   return adapter
 }
-
+


### PR DESCRIPTION
## Summary of What Has Been Done

Added a null/undefined guard in the `generate` method of the AI adapter. The code now checks if `response.content[0]` exists and is a text block before attempting to access its `text` property.

## Changes Made

- `packages/adapters/src/ai/index.ts`: Added `if (!block || block.type !== 'text') return ''` guard before accessing block properties.

## Impact it Made

Prevents runtime TypeErrors when the AI provider returns an empty content array, improving production robustness.

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #3300


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty or unexpected responses from the Anthropic AI provider.
  * Prevented errors when response content is missing or does not contain a text block.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->