### PR TITLE
fix(termui): address #3363 — Stat getters/setters

### DIFF
--- a/packages/widgets/src/data/Stat.ts
+++ b/packages/widgets/src/data/Stat.ts
@@ -31,6 +31,24 @@ export class Stat extends Widget {
         this.markDirty();
     }
 
+    getValue(): string {
+        return this._value;
+    }
+
+    getLabel(): string {
+        return this._label;
+    }
+
+    setLabel(label: string): void {
+        if (this._label === label) return;
+        this._label = label;
+        this.markDirty();
+    }
+
+    getDelta(): number | undefined {
+        return this._delta;
+    }
+
     protected _renderSelf(screen: Screen): void {
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;


### PR DESCRIPTION
## 📄 Description
Fix for [Karanjot786/TermUI #3363](https://github.com/Karanjot786/TermUI/issues/3363).

widgets/Stat — added `getValue()`, `getLabel()`, `setLabel()`, `getDelta()` methods.

## 🔗 Related Issues
- Closes #3363

## 🧩 Type of Change
- [x] Bug fix

## ✅ Checklist
- [x] Code follows project style guidelines
- [x] Tests added/updated if applicable
- [x] Documentation updated if applicable
- [x] Changes don't introduce new warnings
