### PR TITLE
fix : added input range monotonicity validation in motion interpolate function

### DIFF
--- a/packages/motion/src/interpolate.ts
+++ b/packages/motion/src/interpolate.ts
@@ -52,6 +52,12 @@ export function interpolate(
         throw new Error('inputRange and outputRange must have at least 2 elements.');
     }
 
+    for (let i = 1; i < inputRange.length; i++) {
+        if (inputRange[i] <= inputRange[i - 1]) {
+            throw new Error('inputRange must be monotonically increasing');
+        }
+    }
+
     let index = 0;
     while (index < inputRange.length - 2 && value > inputRange[index + 1]) {
         index++;


### PR DESCRIPTION
## Summary of What Has Been Done

Added validation in the `interpolate` function to ensure `inputRange` is monotonically increasing. The function throws a descriptive error immediately if the input range is not sorted.

## Changes Made

- `packages/motion/src/interpolate.ts`: Added a `for` loop after the existing length checks that validates monotonicity of `inputRange`.

## Impact it Made

Invalid input ranges now fail fast with a clear error message instead of silently producing incorrect interpolated values, making animation debugging much easier.

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #3302
