### PR TITLE
feat(widgets): add getMessage, getVariant, getIcon, and setIcon to StatusMessage widget

### DIFF
--- a/packages/widgets/src/feedback/StatusMessage.test.ts
+++ b/packages/widgets/src/feedback/StatusMessage.test.ts
@@ -181,4 +181,17 @@ describe('StatusMessage', () => {
         expect(widget.isDirty).toBe(false);
     });
 
+    it('gets and sets message, variant, and custom icon', () => {
+        const widget = new StatusMessage('Ready', {}, { variant: 'info', icon: '★' });
+        expect(widget.getMessage()).toBe('Ready');
+        expect(widget.getVariant()).toBe('info');
+        expect(widget.getIcon()).toBe('★');
+
+        widget.setMessage('Processing');
+        widget.setVariant('warning');
+        widget.setIcon('⚡');
+        expect(widget.getMessage()).toBe('Processing');
+        expect(widget.getVariant()).toBe('warning');
+        expect(widget.getIcon()).toBe('⚡');
+    });
 });

--- a/packages/widgets/src/feedback/StatusMessage.ts
+++ b/packages/widgets/src/feedback/StatusMessage.ts
@@ -60,10 +60,28 @@ export class StatusMessage extends Widget {
         this.markDirty();
     }
 
+    getMessage(): string {
+        return this._message;
+    }
+
     setVariant(variant: StatusVariant): void {
         if (this._variant === variant) return;
         
         this._variant = variant;
+        this.markDirty();
+    }
+
+    getVariant(): StatusVariant {
+        return this._variant;
+    }
+
+    getIcon(): string | undefined {
+        return this._icon;
+    }
+
+    setIcon(icon?: string): void {
+        if (this._icon === icon) return;
+        this._icon = icon;
         this.markDirty();
     }
 


### PR DESCRIPTION
## Description

Adds missing `getMessage()`, `getVariant()`, `getIcon()`, and `setIcon()` methods to the `StatusMessage` widget in `@termuijs/widgets`.

Closes #3738

## Package Scope

`packages/widgets`

## Checklist before PR
- [x] Run `bun run build && bun vitest run && bun run typecheck`
- [x] Change confined to package scope
- [x] No unrelated lockfile churn