### PR TITLE
fix : added monotonicity validation to interpolate input range

### DIFF
--- a/packages/motion/src/interpolate.test.ts
+++ b/packages/motion/src/interpolate.test.ts
@@ -60,4 +60,16 @@ describe('interpolate and mapRange', () => {
         expect(() => interpolate(5, [0, 1], [0, 1, 2])).toThrow();
         expect(() => interpolate(5, [0], [0])).toThrow();
     });
+
+    it('throws if inputRange is not strictly ascending', () => {
+        expect(() => interpolate(5, [0, 2, 1, 3], [0, 20, 10, 30])).toThrow(
+            'inputRange must contain strictly ascending values'
+        );
+        expect(() => interpolate(5, [0, 1, 1, 2], [0, 10, 20, 30])).toThrow(
+            'inputRange must contain strictly ascending values'
+        );
+        expect(() => interpolate(5, [5, 3], [0, 10])).toThrow(
+            'inputRange must contain strictly ascending values'
+        );
+    });
 });

--- a/packages/motion/src/interpolate.ts
+++ b/packages/motion/src/interpolate.ts
@@ -52,6 +52,15 @@ export function interpolate(
         throw new Error('inputRange and outputRange must have at least 2 elements.');
     }
 
+    for (let i = 0; i < inputRange.length - 1; i++) {
+        if (inputRange[i] >= inputRange[i + 1]) {
+            throw new Error(
+                'inputRange must contain strictly ascending values. ' +
+                `Found inputRange[${i}]=${inputRange[i]} >= inputRange[${i + 1}]=${inputRange[i + 1]}.`
+            );
+        }
+    }
+
     let index = 0;
     while (index < inputRange.length - 2 && value > inputRange[index + 1]) {
         index++;


### PR DESCRIPTION
## Summary of What Has Been Done

Added a monotonicity check in `packages/motion/src/interpolate.ts` that validates `inputRange` is strictly ascending before performing interpolation. If any adjacent pair in `inputRange` violates strict ascending order, a descriptive error is thrown immediately.

Added corresponding test coverage in `packages/motion/src/interpolate.test.ts`.

## Changes Made

- Added a `for` loop after the existing length validation that checks `inputRange[i] < inputRange[i+1]` for all adjacent pairs.
- Throws `Error` with message: `"inputRange must contain strictly ascending values. Found inputRange[i]=X >= inputRange[i+1]=Y."`
- Added test case `'throws if inputRange is not strictly ascending'` with three sub-cases: strictly descending, equal adjacent values, and reversed pairs.

## Impact it Made

Prevents silent incorrect interpolation results when users accidentally pass unsorted input ranges. Makes the function fail fast with a clear error message.

Closes #3393

Note: Please assign this PR to the `tmdeveloper007` account.