### PR TITLE
feat(widgets): add getCode, getLanguage, getShowLineNumbers, and setShowLineNumbers to Code widget

### DIFF
--- a/packages/widgets/src/display/Code.test.ts
+++ b/packages/widgets/src/display/Code.test.ts
@@ -73,4 +73,23 @@ describe('Code', () => {
         expect(screen.back[0][3].char).toBe('t');
         expect(screen.back[0][4].char).toBe('╮'); // topRight corner (width-1 index)
     });
+
+    it('gets and sets code content and language', () => {
+        const code = new Code('const x = 1;', {}, { language: 'typescript' });
+        expect(code.getCode()).toBe('const x = 1;');
+        expect(code.getLanguage()).toBe('typescript');
+
+        code.setCode('let y = 2;');
+        code.setLanguage('javascript');
+        expect(code.getCode()).toBe('let y = 2;');
+        expect(code.getLanguage()).toBe('javascript');
+    });
+
+    it('gets and sets showLineNumbers option', () => {
+        const code = new Code('test', {}, { showLineNumbers: false });
+        expect(code.getShowLineNumbers()).toBe(false);
+
+        code.setShowLineNumbers(true);
+        expect(code.getShowLineNumbers()).toBe(true);
+    });
 });

--- a/packages/widgets/src/display/Code.ts
+++ b/packages/widgets/src/display/Code.ts
@@ -25,12 +25,32 @@ export class Code extends Widget {
     }
 
     setCode(code: string): void {
+        if (this._code === code) return;
         this._code = code;
         this.markDirty();
     }
 
+    getCode(): string {
+        return this._code;
+    }
+
     setLanguage(language: string): void {
+        if (this._language === language) return;
         this._language = language;
+        this.markDirty();
+    }
+
+    getLanguage(): string {
+        return this._language;
+    }
+
+    getShowLineNumbers(): boolean {
+        return this._showLineNumbers;
+    }
+
+    setShowLineNumbers(show: boolean): void {
+        if (this._showLineNumbers === show) return;
+        this._showLineNumbers = show;
         this.markDirty();
     }
 


### PR DESCRIPTION
## Description

Adds missing `getCode()`, `getLanguage()`, `getShowLineNumbers()`, and `setShowLineNumbers()` methods to the `Code` widget in `@termuijs/widgets`.

Closes #3736

## Package Scope

`packages/widgets`

## Checklist before PR
- [x] Run `bun run build && bun vitest run && bun run typecheck`
- [x] Change confined to package scope
- [x] No unrelated lockfile churn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accessors for retrieving code content, language, and line-number visibility.
  * Added the ability to show or hide line numbers in code widgets.

* **Bug Fixes**
  * Prevented unnecessary updates when setting values that have not changed.

* **Tests**
  * Added coverage for code, language, and line-number settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->