### PR TITLE
fix(store): resolve race conditions and state loss in persist writes

### DIFF
--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -357,6 +357,47 @@ export function createStore<T extends object>(
         }
     }
 
+    let exitHookRegistered = false;
+
+    const performWrite = (data: string) => {
+        try {
+            const dir = path.dirname(persistFilePath);
+            if (!fs.existsSync(dir)) {
+                fs.mkdirSync(dir, { recursive: true });
+            }
+            const tempPath = `${persistFilePath}.tmp`;
+            fs.writeFileSync(tempPath, data, 'utf8');
+            fs.renameSync(tempPath, persistFilePath);
+        } catch {
+            // Ignore write errors to keep terminal stable
+        }
+    };
+
+    const flushSync = () => {
+        if (writeTimeout) {
+            clearTimeout(writeTimeout);
+            writeTimeout = null;
+        }
+        try {
+            const dir = path.dirname(persistFilePath);
+            if (!fs.existsSync(dir)) {
+                fs.mkdirSync(dir, { recursive: true });
+            }
+            const dataToSave: Record<string, unknown> = {};
+            for (const [key, val] of Object.entries(state)) {
+                if (typeof val !== 'function') {
+                    dataToSave[key] = val;
+                }
+            }
+            const dataStr = JSON.stringify(dataToSave);
+            const tempPath = `${persistFilePath}.tmp`;
+            fs.writeFileSync(tempPath, dataStr, 'utf8');
+            fs.renameSync(tempPath, persistFilePath);
+        } catch {
+            // Ignore write errors
+        }
+    };
+
     const persistState = () => {
         if (!persistFilePath) return;
 
@@ -366,22 +407,28 @@ export function createStore<T extends object>(
             clearTimeout(writeTimeout);
         }
 
+        if (!exitHookRegistered) {
+            exitHookRegistered = true;
+            process.once('beforeExit', flushSync);
+            process.once('exit', flushSync);
+            process.once('SIGINT', () => {
+                flushSync();
+                process.exit(0);
+            });
+            process.once('SIGTERM', () => {
+                flushSync();
+                process.exit(0);
+            });
+        }
+
         writeTimeout = setTimeout(() => {
-            try {
-                const dir = path.dirname(persistFilePath);
-                if (!fs.existsSync(dir)) {
-                    fs.mkdirSync(dir, { recursive: true });
+            const dataToSave: Record<string, unknown> = {};
+            for (const [key, val] of Object.entries(state)) {
+                if (typeof val !== 'function') {
+                    dataToSave[key] = val;
                 }
-                const dataToSave: Record<string, unknown> = {};
-                for (const [key, val] of Object.entries(state)) {
-                    if (typeof val !== 'function') {
-                        dataToSave[key] = val;
-                    }
-                }
-                fs.writeFileSync(persistFilePath, JSON.stringify(dataToSave), 'utf8');
-            } catch (err) {
-                // Ignore write errors to keep terminal stable
             }
+            performWrite(JSON.stringify(dataToSave));
         }, debounceMs);
     };
 
@@ -680,4 +727,3 @@ export interface UseStore<T> {
     reset(): void;
     getInitialState(): T;
 }
-


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

This PR fixes the race conditions and data loss vulnerabilities associated with state persistence in `@termuijs/store`. Writes are now handled using atomic writes (`fs.writeFileSync` to a `.tmp` file followed by `fs.renameSync`). Additionally, active process exit listeners ensure any debounced writes are synchronously flushed to disk before the application exits.

## Related Issue

Closes #3729

## Which package(s)?

@termuijs/store

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/Unnati1007`

## Screenshots / Recordings (UI changes)

N/A (This is a non-visual background backend state manager bugfix).

## Notes for the Reviewer

- Used synchronous atomic operations (`writeFileSync`/`renameSync`) to ensure correctness inside fake timer test frameworks (`vitest`) and prevent locking clashes.
- Handled SIGINT, SIGTERM, exit, and beforeExit events to prevent state loss on terminal close.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data persistence reliability by preventing incomplete writes.
  * Added safeguards to flush pending changes before application shutdown.
  * Ensured persistence directories are created automatically when needed.
  * Excluded unsupported function values from persisted state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->