### PR TITLE
feat(widgets): add getValue, getLabel, setLabel, and getDelta methods to Stat widget

### DIFF
--- a/packages/widgets/src/data/Stat.test.ts
+++ b/packages/widgets/src/data/Stat.test.ts
@@ -102,4 +102,28 @@ describe('Stat', () => {
         const row1 = screen.back[1].map((c: { char: string }) => c.char).join('').trimEnd();
         expect(row1).toContain('\u2192');
     });
+
+    it('gets value and label via getters and setLabel updates label', async () => {
+        const { Stat } = await import('./Stat.js');
+        const stat = new Stat('Initial Label', '100');
+        expect(stat.getLabel()).toBe('Initial Label');
+        expect(stat.getValue()).toBe('100');
+
+        stat.setLabel('Updated Label');
+        stat.setValue('200');
+        expect(stat.getLabel()).toBe('Updated Label');
+        expect(stat.getValue()).toBe('200');
+    });
+
+    it('gets and sets delta via getDelta and setDelta', async () => {
+        const { Stat } = await import('./Stat.js');
+        const stat = new Stat('CPU', '45%', {}, { delta: 1.5 });
+        expect(stat.getDelta()).toBe(1.5);
+
+        stat.setDelta(-2.0);
+        expect(stat.getDelta()).toBe(-2.0);
+
+        stat.setDelta(undefined);
+        expect(stat.getDelta()).toBeUndefined();
+    });
 });

--- a/packages/widgets/src/data/Stat.ts
+++ b/packages/widgets/src/data/Stat.ts
@@ -22,13 +22,34 @@ export class Stat extends Widget {
     }
 
     setValue(value: string): void {
+        if (this._value === value) return;
         this._value = value;
         this.markDirty();
     }
 
-    setDelta(delta: number | undefined): void {
-        this._delta = delta !== undefined ? validateFinite(delta) : undefined;
+    getValue(): string {
+        return this._value;
+    }
+
+    setLabel(label: string): void {
+        if (this._label === label) return;
+        this._label = label;
         this.markDirty();
+    }
+
+    getLabel(): string {
+        return this._label;
+    }
+
+    setDelta(delta: number | undefined): void {
+        const next = delta !== undefined ? validateFinite(delta) : undefined;
+        if (this._delta === next) return;
+        this._delta = next;
+        this.markDirty();
+    }
+
+    getDelta(): number | undefined {
+        return this._delta;
     }
 
     protected _renderSelf(screen: Screen): void {


### PR DESCRIPTION
## Description

Adds missing getter methods (`getValue`, `getLabel`, `getDelta`) and setter method (`setLabel`) to the `Stat` widget in `@termuijs/widgets`.

Closes #3363

## Package Scope

`packages/widgets`

## Checklist before PR
- [x] Run `bun run build && bun vitest run && bun run typecheck`
- [x] Change confined to package scope
- [x] No unrelated lockfile churn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accessors for reading and updating statistic labels, values, and deltas.
  * Statistic updates now avoid unnecessary changes when the value remains the same.

* **Tests**
  * Added coverage for statistic getters, setters, and clearing delta values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->