### PR TITLE
fix : added bounds check when extracting regex match groups in router route matching

### DIFF
--- a/packages/router/src/route.ts
+++ b/packages/router/src/route.ts
@@ -162,6 +162,9 @@ function matchNested(
             for (let i = 0; i < paramNames.length; i++) {
                 params[paramNames[i]] = match[i + 1] ?? '';
             }
+            if (Object.keys(params).length !== paramNames.length) {
+                return null;
+            }
             const nextChain = [...chain, route];
             return {
                 route,


### PR DESCRIPTION
## Summary of What Has Been Done

Added a length validation after populating route params from regex match groups in `matchNested`. If not all expected parameters were captured, the function now returns `null` instead of returning a partially-populated params object.

## Changes Made

- `packages/router/src/route.ts`: Added `if (Object.keys(params).length !== paramNames.length) return null;` after param extraction.

## Impact it Made

Routes that match but fail to capture all named segments now correctly return `null` instead of a partially-populated params object, preventing downstream bugs in route handlers.

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #3304
