### PR TITLE
fix: fall through unresolved systemd names in services.list

### DIFF
--- a/packages/data/src/services.test.ts
+++ b/packages/data/src/services.test.ts
@@ -151,4 +151,86 @@ describe('services provider', () => {
         expect(result[0].active).toBe(false);
         expect(result[0].status).toBe('stopped');
     });
+
+    it('falls through unresolved systemd names to PM2/process when another unit resolves', () => {
+        const MOCK_SYSTEMCTL_SHOW_NOT_FOUND = [
+            'LoadState=not-found',
+            'ActiveState=inactive',
+            'SubState=dead',
+            'MainPID=0',
+            'NRestarts=0',
+            'ActiveEnterTimestamp=n/a',
+            'Description=my-node-worker.service',
+            '',
+        ].join('\n');
+
+        mockExecFileSync.mockImplementation((cmd: string, args?: string[]) => {
+            if (cmd === 'systemctl' && args?.[0] === '--version') return 'systemd 252';
+            if (cmd === 'systemctl' && args?.[0] === 'show' && args?.[1] === 'ssh.service') {
+                return [
+                    'LoadState=loaded',
+                    'Type=notify',
+                    'ActiveState=active',
+                    'SubState=running',
+                    'MainPID=99',
+                    'NRestarts=0',
+                    'ActiveEnterTimestamp=Mon 2026-06-01 08:00:00 UTC',
+                    'Description=OpenSSH server daemon',
+                    '',
+                ].join('\n');
+            }
+            if (cmd === 'systemctl' && args?.[0] === 'show' && args?.[1] === 'my-node-worker') {
+                return MOCK_SYSTEMCTL_SHOW_NOT_FOUND;
+            }
+            if (cmd === 'ps' && args?.[0] === '-p') return '  0.1  0.2\n';
+            if (cmd === 'pm2') {
+                return JSON.stringify([
+                    {
+                        name: 'my-node-worker',
+                        pid: 4242,
+                        pm2_env: { status: 'online', restart_time: 0, pm_uptime: Date.now() - 60000 },
+                        monit: { cpu: 4, memory: 64 * 1024 * 1024 },
+                    },
+                ]);
+            }
+            throw new Error(`unexpected exec: ${cmd} ${(args ?? []).join(' ')}`);
+        });
+
+        const result = services.list(['ssh.service', 'my-node-worker']);
+
+        expect(result.map(s => s.name)).toEqual(['ssh.service', 'my-node-worker']);
+        expect(result[0].active).toBe(true);
+        expect(result[0].pid).toBe(99);
+        expect(result[1].active).toBe(true);
+        expect(result[1].pid).toBe(4242);
+        expect(result[1].mem).toBe(64);
+    });
+
+    it('falls through names that throw from systemctl show', () => {
+        const MOCK_PS_AUX = [
+            'USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND',
+            'root      7777  1.5  2.0 123456 78900 ?        Ss   Jun01   0:10 /usr/bin/orphan-worker',
+        ].join('\n');
+
+        mockExecFileSync.mockImplementation((cmd: string, args?: string[]) => {
+            if (cmd === 'systemctl' && args?.[0] === '--version') return 'systemd 252';
+            if (cmd === 'systemctl' && args?.[0] === 'show' && args?.[1] === 'nginx') {
+                return MOCK_SYSTEMCTL_SHOW_NGINX;
+            }
+            if (cmd === 'systemctl' && args?.[0] === 'show' && args?.[1] === 'orphan-worker') {
+                throw new Error('Unit orphan-worker.service could not be found.');
+            }
+            if (cmd === 'ps' && args?.[0] === '-p') return MOCK_PS_OUTPUT;
+            if (cmd === 'pm2') throw new Error('pm2 not found');
+            if (cmd === 'ps' && args?.[0] === 'aux') return MOCK_PS_AUX;
+            throw new Error(`unexpected exec: ${cmd} ${(args ?? []).join(' ')}`);
+        });
+
+        const result = services.list(['nginx', 'orphan-worker']);
+
+        expect(result.map(s => s.name)).toEqual(['nginx', 'orphan-worker']);
+        expect(result[0].pid).toBe(1234);
+        expect(result[1].active).toBe(true);
+        expect(result[1].pid).toBe(7777);
+    });
 });

--- a/packages/data/src/services.ts
+++ b/packages/data/src/services.ts
@@ -49,6 +49,12 @@ function parseSystemdShow(output: string, serviceName: string): ParsedSystemdSer
         props[line.slice(0, idx)] = line.slice(idx + 1);
     }
 
+    // systemctl show exits 0 for unknown units and reports LoadState=not-found.
+    // Treat those as unresolved so PM2 / process matching can still run.
+    if ((props['LoadState'] ?? '') === 'not-found') {
+        return null;
+    }
+
     const activeState = props['ActiveState'] ?? 'unknown';
     const description = props['Description'] ?? serviceName;
     const pid = parseInt(props['MainPID'] ?? '0', 10) || 0;
@@ -233,22 +239,30 @@ export const services = {
     list(serviceNames: string[]): ServiceInfo[] {
         if (serviceNames.length === 0) return [];
 
+        const results: ServiceInfo[] = [];
+        let remaining = serviceNames;
+
         // Try systemd on Linux
         if (os.platform() === 'linux') {
             try {
                 execFileSync('systemctl', ['--version'], { encoding: 'utf-8', timeout: 1000 });
-                const svcs = getSystemdServices(serviceNames);
-                if (svcs.length > 0) return svcs;
+                const systemdSvcs = getSystemdServices(serviceNames);
+                results.push(...systemdSvcs);
+                const resolved = new Set(systemdSvcs.map(s => s.name));
+                remaining = serviceNames.filter(n => !resolved.has(n));
+                if (remaining.length === 0) {
+                    return results;
+                }
             } catch {
                 // systemctl not available — continue to PM2
             }
         }
 
-        // Try PM2
-        const pm2Svcs = getPm2Services(serviceNames);
+        // Try PM2 for names systemd did not resolve
+        const pm2Svcs = getPm2Services(remaining);
         const pm2Names = new Set(pm2Svcs.map(s => s.name));
-        const missing = serviceNames.filter(n => !pm2Names.has(n));
-        const results = [...pm2Svcs];
+        results.push(...pm2Svcs);
+        const missing = remaining.filter(n => !pm2Names.has(n));
 
         // Fall back to process name matching for services PM2 didn't cover
         if (missing.length > 0) {


### PR DESCRIPTION
## Description

`services.list()` returned early with whatever systemd resolved, dropping any remaining names. Unresolved units (throw from `systemctl show`, or `LoadState=not-found`) now continue through PM2 and process-name matching so every requested name gets an entry.

## Related Issue

Closes #3385

## Which package(s)?

@termuijs/data

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/nyxsky404`

## Screenshots / Recordings (UI changes)

N/A

## Notes for the Reviewer

Also treats `LoadState=not-found` as unresolved — `systemctl show` exits 0 for unknown units, so without that check a missing name looked "resolved" and never hit PM2/process fallback.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service discovery when systemd units are missing or unavailable.
  * Added fallback matching through PM2 and running processes for unresolved services.
  * Preserved successfully detected services while combining results from multiple service sources.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->