### PR TITLE
fix: emit re-entrancy safety with hasSkippedHandlers

### DIFF
--- a/packages/core/src/events/EventEmitter.test.ts
+++ b/packages/core/src/events/EventEmitter.test.ts
@@ -276,4 +276,34 @@ describe('EventEmitter', () => {
         expect(handlerB).toHaveBeenCalledTimes(1); // Not called again
         expect(handlerC).toHaveBeenCalledTimes(2);
     });
+
+    it('hasSkippedHandlers returns true when regular handlers are skipped due to re-entrant emit', () => {
+        const emitter = new EventEmitter<TestEvents>();
+        const outerHandler = vi.fn();
+        const innerHandler = vi.fn();
+
+        emitter.on('message', outerHandler);
+        emitter.on('message', () => {
+            innerHandler();
+            // Re-entrant emit on same event
+            emitter.emit('message', 'reentrant');
+        });
+
+        // Normal emit: both handlers fire (re-entrant emit fires once handlers but skips regulars)
+        emitter.emit('message', 'first');
+        expect(outerHandler).toHaveBeenCalledTimes(1);
+        expect(innerHandler).toHaveBeenCalledTimes(1);
+        // hasSkippedHandlers = true because a re-entrant emit occurred during this cycle
+        expect(emitter.hasSkippedHandlers('message')).toBe(true);
+    });
+
+    it('hasSkippedHandlers returns false after a normal emit with no re-entrancy', () => {
+        const emitter = new EventEmitter<TestEvents>();
+        const handler = vi.fn();
+        emitter.on('message', handler);
+
+        // Normal emit with no re-entrant calls
+        emitter.emit('message', 'test');
+        expect(emitter.hasSkippedHandlers('message')).toBe(false);
+    });
 });

--- a/packages/core/src/events/EventEmitter.ts
+++ b/packages/core/src/events/EventEmitter.ts
@@ -9,7 +9,9 @@
 export class EventEmitter<TEventMap extends Record<string, any>> {
     private _handlers: Map<keyof TEventMap, Set<(data: any) => void>> = new Map();
     private _onceHandlers: Map<keyof TEventMap, Set<(data: any) => void>> = new Map();
-    private _emitting: Set<keyof TEventMap> = new Set();
+    // Tracks the current emit depth for each event (0 = not emitting, 1 = outermost, 2+ = re-entrant)
+    private _emitting: Map<keyof TEventMap, number> = new Map();
+    private _skipped: Set<keyof TEventMap> = new Set();
 
     /** Optional error handler for event handler errors. Called when a handler throws. */
     onError?: (event: keyof TEventMap, error: unknown) => void;
@@ -79,9 +81,11 @@ export class EventEmitter<TEventMap extends Record<string, any>> {
             this._onceHandlers.delete(event);
         }
 
-        // Regular handlers — iterate over a snapshot to prevent concurrent modification issues
-        if (!this._emitting.has(event)) {
-            this._emitting.add(event);
+        // Capture depth before modifying anything — used to detect re-entrancy
+        const depth = this._emitting.get(event) ?? 0;
+        if (depth === 0) {
+            // Outermost emit: start fresh; clear any prior _skipped state for this event
+            this._emitting.set(event, 1);
             const handlers = this._handlers.get(event);
             if (handlers) {
                 for (const handler of [...handlers]) {
@@ -90,10 +94,23 @@ export class EventEmitter<TEventMap extends Record<string, any>> {
                     }
                 }
             }
+            // Detect if any re-entrant emit occurred during this cycle
+            const wasReentrant = (this._emitting.get(event) ?? 1) > 1;
+            // Set _skipped only if re-entrant emit occurred during this cycle
+            if (wasReentrant) {
+                this._skipped.add(event);
+            } else {
+                this._skipped.delete(event);
+            }
+            // Always clear _emitting so the next emit starts fresh
             this._emitting.delete(event);
+        } else {
+            // Re-entrant emit: regular handlers are skipped; track this
+            this._skipped.add(event);
+            this._emitting.set(event, depth + 1);
         }
 
-        // Once handlers — fire removed handlers
+        // Once handlers — fire removed handlers (fires even on re-entrant emit)
         for (const handler of onceSnapshot) {
             try { handler(data); } catch (err) {
                 this.onError?.(event, err);
@@ -122,5 +139,14 @@ export class EventEmitter<TEventMap extends Record<string, any>> {
             (this._handlers.get(event)?.size ?? 0) > 0 ||
             (this._onceHandlers.get(event)?.size ?? 0) > 0
         );
+    }
+
+    /**
+     * Check if handlers were skipped due to a re-entrant emit call.
+     * Returns true if emit() was called re-entrantly (from within a handler),
+     * causing regular handlers for this event to be skipped.
+     */
+    hasSkippedHandlers(event: keyof TEventMap): boolean {
+        return this._skipped.has(event);
     }
 }


### PR DESCRIPTION
## Description

Add re-entrancy safety to EventEmitter.emit() with depth-tracking.

- Tracks emit depth via a `_emitting` Map (1=outermost, 2+=re-entrant)
- Re-entrant emits skip regular handlers and set a `_skipped` flag
- New `hasSkippedHandlers(event)` method reports whether handlers were skipped due to re-entrancy
- All 22 EventEmitter tests pass

## Related Issues

Closes #3395

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] Tests pass (22/22 EventEmitter tests)
- [x] TypeScript compiles without errors
