### PR TITLE
feat(widgets): add getPairs method to Definition widget

### DIFF
--- a/packages/widgets/src/data/Definition.test.ts
+++ b/packages/widgets/src/data/Definition.test.ts
@@ -79,4 +79,14 @@ describe('Definition', () => {
     def.updateRect({ x: 0, y: 0, width: 30, height: 3 });
     expect(() => def.render(screen)).not.toThrow();
   });
+
+  it('returns current pairs via getPairs', () => {
+    const initial = [{ term: 'Term1', definition: 'Def1' }];
+    const def = new Definition(initial);
+    expect(def.getPairs()).toEqual(initial);
+
+    const updated = [{ term: 'Term2', definition: 'Def2' }];
+    def.setPairs(updated);
+    expect(def.getPairs()).toEqual(updated);
+  });
 });

--- a/packages/widgets/src/data/Definition.ts
+++ b/packages/widgets/src/data/Definition.ts
@@ -59,6 +59,10 @@ export class Definition extends Widget {
         this.markDirty();
     }
 
+    getPairs(): DefinitionPair[] {
+        return this._pairs;
+    }
+
     protected _renderSelf(screen: Screen): void {
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;


### PR DESCRIPTION
## Description

Adds missing `getPairs(): DefinitionPair[]` getter method to the `Definition` widget in `@termuijs/widgets`.

Closes #3525

## Package Scope

`packages/widgets`

## Checklist before PR
- [x] Run `bun run build && bun vitest run && bun run typecheck`
- [x] Change confined to package scope
- [x] No unrelated lockfile churn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access to the current definition pairs for widgets.
  * Retrieved pairs reflect updates made to the widget definition.

* **Tests**
  * Added coverage confirming initial pairs and subsequent updates are returned correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->