### PR TITLE
fix : added ASCII fallback for LineChart and SplitPane Unicode characters

### DIFF
--- a/packages/widgets/src/data/LineChart.test.ts
+++ b/packages/widgets/src/data/LineChart.test.ts
@@ -406,5 +406,41 @@ describe('LineChart', () => {
             expect(hasBraille).toBe(true);
         });
     });
+
+    describe('ASCII fallback for axes', () => {
+        it('uses ASCII pipe for Y-axis separator when caps.unicode is false', async () => {
+            vi.stubEnv('NO_UNICODE', '1');
+            vi.stubEnv('TERM', '');
+            vi.resetModules();
+
+            const lines = await renderLineChart([10, 50, 90], { showYAxis: true }, 20, 5);
+            const asciiPipeCount = countCharInGrid(lines, '|');
+            const unicodePipeCount = countCharInGrid(lines, '│');
+            expect(asciiPipeCount).toBeGreaterThan(0);
+            expect(unicodePipeCount).toBe(0);
+        });
+
+        it('uses ASCII dash for X-axis line when caps.unicode is false', async () => {
+            vi.stubEnv('NO_UNICODE', '1');
+            vi.stubEnv('TERM', '');
+            vi.resetModules();
+
+            const lines = await renderLineChart([10, 50, 90], { showXAxis: true }, 20, 5);
+            const asciiDashCount = countCharInGrid(lines, '-');
+            const unicodeDashCount = countCharInGrid(lines, '─');
+            expect(asciiDashCount).toBeGreaterThan(0);
+            expect(unicodeDashCount).toBe(0);
+        });
+
+        it('uses ASCII chars for Y-axis tick marks when caps.unicode is false', async () => {
+            vi.stubEnv('NO_UNICODE', '1');
+            vi.stubEnv('TERM', '');
+            vi.resetModules();
+
+            const lines = await renderLineChart([0, 100], { showYAxis: true }, 20, 5);
+            expect(lines[0]).not.toContain('┤');
+            expect(lines[0]).toContain('+');
+        });
+    });
 });
 

--- a/packages/widgets/src/data/LineChart.ts
+++ b/packages/widgets/src/data/LineChart.ts
@@ -105,9 +105,9 @@ export class LineChart extends Widget {
                 const v = plotHeight > 1 ? max - (row / (plotHeight - 1)) * range : max;
                 if (row === 0 || row === plotHeight - 1) {
                     const label = v.toFixed(0).padStart(yAxisWidth - 1, ' ');
-                    screen.writeString(x, y + row, label + '┤', { ...attrs, dim: true });
+                    screen.writeString(x, y + row, label + (caps.unicode ? '┤' : '+'), { ...attrs, dim: true });
                 } else {
-                    screen.writeString(x + yAxisWidth - 1, y + row, '│', { ...attrs, dim: true });
+                    screen.writeString(x + yAxisWidth - 1, y + row, caps.unicode ? '│' : '|', { ...attrs, dim: true });
                 }
             }
         }
@@ -157,7 +157,7 @@ export class LineChart extends Widget {
                     const top = Math.min(prevRow, row) + 1;
                     const bottom = Math.max(prevRow, row);
                     for (let r = top; r < bottom; r++) {
-                        screen.setCell(plotX + col, y + r, { char: '│', fg: this._color, dim: true });
+                        screen.setCell(plotX + col, y + r, { char: caps.unicode ? '│' : '|', fg: this._color, dim: true });
                     }
                 }
 
@@ -172,10 +172,10 @@ export class LineChart extends Widget {
         if (this._showXAxis) {
             const axisY = y + height - 1;
             for (let col = 0; col < plotWidth; col++) {
-                screen.setCell(plotX + col, axisY, { char: '─', ...attrs, dim: true });
+                screen.setCell(plotX + col, axisY, { char: caps.unicode ? '─' : '-', ...attrs, dim: true });
             }
             if (yAxisWidth > 0) {
-                screen.setCell(plotX - 1, axisY, { char: '└', ...attrs, dim: true });
+                screen.setCell(plotX - 1, axisY, { char: caps.unicode ? '└' : '+', ...attrs, dim: true });
             }
         }
     }

--- a/packages/widgets/src/display/Code.test.ts
+++ b/packages/widgets/src/display/Code.test.ts
@@ -2,8 +2,8 @@
 // @termuijs/widgets — Tests for Code widget
 // ─────────────────────────────────────────────────────
 
-import { describe, it, expect } from 'vitest';
-import { Screen } from '@termuijs/core';
+import { describe, it, expect, vi } from 'vitest';
+import { Screen, caps } from '@termuijs/core';
 import { Code } from './Code.js';
 
 describe('Code', () => {
@@ -72,5 +72,14 @@ describe('Code', () => {
         expect(screen.back[0][2].char).toBe('[');
         expect(screen.back[0][3].char).toBe('t');
         expect(screen.back[0][4].char).toBe('╮'); // topRight corner (width-1 index)
+    });
+
+    it('uses ASCII pipe for gutter separator when caps.unicode is false', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+        const code = new Code('hello');
+        code.updateRect({ x: 0, y: 0, width: 12, height: 4 });
+        const screen = new Screen(12, 4);
+        code.render(screen);
+        expect(screen.back[1][2].char).toBe('|');
     });
 });

--- a/packages/widgets/src/display/Code.ts
+++ b/packages/widgets/src/display/Code.ts
@@ -49,7 +49,7 @@ export class Code extends Widget {
                 screen.writeString(x, y, lineNum, { dim: true });
                 x += lineNumWidth;
 
-                screen.setCell(x, y, { char: '│', dim: true });
+                screen.setCell(x, y, { char: caps.unicode ? '│' : '|', dim: true });
                 x++;
 
                 screen.setCell(x, y, { char: ' ' });

--- a/packages/widgets/src/layout/SplitPane.test.ts
+++ b/packages/widgets/src/layout/SplitPane.test.ts
@@ -119,6 +119,24 @@ describe('SplitPane layout', () => {
         expect(markDirtySpy).toHaveBeenCalled();
     });
 
+    it('vertical split uses ASCII dash for divider when caps.unicode is false', () => {
+        vi.spyOn(caps, 'unicode', 'get').mockReturnValue(false);
+
+        const left = new Box();
+        const right = new Box();
+        const pane = new SplitPane(left, right, { width: 10, height: 6 }, { ratio: 0.5, direction: 'vertical' });
+
+        const node = pane.getLayoutNode();
+        computeLayout(node, 10, 6);
+        pane.syncLayout();
+
+        const screen = new Screen(10, 6);
+        pane.render(screen);
+
+        const dividerRow = screen.back[3].map(c => c.char).join('');
+        expect(dividerRow).toContain('-');
+    });
+
     describe('mouse drag', () => {
         function makePane(opts: { ratio?: number; minSize?: number } = {}) {
             const left = new Box();

--- a/packages/widgets/src/layout/SplitPane.ts
+++ b/packages/widgets/src/layout/SplitPane.ts
@@ -219,7 +219,7 @@ export class SplitPane extends Widget {
 
             for (let col = 0; col < width; col++) {
                 screen.setCell(col + x, dividerY, {
-                    char: '─',
+                    char: caps.unicode ? '─' : '-',
                     ...attrs,
                 });
             }


### PR DESCRIPTION
## Description

Fixes a bug in the LineChart and SplitPane widgets where various characters (Y-axis tick marks `┤`, vertical connectors `│`, X-axis lines `─`, origin corners `└`, and vertical split dividers) always render in Unicode, even when the terminal does not support Unicode. This causes display issues on ASCII-only terminals.

The fix adds `caps.unicode` checks across both widgets, falling back to ASCII equivalents (`+`, `|`, `-`) when Unicode is disabled.

## Changes

- `packages/widgets/src/data/LineChart.ts` — replaced `┤`, `│`, `─`, `└` with `caps.unicode` checks
- `packages/widgets/src/data/LineChart.test.ts` — added tests for Y-axis, X-axis, and tick mark ASCII fallbacks
- `packages/widgets/src/layout/SplitPane.ts` — replaced `─` with `caps.unicode ? '─' : '-'` for vertical split divider
- `packages/widgets/src/layout/SplitPane.test.ts` — added test for vertical split ASCII fallback

## Related Issues

- Fixes #3434

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] Code follows the existing style
- [x] Tests added or updated
- [x] Documentation updated (if applicable)
- [x] All tests pass locally

Note: Please assign this PR to the `tmdeveloper007` account.