### PR TITLE
fix : added warning when useNavigate called without router context

### DIFF
--- a/packages/router/src/hooks.test.ts
+++ b/packages/router/src/hooks.test.ts
@@ -128,4 +128,36 @@ describe('Router hooks', () => {
         
         t.unmount();
     });
+
+    it('useNavigate warns when called without a router context', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        // Component that calls useNavigate inside a Router context
+        let capturedNavigate: any;
+        const TestComponent = () => {
+            capturedNavigate = useNavigate();
+            return { type: 'box', props: {}, children: [] } as any;
+        };
+
+        // Create VNode manually so render() calls the component via reconcile/renderComponent
+        const vnode: any = { type: TestComponent, props: {}, children: [] };
+
+        // Render outside a Router context (no RouterContext.Provider in the tree)
+        const t = render(vnode);
+
+        // capturedNavigate should be set by the component rendering
+        // (it captures the navigate function via closure)
+        expect(typeof capturedNavigate).toBe('function');
+
+        // Calling navigate with no router context should warn
+        capturedNavigate('/some-route');
+
+        expect(warn).toHaveBeenCalledOnce();
+        expect(warn).toHaveBeenCalledWith(
+            '[useNavigate] No Router context found. ' +
+            'Ensure your component is rendered inside a <Router>.'
+        );
+
+        t.unmount();
+    });
 });

--- a/packages/router/src/hooks.ts
+++ b/packages/router/src/hooks.ts
@@ -27,6 +27,10 @@ export function useNavigate(): (path: string, options?: { replace?: boolean; que
     
     return (path: string, options?: { replace?: boolean; query?: QueryParams }) => {
         if (!router) {
+            console.warn(
+                '[useNavigate] No Router context found. ' +
+                'Ensure your component is rendered inside a <Router>.'
+            );
             return;
         }
         if (options?.replace) {


### PR DESCRIPTION
## Summary of What Has Been Done

Changed `useNavigate` in `packages/router/src/hooks.ts` to log a `console.warn` when called without a `Router` context, instead of silently doing nothing.

Added a test case in `packages/router/src/hooks.test.ts` that renders a component calling `useNavigate` outside a `RouterContext.Provider` and verifies the warning is emitted.

## Changes Made

- In the inner callback returned by `useNavigate`, replaced the silent `return;` with:
  ```typescript
  console.warn(
      '[useNavigate] No Router context found. ' +
      'Ensure your component is rendered inside a <Router>.'
  );
  ```
- Added test `'useNavigate warns when called without a router context'` that renders a component outside a Router context and asserts the warning is called exactly once with the expected message.

## Impact it Made

Makes the missing Router context immediately visible during development instead of silently failing. Prevents subtle bugs where callers believe navigation occurred when it did not.

Closes #3394

Note: Please assign this PR to the `tmdeveloper007` account.