### PR TITLE
fix(termui): address #3364 — LineGauge getters/setters

### DIFF
--- a/packages/widgets/src/data/LineGauge.ts
+++ b/packages/widgets/src/data/LineGauge.ts
@@ -44,6 +44,26 @@ export class LineGauge extends Widget {
         return this._value;
     }
 
+    getShowLabel(): boolean {
+        return this._showLabel;
+    }
+
+    setShowLabel(show: boolean): void {
+        if (this._showLabel === show) return;
+        this._showLabel = show;
+        this.markDirty();
+    }
+
+    getFilledChar(): string {
+        return this._filledChar;
+    }
+
+    setFilledChar(char: string): void {
+        if (this._filledChar === char) return;
+        this._filledChar = char;
+        this.markDirty();
+    }
+
     protected _renderSelf(screen: Screen): void {
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;


### PR DESCRIPTION
## 📄 Description
Fix for [Karanjot786/TermUI #3364](https://github.com/Karanjot786/TermUI/issues/3364).

widgets/LineGauge — added `getShowLabel()`, `setShowLabel()`, `getFilledChar()`, `setFilledChar()` methods.

## 🔗 Related Issues
- Closes #3364

## 🧩 Type of Change
- [x] Bug fix

## ✅ Checklist
- [x] Code follows project style guidelines
- [x] Tests added/updated if applicable
- [x] Documentation updated if applicable
- [x] Changes don't introduce new warnings
