### PR TITLE
fix(termui): address #3351 — Timeline ASCII fallback

### DIFF
--- a/packages/widgets/src/display/Timeline.ts
+++ b/packages/widgets/src/display/Timeline.ts
@@ -49,10 +49,10 @@ export class Timeline extends Widget {
             const status = item.status ?? 'pending';
 
             let connector: string;
-            if (isLast) {
-                connector = '\u2514\u2500'; // └─
+            if (caps.unicode) {
+                connector = isLast ? '\u2514\u2500' : '\u251C\u2500'; // └─ / ├─
             } else {
-                connector = '\u251C\u2500'; // ├─
+                connector = isLast ? '`-' : '|-'; // ASCII fallback
             }
 
             let icon: string;


### PR DESCRIPTION
## 📄 Description
Fix for [Karanjot786/TermUI #3351](https://github.com/Karanjot786/TermUI/issues/3351).

widgets/Timeline — connectors now use ASCII fallbacks (`|-` / `` ` ``) for non-Unicode terminals.

## 🔗 Related Issues
- Closes #3351

## 🧩 Type of Change
- [x] Bug fix

## ✅ Checklist
- [x] Code follows project style guidelines
- [x] Tests added/updated if applicable
- [x] Documentation updated if applicable
- [x] Changes don't introduce new warnings
