### PR TITLE
feat(widgets): add getShowLabel, setShowLabel, getFilledChar, and setFilledChar methods to LineGauge widget

### DIFF
--- a/packages/widgets/src/data/LineGauge.test.ts
+++ b/packages/widgets/src/data/LineGauge.test.ts
@@ -93,4 +93,25 @@ describe('LineGauge', () => {
         gauge.setValue(0.3);
         expect(spy).toHaveBeenCalled();
     });
+
+    it('gets and sets showLabel option', async () => {
+        const { LineGauge } = await import('./LineGauge.js');
+        const gauge = new LineGauge({}, { showLabel: false });
+        expect(gauge.getShowLabel()).toBe(false);
+
+        gauge.setShowLabel(true);
+        expect(gauge.getShowLabel()).toBe(true);
+    });
+
+    it('gets and sets filledChar and emptyChar options', async () => {
+        const { LineGauge } = await import('./LineGauge.js');
+        const gauge = new LineGauge({}, { filledChar: '#', emptyChar: '.' });
+        expect(gauge.getFilledChar()).toBe('#');
+        expect(gauge.getEmptyChar()).toBe('.');
+
+        gauge.setFilledChar('=');
+        gauge.setEmptyChar('-');
+        expect(gauge.getFilledChar()).toBe('=');
+        expect(gauge.getEmptyChar()).toBe('-');
+    });
 });

--- a/packages/widgets/src/data/LineGauge.ts
+++ b/packages/widgets/src/data/LineGauge.ts
@@ -44,6 +44,36 @@ export class LineGauge extends Widget {
         return this._value;
     }
 
+    getShowLabel(): boolean {
+        return this._showLabel;
+    }
+
+    setShowLabel(showLabel: boolean): void {
+        if (this._showLabel === showLabel) return;
+        this._showLabel = showLabel;
+        this.markDirty();
+    }
+
+    getFilledChar(): string {
+        return this._filledChar;
+    }
+
+    setFilledChar(filledChar: string): void {
+        if (this._filledChar === filledChar) return;
+        this._filledChar = filledChar;
+        this.markDirty();
+    }
+
+    getEmptyChar(): string {
+        return this._emptyChar;
+    }
+
+    setEmptyChar(emptyChar: string): void {
+        if (this._emptyChar === emptyChar) return;
+        this._emptyChar = emptyChar;
+        this.markDirty();
+    }
+
     protected _renderSelf(screen: Screen): void {
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;


### PR DESCRIPTION
## Description

Adds missing getter and setter methods (`getShowLabel`, `setShowLabel`, `getFilledChar`, `setFilledChar`, `getEmptyChar`, `setEmptyChar`) to the `LineGauge` widget in `@termuijs/widgets`.

Closes #3364

## Package Scope

`packages/widgets`

## Checklist before PR
- [x] Run `bun run build && bun vitest run && bun run typecheck`
- [x] Change confined to package scope
- [x] No unrelated lockfile churn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added controls for showing or hiding gauge labels.
  * Added customization options for the characters used to represent filled and empty portions of line gauges.
  * Gauge updates now refresh only when settings change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->