### PR TITLE
fix : added console warning for silent persistence errors in store

### DIFF
--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -380,7 +380,7 @@ export function createStore<T extends object>(
                 }
                 fs.writeFileSync(persistFilePath, JSON.stringify(dataToSave), 'utf8');
             } catch (err) {
-                // Ignore write errors to keep terminal stable
+                console.warn(`[termui/store] Failed to persist state to ${persistFilePath}:`, err);
             }
         }, debounceMs);
     };


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced the silent catch block in the store's `persistState` function with a `console.warn` that surfaces the error with context.

## Changes Made

- `packages/store/src/store.ts`: Changed `catch (err) { /* Ignore */ }` to `catch (err) { console.warn(...) }`.

## Impact it Made

Developers can now diagnose persistence failures (disk full, permissions, corrupted state files) without manual logging. Terminal remains stable while surfacing actionable warnings.

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #3301


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a warning when saving persisted state fails, improving visibility into storage issues while allowing the application to continue running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->