### PR TITLE
fix(jsx): cancel in-flight requests and prevent memory leaks in useAsync

### DIFF
--- a/packages/jsx/src/hooks.ts
+++ b/packages/jsx/src/hooks.ts
@@ -785,10 +785,13 @@ export function useAsync<T>(
                     setLoading(false);
                 }
             });
-    }, deps);
+    }, []);
 
     useEffect(() => {
         refetch();
+        return () => {
+            versionRef.current++;
+        };
     }, deps);
 
     return { data, loading, error, refetch };


### PR DESCRIPTION
<!-- Thanks for contributing to TermUI. GSSoC 2026 contributors: fill every section. Your PR title must follow `type: short description` (example: `fix: handle empty list in VirtualList`). -->

## Description

This PR fixes memory leaks and race conditions inside the `useAsync` hook under `@termuijs/jsx`. An active cleanup step was added to the `useEffect` block to discard in-flight state updates when dependencies change or when the component unmounts. In addition, the `useCallback` dependency array was emptied to keep the `refetch` function identity stable.

## Related Issue

Closes #3731

## Which package(s)?

@termuijs/jsx

## Type of Change

- [x] 🐛 Bug fix (`type:bug`)
- [ ] ✨ Feature (`type:feature`)
- [ ] 📝 Docs (`type:docs`)
- [ ] 🧪 Tests (`type:testing`)
- [ ] ♻️ Refactor (`type:refactor`)
- [ ] 🎨 Design / UX (`type:design`)
- [ ] ♿ Accessibility (`type:accessibility`)
- [ ] ⚡ Performance (`type:performance`)
- [ ] 🔧 DevOps / CI (`type:devops`)
- [ ] 🔒 Security (`type:security`)

## Checklist

- [x] ⭐ You starred the repo. The `needs-star` check blocks your merge otherwise.
- [x] Tests pass locally: `bun vitest run`
- [x] Build passes: `bun run build`
- [x] Typecheck passes: `bun run typecheck`
- [x] You read [`CONTRIBUTING.md`](./CONTRIBUTING.md).
- [x] Your PR title follows `type: short description`.
- [x] Widget state mutators call `markDirty()` (if your change affects rendering).
- [x] No new `any` types without an inline comment explaining why.
- [x] No unrelated refactors bundled into this PR.

## GSSoC 2026 Participation

- [x] You are a GSSoC 2026 contributor.
- Your GSSoC profile: `https://gssoc.girlscript.org/profile/Unnati1007`

## Screenshots / Recordings (UI changes)

N/A (This is a non-visual background hooks lifecycle fix).

## Notes for the Reviewer

- Cleaned up active async version identifiers in `useEffect`'s return function to avoid updating state on a destroyed fiber.
- Discarded stale request triggers by stabilizing the `refetch` identity across renders.
