### PR TITLE
fix : added process.env fallback to keychain delete method

### DIFF
--- a/packages/adapters/src/keychain/index.ts
+++ b/packages/adapters/src/keychain/index.ts
@@ -75,6 +75,15 @@ export function useKeychain(appName: string): UseKeychainResult {
     return fallbackStore.get(account) ?? process.env[accountToEnvName(account)] ?? null
   }
 
+  function deleteFallback(account: string): boolean {
+    const envName = accountToEnvName(account)
+    const envHadKey = envName in process.env
+    if (envHadKey) {
+      delete process.env[envName]
+    }
+    return fallbackStore.delete(account) || envHadKey
+  }
+
   return {
     async get(account: string): Promise<string | null> {
       if (!keytar) return getFallback(account)
@@ -105,7 +114,7 @@ export function useKeychain(appName: string): UseKeychainResult {
 
     async delete(account: string): Promise<boolean> {
       if (!keytar) {
-        return fallbackStore.delete(account)
+        return deleteFallback(account)
       }
 
       try {
@@ -113,7 +122,7 @@ export function useKeychain(appName: string): UseKeychainResult {
       } catch (error) {
         warnFallback(error)
         keytar = null
-        return fallbackStore.delete(account)
+        return deleteFallback(account)
       }
     },
   }


### PR DESCRIPTION
## Summary of What Has Been Done

Added a `deleteFallback` helper function to `packages/adapters/src/keychain/index.ts` that removes the corresponding environment variable in addition to the in-memory fallback store when keytar is unavailable. The `delete` method now uses this helper in both the initial and runtime-failure fallback paths.

## Changes Made

- Added `deleteFallback(account: string): boolean` function that checks and removes `process.env[accountToEnvName(account)]` before calling `fallbackStore.delete(account)`.
- Updated `delete` method to call `deleteFallback` instead of `fallbackStore.delete` directly in both fallback paths.

## Impact it Made

The `delete` operation now has consistent fallback behavior with `get` and `set` — all three operations check environment variables when keytar is unavailable.

Closes #3392

Note: Please assign this PR to the `tmdeveloper007` account.