### PR TITLE
feat : added add hasNext and hasPrev navigation helpers to VirtualList

### DIFF
--- a/packages/widgets/src/input/VirtualList.ts
+++ b/packages/widgets/src/input/VirtualList.ts
@@ -113,6 +113,16 @@ export class VirtualList extends Widget {
 
     get totalItems(): number { return this._totalItems; }
     get selectedIndex(): number { return this._selectedIndex; }
+    /** Whether there is a next item to select */
+    hasNext(): boolean {
+        return this._selectedIndex < this._totalItems - 1;
+    }
+
+    /** Whether there is a previous item to select */
+    hasPrev(): boolean {
+        return this._selectedIndex > 0;
+    }
+
     get scrollOffset(): number { return this._scrollOffset; }
 
     // ── Public API ──


### PR DESCRIPTION
Closes #3406

## Summary of What Has Been Done

VirtualList exposes navigation methods but lacks hasNext() and hasPrev() boolean helpers for checking navigation boundaries.

## Changes Made

Add hasNext(): boolean and hasPrev(): boolean getter methods to VirtualList in packages/widgets/src/input/VirtualList.ts before the scrollOffset getter.

## Impact it Made

Provides standard navigation helpers preventing callers from duplicating boundary check logic.

## Note: Please assign this PR to the `tmdeveloper007` account.
