### PR TITLE
fix : added replace emoji in EmptyState default icon with ASCII fallback

### DIFF
--- a/packages/widgets/src/feedback/EmptyState.ts
+++ b/packages/widgets/src/feedback/EmptyState.ts
@@ -16,7 +16,7 @@ export class EmptyState extends Widget {
     constructor(title: string, style: Partial<Style> = {}, opts: EmptyStateOptions = {}) {
         super(style);
         this._title = title;
-        this._icon = opts.icon ?? (caps.unicode ? '📭' : '[]');
+        this._icon = opts.icon ?? (caps.unicode ? '[x]' : '[]');
         if (opts.description !== undefined) this._description = opts.description;
         if (opts.hint !== undefined) this._hint = opts.hint;
         this._updateA11y();


### PR DESCRIPTION
Closes #3404

## Summary of What Has Been Done

The EmptyState widget uses emoji character in its default icon when caps.unicode is true. The project hard rules prohibit emojis in source code.

## Changes Made

Replace the default icon 'inbox tissue' emoji with ASCII '[x]' in packages/widgets/src/feedback/EmptyState.ts.

## Impact it Made

Ensures EmptyState renders correctly in all terminals and aligns with coding standards.

## Note: Please assign this PR to the `tmdeveloper007` account.
