### PR TITLE
fix(termui): address #3350 — node: prefix for readline

### DIFF
--- a/packages/ui/src/prompts.ts
+++ b/packages/ui/src/prompts.ts
@@ -2,7 +2,7 @@
 // @termuijs/ui — Imperative Prompts
 // ─────────────────────────────────────────────────────
 
-import * as readline from 'readline';
+import * as readline from 'node:readline';
 import { App, TermUIAbortError } from '@termuijs/core';
 import { TextInput, Widget } from '@termuijs/widgets';
 import { Select, type SelectOption, type SelectOptions } from './Select.js';


### PR DESCRIPTION
## 📄 Description
Fix for [Karanjot786/TermUI #3350](https://github.com/Karanjot786/TermUI/issues/3350).

ui/prompts.ts — prefixed Node.js built-in `readline` import with `node:` protocol.

## 🔗 Related Issues
- Closes #3350

## 🧩 Type of Change
- [x] Bug fix

## ✅ Checklist
- [x] Code follows project style guidelines
- [x] Tests added/updated if applicable
- [x] Documentation updated if applicable
- [x] Changes don't introduce new warnings
