### PR TITLE
feat : added add removeChild method to Grid for proper area cleanup

### DIFF
--- a/packages/widgets/src/layout/Grid.ts
+++ b/packages/widgets/src/layout/Grid.ts
@@ -154,6 +154,16 @@ export class Grid extends Widget {
         this.markDirty();
     }
 
+    override removeChild(child: Widget): void {
+        child.setStyle({
+            gridColumnStart: undefined,
+            gridColumnEnd: undefined,
+            gridRowStart: undefined,
+            gridRowEnd: undefined,
+        });
+        super.removeChild(child);
+    }
+
     protected _renderSelf(_screen: Screen): void {
         // Grid is a pure layout container — no self-rendering needed.
     }
@@ -195,6 +205,16 @@ export class GridItem extends Widget {
             ...style
         });
         this.gridArea = options.area;
+    }
+
+    override removeChild(child: Widget): void {
+        child.setStyle({
+            gridColumnStart: undefined,
+            gridColumnEnd: undefined,
+            gridRowStart: undefined,
+            gridRowEnd: undefined,
+        });
+        super.removeChild(child);
     }
 
     protected _renderSelf(_screen: Screen): void {


### PR DESCRIPTION
Closes #3408

## Summary of What Has Been Done

Grid overrides addChild to apply named area placement styles but does not override removeChild, leaving stale styles on removed children.

## Changes Made

Override removeChild(child: Widget): void in Grid class in packages/widgets/src/layout/Grid.ts before _renderSelf.

## Impact it Made

Prevents layout side-effects when Grid children are removed and re-used elsewhere.

## Note: Please assign this PR to the `tmdeveloper007` account.
