### PR TITLE
fix : added ASCII fallback for Markdown blockquote pipe character

### DIFF
--- a/packages/widgets/src/display/Code.test.ts
+++ b/packages/widgets/src/display/Code.test.ts
@@ -2,8 +2,8 @@
 // @termuijs/widgets — Tests for Code widget
 // ─────────────────────────────────────────────────────
 
-import { describe, it, expect } from 'vitest';
-import { Screen } from '@termuijs/core';
+import { describe, it, expect, vi } from 'vitest';
+import { Screen, caps } from '@termuijs/core';
 import { Code } from './Code.js';
 
 describe('Code', () => {
@@ -72,5 +72,14 @@ describe('Code', () => {
         expect(screen.back[0][2].char).toBe('[');
         expect(screen.back[0][3].char).toBe('t');
         expect(screen.back[0][4].char).toBe('╮'); // topRight corner (width-1 index)
+    });
+
+    it('uses ASCII pipe for gutter separator when caps.unicode is false', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+        const code = new Code('hello');
+        code.updateRect({ x: 0, y: 0, width: 12, height: 4 });
+        const screen = new Screen(12, 4);
+        code.render(screen);
+        expect(screen.back[1][2].char).toBe('|');
     });
 });

--- a/packages/widgets/src/display/Code.ts
+++ b/packages/widgets/src/display/Code.ts
@@ -49,7 +49,7 @@ export class Code extends Widget {
                 screen.writeString(x, y, lineNum, { dim: true });
                 x += lineNumWidth;
 
-                screen.setCell(x, y, { char: '│', dim: true });
+                screen.setCell(x, y, { char: caps.unicode ? '│' : '|', dim: true });
                 x++;
 
                 screen.setCell(x, y, { char: ' ' });

--- a/packages/widgets/src/display/Markdown.test.ts
+++ b/packages/widgets/src/display/Markdown.test.ts
@@ -50,6 +50,15 @@ describe('Markdown', () => {
         expect(pipeCell.italic).toBe(true);
     });
 
+    it('renders blockquote with ASCII pipe when caps.unicode is false', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+        const screen = render('> quote text');
+        const row = screen.back[0].map(c => c.char).join('');
+        expect(row).toContain('|');
+        expect(row).not.toContain('│');
+        expect(row).toContain('quote text');
+    });
+
     it('renders bullet list items with • when unicode is enabled', () => {
         vi.spyOn(caps, 'unicode', 'get').mockReturnValue(true);
         const screen = render('- item one');

--- a/packages/widgets/src/display/Markdown.ts
+++ b/packages/widgets/src/display/Markdown.ts
@@ -189,7 +189,7 @@ export class Markdown extends Widget {
     screen.writeString(
         rect.x,
         rect.y + screenRow,
-        `│ ${line.slice(2)}`,
+`${caps.unicode ? '│' : '|'} ${line.slice(2)}`,
         {
             italic: true
         }


### PR DESCRIPTION
## Description

Fixes a bug in the Markdown widget where blockquote lines always render with a Unicode box-drawing pipe character `│` (`U+2502`), even when the terminal does not support Unicode. This causes display issues on ASCII-only terminals.

The fix adds a `caps.unicode` check and falls back to the ASCII pipe character `|` when Unicode is disabled.

## Changes

- `packages/widgets/src/display/Markdown.ts` — replaced hardcoded `│` with `${caps.unicode ? '│' : '|'}`
- `packages/widgets/src/display/Markdown.test.ts` — added test verifying ASCII pipe fallback

## Related Issues

- Fixes #3431

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] Code follows the existing style
- [x] Tests added or updated
- [x] Documentation updated (if applicable)
- [x] All tests pass locally

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code and Markdown rendering in environments without Unicode support.
  * Gutter separators and blockquote borders now use the ASCII `|` character when needed, while retaining the Unicode `│` character where supported.
* **Tests**
  * Added coverage to verify correct separator rendering across supported display modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->