### PR TITLE
feat(widgets): add getShowSeconds, setShowSeconds, getUse24Hour, and setUse24Hour to Clock widget

### DIFF
--- a/packages/widgets/src/display/Clock.test.ts
+++ b/packages/widgets/src/display/Clock.test.ts
@@ -122,4 +122,20 @@ describe('Clock', () => {
         clock.destroy();
         expect(spy).toHaveBeenCalled();
     });
+
+    it('gets and sets showSeconds option', () => {
+        const clock = new Clock({}, { showSeconds: false });
+        expect(clock.getShowSeconds()).toBe(false);
+
+        clock.setShowSeconds(true);
+        expect(clock.getShowSeconds()).toBe(true);
+    });
+
+    it('gets and sets use24Hour option', () => {
+        const clock = new Clock({}, { use24Hour: false });
+        expect(clock.getUse24Hour()).toBe(false);
+
+        clock.setUse24Hour(true);
+        expect(clock.getUse24Hour()).toBe(true);
+    });
 });

--- a/packages/widgets/src/display/Clock.ts
+++ b/packages/widgets/src/display/Clock.ts
@@ -65,6 +65,26 @@ export class Clock extends Widget {
         this.markDirty();
     }
 
+    getShowSeconds(): boolean {
+        return this._showSeconds;
+    }
+
+    setShowSeconds(showSeconds: boolean): void {
+        if (this._showSeconds === showSeconds) return;
+        this._showSeconds = showSeconds;
+        this.markDirty();
+    }
+
+    getUse24Hour(): boolean {
+        return this._use24Hour;
+    }
+
+    setUse24Hour(use24Hour: boolean): void {
+        if (this._use24Hour === use24Hour) return;
+        this._use24Hour = use24Hour;
+        this.markDirty();
+    }
+
     protected _renderSelf(screen: Screen): void {
         const rect = this._getContentRect();
         const { x, y, width, height } = rect;


### PR DESCRIPTION
## Description

Adds missing `getShowSeconds()`, `setShowSeconds()`, `getUse24Hour()`, and `setUse24Hour()` methods to the `Clock` widget in `@termuijs/widgets`.

Closes #3735

## Package Scope

`packages/widgets`

## Checklist before PR
- [x] Run `bun run build && bun vitest run && bun run typecheck`
- [x] Change confined to package scope
- [x] No unrelated lockfile churn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added controls for showing or hiding seconds on the clock.
  * Added support for switching between 12-hour and 24-hour time formats.
  * Clock settings update automatically when changed.

* **Tests**
  * Added coverage for the new clock display and time-format settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->