### PR TITLE
fix : added ASCII fallback for Chart widget axis characters

### DIFF
--- a/packages/widgets/src/data/Chart.test.ts
+++ b/packages/widgets/src/data/Chart.test.ts
@@ -70,4 +70,23 @@ describe('Chart', () => {
         expect(row0).toContain('CPU');
         expect(row0).toContain('RAM');
     });
+
+    it('renders axes with ASCII fallback when caps.unicode is false', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+        const chart = new Chart({
+            showAxes: true,
+            series: [{ label: 'X', color: 'green', data: [0, 10] }]
+        });
+        chart.updateRect({ x: 0, y: 0, width: 15, height: 5 });
+        chart.render(screen);
+
+        const row0 = screen.back[0].map(c => c.char).join('');
+        expect(row0).toContain('10.0+');
+
+        const row4 = screen.back[4].map(c => c.char).join('');
+        expect(row4).toContain('+----');
+
+        expect(row0).not.toContain('┤');
+        expect(row4).not.toContain('└');
+    });
 });

--- a/packages/widgets/src/data/Chart.ts
+++ b/packages/widgets/src/data/Chart.ts
@@ -80,20 +80,25 @@ export class Chart extends Widget {
             
             if (chartWidth <= 0 || chartHeight <= 0) return;
 
+            const axisVert = caps.unicode ? '│' : '|';
+            const axisHoriz = caps.unicode ? '─' : '-';
+            const axisCorner = caps.unicode ? '└' : '+';
+            const axisTick = caps.unicode ? '┤' : '+';
+
             // Draw Y-axis line
             for (let r = 0; r < chartHeight; r++) {
-                screen.setCell(chartX - 1, y + r, { char: '│', ...attrs });
+                screen.setCell(chartX - 1, y + r, { char: axisVert, ...attrs });
             }
             // Draw X-axis line
             for (let c = 0; c < chartWidth; c++) {
-                screen.setCell(chartX + c, y + chartHeight, { char: '─', ...attrs });
+                screen.setCell(chartX + c, y + chartHeight, { char: axisHoriz, ...attrs });
             }
             // Draw origin corner
-            screen.setCell(chartX - 1, y + chartHeight, { char: '└', ...attrs });
+            screen.setCell(chartX - 1, y + chartHeight, { char: axisCorner, ...attrs });
 
             // Draw Y-axis labels
-            screen.writeString(x, y, maxStr.padStart(yAxisLabelWidth - 1) + '┤', attrs);
-            screen.writeString(x, y + chartHeight - 1, minStr.padStart(yAxisLabelWidth - 1) + '┤', attrs);
+            screen.writeString(x, y, maxStr.padStart(yAxisLabelWidth - 1) + axisTick, attrs);
+            screen.writeString(x, y + chartHeight - 1, minStr.padStart(yAxisLabelWidth - 1) + axisTick, attrs);
         }
 
         if (chartWidth <= 0 || chartHeight <= 0) return;

--- a/packages/widgets/src/display/Code.test.ts
+++ b/packages/widgets/src/display/Code.test.ts
@@ -2,8 +2,8 @@
 // @termuijs/widgets — Tests for Code widget
 // ─────────────────────────────────────────────────────
 
-import { describe, it, expect } from 'vitest';
-import { Screen } from '@termuijs/core';
+import { describe, it, expect, vi } from 'vitest';
+import { Screen, caps } from '@termuijs/core';
 import { Code } from './Code.js';
 
 describe('Code', () => {
@@ -72,5 +72,14 @@ describe('Code', () => {
         expect(screen.back[0][2].char).toBe('[');
         expect(screen.back[0][3].char).toBe('t');
         expect(screen.back[0][4].char).toBe('╮'); // topRight corner (width-1 index)
+    });
+
+    it('uses ASCII pipe for gutter separator when caps.unicode is false', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+        const code = new Code('hello');
+        code.updateRect({ x: 0, y: 0, width: 12, height: 4 });
+        const screen = new Screen(12, 4);
+        code.render(screen);
+        expect(screen.back[1][2].char).toBe('|');
     });
 });

--- a/packages/widgets/src/display/Code.ts
+++ b/packages/widgets/src/display/Code.ts
@@ -49,7 +49,7 @@ export class Code extends Widget {
                 screen.writeString(x, y, lineNum, { dim: true });
                 x += lineNumWidth;
 
-                screen.setCell(x, y, { char: '│', dim: true });
+                screen.setCell(x, y, { char: caps.unicode ? '│' : '|', dim: true });
                 x++;
 
                 screen.setCell(x, y, { char: ' ' });


### PR DESCRIPTION
## Description

Fixes a bug in the Chart widget where axis lines always render with Unicode box-drawing characters (`│`, `─`, `└`, `┤`), even when the terminal does not support Unicode. This causes display issues on ASCII-only terminals.

The fix adds `caps.unicode` checks for all axis characters, falling back to `|`, `-`, `+` when Unicode is disabled.

## Changes

- `packages/widgets/src/data/Chart.ts` — added `axisVert`, `axisHoriz`, `axisCorner`, `axisTick` constants using `caps.unicode`
- `packages/widgets/src/data/Chart.test.ts` — added test verifying ASCII axis fallback

## Related Issues

- Fixes #3433

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] Code follows the existing style
- [x] Tests added or updated
- [x] Documentation updated (if applicable)
- [x] All tests pass locally

Note: Please assign this PR to the `tmdeveloper007` account.