### PR TITLE
fix : replaced unsafe non-null assertion on stack.pop() in testing queries

### DIFF
--- a/packages/testing/src/queries.ts
+++ b/packages/testing/src/queries.ts
@@ -12,7 +12,8 @@ function walkWidgets(
   const stack: Widget[] = [root];
 
   while (stack.length > 0) {
-    const widget = stack.pop()!;
+    const widget = stack.pop();
+    if (widget === undefined) continue;
 
     if (predicate(widget)) {
       result.push(widget);


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced the non-null assertion (`!`) on `stack.pop()` with a safe `undefined` guard in the `walkWidgets` function.

## Changes Made

- `packages/testing/src/queries.ts`: Changed `const widget = stack.pop()!;` to `const widget = stack.pop(); if (widget === undefined) continue;`.

## Impact it Made

Eliminates a potential source of TypeErrors in test tooling. The code is more defensive and easier for static analysis tools to verify correctness.

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #3303
